### PR TITLE
cli: add compiler command and update e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # emx-onnx2c
+
+## CLI
+
+Compile an ONNX model into a C source file:
+
+```bash
+python -m onnx2c compile path/to/model.onnx build/model.c
+```
+
+Emit a JSON-producing testbench for end-to-end validation:
+
+```bash
+python -m onnx2c compile path/to/model.onnx build/model.c --emit-testbench
+```

--- a/src/onnx2c/__main__.py
+++ b/src/onnx2c/__main__.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import sys
+
+from .cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/onnx2c/cli.py
+++ b/src/onnx2c/cli.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Sequence
+
+import onnx
+
+from .compiler import Compiler, CompilerOptions
+from .errors import CodegenError, ShapeInferenceError, UnsupportedOpError
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="onnx2c", description="ONNX to C compiler")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    compile_parser = subparsers.add_parser(
+        "compile", help="Compile an ONNX model into C source"
+    )
+    compile_parser.add_argument("model", type=Path, help="Path to the ONNX model")
+    compile_parser.add_argument("output", type=Path, help="Output C file path")
+    compile_parser.add_argument(
+        "--template-dir",
+        type=Path,
+        default=Path("templates"),
+        help="Template directory (default: templates)",
+    )
+    compile_parser.add_argument(
+        "--model-name",
+        type=str,
+        default=None,
+        help="Override the generated model name (default: output file stem)",
+    )
+    compile_parser.add_argument(
+        "--emit-testbench",
+        action="store_true",
+        help="Emit a JSON-producing testbench main() for validation",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO)
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "compile":
+        return _handle_compile(args)
+    parser.error(f"Unknown command {args.command}")
+    return 1
+
+
+def _handle_compile(args: argparse.Namespace) -> int:
+    model_path: Path = args.model
+    output_path: Path = args.output
+    model_name = args.model_name or output_path.stem
+    try:
+        model = onnx.load_model(model_path)
+        options = CompilerOptions(
+            template_dir=args.template_dir,
+            model_name=model_name,
+            emit_testbench=args.emit_testbench,
+        )
+        compiler = Compiler(options)
+        generated = compiler.compile(model)
+    except (OSError, CodegenError, ShapeInferenceError, UnsupportedOpError) as exc:
+        LOGGER.error("Failed to compile %s: %s", model_path, exc)
+        return 1
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(generated, encoding="utf-8")
+    LOGGER.info("Wrote C source to %s", output_path)
+    return 0

--- a/tests/test_endtoend_features.py
+++ b/tests/test_endtoend_features.py
@@ -4,6 +4,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
@@ -14,8 +15,8 @@ import pytest
 
 from onnx import TensorProto, helper
 
-from onnx2c import Compiler
-from onnx2c.compiler import CompilerOptions
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = PROJECT_ROOT / "src"
 
 
 def _make_add_initializer_model() -> tuple[onnx.ModelProto, np.ndarray]:
@@ -50,10 +51,7 @@ def _make_add_initializer_model() -> tuple[onnx.ModelProto, np.ndarray]:
     return model, weight_values
 
 
-def _compile_and_run_testbench(model: onnx.ModelProto) -> dict[str, object]:
-    options = CompilerOptions(template_dir=Path("templates"), emit_testbench=True)
-    compiler = Compiler(options)
-    generated = compiler.compile(model)
+def _compile_and_run_testbench(model: onnx.ModelProto) -> tuple[dict[str, object], str]:
     compiler_cmd = os.environ.get("CC") or shutil.which("cc") or shutil.which("gcc")
     if compiler_cmd is None:
         pytest.skip("C compiler not available (set CC or install gcc/clang)")
@@ -61,7 +59,31 @@ def _compile_and_run_testbench(model: onnx.ModelProto) -> dict[str, object]:
         temp_path = Path(temp_dir)
         c_path = temp_path / "model.c"
         exe_path = temp_path / "model"
-        c_path.write_text(generated, encoding="utf-8")
+        model_path = temp_path / "model.onnx"
+        onnx.save_model(model, model_path)
+        env = os.environ.copy()
+        python_path = str(SRC_ROOT)
+        if env.get("PYTHONPATH"):
+            python_path = f"{python_path}{os.pathsep}{env['PYTHONPATH']}"
+        env["PYTHONPATH"] = python_path
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "onnx2c",
+                "compile",
+                str(model_path),
+                str(c_path),
+                "--template-dir",
+                str(PROJECT_ROOT / "templates"),
+                "--emit-testbench",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=PROJECT_ROOT,
+            env=env,
+        )
         subprocess.run(
             [compiler_cmd, "-std=c99", "-O2", str(c_path), "-o", str(exe_path), "-lm"],
             check=True,
@@ -74,15 +96,14 @@ def _compile_and_run_testbench(model: onnx.ModelProto) -> dict[str, object]:
             capture_output=True,
             text=True,
         )
-    return json.loads(result.stdout)
+        generated = c_path.read_text(encoding="utf-8")
+    return json.loads(result.stdout), generated
 
 
 def test_initializer_weights_emitted_as_static_arrays() -> None:
     model, weights = _make_add_initializer_model()
-    compiler = Compiler()
-    generated = compiler.compile(model)
+    payload, generated = _compile_and_run_testbench(model)
     assert "static const float weight" in generated
-    payload = _compile_and_run_testbench(model)
     inputs = {
         name: np.array(value["data"], dtype=np.float32)
         for name, value in payload["inputs"].items()


### PR DESCRIPTION
### Motivation

- Provide a command-line entrypoint to compile ONNX models to C so the compiler can be used as a CLI tool.
- Make end-to-end tests exercise the public CLI instead of calling compiler internals to better verify real usage.
- Allow emitting a JSON testbench from the generated C to validate correctness in integration tests.

### Description

- Add `src/onnx2c/cli.py` implementing `onnx2c compile` with options `--template-dir`, `--model-name`, and `--emit-testbench` and a `main()` function that returns an exit code.
- Add `src/onnx2c/__main__.py` to enable `python -m onnx2c` invocation.
- Update end-to-end tests in `tests/test_endtoend_ops.py` and `tests/test_endtoend_features.py` to invoke the CLI via `python -m onnx2c compile ...`, set `PYTHONPATH` so the local `src` is loadable, and consume the generated C/testbench outputs.
- Document CLI usage and testbench invocation in `README.md` with example `python -m onnx2c compile path/to/model.onnx build/model.c` commands.

### Testing

- Ran `pytest -q tests/test_endtoend_ops.py tests/test_endtoend_features.py` which completed successfully.
- The test run reported `6 passed` (all modified end-to-end tests passed).
- The tests compile the generated C with the system C compiler and execute the emitted JSON testbench to validate outputs.
- No additional automated test failures were observed during the rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696275a21fcc83259afa8d16c734b3f7)