### PR TITLE
tests: validate expected errors for first 100 official ONNX models

### DIFF
--- a/tests/test_official_onnx_files.py
+++ b/tests/test_official_onnx_files.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import onnx
+
+from onnx2c.compiler import Compiler
+
 OFFICIAL_ONNX_FILES = [
     "light/light_bvlc_alexnet.onnx",
     "light/light_densenet121.onnx",
@@ -1807,6 +1811,286 @@ OFFICIAL_ONNX_FILES = [
     "simple/test_strnorm_model_nostopwords_nochangecase/model.onnx",
 ]
 
+OFFICIAL_ONNX_FILE_EXPECTATIONS = [
+    (
+        "light/light_bvlc_alexnet.onnx",
+        "Unsupported elem_type 7 for initializer conv1_b_0__SHAPE",
+    ),
+    (
+        "light/light_densenet121.onnx",
+        "Unsupported elem_type 7 for initializer conv1_w_0__SHAPE",
+    ),
+    (
+        "light/light_inception_v1.onnx",
+        "Unsupported elem_type 7 for initializer conv1/7x7_s2_w_0__SHAPE",
+    ),
+    (
+        "light/light_inception_v2.onnx",
+        "Unsupported elem_type 7 for initializer conv1/7x7_s2_w_0__SHAPE",
+    ),
+    (
+        "light/light_resnet50.onnx",
+        "Unsupported elem_type 7 for initializer gpu_0/conv1_w_0__SHAPE",
+    ),
+    (
+        "light/light_shufflenet.onnx",
+        "Unsupported elem_type 7 for initializer gpu_0/conv3_0_w_0__SHAPE",
+    ),
+    (
+        "light/light_squeezenet.onnx",
+        "Unsupported elem_type 7 for initializer conv10_b_0__SHAPE",
+    ),
+    (
+        "light/light_vgg19.onnx",
+        "Unsupported elem_type 7 for initializer conv1_1_w_0__SHAPE",
+    ),
+    (
+        "light/light_zfnet512.onnx",
+        "Unsupported elem_type 7 for initializer gpu_0/conv1_b_0__SHAPE",
+    ),
+    ("node/test_abs/model.onnx", "Unsupported op Abs"),
+    ("node/test_acos/model.onnx", "Unsupported op Acos"),
+    ("node/test_acos_example/model.onnx", "Unsupported op Acos"),
+    ("node/test_acosh/model.onnx", "Unsupported op Acosh"),
+    ("node/test_acosh_example/model.onnx", "Unsupported op Acosh"),
+    ("node/test_adagrad/model.onnx", "Unsupported elem_type 7 for T"),
+    ("node/test_adagrad_multiple/model.onnx", "Unsupported elem_type 7 for T"),
+    ("node/test_adam/model.onnx", "Unsupported elem_type 7 for T"),
+    ("node/test_adam_multiple/model.onnx", "Unsupported elem_type 7 for T"),
+    ("node/test_add/model.onnx", ""),
+    ("node/test_add_bcast/model.onnx", ""),
+    ("node/test_add_int16/model.onnx", "Unsupported elem_type 5 for x"),
+    ("node/test_add_int8/model.onnx", "Unsupported elem_type 3 for x"),
+    ("node/test_add_uint16/model.onnx", "Unsupported elem_type 4 for x"),
+    ("node/test_add_uint32/model.onnx", "Unsupported elem_type 12 for x"),
+    ("node/test_add_uint64/model.onnx", "Unsupported elem_type 13 for x"),
+    ("node/test_add_uint8/model.onnx", "Unsupported elem_type 2 for x"),
+    ("node/test_affine_grid_2d/model.onnx", "Unsupported elem_type 7 for size"),
+    (
+        "node/test_affine_grid_2d_align_corners/model.onnx",
+        "Unsupported elem_type 7 for size",
+    ),
+    (
+        "node/test_affine_grid_2d_align_corners_expanded/model.onnx",
+        "Unsupported elem_type 7 for size",
+    ),
+    ("node/test_affine_grid_2d_expanded/model.onnx", "Unsupported elem_type 7 for size"),
+    ("node/test_affine_grid_3d/model.onnx", "Unsupported elem_type 7 for size"),
+    (
+        "node/test_affine_grid_3d_align_corners/model.onnx",
+        "Unsupported elem_type 7 for size",
+    ),
+    (
+        "node/test_affine_grid_3d_align_corners_expanded/model.onnx",
+        "Unsupported elem_type 7 for size",
+    ),
+    ("node/test_affine_grid_3d_expanded/model.onnx", "Unsupported elem_type 7 for size"),
+    (
+        "node/test_ai_onnx_ml_array_feature_extractor/model.onnx",
+        "Unsupported elem_type 7 for y",
+    ),
+    ("node/test_ai_onnx_ml_binarizer/model.onnx", "Unsupported op Binarizer"),
+    (
+        "node/test_ai_onnx_ml_label_encoder_string_int/model.onnx",
+        "Unsupported elem_type 8 for X",
+    ),
+    (
+        "node/test_ai_onnx_ml_label_encoder_string_int_no_default/model.onnx",
+        "Unsupported elem_type 8 for X",
+    ),
+    (
+        "node/test_ai_onnx_ml_label_encoder_tensor_mapping/model.onnx",
+        "Unsupported elem_type 8 for X",
+    ),
+    (
+        "node/test_ai_onnx_ml_label_encoder_tensor_value_only_mapping/model.onnx",
+        "Unsupported elem_type 8 for X",
+    ),
+    (
+        "node/test_ai_onnx_ml_tree_ensemble_set_membership/model.onnx",
+        "Unsupported op TreeEnsemble",
+    ),
+    (
+        "node/test_ai_onnx_ml_tree_ensemble_single_tree/model.onnx",
+        "Unsupported elem_type 11 for X",
+    ),
+    ("node/test_and2d/model.onnx", "Unsupported elem_type 9 for x"),
+    ("node/test_and3d/model.onnx", "Unsupported elem_type 9 for x"),
+    ("node/test_and4d/model.onnx", "Unsupported elem_type 9 for x"),
+    ("node/test_and_bcast3v1d/model.onnx", "Unsupported elem_type 9 for x"),
+    ("node/test_and_bcast3v2d/model.onnx", "Unsupported elem_type 9 for x"),
+    ("node/test_and_bcast4v2d/model.onnx", "Unsupported elem_type 9 for x"),
+    ("node/test_and_bcast4v3d/model.onnx", "Unsupported elem_type 9 for x"),
+    ("node/test_and_bcast4v4d/model.onnx", "Unsupported elem_type 9 for x"),
+    (
+        "node/test_argmax_default_axis_example/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmax_default_axis_example_select_last_index/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmax_default_axis_random/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmax_default_axis_random_select_last_index/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmax_keepdims_example/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmax_keepdims_example_select_last_index/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmax_keepdims_random/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmax_keepdims_random_select_last_index/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmax_negative_axis_keepdims_example/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmax_negative_axis_keepdims_example_select_last_index/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmax_negative_axis_keepdims_random/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmax_negative_axis_keepdims_random_select_last_index/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmax_no_keepdims_example/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmax_no_keepdims_example_select_last_index/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmax_no_keepdims_random/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmax_no_keepdims_random_select_last_index/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmin_default_axis_example/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmin_default_axis_example_select_last_index/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmin_default_axis_random/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmin_default_axis_random_select_last_index/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmin_keepdims_example/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmin_keepdims_example_select_last_index/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmin_keepdims_random/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmin_keepdims_random_select_last_index/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmin_negative_axis_keepdims_example/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmin_negative_axis_keepdims_example_select_last_index/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmin_negative_axis_keepdims_random/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmin_negative_axis_keepdims_random_select_last_index/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmin_no_keepdims_example/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmin_no_keepdims_example_select_last_index/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmin_no_keepdims_random/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    (
+        "node/test_argmin_no_keepdims_random_select_last_index/model.onnx",
+        "Unsupported elem_type 7 for result",
+    ),
+    ("node/test_asin/model.onnx", "Unsupported op Asin"),
+    ("node/test_asin_example/model.onnx", "Unsupported op Asin"),
+    ("node/test_asinh/model.onnx", "Unsupported op Asinh"),
+    ("node/test_asinh_example/model.onnx", "Unsupported op Asinh"),
+    ("node/test_atan/model.onnx", "Unsupported op Atan"),
+    ("node/test_atan_example/model.onnx", "Unsupported op Atan"),
+    ("node/test_atanh/model.onnx", "Unsupported op Atanh"),
+    ("node/test_atanh_example/model.onnx", "Unsupported op Atanh"),
+    ("node/test_attention_3d/model.onnx", "Unsupported op Attention"),
+    ("node/test_attention_3d_attn_mask/model.onnx", "Unsupported op Attention"),
+    (
+        "node/test_attention_3d_attn_mask_expanded/model.onnx",
+        "Only one- or two-node graphs are supported, got 72",
+    ),
+    ("node/test_attention_3d_causal/model.onnx", "Unsupported op Attention"),
+    (
+        "node/test_attention_3d_causal_expanded/model.onnx",
+        "Only one- or two-node graphs are supported, got 84",
+    ),
+    (
+        "node/test_attention_3d_diff_heads_sizes/model.onnx",
+        "Unsupported op Attention",
+    ),
+    (
+        "node/test_attention_3d_diff_heads_sizes_attn_mask/model.onnx",
+        "Unsupported op Attention",
+    ),
+    (
+        "node/test_attention_3d_diff_heads_sizes_attn_mask_expanded/model.onnx",
+        "Only one- or two-node graphs are supported, got 72",
+    ),
+    (
+        "node/test_attention_3d_diff_heads_sizes_causal/model.onnx",
+        "Unsupported op Attention",
+    ),
+    (
+        "node/test_attention_3d_diff_heads_sizes_causal_expanded/model.onnx",
+        "Only one- or two-node graphs are supported, got 84",
+    ),
+]
+
 
 def _collect_onnx_files(data_root: Path) -> list[str]:
     return sorted(p.relative_to(data_root).as_posix() for p in data_root.rglob("*.onnx"))
@@ -1824,3 +2108,23 @@ def test_official_onnx_files() -> None:
         "Official ONNX file list mismatch. "
         f"Missing: {missing}. Extra: {extra}."
     )
+
+
+def test_official_onnx_first_100_expected_errors() -> None:
+    data_root = Path(__file__).resolve().parents[1] / "onnx-org" / "onnx" / "backend" / "test" / "data"
+    expected_paths = [path for path, _ in OFFICIAL_ONNX_FILE_EXPECTATIONS]
+    assert expected_paths == OFFICIAL_ONNX_FILES[:100]
+    compiler = Compiler()
+    for rel_path, expected_error in OFFICIAL_ONNX_FILE_EXPECTATIONS:
+        model_path = data_root / rel_path
+        model = onnx.load_model(model_path)
+        try:
+            compiler.compile(model)
+        except Exception as exc:
+            actual_error = str(exc)
+        else:
+            actual_error = ""
+        assert actual_error == expected_error, (
+            f"Unexpected result for {rel_path}. Expected: {expected_error!r}. "
+            f"Got: {actual_error!r}."
+        )


### PR DESCRIPTION
### Motivation

- Ensure the test suite verifies expected failure modes for the first 100 official ONNX files to detect regressions in import/compilation error reporting. 
- Capture the current compiler behavior for these models as a stable, reviewable expectation. 

### Description

- Added an `OFFICIAL_ONNX_FILE_EXPECTATIONS` list mapping the first 100 `OFFICIAL_ONNX_FILES` to their expected error messages. 
- Imported `onnx` and the `Compiler` and added `test_official_onnx_first_100_expected_errors` which loads each model via `onnx.load_model` and asserts `compiler.compile` yields the expected error string. 
- The test also asserts the expectation list ordering matches `OFFICIAL_ONNX_FILES[:100]` to keep determinism. 
- Kept the original official file list validation intact in `tests/test_official_onnx_files.py`.

### Testing

- Ran `pytest tests/test_official_onnx_files.py` which executed the original list check and the new first-100 expectations test. 
- Result: both tests passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6962fee72e108325b380063aea072025)