### PR TITLE
docs: require test duration output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,9 @@ When making architectural decisions, prefer clean and maintainable design even i
 pytest -n auto -q
 ```
 
+When running tests, ensure the test duration is always emitted in the output
+(for example, by adding `--durations=0` to pytest).
+
 ## Compiler Pipeline (conceptual)
 
 1. **Load ONNX**


### PR DESCRIPTION
### Motivation

- Ensure test runs consistently report per-test durations so timing is always available for diagnostics.
- Make the repository's test-running guidance explicit to match the requested convention to always emit test durations.

### Description

- Added a short note to `AGENTS.md` under the "Unit tests" section advising to run pytest with `--durations=0` so durations are always shown.
- This change is purely documentation and does not modify runtime code or tests.

### Testing

- Executed `pytest -n auto -q --durations=0` to verify the instruction and capture duration output.
- The test run completed successfully with `22 passed in 7.37s` and printed the slowest durations summary.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696301615d288325bd7e4214b5797c16)