### PR TITLE
compiler: add Atanh unary op support

### DIFF
--- a/src/onnx2c/codegen/c_emitter.py
+++ b/src/onnx2c/codegen/c_emitter.py
@@ -101,7 +101,7 @@ class CEmitter:
         if emit_testbench:
             includes.extend(("#include <stdio.h>", "#include <stdint.h>"))
         if any(
-            isinstance(op, UnaryOp) and op.operator == "tanhf"
+            isinstance(op, UnaryOp) and op.operator in {"tanhf", "atanhf"}
             for op in resolved_ops
         ):
             includes.append("#include <math.h>")

--- a/src/onnx2c/compiler.py
+++ b/src/onnx2c/compiler.py
@@ -318,6 +318,8 @@ def _unary_op_symbol(op_type: str) -> str | None:
         return "relu"
     if op_type == "Tanh":
         return "tanhf"
+    if op_type == "Atanh":
+        return "atanhf"
     return None
 
 
@@ -332,6 +334,8 @@ def _apply_unary_op(op_symbol: str, value: np.ndarray) -> np.ndarray:
         return np.maximum(value, 0)
     if op_symbol == "tanhf":
         return np.tanh(value)
+    if op_symbol == "atanhf":
+        return np.arctanh(value)
     raise UnsupportedOpError(f"Unsupported unary op {op_symbol}")
 
 

--- a/tests/official_onnx_first_500_expected_errors.json
+++ b/tests/official_onnx_first_500_expected_errors.json
@@ -353,11 +353,11 @@
   ],
   [
     "node/test_atanh/model.onnx",
-    "Unsupported op Atanh"
+    ""
   ],
   [
     "node/test_atanh_example/model.onnx",
-    "Unsupported op Atanh"
+    ""
   ],
   [
     "node/test_attention_3d/model.onnx",


### PR DESCRIPTION
### Motivation
- Support the ONNX `Atanh` operator so models like `node/test_atanh_example/model.onnx` can be lowered, executed, and emitted as C.
- Ensure generated C includes the correct math dependency when math functions are used by unary ops.

### Description
- Add `Atanh` → `atanhf` mapping in `_unary_op_symbol`.
- Implement runtime evaluation for the `atanhf` symbol via `np.arctanh` in `_apply_unary_op`.
- Make the C emitter include `<math.h>` when unary ops use `tanhf` or `atanhf`.
- Update `tests/official_onnx_first_500_expected_errors.json` to clear the previous "Unsupported op Atanh" expectations.

### Testing
- Ran `pytest -n auto -q --durations=0 tests/test_official_onnx_files.py::test_official_onnx_first_500_expected_errors`.
- The test passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69630d086acc8325b058e4efaab56688)