### PR TITLE
tests: ignore *-org directories

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+norecursedirs = *-org


### PR DESCRIPTION
### Motivation
- Exclude `*-org` directories from pytest collection to avoid running third-party or vendored test suites.
- Limit pytest discovery to the `tests/` directory to make runs deterministic and faster.
- Ensure test runs focus on the repository's tests as requested.

### Description
- Add a root `pytest.ini` file with `testpaths = tests` and `norecursedirs = *-org`.
- The new configuration file is created at the repository root as `pytest.ini`.
- No other source code changes were made.

### Testing
- Ran `pytest -n auto -q` as the automated test command.
- All tests passed: `21 passed in 6.94s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6962afb8f948832595f329faba6f6f73)