### PR TITLE
ci: add pytest GitHub Actions workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: python -m pip install -r requirements-ci.txt
+
+      - name: Run tests
+        run: pytest -n auto -q


### PR DESCRIPTION
### Motivation
- Add a CI workflow to run the test suite automatically on pushes and pull requests to ensure regressions are caught early.
- Mirror the test workflow pattern used in the PyTorch→C project by running `pytest` across a Python matrix for broader coverage.
- Ensure project contributors can rely on a consistent, reproducible test run using `requirements-ci.txt`.

### Description
- Add a new GitHub Actions workflow file at `.github/workflows/tests.yml` that triggers on `push` and `pull_request` events.
- The workflow uses a matrix to run on Python `3.10` and `3.11` and includes steps to `checkout`, `setup-python`, install dependencies with `python -m pip install -r requirements-ci.txt`, and run `pytest -n auto -q`.
- The workflow caches pip between runs by using `actions/setup-python` with `cache: pip` to speed up CI.

### Testing
- Ran `pytest -n auto -q` locally and observed `6 passed` (run completed in ~9.25s).
- The new workflow will run the same `pytest -n auto -q` command on GitHub Actions across the Python `3.10/3.11` matrix when triggered and is expected to reproduce the local test results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696152c37c708325bbac81ba1746f7ae)