### PR TITLE
tests: validate first 500 official ONNX files via JSON snapshot

### DIFF
--- a/tests/official_onnx_first_500_expected_errors.json
+++ b/tests/official_onnx_first_500_expected_errors.json
@@ -1,0 +1,2002 @@
+[
+  [
+    "light/light_bvlc_alexnet.onnx",
+    "Unsupported elem_type 7 (INT64) for initializer conv1_b_0__SHAPE. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 initializers."
+  ],
+  [
+    "light/light_densenet121.onnx",
+    "Unsupported elem_type 7 (INT64) for initializer conv1_w_0__SHAPE. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 initializers."
+  ],
+  [
+    "light/light_inception_v1.onnx",
+    "Unsupported elem_type 7 (INT64) for initializer conv1/7x7_s2_w_0__SHAPE. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 initializers."
+  ],
+  [
+    "light/light_inception_v2.onnx",
+    "Unsupported elem_type 7 (INT64) for initializer conv1/7x7_s2_w_0__SHAPE. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 initializers."
+  ],
+  [
+    "light/light_resnet50.onnx",
+    "Unsupported elem_type 7 (INT64) for initializer gpu_0/conv1_w_0__SHAPE. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 initializers."
+  ],
+  [
+    "light/light_shufflenet.onnx",
+    "Unsupported elem_type 7 (INT64) for initializer gpu_0/conv3_0_w_0__SHAPE. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 initializers."
+  ],
+  [
+    "light/light_squeezenet.onnx",
+    "Unsupported elem_type 7 (INT64) for initializer conv10_b_0__SHAPE. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 initializers."
+  ],
+  [
+    "light/light_vgg19.onnx",
+    "Unsupported elem_type 7 (INT64) for initializer conv1_1_w_0__SHAPE. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 initializers."
+  ],
+  [
+    "light/light_zfnet512.onnx",
+    "Unsupported elem_type 7 (INT64) for initializer gpu_0/conv1_b_0__SHAPE. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 initializers."
+  ],
+  [
+    "node/test_abs/model.onnx",
+    "Unsupported op Abs"
+  ],
+  [
+    "node/test_acos/model.onnx",
+    "Unsupported op Acos"
+  ],
+  [
+    "node/test_acos_example/model.onnx",
+    "Unsupported op Acos"
+  ],
+  [
+    "node/test_acosh/model.onnx",
+    "Unsupported op Acosh"
+  ],
+  [
+    "node/test_acosh_example/model.onnx",
+    "Unsupported op Acosh"
+  ],
+  [
+    "node/test_adagrad/model.onnx",
+    "Unsupported elem_type 7 (INT64) for T. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_adagrad_multiple/model.onnx",
+    "Unsupported elem_type 7 (INT64) for T. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_adam/model.onnx",
+    "Unsupported elem_type 7 (INT64) for T. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_adam_multiple/model.onnx",
+    "Unsupported elem_type 7 (INT64) for T. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_add/model.onnx",
+    ""
+  ],
+  [
+    "node/test_add_bcast/model.onnx",
+    ""
+  ],
+  [
+    "node/test_add_int16/model.onnx",
+    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_add_int8/model.onnx",
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_add_uint16/model.onnx",
+    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_add_uint32/model.onnx",
+    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_add_uint64/model.onnx",
+    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_add_uint8/model.onnx",
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_affine_grid_2d/model.onnx",
+    "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_affine_grid_2d_align_corners/model.onnx",
+    "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_affine_grid_2d_align_corners_expanded/model.onnx",
+    "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_affine_grid_2d_expanded/model.onnx",
+    "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_affine_grid_3d/model.onnx",
+    "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_affine_grid_3d_align_corners/model.onnx",
+    "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_affine_grid_3d_align_corners_expanded/model.onnx",
+    "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_affine_grid_3d_expanded/model.onnx",
+    "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_ai_onnx_ml_array_feature_extractor/model.onnx",
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_ai_onnx_ml_binarizer/model.onnx",
+    "Unsupported op Binarizer"
+  ],
+  [
+    "node/test_ai_onnx_ml_label_encoder_string_int/model.onnx",
+    "Unsupported elem_type 8 (STRING) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_ai_onnx_ml_label_encoder_string_int_no_default/model.onnx",
+    "Unsupported elem_type 8 (STRING) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_ai_onnx_ml_label_encoder_tensor_mapping/model.onnx",
+    "Unsupported elem_type 8 (STRING) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_ai_onnx_ml_label_encoder_tensor_value_only_mapping/model.onnx",
+    "Unsupported elem_type 8 (STRING) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_ai_onnx_ml_tree_ensemble_set_membership/model.onnx",
+    "Unsupported op TreeEnsemble"
+  ],
+  [
+    "node/test_ai_onnx_ml_tree_ensemble_single_tree/model.onnx",
+    "Unsupported elem_type 11 (DOUBLE) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_and2d/model.onnx",
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_and3d/model.onnx",
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_and4d/model.onnx",
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_and_bcast3v1d/model.onnx",
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_and_bcast3v2d/model.onnx",
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_and_bcast4v2d/model.onnx",
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_and_bcast4v3d/model.onnx",
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_and_bcast4v4d/model.onnx",
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmax_default_axis_example/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmax_default_axis_example_select_last_index/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmax_default_axis_random/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmax_default_axis_random_select_last_index/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmax_keepdims_example/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmax_keepdims_example_select_last_index/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmax_keepdims_random/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmax_keepdims_random_select_last_index/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmax_negative_axis_keepdims_example/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmax_negative_axis_keepdims_example_select_last_index/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmax_negative_axis_keepdims_random/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmax_negative_axis_keepdims_random_select_last_index/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmax_no_keepdims_example/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmax_no_keepdims_example_select_last_index/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmax_no_keepdims_random/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmax_no_keepdims_random_select_last_index/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmin_default_axis_example/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmin_default_axis_example_select_last_index/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmin_default_axis_random/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmin_default_axis_random_select_last_index/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmin_keepdims_example/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmin_keepdims_example_select_last_index/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmin_keepdims_random/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmin_keepdims_random_select_last_index/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmin_negative_axis_keepdims_example/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmin_negative_axis_keepdims_example_select_last_index/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmin_negative_axis_keepdims_random/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmin_negative_axis_keepdims_random_select_last_index/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmin_no_keepdims_example/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmin_no_keepdims_example_select_last_index/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmin_no_keepdims_random/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_argmin_no_keepdims_random_select_last_index/model.onnx",
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_asin/model.onnx",
+    "Unsupported op Asin"
+  ],
+  [
+    "node/test_asin_example/model.onnx",
+    "Unsupported op Asin"
+  ],
+  [
+    "node/test_asinh/model.onnx",
+    "Unsupported op Asinh"
+  ],
+  [
+    "node/test_asinh_example/model.onnx",
+    "Unsupported op Asinh"
+  ],
+  [
+    "node/test_atan/model.onnx",
+    "Unsupported op Atan"
+  ],
+  [
+    "node/test_atan_example/model.onnx",
+    "Unsupported op Atan"
+  ],
+  [
+    "node/test_atanh/model.onnx",
+    "Unsupported op Atanh"
+  ],
+  [
+    "node/test_atanh_example/model.onnx",
+    "Unsupported op Atanh"
+  ],
+  [
+    "node/test_attention_3d/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_3d_attn_mask/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_3d_attn_mask_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 72"
+  ],
+  [
+    "node/test_attention_3d_causal/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_3d_causal_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 84"
+  ],
+  [
+    "node/test_attention_3d_diff_heads_sizes/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_3d_diff_heads_sizes_attn_mask/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_3d_diff_heads_sizes_attn_mask_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 72"
+  ],
+  [
+    "node/test_attention_3d_diff_heads_sizes_causal/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_3d_diff_heads_sizes_causal_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 84"
+  ],
+  [
+    "node/test_attention_3d_diff_heads_sizes_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 71"
+  ],
+  [
+    "node/test_attention_3d_diff_heads_sizes_scaled/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_3d_diff_heads_sizes_scaled_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 71"
+  ],
+  [
+    "node/test_attention_3d_diff_heads_sizes_softcap/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_3d_diff_heads_sizes_softcap_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 75"
+  ],
+  [
+    "node/test_attention_3d_diff_heads_with_past_and_present/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_3d_diff_heads_with_past_and_present_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 74"
+  ],
+  [
+    "node/test_attention_3d_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 71"
+  ],
+  [
+    "node/test_attention_3d_gqa/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_3d_gqa_attn_mask/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_3d_gqa_attn_mask_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 72"
+  ],
+  [
+    "node/test_attention_3d_gqa_causal/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_3d_gqa_causal_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 84"
+  ],
+  [
+    "node/test_attention_3d_gqa_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 71"
+  ],
+  [
+    "node/test_attention_3d_gqa_scaled/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_3d_gqa_scaled_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 71"
+  ],
+  [
+    "node/test_attention_3d_gqa_softcap/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_3d_gqa_softcap_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 75"
+  ],
+  [
+    "node/test_attention_3d_gqa_with_past_and_present/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_3d_gqa_with_past_and_present_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 74"
+  ],
+  [
+    "node/test_attention_3d_scaled/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_3d_scaled_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 71"
+  ],
+  [
+    "node/test_attention_3d_softcap/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_3d_softcap_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 75"
+  ],
+  [
+    "node/test_attention_3d_transpose_verification/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_3d_transpose_verification_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 71"
+  ],
+  [
+    "node/test_attention_3d_with_past_and_present/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_3d_with_past_and_present_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 74"
+  ],
+  [
+    "node/test_attention_3d_with_past_and_present_qk_matmul/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_3d_with_past_and_present_qk_matmul_bias/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_3d_with_past_and_present_qk_matmul_bias_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 75"
+  ],
+  [
+    "node/test_attention_3d_with_past_and_present_qk_matmul_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 75"
+  ],
+  [
+    "node/test_attention_3d_with_past_and_present_qk_matmul_softcap/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 79"
+  ],
+  [
+    "node/test_attention_3d_with_past_and_present_qk_matmul_softmax/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 75"
+  ],
+  [
+    "node/test_attention_4d/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_attn_mask/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_attn_mask_3d/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_attn_mask_3d_causal/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_attn_mask_3d_causal_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 75"
+  ],
+  [
+    "node/test_attention_4d_attn_mask_3d_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 62"
+  ],
+  [
+    "node/test_attention_4d_attn_mask_4d/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_attn_mask_4d_causal/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_attn_mask_4d_causal_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 75"
+  ],
+  [
+    "node/test_attention_4d_attn_mask_4d_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 62"
+  ],
+  [
+    "node/test_attention_4d_attn_mask_bool/model.onnx",
+    "Unsupported elem_type 9 (BOOL) for attn_mask. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_attention_4d_attn_mask_bool_4d/model.onnx",
+    "Unsupported elem_type 9 (BOOL) for attn_mask. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_attention_4d_attn_mask_bool_4d_expanded/model.onnx",
+    "Unsupported elem_type 9 (BOOL) for attn_mask. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_attention_4d_attn_mask_bool_expanded/model.onnx",
+    "Unsupported elem_type 9 (BOOL) for attn_mask. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_attention_4d_attn_mask_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 62"
+  ],
+  [
+    "node/test_attention_4d_causal/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_causal_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 74"
+  ],
+  [
+    "node/test_attention_4d_diff_heads_mask4d_padded_kv/model.onnx",
+    "Unsupported elem_type 7 (INT64) for nonpad_kv_seqlen. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_attention_4d_diff_heads_mask4d_padded_kv_expanded/model.onnx",
+    "Unsupported elem_type 7 (INT64) for nonpad_kv_seqlen. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_attention_4d_diff_heads_sizes/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_diff_heads_sizes_attn_mask/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_diff_heads_sizes_attn_mask_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 62"
+  ],
+  [
+    "node/test_attention_4d_diff_heads_sizes_causal/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_diff_heads_sizes_causal_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 74"
+  ],
+  [
+    "node/test_attention_4d_diff_heads_sizes_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 61"
+  ],
+  [
+    "node/test_attention_4d_diff_heads_sizes_scaled/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_diff_heads_sizes_scaled_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 61"
+  ],
+  [
+    "node/test_attention_4d_diff_heads_sizes_softcap/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_diff_heads_sizes_softcap_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 65"
+  ],
+  [
+    "node/test_attention_4d_diff_heads_with_past_and_present/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_diff_heads_with_past_and_present_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 64"
+  ],
+  [
+    "node/test_attention_4d_diff_heads_with_past_and_present_mask3d/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_diff_heads_with_past_and_present_mask3d_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 64"
+  ],
+  [
+    "node/test_attention_4d_diff_heads_with_past_and_present_mask4d/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_diff_heads_with_past_and_present_mask4d_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 64"
+  ],
+  [
+    "node/test_attention_4d_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 61"
+  ],
+  [
+    "node/test_attention_4d_fp16/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for Q. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_attention_4d_fp16_expanded/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for Q. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_attention_4d_gqa/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_gqa_attn_mask/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_gqa_attn_mask_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 62"
+  ],
+  [
+    "node/test_attention_4d_gqa_causal/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_gqa_causal_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 74"
+  ],
+  [
+    "node/test_attention_4d_gqa_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 61"
+  ],
+  [
+    "node/test_attention_4d_gqa_scaled/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_gqa_scaled_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 61"
+  ],
+  [
+    "node/test_attention_4d_gqa_softcap/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_gqa_softcap_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 65"
+  ],
+  [
+    "node/test_attention_4d_gqa_with_past_and_present/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_gqa_with_past_and_present_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 64"
+  ],
+  [
+    "node/test_attention_4d_gqa_with_past_and_present_fp16/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for Q. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_attention_4d_gqa_with_past_and_present_fp16_expanded/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for Q. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_attention_4d_scaled/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_scaled_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 61"
+  ],
+  [
+    "node/test_attention_4d_softcap/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_softcap_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 65"
+  ],
+  [
+    "node/test_attention_4d_with_past_and_present/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_with_past_and_present_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 64"
+  ],
+  [
+    "node/test_attention_4d_with_past_and_present_qk_matmul/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_with_past_and_present_qk_matmul_bias/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 78"
+  ],
+  [
+    "node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 65"
+  ],
+  [
+    "node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 78"
+  ],
+  [
+    "node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 65"
+  ],
+  [
+    "node/test_attention_4d_with_past_and_present_qk_matmul_bias_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 65"
+  ],
+  [
+    "node/test_attention_4d_with_past_and_present_qk_matmul_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 65"
+  ],
+  [
+    "node/test_attention_4d_with_qk_matmul/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_with_qk_matmul_bias/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_with_qk_matmul_bias_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 63"
+  ],
+  [
+    "node/test_attention_4d_with_qk_matmul_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 62"
+  ],
+  [
+    "node/test_attention_4d_with_qk_matmul_softcap/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_with_qk_matmul_softcap_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 67"
+  ],
+  [
+    "node/test_attention_4d_with_qk_matmul_softmax/model.onnx",
+    "Unsupported op Attention"
+  ],
+  [
+    "node/test_attention_4d_with_qk_matmul_softmax_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 63"
+  ],
+  [
+    "node/test_averagepool_1d_default/model.onnx",
+    "Unsupported op AveragePool"
+  ],
+  [
+    "node/test_averagepool_2d_ceil/model.onnx",
+    "Unsupported op AveragePool"
+  ],
+  [
+    "node/test_averagepool_2d_ceil_last_window_starts_on_pad/model.onnx",
+    "Unsupported op AveragePool"
+  ],
+  [
+    "node/test_averagepool_2d_default/model.onnx",
+    "Unsupported op AveragePool"
+  ],
+  [
+    "node/test_averagepool_2d_dilations/model.onnx",
+    "Unsupported op AveragePool"
+  ],
+  [
+    "node/test_averagepool_2d_pads/model.onnx",
+    "Unsupported op AveragePool"
+  ],
+  [
+    "node/test_averagepool_2d_pads_count_include_pad/model.onnx",
+    "Unsupported op AveragePool"
+  ],
+  [
+    "node/test_averagepool_2d_precomputed_pads/model.onnx",
+    "Unsupported op AveragePool"
+  ],
+  [
+    "node/test_averagepool_2d_precomputed_pads_count_include_pad/model.onnx",
+    "Unsupported op AveragePool"
+  ],
+  [
+    "node/test_averagepool_2d_precomputed_same_upper/model.onnx",
+    "Unsupported op AveragePool"
+  ],
+  [
+    "node/test_averagepool_2d_precomputed_strides/model.onnx",
+    "Unsupported op AveragePool"
+  ],
+  [
+    "node/test_averagepool_2d_same_lower/model.onnx",
+    "Unsupported op AveragePool"
+  ],
+  [
+    "node/test_averagepool_2d_same_upper/model.onnx",
+    "Unsupported op AveragePool"
+  ],
+  [
+    "node/test_averagepool_2d_strides/model.onnx",
+    "Unsupported op AveragePool"
+  ],
+  [
+    "node/test_averagepool_3d_default/model.onnx",
+    "Unsupported op AveragePool"
+  ],
+  [
+    "node/test_averagepool_3d_dilations_large_count_include_pad_is_0_ceil_mode_is_False/model.onnx",
+    "Unsupported op AveragePool"
+  ],
+  [
+    "node/test_averagepool_3d_dilations_large_count_include_pad_is_0_ceil_mode_is_True/model.onnx",
+    "Unsupported op AveragePool"
+  ],
+  [
+    "node/test_averagepool_3d_dilations_large_count_include_pad_is_1_ceil_mode_is_False/model.onnx",
+    "Unsupported op AveragePool"
+  ],
+  [
+    "node/test_averagepool_3d_dilations_large_count_include_pad_is_1_ceil_mode_is_True/model.onnx",
+    "Unsupported op AveragePool"
+  ],
+  [
+    "node/test_averagepool_3d_dilations_small/model.onnx",
+    "Unsupported op AveragePool"
+  ],
+  [
+    "node/test_basic_conv_with_padding/model.onnx",
+    "Unsupported op Conv"
+  ],
+  [
+    "node/test_basic_conv_without_padding/model.onnx",
+    "Unsupported op Conv"
+  ],
+  [
+    "node/test_basic_deform_conv_with_padding/model.onnx",
+    "Unsupported op DeformConv"
+  ],
+  [
+    "node/test_basic_deform_conv_without_padding/model.onnx",
+    "Unsupported op DeformConv"
+  ],
+  [
+    "node/test_batchnorm_epsilon/model.onnx",
+    "Unsupported op BatchNormalization"
+  ],
+  [
+    "node/test_batchnorm_epsilon_training_mode/model.onnx",
+    "Unsupported op BatchNormalization"
+  ],
+  [
+    "node/test_batchnorm_example/model.onnx",
+    "Unsupported op BatchNormalization"
+  ],
+  [
+    "node/test_batchnorm_example_training_mode/model.onnx",
+    "Unsupported op BatchNormalization"
+  ],
+  [
+    "node/test_bernoulli/model.onnx",
+    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bernoulli_double/model.onnx",
+    "Unsupported elem_type 11 (DOUBLE) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bernoulli_double_expanded/model.onnx",
+    "Unsupported elem_type 11 (DOUBLE) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bernoulli_expanded/model.onnx",
+    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bernoulli_seed/model.onnx",
+    "Unsupported op Bernoulli"
+  ],
+  [
+    "node/test_bernoulli_seed_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 3"
+  ],
+  [
+    "node/test_bitshift_left_uint16/model.onnx",
+    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bitshift_left_uint32/model.onnx",
+    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bitshift_left_uint64/model.onnx",
+    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bitshift_left_uint8/model.onnx",
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bitshift_right_uint16/model.onnx",
+    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bitshift_right_uint32/model.onnx",
+    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bitshift_right_uint64/model.onnx",
+    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bitshift_right_uint8/model.onnx",
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bitwise_and_i16_3d/model.onnx",
+    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bitwise_and_i32_2d/model.onnx",
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bitwise_and_ui64_bcast_3v1d/model.onnx",
+    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bitwise_and_ui8_bcast_4v3d/model.onnx",
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bitwise_not_2d/model.onnx",
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bitwise_not_3d/model.onnx",
+    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bitwise_not_4d/model.onnx",
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bitwise_or_i16_4d/model.onnx",
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bitwise_or_i32_2d/model.onnx",
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bitwise_or_ui64_bcast_3v1d/model.onnx",
+    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bitwise_or_ui8_bcast_4v3d/model.onnx",
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bitwise_xor_i16_3d/model.onnx",
+    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bitwise_xor_i32_2d/model.onnx",
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bitwise_xor_ui64_bcast_3v1d/model.onnx",
+    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_bitwise_xor_ui8_bcast_4v3d/model.onnx",
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_blackmanwindow/model.onnx",
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_blackmanwindow_expanded/model.onnx",
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_blackmanwindow_symmetric/model.onnx",
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_blackmanwindow_symmetric_expanded/model.onnx",
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_BFLOAT16_to_FLOAT/model.onnx",
+    "Unsupported elem_type 16 (BFLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_DOUBLE_to_FLOAT/model.onnx",
+    "Unsupported elem_type 11 (DOUBLE) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_DOUBLE_to_FLOAT16/model.onnx",
+    "Unsupported elem_type 11 (DOUBLE) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT16_to_DOUBLE/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT16_to_FLOAT/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT16_to_FLOAT4E2M1/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT16_to_FLOAT8E4M3FN/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT16_to_FLOAT8E4M3FNUZ/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT16_to_FLOAT8E5M2/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT16_to_FLOAT8E5M2FNUZ/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT16_to_INT2/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT16_to_INT4/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT16_to_UINT2/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT16_to_UINT4/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT4E2M1_to_FLOAT/model.onnx",
+    "Unsupported elem_type 23 (FLOAT4E2M1) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT4E2M1_to_FLOAT16/model.onnx",
+    "Unsupported elem_type 23 (FLOAT4E2M1) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT8E4M3FNUZ_to_FLOAT/model.onnx",
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT8E4M3FNUZ_to_FLOAT16/model.onnx",
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT8E4M3FN_to_FLOAT/model.onnx",
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT8E4M3FN_to_FLOAT16/model.onnx",
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT8E5M2FNUZ_to_FLOAT/model.onnx",
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT8E5M2FNUZ_to_FLOAT16/model.onnx",
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT8E5M2_to_FLOAT/model.onnx",
+    "Unsupported elem_type 19 (FLOAT8E5M2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT8E5M2_to_FLOAT16/model.onnx",
+    "Unsupported elem_type 19 (FLOAT8E5M2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT_to_BFLOAT16/model.onnx",
+    "Unsupported elem_type 16 (BFLOAT16) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT_to_DOUBLE/model.onnx",
+    "Unsupported elem_type 11 (DOUBLE) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT_to_FLOAT16/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT_to_FLOAT4E2M1/model.onnx",
+    "Unsupported elem_type 23 (FLOAT4E2M1) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT_to_FLOAT8E4M3FN/model.onnx",
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT_to_FLOAT8E4M3FNUZ/model.onnx",
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT_to_FLOAT8E5M2/model.onnx",
+    "Unsupported elem_type 19 (FLOAT8E5M2) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT_to_FLOAT8E5M2FNUZ/model.onnx",
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT_to_INT2/model.onnx",
+    "Unsupported elem_type 26 (INT2) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT_to_INT4/model.onnx",
+    "Unsupported elem_type 22 (INT4) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT_to_UINT2/model.onnx",
+    "Unsupported elem_type 25 (UINT2) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_FLOAT_to_UINT4/model.onnx",
+    "Unsupported elem_type 21 (UINT4) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_INT2_to_FLOAT/model.onnx",
+    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_INT2_to_FLOAT16/model.onnx",
+    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_INT2_to_INT8/model.onnx",
+    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_INT4_to_FLOAT/model.onnx",
+    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_INT4_to_FLOAT16/model.onnx",
+    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_INT4_to_INT8/model.onnx",
+    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_UINT2_to_FLOAT/model.onnx",
+    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_UINT2_to_FLOAT16/model.onnx",
+    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_UINT2_to_UINT8/model.onnx",
+    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_UINT4_to_FLOAT/model.onnx",
+    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_UINT4_to_FLOAT16/model.onnx",
+    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_UINT4_to_UINT8/model.onnx",
+    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_e8m0_FLOAT16_to_FLOAT8E8M0/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_e8m0_FLOAT8E8M0_to_FLOAT/model.onnx",
+    "Unsupported elem_type 24 (FLOAT8E8M0) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_e8m0_FLOAT8E8M0_to_FLOAT16/model.onnx",
+    "Unsupported elem_type 24 (FLOAT8E8M0) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_e8m0_FLOAT_to_FLOAT8E8M0/model.onnx",
+    "Unsupported elem_type 24 (FLOAT8E8M0) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_no_saturate_FLOAT16_to_FLOAT8E4M3FN/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_no_saturate_FLOAT16_to_FLOAT8E4M3FNUZ/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_no_saturate_FLOAT16_to_FLOAT8E5M2/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_no_saturate_FLOAT16_to_FLOAT8E5M2FNUZ/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_no_saturate_FLOAT_to_FLOAT8E4M3FN/model.onnx",
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_no_saturate_FLOAT_to_FLOAT8E4M3FNUZ/model.onnx",
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_no_saturate_FLOAT_to_FLOAT8E5M2/model.onnx",
+    "Unsupported elem_type 19 (FLOAT8E5M2) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_cast_no_saturate_FLOAT_to_FLOAT8E5M2FNUZ/model.onnx",
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_BFLOAT16_to_FLOAT/model.onnx",
+    "Unsupported elem_type 16 (BFLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_BFLOAT16_to_FLOAT_expanded/model.onnx",
+    "Unsupported elem_type 16 (BFLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_DOUBLE_to_FLOAT/model.onnx",
+    "Unsupported elem_type 11 (DOUBLE) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_DOUBLE_to_FLOAT16/model.onnx",
+    "Unsupported elem_type 11 (DOUBLE) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_DOUBLE_to_FLOAT16_expanded/model.onnx",
+    "Unsupported elem_type 11 (DOUBLE) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_DOUBLE_to_FLOAT_expanded/model.onnx",
+    "Unsupported elem_type 11 (DOUBLE) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT16_to_DOUBLE/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT16_to_DOUBLE_expanded/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT16_to_FLOAT/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT16_to_FLOAT4E2M1/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT16_to_FLOAT4E2M1_expanded/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT16_to_FLOAT8E4M3FN/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT16_to_FLOAT8E4M3FNUZ/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT16_to_FLOAT8E4M3FNUZ_expanded/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT16_to_FLOAT8E4M3FN_expanded/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT16_to_FLOAT8E5M2/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT16_to_FLOAT8E5M2FNUZ/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT16_to_FLOAT8E5M2FNUZ_expanded/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT16_to_FLOAT8E5M2_expanded/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT16_to_FLOAT_expanded/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT16_to_INT2/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT16_to_INT2_expanded/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT16_to_INT4/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT16_to_INT4_expanded/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT16_to_UINT2/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT16_to_UINT2_expanded/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT16_to_UINT4/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT16_to_UINT4_expanded/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT4E2M1_to_FLOAT/model.onnx",
+    "Unsupported elem_type 23 (FLOAT4E2M1) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT4E2M1_to_FLOAT16/model.onnx",
+    "Unsupported elem_type 23 (FLOAT4E2M1) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT4E2M1_to_FLOAT16_expanded/model.onnx",
+    "Unsupported elem_type 23 (FLOAT4E2M1) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT4E2M1_to_FLOAT_expanded/model.onnx",
+    "Unsupported elem_type 23 (FLOAT4E2M1) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT8E4M3FNUZ_to_FLOAT/model.onnx",
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT8E4M3FNUZ_to_FLOAT16/model.onnx",
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT8E4M3FNUZ_to_FLOAT16_expanded/model.onnx",
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT8E4M3FNUZ_to_FLOAT_expanded/model.onnx",
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT8E4M3FN_to_FLOAT/model.onnx",
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT8E4M3FN_to_FLOAT16/model.onnx",
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT8E4M3FN_to_FLOAT16_expanded/model.onnx",
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT8E4M3FN_to_FLOAT_expanded/model.onnx",
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT8E5M2FNUZ_to_FLOAT/model.onnx",
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT8E5M2FNUZ_to_FLOAT16/model.onnx",
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT8E5M2FNUZ_to_FLOAT16_expanded/model.onnx",
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT8E5M2FNUZ_to_FLOAT_expanded/model.onnx",
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT8E5M2_to_FLOAT/model.onnx",
+    "Unsupported elem_type 19 (FLOAT8E5M2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT8E5M2_to_FLOAT16/model.onnx",
+    "Unsupported elem_type 19 (FLOAT8E5M2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT8E5M2_to_FLOAT16_expanded/model.onnx",
+    "Unsupported elem_type 19 (FLOAT8E5M2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT8E5M2_to_FLOAT_expanded/model.onnx",
+    "Unsupported elem_type 19 (FLOAT8E5M2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT_to_BFLOAT16/model.onnx",
+    "Unsupported elem_type 16 (BFLOAT16) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT_to_BFLOAT16_expanded/model.onnx",
+    "Unsupported elem_type 16 (BFLOAT16) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT_to_DOUBLE/model.onnx",
+    "Unsupported elem_type 11 (DOUBLE) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT_to_DOUBLE_expanded/model.onnx",
+    "Unsupported elem_type 11 (DOUBLE) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT_to_FLOAT16/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT_to_FLOAT16_expanded/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT_to_FLOAT4E2M1/model.onnx",
+    "Unsupported elem_type 23 (FLOAT4E2M1) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT_to_FLOAT4E2M1_expanded/model.onnx",
+    "Unsupported elem_type 23 (FLOAT4E2M1) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT_to_FLOAT8E4M3FN/model.onnx",
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT_to_FLOAT8E4M3FNUZ/model.onnx",
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT_to_FLOAT8E4M3FNUZ_expanded/model.onnx",
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT_to_FLOAT8E4M3FN_expanded/model.onnx",
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT_to_FLOAT8E5M2/model.onnx",
+    "Unsupported elem_type 19 (FLOAT8E5M2) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT_to_FLOAT8E5M2FNUZ/model.onnx",
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT_to_FLOAT8E5M2FNUZ_expanded/model.onnx",
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT_to_FLOAT8E5M2_expanded/model.onnx",
+    "Unsupported elem_type 19 (FLOAT8E5M2) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT_to_INT2/model.onnx",
+    "Unsupported elem_type 26 (INT2) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT_to_INT2_expanded/model.onnx",
+    "Unsupported elem_type 26 (INT2) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT_to_INT4/model.onnx",
+    "Unsupported elem_type 22 (INT4) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT_to_INT4_expanded/model.onnx",
+    "Unsupported elem_type 22 (INT4) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT_to_UINT2/model.onnx",
+    "Unsupported elem_type 25 (UINT2) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT_to_UINT2_expanded/model.onnx",
+    "Unsupported elem_type 25 (UINT2) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT_to_UINT4/model.onnx",
+    "Unsupported elem_type 21 (UINT4) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_FLOAT_to_UINT4_expanded/model.onnx",
+    "Unsupported elem_type 21 (UINT4) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_INT2_to_FLOAT/model.onnx",
+    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_INT2_to_FLOAT16/model.onnx",
+    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_INT2_to_FLOAT16_expanded/model.onnx",
+    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_INT2_to_FLOAT_expanded/model.onnx",
+    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_INT2_to_INT8/model.onnx",
+    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_INT2_to_INT8_expanded/model.onnx",
+    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_INT4_to_FLOAT/model.onnx",
+    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_INT4_to_FLOAT16/model.onnx",
+    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_INT4_to_FLOAT16_expanded/model.onnx",
+    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_INT4_to_FLOAT_expanded/model.onnx",
+    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_INT4_to_INT8/model.onnx",
+    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_INT4_to_INT8_expanded/model.onnx",
+    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_UINT2_to_FLOAT/model.onnx",
+    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_UINT2_to_FLOAT16/model.onnx",
+    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_UINT2_to_FLOAT16_expanded/model.onnx",
+    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_UINT2_to_FLOAT_expanded/model.onnx",
+    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_UINT2_to_UINT8/model.onnx",
+    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_UINT2_to_UINT8_expanded/model.onnx",
+    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_UINT4_to_FLOAT/model.onnx",
+    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_UINT4_to_FLOAT16/model.onnx",
+    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_UINT4_to_FLOAT16_expanded/model.onnx",
+    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_UINT4_to_FLOAT_expanded/model.onnx",
+    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_UINT4_to_UINT8/model.onnx",
+    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_UINT4_to_UINT8_expanded/model.onnx",
+    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E4M3FN/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E4M3FNUZ/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E4M3FNUZ_expanded/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E4M3FN_expanded/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E5M2/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E5M2FNUZ/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E5M2FNUZ_expanded/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E5M2_expanded/model.onnx",
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_no_saturate_FLOAT_to_FLOAT8E4M3FN/model.onnx",
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_no_saturate_FLOAT_to_FLOAT8E4M3FNUZ/model.onnx",
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_no_saturate_FLOAT_to_FLOAT8E4M3FNUZ_expanded/model.onnx",
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_no_saturate_FLOAT_to_FLOAT8E4M3FN_expanded/model.onnx",
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_no_saturate_FLOAT_to_FLOAT8E5M2/model.onnx",
+    "Unsupported elem_type 19 (FLOAT8E5M2) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_no_saturate_FLOAT_to_FLOAT8E5M2FNUZ/model.onnx",
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_no_saturate_FLOAT_to_FLOAT8E5M2FNUZ_expanded/model.onnx",
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_castlike_no_saturate_FLOAT_to_FLOAT8E5M2_expanded/model.onnx",
+    "Unsupported elem_type 19 (FLOAT8E5M2) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_ceil/model.onnx",
+    "Unsupported op Ceil"
+  ],
+  [
+    "node/test_ceil_example/model.onnx",
+    "Unsupported op Ceil"
+  ],
+  [
+    "node/test_celu/model.onnx",
+    "Unsupported op Celu"
+  ],
+  [
+    "node/test_celu_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 4"
+  ],
+  [
+    "node/test_center_crop_pad_crop/model.onnx",
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_center_crop_pad_crop_and_pad/model.onnx",
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_center_crop_pad_crop_and_pad_expanded/model.onnx",
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_center_crop_pad_crop_axes_chw/model.onnx",
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_center_crop_pad_crop_axes_chw_expanded/model.onnx",
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_center_crop_pad_crop_axes_hwc/model.onnx",
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_center_crop_pad_crop_axes_hwc_expanded/model.onnx",
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_center_crop_pad_crop_expanded/model.onnx",
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_center_crop_pad_crop_negative_axes_hwc/model.onnx",
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_center_crop_pad_crop_negative_axes_hwc_expanded/model.onnx",
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_center_crop_pad_pad/model.onnx",
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_center_crop_pad_pad_expanded/model.onnx",
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_clip/model.onnx",
+    "Unsupported op Clip"
+  ],
+  [
+    "node/test_clip_default_inbounds/model.onnx",
+    "Unsupported op Clip"
+  ],
+  [
+    "node/test_clip_default_inbounds_expanded/model.onnx",
+    "Unsupported op Identity"
+  ],
+  [
+    "node/test_clip_default_int8_inbounds/model.onnx",
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_clip_default_int8_inbounds_expanded/model.onnx",
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_clip_default_int8_max/model.onnx",
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_clip_default_int8_max_expanded/model.onnx",
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_clip_default_int8_min/model.onnx",
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_clip_default_int8_min_expanded/model.onnx",
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_clip_default_max/model.onnx",
+    "Unsupported op Clip"
+  ],
+  [
+    "node/test_clip_default_max_expanded/model.onnx",
+    "Unsupported op Less"
+  ],
+  [
+    "node/test_clip_default_min/model.onnx",
+    "Unsupported op Clip"
+  ],
+  [
+    "node/test_clip_default_min_expanded/model.onnx",
+    "Unsupported op Less"
+  ],
+  [
+    "node/test_clip_example/model.onnx",
+    "Unsupported op Clip"
+  ],
+  [
+    "node/test_clip_example_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 4"
+  ],
+  [
+    "node/test_clip_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 4"
+  ],
+  [
+    "node/test_clip_inbounds/model.onnx",
+    "Unsupported op Clip"
+  ],
+  [
+    "node/test_clip_inbounds_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 4"
+  ],
+  [
+    "node/test_clip_min_greater_than_max/model.onnx",
+    "Unsupported op Clip"
+  ],
+  [
+    "node/test_clip_min_greater_than_max_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 4"
+  ],
+  [
+    "node/test_clip_outbounds/model.onnx",
+    "Unsupported op Clip"
+  ],
+  [
+    "node/test_clip_outbounds_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 4"
+  ],
+  [
+    "node/test_clip_splitbounds/model.onnx",
+    "Unsupported op Clip"
+  ],
+  [
+    "node/test_clip_splitbounds_expanded/model.onnx",
+    "Only one- or two-node graphs are supported, got 4"
+  ],
+  [
+    "node/test_col2im/model.onnx",
+    "Unsupported elem_type 7 (INT64) for image_shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_col2im_5d/model.onnx",
+    "Unsupported elem_type 7 (INT64) for image_shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_col2im_dilations/model.onnx",
+    "Unsupported elem_type 7 (INT64) for image_shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_col2im_pads/model.onnx",
+    "Unsupported elem_type 7 (INT64) for image_shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_col2im_strides/model.onnx",
+    "Unsupported elem_type 7 (INT64) for image_shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_compress_0/model.onnx",
+    "Unsupported elem_type 9 (BOOL) for condition. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_compress_1/model.onnx",
+    "Unsupported elem_type 9 (BOOL) for condition. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_compress_default_axis/model.onnx",
+    "Unsupported elem_type 9 (BOOL) for condition. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_compress_negative_axis/model.onnx",
+    "Unsupported elem_type 9 (BOOL) for condition. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+  ],
+  [
+    "node/test_concat_1d_axis_0/model.onnx",
+    "Unsupported op Concat"
+  ],
+  [
+    "node/test_concat_1d_axis_negative_1/model.onnx",
+    "Unsupported op Concat"
+  ],
+  [
+    "node/test_concat_2d_axis_0/model.onnx",
+    "Unsupported op Concat"
+  ],
+  [
+    "node/test_concat_2d_axis_1/model.onnx",
+    "Unsupported op Concat"
+  ]
+]

--- a/tests/test_official_onnx_files.py
+++ b/tests/test_official_onnx_files.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import onnx
@@ -1811,310 +1812,15 @@ OFFICIAL_ONNX_FILES = [
     "simple/test_strnorm_model_nostopwords_nochangecase/model.onnx",
 ]
 
-OFFICIAL_ONNX_FILE_EXPECTATIONS = [
-    (
-        "light/light_bvlc_alexnet.onnx",
-        "Unsupported elem_type 7 (INT64) for initializer conv1_b_0__SHAPE. "
-        "Supported elem_types: 1 (FLOAT). Hint: export the model with float32 initializers.",
-    ),
-    (
-        "light/light_densenet121.onnx",
-        "Unsupported elem_type 7 (INT64) for initializer conv1_w_0__SHAPE. "
-        "Supported elem_types: 1 (FLOAT). Hint: export the model with float32 initializers.",
-    ),
-    (
-        "light/light_inception_v1.onnx",
-        "Unsupported elem_type 7 (INT64) for initializer conv1/7x7_s2_w_0__SHAPE. "
-        "Supported elem_types: 1 (FLOAT). Hint: export the model with float32 initializers.",
-    ),
-    (
-        "light/light_inception_v2.onnx",
-        "Unsupported elem_type 7 (INT64) for initializer conv1/7x7_s2_w_0__SHAPE. "
-        "Supported elem_types: 1 (FLOAT). Hint: export the model with float32 initializers.",
-    ),
-    (
-        "light/light_resnet50.onnx",
-        "Unsupported elem_type 7 (INT64) for initializer gpu_0/conv1_w_0__SHAPE. "
-        "Supported elem_types: 1 (FLOAT). Hint: export the model with float32 initializers.",
-    ),
-    (
-        "light/light_shufflenet.onnx",
-        "Unsupported elem_type 7 (INT64) for initializer gpu_0/conv3_0_w_0__SHAPE. "
-        "Supported elem_types: 1 (FLOAT). Hint: export the model with float32 initializers.",
-    ),
-    (
-        "light/light_squeezenet.onnx",
-        "Unsupported elem_type 7 (INT64) for initializer conv10_b_0__SHAPE. "
-        "Supported elem_types: 1 (FLOAT). Hint: export the model with float32 initializers.",
-    ),
-    (
-        "light/light_vgg19.onnx",
-        "Unsupported elem_type 7 (INT64) for initializer conv1_1_w_0__SHAPE. "
-        "Supported elem_types: 1 (FLOAT). Hint: export the model with float32 initializers.",
-    ),
-    (
-        "light/light_zfnet512.onnx",
-        "Unsupported elem_type 7 (INT64) for initializer gpu_0/conv1_b_0__SHAPE. "
-        "Supported elem_types: 1 (FLOAT). Hint: export the model with float32 initializers.",
-    ),
-    ("node/test_abs/model.onnx", "Unsupported op Abs"),
-    ("node/test_acos/model.onnx", "Unsupported op Acos"),
-    ("node/test_acos_example/model.onnx", "Unsupported op Acos"),
-    ("node/test_acosh/model.onnx", "Unsupported op Acosh"),
-    ("node/test_acosh_example/model.onnx", "Unsupported op Acosh"),
-    (
-        "node/test_adagrad/model.onnx",
-        "Unsupported elem_type 7 (INT64) for T. Supported elem_types: 1 (FLOAT). "
-        "Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_adagrad_multiple/model.onnx",
-        "Unsupported elem_type 7 (INT64) for T. Supported elem_types: 1 (FLOAT). "
-        "Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_adam/model.onnx",
-        "Unsupported elem_type 7 (INT64) for T. Supported elem_types: 1 (FLOAT). "
-        "Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_adam_multiple/model.onnx",
-        "Unsupported elem_type 7 (INT64) for T. Supported elem_types: 1 (FLOAT). "
-        "Hint: export the model with float32 tensors.",
-    ),
-    ("node/test_add/model.onnx", ""),
-    ("node/test_add_bcast/model.onnx", ""),
-    ("node/test_add_int16/model.onnx", "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."),
-    ("node/test_add_int8/model.onnx", "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."),
-    ("node/test_add_uint16/model.onnx", "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."),
-    ("node/test_add_uint32/model.onnx", "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."),
-    ("node/test_add_uint64/model.onnx", "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."),
-    ("node/test_add_uint8/model.onnx", "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."),
-    ("node/test_affine_grid_2d/model.onnx", "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."),
-    (
-        "node/test_affine_grid_2d_align_corners/model.onnx",
-        "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_affine_grid_2d_align_corners_expanded/model.onnx",
-        "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    ("node/test_affine_grid_2d_expanded/model.onnx", "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."),
-    ("node/test_affine_grid_3d/model.onnx", "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."),
-    (
-        "node/test_affine_grid_3d_align_corners/model.onnx",
-        "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_affine_grid_3d_align_corners_expanded/model.onnx",
-        "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    ("node/test_affine_grid_3d_expanded/model.onnx", "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."),
-    (
-        "node/test_ai_onnx_ml_array_feature_extractor/model.onnx",
-        "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    ("node/test_ai_onnx_ml_binarizer/model.onnx", "Unsupported op Binarizer"),
-    (
-        "node/test_ai_onnx_ml_label_encoder_string_int/model.onnx",
-        "Unsupported elem_type 8 (STRING) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_ai_onnx_ml_label_encoder_string_int_no_default/model.onnx",
-        "Unsupported elem_type 8 (STRING) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_ai_onnx_ml_label_encoder_tensor_mapping/model.onnx",
-        "Unsupported elem_type 8 (STRING) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_ai_onnx_ml_label_encoder_tensor_value_only_mapping/model.onnx",
-        "Unsupported elem_type 8 (STRING) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_ai_onnx_ml_tree_ensemble_set_membership/model.onnx",
-        "Unsupported op TreeEnsemble",
-    ),
-    (
-        "node/test_ai_onnx_ml_tree_ensemble_single_tree/model.onnx",
-        "Unsupported elem_type 11 (DOUBLE) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    ("node/test_and2d/model.onnx", "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."),
-    ("node/test_and3d/model.onnx", "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."),
-    ("node/test_and4d/model.onnx", "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."),
-    ("node/test_and_bcast3v1d/model.onnx", "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."),
-    ("node/test_and_bcast3v2d/model.onnx", "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."),
-    ("node/test_and_bcast4v2d/model.onnx", "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."),
-    ("node/test_and_bcast4v3d/model.onnx", "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."),
-    ("node/test_and_bcast4v4d/model.onnx", "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."),
-    (
-        "node/test_argmax_default_axis_example/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmax_default_axis_example_select_last_index/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmax_default_axis_random/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmax_default_axis_random_select_last_index/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmax_keepdims_example/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmax_keepdims_example_select_last_index/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmax_keepdims_random/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmax_keepdims_random_select_last_index/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmax_negative_axis_keepdims_example/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmax_negative_axis_keepdims_example_select_last_index/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmax_negative_axis_keepdims_random/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmax_negative_axis_keepdims_random_select_last_index/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmax_no_keepdims_example/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmax_no_keepdims_example_select_last_index/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmax_no_keepdims_random/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmax_no_keepdims_random_select_last_index/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmin_default_axis_example/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmin_default_axis_example_select_last_index/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmin_default_axis_random/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmin_default_axis_random_select_last_index/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmin_keepdims_example/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmin_keepdims_example_select_last_index/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmin_keepdims_random/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmin_keepdims_random_select_last_index/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmin_negative_axis_keepdims_example/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmin_negative_axis_keepdims_example_select_last_index/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmin_negative_axis_keepdims_random/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmin_negative_axis_keepdims_random_select_last_index/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmin_no_keepdims_example/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmin_no_keepdims_example_select_last_index/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmin_no_keepdims_random/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    (
-        "node/test_argmin_no_keepdims_random_select_last_index/model.onnx",
-        "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors.",
-    ),
-    ("node/test_asin/model.onnx", "Unsupported op Asin"),
-    ("node/test_asin_example/model.onnx", "Unsupported op Asin"),
-    ("node/test_asinh/model.onnx", "Unsupported op Asinh"),
-    ("node/test_asinh_example/model.onnx", "Unsupported op Asinh"),
-    ("node/test_atan/model.onnx", "Unsupported op Atan"),
-    ("node/test_atan_example/model.onnx", "Unsupported op Atan"),
-    ("node/test_atanh/model.onnx", "Unsupported op Atanh"),
-    ("node/test_atanh_example/model.onnx", "Unsupported op Atanh"),
-    ("node/test_attention_3d/model.onnx", "Unsupported op Attention"),
-    ("node/test_attention_3d_attn_mask/model.onnx", "Unsupported op Attention"),
-    (
-        "node/test_attention_3d_attn_mask_expanded/model.onnx",
-        "Only one- or two-node graphs are supported, got 72",
-    ),
-    ("node/test_attention_3d_causal/model.onnx", "Unsupported op Attention"),
-    (
-        "node/test_attention_3d_causal_expanded/model.onnx",
-        "Only one- or two-node graphs are supported, got 84",
-    ),
-    (
-        "node/test_attention_3d_diff_heads_sizes/model.onnx",
-        "Unsupported op Attention",
-    ),
-    (
-        "node/test_attention_3d_diff_heads_sizes_attn_mask/model.onnx",
-        "Unsupported op Attention",
-    ),
-    (
-        "node/test_attention_3d_diff_heads_sizes_attn_mask_expanded/model.onnx",
-        "Only one- or two-node graphs are supported, got 72",
-    ),
-    (
-        "node/test_attention_3d_diff_heads_sizes_causal/model.onnx",
-        "Unsupported op Attention",
-    ),
-    (
-        "node/test_attention_3d_diff_heads_sizes_causal_expanded/model.onnx",
-        "Only one- or two-node graphs are supported, got 84",
-    ),
-]
+OFFICIAL_ONNX_FILE_EXPECTATIONS_PATH = (
+    Path(__file__).resolve().parent / "official_onnx_first_500_expected_errors.json"
+)
+
+
+def _load_official_onnx_file_expectations() -> list[tuple[str, str]]:
+    data = json.loads(OFFICIAL_ONNX_FILE_EXPECTATIONS_PATH.read_text(encoding="utf-8"))
+    return [(path, error) for path, error in data]
+
 
 
 def _collect_onnx_files(data_root: Path) -> list[str]:
@@ -2135,12 +1841,13 @@ def test_official_onnx_files() -> None:
     )
 
 
-def test_official_onnx_first_100_expected_errors() -> None:
+def test_official_onnx_first_500_expected_errors() -> None:
     data_root = Path(__file__).resolve().parents[1] / "onnx-org" / "onnx" / "backend" / "test" / "data"
-    expected_paths = [path for path, _ in OFFICIAL_ONNX_FILE_EXPECTATIONS]
-    assert expected_paths == OFFICIAL_ONNX_FILES[:100]
+    expectations = _load_official_onnx_file_expectations()
+    expected_paths = [path for path, _ in expectations]
+    assert expected_paths == OFFICIAL_ONNX_FILES[:500]
     compiler = Compiler()
-    for rel_path, expected_error in OFFICIAL_ONNX_FILE_EXPECTATIONS:
+    for rel_path, expected_error in expectations:
         model_path = data_root / rel_path
         model = onnx.load_model(model_path)
         try:


### PR DESCRIPTION
### Motivation

- Increase coverage of the official ONNX test suite by checking the first 500 ONNX test models deterministically.
- Avoid embedding a large expectations table in the test file to keep the test source compact and maintainable.

### Description

- Load expected outcomes from a snapshot file `tests/official_onnx_first_500_expected_errors.json` instead of the in-file tuple.
- Replace the inline `OFFICIAL_ONNX_FILE_EXPECTATIONS` with `OFFICIAL_ONNX_FILE_EXPECTATIONS_PATH` and add a loader `_load_official_onnx_file_expectations()`.
- Update the test name to `test_official_onnx_first_500_expected_errors` and assert expectations cover `OFFICIAL_ONNX_FILES[:500]`.
- Modified files: `tests/test_official_onnx_files.py` and added `tests/official_onnx_first_500_expected_errors.json`.

### Testing

- Ran `pytest -q --durations=0 tests/test_official_onnx_files.py` to exercise the updated test.
- Test run result: `2 passed` and durations printed, indicating the new JSON-backed test passed.
- The JSON snapshot was generated by compiling the first 500 models with `Compiler().compile()` and saved to `tests/official_onnx_first_500_expected_errors.json` prior to the test update.
- No other automated tests were changed in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696303461a188325a1985e54cb9b0841)