### PR TITLE
onnx_import: remove float32 export hint from elem_type errors

### DIFF
--- a/src/onnx2c/onnx_import.py
+++ b/src/onnx2c/onnx_import.py
@@ -31,8 +31,7 @@ def _tensor_type(value_info: onnx.ValueInfoProto) -> TensorType:
             "Unsupported elem_type "
             f"{_format_elem_type(tensor_type.elem_type)} for {value_info.name}. "
             "Supported elem_types: "
-            f"{', '.join(_format_elem_type(elem) for elem in _ONNX_TO_DTYPE)}. "
-            "Hint: export the model with float32 tensors."
+            f"{', '.join(_format_elem_type(elem) for elem in _ONNX_TO_DTYPE)}."
         )
     shape = []
     for dim in tensor_type.shape.dim:

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -57,19 +57,19 @@
   ],
   [
     "node/test_adagrad/model.onnx",
-    "Unsupported elem_type 7 (INT64) for T. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for T. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_adagrad_multiple/model.onnx",
-    "Unsupported elem_type 7 (INT64) for T. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for T. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_adam/model.onnx",
-    "Unsupported elem_type 7 (INT64) for T. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for T. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_adam_multiple/model.onnx",
-    "Unsupported elem_type 7 (INT64) for T. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for T. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_add/model.onnx",
@@ -81,63 +81,63 @@
   ],
   [
     "node/test_add_int16/model.onnx",
-    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_add_int8/model.onnx",
-    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_add_uint16/model.onnx",
-    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_add_uint32/model.onnx",
-    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_add_uint64/model.onnx",
-    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_add_uint8/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_affine_grid_2d/model.onnx",
-    "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_affine_grid_2d_align_corners/model.onnx",
-    "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_affine_grid_2d_align_corners_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_affine_grid_2d_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_affine_grid_3d/model.onnx",
-    "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_affine_grid_3d_align_corners/model.onnx",
-    "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_affine_grid_3d_align_corners_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_affine_grid_3d_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for size. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_ai_onnx_ml_array_feature_extractor/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_ai_onnx_ml_binarizer/model.onnx",
@@ -145,19 +145,19 @@
   ],
   [
     "node/test_ai_onnx_ml_label_encoder_string_int/model.onnx",
-    "Unsupported elem_type 8 (STRING) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for X. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_ai_onnx_ml_label_encoder_string_int_no_default/model.onnx",
-    "Unsupported elem_type 8 (STRING) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for X. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_ai_onnx_ml_label_encoder_tensor_mapping/model.onnx",
-    "Unsupported elem_type 8 (STRING) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for X. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_ai_onnx_ml_label_encoder_tensor_value_only_mapping/model.onnx",
-    "Unsupported elem_type 8 (STRING) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for X. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_ai_onnx_ml_tree_ensemble_set_membership/model.onnx",
@@ -165,167 +165,167 @@
   ],
   [
     "node/test_ai_onnx_ml_tree_ensemble_single_tree/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for X. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_and2d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_and3d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_and4d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_and_bcast3v1d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_and_bcast3v2d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_and_bcast4v2d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_and_bcast4v3d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_and_bcast4v4d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmax_default_axis_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmax_default_axis_example_select_last_index/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmax_default_axis_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmax_default_axis_random_select_last_index/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmax_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmax_keepdims_example_select_last_index/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmax_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmax_keepdims_random_select_last_index/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmax_negative_axis_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmax_negative_axis_keepdims_example_select_last_index/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmax_negative_axis_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmax_negative_axis_keepdims_random_select_last_index/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmax_no_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmax_no_keepdims_example_select_last_index/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmax_no_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmax_no_keepdims_random_select_last_index/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmin_default_axis_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmin_default_axis_example_select_last_index/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmin_default_axis_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmin_default_axis_random_select_last_index/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmin_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmin_keepdims_example_select_last_index/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmin_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmin_keepdims_random_select_last_index/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmin_negative_axis_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmin_negative_axis_keepdims_example_select_last_index/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmin_negative_axis_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmin_negative_axis_keepdims_random_select_last_index/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmin_no_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmin_no_keepdims_example_select_last_index/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmin_no_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_argmin_no_keepdims_random_select_last_index/model.onnx",
-    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for result. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_asin/model.onnx",
@@ -585,19 +585,19 @@
   ],
   [
     "node/test_attention_4d_attn_mask_bool/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for attn_mask. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for attn_mask. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_attention_4d_attn_mask_bool_4d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for attn_mask. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for attn_mask. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_attention_4d_attn_mask_bool_4d_expanded/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for attn_mask. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for attn_mask. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_attention_4d_attn_mask_bool_expanded/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for attn_mask. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for attn_mask. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_attention_4d_attn_mask_expanded/model.onnx",
@@ -613,11 +613,11 @@
   ],
   [
     "node/test_attention_4d_diff_heads_mask4d_padded_kv/model.onnx",
-    "Unsupported elem_type 7 (INT64) for nonpad_kv_seqlen. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for nonpad_kv_seqlen. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_attention_4d_diff_heads_mask4d_padded_kv_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for nonpad_kv_seqlen. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for nonpad_kv_seqlen. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_attention_4d_diff_heads_sizes/model.onnx",
@@ -689,11 +689,11 @@
   ],
   [
     "node/test_attention_4d_fp16/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for Q. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for Q. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_attention_4d_fp16_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for Q. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for Q. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_attention_4d_gqa/model.onnx",
@@ -745,11 +745,11 @@
   ],
   [
     "node/test_attention_4d_gqa_with_past_and_present_fp16/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for Q. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for Q. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_attention_4d_gqa_with_past_and_present_fp16_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for Q. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for Q. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_attention_4d_scaled/model.onnx",
@@ -969,19 +969,19 @@
   ],
   [
     "node/test_bernoulli/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bernoulli_double/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bernoulli_double_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bernoulli_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bernoulli_seed/model.onnx",
@@ -993,799 +993,799 @@
   ],
   [
     "node/test_bitshift_left_uint16/model.onnx",
-    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bitshift_left_uint32/model.onnx",
-    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bitshift_left_uint64/model.onnx",
-    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bitshift_left_uint8/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bitshift_right_uint16/model.onnx",
-    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bitshift_right_uint32/model.onnx",
-    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bitshift_right_uint64/model.onnx",
-    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bitshift_right_uint8/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bitwise_and_i16_3d/model.onnx",
-    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bitwise_and_i32_2d/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bitwise_and_ui64_bcast_3v1d/model.onnx",
-    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bitwise_and_ui8_bcast_4v3d/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bitwise_not_2d/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bitwise_not_3d/model.onnx",
-    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bitwise_not_4d/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bitwise_or_i16_4d/model.onnx",
-    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bitwise_or_i32_2d/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bitwise_or_ui64_bcast_3v1d/model.onnx",
-    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bitwise_or_ui8_bcast_4v3d/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bitwise_xor_i16_3d/model.onnx",
-    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bitwise_xor_i32_2d/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bitwise_xor_ui64_bcast_3v1d/model.onnx",
-    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_bitwise_xor_ui8_bcast_4v3d/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_blackmanwindow/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_blackmanwindow_expanded/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_blackmanwindow_symmetric/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_blackmanwindow_symmetric_expanded/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_BFLOAT16_to_FLOAT/model.onnx",
-    "Unsupported elem_type 16 (BFLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 16 (BFLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_DOUBLE_to_FLOAT/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_DOUBLE_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT16_to_DOUBLE/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT16_to_FLOAT/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT16_to_FLOAT4E2M1/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT16_to_FLOAT8E4M3FN/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT16_to_FLOAT8E4M3FNUZ/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT16_to_FLOAT8E5M2/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT16_to_FLOAT8E5M2FNUZ/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT16_to_INT2/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT16_to_INT4/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT16_to_UINT2/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT16_to_UINT4/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT4E2M1_to_FLOAT/model.onnx",
-    "Unsupported elem_type 23 (FLOAT4E2M1) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 23 (FLOAT4E2M1) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT4E2M1_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 23 (FLOAT4E2M1) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 23 (FLOAT4E2M1) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT8E4M3FNUZ_to_FLOAT/model.onnx",
-    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT8E4M3FNUZ_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT8E4M3FN_to_FLOAT/model.onnx",
-    "Unsupported elem_type 17 (FLOAT8E4M3FN) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT8E4M3FN_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 17 (FLOAT8E4M3FN) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT8E5M2FNUZ_to_FLOAT/model.onnx",
-    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT8E5M2FNUZ_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT8E5M2_to_FLOAT/model.onnx",
-    "Unsupported elem_type 19 (FLOAT8E5M2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 19 (FLOAT8E5M2) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT8E5M2_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 19 (FLOAT8E5M2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 19 (FLOAT8E5M2) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT_to_BFLOAT16/model.onnx",
-    "Unsupported elem_type 16 (BFLOAT16) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 16 (BFLOAT16) for output. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT_to_DOUBLE/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for output. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for output. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT_to_FLOAT4E2M1/model.onnx",
-    "Unsupported elem_type 23 (FLOAT4E2M1) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 23 (FLOAT4E2M1) for output. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT_to_FLOAT8E4M3FN/model.onnx",
-    "Unsupported elem_type 17 (FLOAT8E4M3FN) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for output. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT_to_FLOAT8E4M3FNUZ/model.onnx",
-    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for output. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT_to_FLOAT8E5M2/model.onnx",
-    "Unsupported elem_type 19 (FLOAT8E5M2) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 19 (FLOAT8E5M2) for output. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT_to_FLOAT8E5M2FNUZ/model.onnx",
-    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for output. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT_to_INT2/model.onnx",
-    "Unsupported elem_type 26 (INT2) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 26 (INT2) for output. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT_to_INT4/model.onnx",
-    "Unsupported elem_type 22 (INT4) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 22 (INT4) for output. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT_to_UINT2/model.onnx",
-    "Unsupported elem_type 25 (UINT2) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 25 (UINT2) for output. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_FLOAT_to_UINT4/model.onnx",
-    "Unsupported elem_type 21 (UINT4) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 21 (UINT4) for output. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_INT2_to_FLOAT/model.onnx",
-    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_INT2_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_INT2_to_INT8/model.onnx",
-    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_INT4_to_FLOAT/model.onnx",
-    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_INT4_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_INT4_to_INT8/model.onnx",
-    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_UINT2_to_FLOAT/model.onnx",
-    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_UINT2_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_UINT2_to_UINT8/model.onnx",
-    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_UINT4_to_FLOAT/model.onnx",
-    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_UINT4_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_UINT4_to_UINT8/model.onnx",
-    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_e8m0_FLOAT16_to_FLOAT8E8M0/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_e8m0_FLOAT8E8M0_to_FLOAT/model.onnx",
-    "Unsupported elem_type 24 (FLOAT8E8M0) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 24 (FLOAT8E8M0) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_e8m0_FLOAT8E8M0_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 24 (FLOAT8E8M0) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 24 (FLOAT8E8M0) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_e8m0_FLOAT_to_FLOAT8E8M0/model.onnx",
-    "Unsupported elem_type 24 (FLOAT8E8M0) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 24 (FLOAT8E8M0) for output. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_no_saturate_FLOAT16_to_FLOAT8E4M3FN/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_no_saturate_FLOAT16_to_FLOAT8E4M3FNUZ/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_no_saturate_FLOAT16_to_FLOAT8E5M2/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_no_saturate_FLOAT16_to_FLOAT8E5M2FNUZ/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_no_saturate_FLOAT_to_FLOAT8E4M3FN/model.onnx",
-    "Unsupported elem_type 17 (FLOAT8E4M3FN) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for output. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_no_saturate_FLOAT_to_FLOAT8E4M3FNUZ/model.onnx",
-    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for output. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_no_saturate_FLOAT_to_FLOAT8E5M2/model.onnx",
-    "Unsupported elem_type 19 (FLOAT8E5M2) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 19 (FLOAT8E5M2) for output. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cast_no_saturate_FLOAT_to_FLOAT8E5M2FNUZ/model.onnx",
-    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for output. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_BFLOAT16_to_FLOAT/model.onnx",
-    "Unsupported elem_type 16 (BFLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 16 (BFLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_BFLOAT16_to_FLOAT_expanded/model.onnx",
-    "Unsupported elem_type 16 (BFLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 16 (BFLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_DOUBLE_to_FLOAT/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_DOUBLE_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_DOUBLE_to_FLOAT16_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_DOUBLE_to_FLOAT_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT16_to_DOUBLE/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT16_to_DOUBLE_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT16_to_FLOAT/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT16_to_FLOAT4E2M1/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT16_to_FLOAT4E2M1_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT16_to_FLOAT8E4M3FN/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT16_to_FLOAT8E4M3FNUZ/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT16_to_FLOAT8E4M3FNUZ_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT16_to_FLOAT8E4M3FN_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT16_to_FLOAT8E5M2/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT16_to_FLOAT8E5M2FNUZ/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT16_to_FLOAT8E5M2FNUZ_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT16_to_FLOAT8E5M2_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT16_to_FLOAT_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT16_to_INT2/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT16_to_INT2_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT16_to_INT4/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT16_to_INT4_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT16_to_UINT2/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT16_to_UINT2_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT16_to_UINT4/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT16_to_UINT4_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT4E2M1_to_FLOAT/model.onnx",
-    "Unsupported elem_type 23 (FLOAT4E2M1) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 23 (FLOAT4E2M1) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT4E2M1_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 23 (FLOAT4E2M1) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 23 (FLOAT4E2M1) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT4E2M1_to_FLOAT16_expanded/model.onnx",
-    "Unsupported elem_type 23 (FLOAT4E2M1) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 23 (FLOAT4E2M1) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT4E2M1_to_FLOAT_expanded/model.onnx",
-    "Unsupported elem_type 23 (FLOAT4E2M1) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 23 (FLOAT4E2M1) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT8E4M3FNUZ_to_FLOAT/model.onnx",
-    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT8E4M3FNUZ_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT8E4M3FNUZ_to_FLOAT16_expanded/model.onnx",
-    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT8E4M3FNUZ_to_FLOAT_expanded/model.onnx",
-    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT8E4M3FN_to_FLOAT/model.onnx",
-    "Unsupported elem_type 17 (FLOAT8E4M3FN) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT8E4M3FN_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 17 (FLOAT8E4M3FN) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT8E4M3FN_to_FLOAT16_expanded/model.onnx",
-    "Unsupported elem_type 17 (FLOAT8E4M3FN) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT8E4M3FN_to_FLOAT_expanded/model.onnx",
-    "Unsupported elem_type 17 (FLOAT8E4M3FN) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT8E5M2FNUZ_to_FLOAT/model.onnx",
-    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT8E5M2FNUZ_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT8E5M2FNUZ_to_FLOAT16_expanded/model.onnx",
-    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT8E5M2FNUZ_to_FLOAT_expanded/model.onnx",
-    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT8E5M2_to_FLOAT/model.onnx",
-    "Unsupported elem_type 19 (FLOAT8E5M2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 19 (FLOAT8E5M2) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT8E5M2_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 19 (FLOAT8E5M2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 19 (FLOAT8E5M2) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT8E5M2_to_FLOAT16_expanded/model.onnx",
-    "Unsupported elem_type 19 (FLOAT8E5M2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 19 (FLOAT8E5M2) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT8E5M2_to_FLOAT_expanded/model.onnx",
-    "Unsupported elem_type 19 (FLOAT8E5M2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 19 (FLOAT8E5M2) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT_to_BFLOAT16/model.onnx",
-    "Unsupported elem_type 16 (BFLOAT16) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 16 (BFLOAT16) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT_to_BFLOAT16_expanded/model.onnx",
-    "Unsupported elem_type 16 (BFLOAT16) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 16 (BFLOAT16) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT_to_DOUBLE/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT_to_DOUBLE_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT_to_FLOAT16_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT_to_FLOAT4E2M1/model.onnx",
-    "Unsupported elem_type 23 (FLOAT4E2M1) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 23 (FLOAT4E2M1) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT_to_FLOAT4E2M1_expanded/model.onnx",
-    "Unsupported elem_type 23 (FLOAT4E2M1) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 23 (FLOAT4E2M1) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT_to_FLOAT8E4M3FN/model.onnx",
-    "Unsupported elem_type 17 (FLOAT8E4M3FN) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT_to_FLOAT8E4M3FNUZ/model.onnx",
-    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT_to_FLOAT8E4M3FNUZ_expanded/model.onnx",
-    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT_to_FLOAT8E4M3FN_expanded/model.onnx",
-    "Unsupported elem_type 17 (FLOAT8E4M3FN) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT_to_FLOAT8E5M2/model.onnx",
-    "Unsupported elem_type 19 (FLOAT8E5M2) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 19 (FLOAT8E5M2) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT_to_FLOAT8E5M2FNUZ/model.onnx",
-    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT_to_FLOAT8E5M2FNUZ_expanded/model.onnx",
-    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT_to_FLOAT8E5M2_expanded/model.onnx",
-    "Unsupported elem_type 19 (FLOAT8E5M2) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 19 (FLOAT8E5M2) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT_to_INT2/model.onnx",
-    "Unsupported elem_type 26 (INT2) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 26 (INT2) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT_to_INT2_expanded/model.onnx",
-    "Unsupported elem_type 26 (INT2) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 26 (INT2) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT_to_INT4/model.onnx",
-    "Unsupported elem_type 22 (INT4) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 22 (INT4) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT_to_INT4_expanded/model.onnx",
-    "Unsupported elem_type 22 (INT4) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 22 (INT4) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT_to_UINT2/model.onnx",
-    "Unsupported elem_type 25 (UINT2) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 25 (UINT2) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT_to_UINT2_expanded/model.onnx",
-    "Unsupported elem_type 25 (UINT2) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 25 (UINT2) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT_to_UINT4/model.onnx",
-    "Unsupported elem_type 21 (UINT4) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 21 (UINT4) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_FLOAT_to_UINT4_expanded/model.onnx",
-    "Unsupported elem_type 21 (UINT4) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 21 (UINT4) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_INT2_to_FLOAT/model.onnx",
-    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_INT2_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_INT2_to_FLOAT16_expanded/model.onnx",
-    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_INT2_to_FLOAT_expanded/model.onnx",
-    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_INT2_to_INT8/model.onnx",
-    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_INT2_to_INT8_expanded/model.onnx",
-    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 26 (INT2) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_INT4_to_FLOAT/model.onnx",
-    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_INT4_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_INT4_to_FLOAT16_expanded/model.onnx",
-    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_INT4_to_FLOAT_expanded/model.onnx",
-    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_INT4_to_INT8/model.onnx",
-    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_INT4_to_INT8_expanded/model.onnx",
-    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 22 (INT4) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_UINT2_to_FLOAT/model.onnx",
-    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_UINT2_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_UINT2_to_FLOAT16_expanded/model.onnx",
-    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_UINT2_to_FLOAT_expanded/model.onnx",
-    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_UINT2_to_UINT8/model.onnx",
-    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_UINT2_to_UINT8_expanded/model.onnx",
-    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 25 (UINT2) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_UINT4_to_FLOAT/model.onnx",
-    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_UINT4_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_UINT4_to_FLOAT16_expanded/model.onnx",
-    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_UINT4_to_FLOAT_expanded/model.onnx",
-    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_UINT4_to_UINT8/model.onnx",
-    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_UINT4_to_UINT8_expanded/model.onnx",
-    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 21 (UINT4) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E4M3FN/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E4M3FNUZ/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E4M3FNUZ_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E4M3FN_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E5M2/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E5M2FNUZ/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E5M2FNUZ_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E5M2_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for input. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_no_saturate_FLOAT_to_FLOAT8E4M3FN/model.onnx",
-    "Unsupported elem_type 17 (FLOAT8E4M3FN) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_no_saturate_FLOAT_to_FLOAT8E4M3FNUZ/model.onnx",
-    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_no_saturate_FLOAT_to_FLOAT8E4M3FNUZ_expanded/model.onnx",
-    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_no_saturate_FLOAT_to_FLOAT8E4M3FN_expanded/model.onnx",
-    "Unsupported elem_type 17 (FLOAT8E4M3FN) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_no_saturate_FLOAT_to_FLOAT8E5M2/model.onnx",
-    "Unsupported elem_type 19 (FLOAT8E5M2) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 19 (FLOAT8E5M2) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_no_saturate_FLOAT_to_FLOAT8E5M2FNUZ/model.onnx",
-    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_no_saturate_FLOAT_to_FLOAT8E5M2FNUZ_expanded/model.onnx",
-    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_castlike_no_saturate_FLOAT_to_FLOAT8E5M2_expanded/model.onnx",
-    "Unsupported elem_type 19 (FLOAT8E5M2) for like. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 19 (FLOAT8E5M2) for like. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_ceil/model.onnx",
@@ -1805,51 +1805,51 @@
   ],
   [
     "node/test_center_crop_pad_crop/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_center_crop_pad_crop_and_pad/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_center_crop_pad_crop_and_pad_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_center_crop_pad_crop_axes_chw/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_center_crop_pad_crop_axes_chw_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_center_crop_pad_crop_axes_hwc/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_center_crop_pad_crop_axes_hwc_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_center_crop_pad_crop_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_center_crop_pad_crop_negative_axes_hwc/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_center_crop_pad_crop_negative_axes_hwc_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_center_crop_pad_pad/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_center_crop_pad_pad_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_clip/model.onnx",
@@ -1865,27 +1865,27 @@
   ],
   [
     "node/test_clip_default_int8_inbounds/model.onnx",
-    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_clip_default_int8_inbounds_expanded/model.onnx",
-    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_clip_default_int8_max/model.onnx",
-    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_clip_default_int8_max_expanded/model.onnx",
-    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_clip_default_int8_min/model.onnx",
-    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_clip_default_int8_min_expanded/model.onnx",
-    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_clip_default_max/model.onnx",
@@ -1949,39 +1949,39 @@
   ],
   [
     "node/test_col2im/model.onnx",
-    "Unsupported elem_type 7 (INT64) for image_shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for image_shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_col2im_5d/model.onnx",
-    "Unsupported elem_type 7 (INT64) for image_shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for image_shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_col2im_dilations/model.onnx",
-    "Unsupported elem_type 7 (INT64) for image_shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for image_shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_col2im_pads/model.onnx",
-    "Unsupported elem_type 7 (INT64) for image_shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for image_shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_col2im_strides/model.onnx",
-    "Unsupported elem_type 7 (INT64) for image_shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for image_shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_compress_0/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for condition. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for condition. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_compress_1/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for condition. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for condition. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_compress_default_axis/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for condition. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for condition. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_compress_negative_axis/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for condition. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for condition. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_concat_1d_axis_0/model.onnx",
@@ -2037,27 +2037,27 @@
   ],
   [
     "node/test_constant_pad/model.onnx",
-    "Unsupported elem_type 7 (INT64) for pads. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for pads. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_constant_pad_axes/model.onnx",
-    "Unsupported elem_type 7 (INT64) for pads. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for pads. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_constant_pad_negative_axes/model.onnx",
-    "Unsupported elem_type 7 (INT64) for pads. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for pads. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_constantofshape_float_ones/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_constantofshape_int_shape_zero/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_constantofshape_int_zeros/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_conv_with_autopad_same/model.onnx",
@@ -2077,11 +2077,11 @@
   ],
   [
     "node/test_convinteger_with_padding/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_convinteger_without_padding/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_convtranspose/model.onnx",
@@ -2145,39 +2145,39 @@
   ],
   [
     "node/test_cumsum_1d/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cumsum_1d_exclusive/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cumsum_1d_int32_exclusive/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cumsum_1d_reverse/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cumsum_1d_reverse_exclusive/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cumsum_2d_axis_0/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cumsum_2d_axis_1/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cumsum_2d_int32/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_cumsum_2d_negative_axis/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_deform_conv_with_mask_bias/model.onnx",
@@ -2197,59 +2197,59 @@
   ],
   [
     "node/test_dequantizelinear/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_dequantizelinear_axis/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_dequantizelinear_blocked/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_dequantizelinear_e4m3fn/model.onnx",
-    "Unsupported elem_type 17 (FLOAT8E4M3FN) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_dequantizelinear_e4m3fn_float16/model.onnx",
-    "Unsupported elem_type 17 (FLOAT8E4M3FN) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_dequantizelinear_e4m3fn_zero_point/model.onnx",
-    "Unsupported elem_type 17 (FLOAT8E4M3FN) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_dequantizelinear_e5m2/model.onnx",
-    "Unsupported elem_type 19 (FLOAT8E5M2) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 19 (FLOAT8E5M2) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_dequantizelinear_float4e2m1/model.onnx",
-    "Unsupported elem_type 23 (FLOAT4E2M1) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 23 (FLOAT4E2M1) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_dequantizelinear_int16/model.onnx",
-    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_dequantizelinear_int2/model.onnx",
-    "Unsupported elem_type 26 (INT2) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 26 (INT2) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_dequantizelinear_int4/model.onnx",
-    "Unsupported elem_type 22 (INT4) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 22 (INT4) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_dequantizelinear_uint16/model.onnx",
-    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_dequantizelinear_uint2/model.onnx",
-    "Unsupported elem_type 25 (UINT2) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 25 (UINT2) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_dequantizelinear_uint4/model.onnx",
-    "Unsupported elem_type 21 (UINT4) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 21 (UINT4) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_det_2d/model.onnx",
@@ -2261,11 +2261,11 @@
   ],
   [
     "node/test_dft/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axis. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axis. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_dft_axis/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axis. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axis. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_dft_axis_opset19/model.onnx",
@@ -2273,7 +2273,7 @@
   ],
   [
     "node/test_dft_inverse/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axis. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axis. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_dft_inverse_opset19/model.onnx",
@@ -2297,27 +2297,27 @@
   ],
   [
     "node/test_div_int16/model.onnx",
-    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_div_int8/model.onnx",
-    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_div_uint16/model.onnx",
-    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_div_uint32/model.onnx",
-    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_div_uint64/model.onnx",
-    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_div_uint8/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_dropout_default/model.onnx",
@@ -2325,11 +2325,11 @@
   ],
   [
     "node/test_dropout_default_mask/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for z. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for z. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_dropout_default_mask_ratio/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for z. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for z. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_dropout_default_old/model.onnx",
@@ -2345,55 +2345,55 @@
   ],
   [
     "node/test_dynamicquantizelinear/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_dynamicquantizelinear_expanded/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_dynamicquantizelinear_max_adjusted/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_dynamicquantizelinear_max_adjusted_expanded/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_dynamicquantizelinear_min_adjusted/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_dynamicquantizelinear_min_adjusted_expanded/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_edge_pad/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_einsum_batch_diagonal/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_einsum_batch_matmul/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_einsum_inner_prod/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_einsum_scalar/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_einsum_sum/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_einsum_transpose/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_elu/model.onnx",
@@ -2421,43 +2421,43 @@
   ],
   [
     "node/test_equal/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_equal_bcast/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_equal_int16/model.onnx",
-    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_equal_int8/model.onnx",
-    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_equal_string/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_equal_string_broadcast/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_equal_uint16/model.onnx",
-    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_equal_uint32/model.onnx",
-    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_equal_uint64/model.onnx",
-    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_equal_uint8/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_erf/model.onnx",
@@ -2473,23 +2473,23 @@
   ],
   [
     "node/test_expand_dim_changed/model.onnx",
-    "Unsupported elem_type 7 (INT64) for new_shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for new_shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_expand_dim_unchanged/model.onnx",
-    "Unsupported elem_type 7 (INT64) for new_shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for new_shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_eyelike_populate_off_main_diagonal/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_eyelike_with_dtype/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_eyelike_without_dtype/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_flatten_axis0/model.onnx",
@@ -2537,43 +2537,43 @@
   ],
   [
     "node/test_gather_0/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_gather_1/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_gather_2d_indices/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_gather_elements_0/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_gather_elements_1/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_gather_elements_negative_indices/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_gather_negative_indices/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_gathernd_example_float32/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_gathernd_example_int32/model.onnx",
-    "Unsupported elem_type 6 (INT32) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_gathernd_example_int32_batch_dim1/model.onnx",
-    "Unsupported elem_type 6 (INT32) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_gelu_default_1/model.onnx",
@@ -2669,99 +2669,99 @@
   ],
   [
     "node/test_greater/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for greater. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for greater. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_greater_bcast/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for greater. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for greater. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_greater_equal/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for greater_equal. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for greater_equal. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_greater_equal_bcast/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for greater_equal. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for greater_equal. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_greater_equal_bcast_expanded/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for greater_equal. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for greater_equal. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_greater_equal_expanded/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for greater_equal. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for greater_equal. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_greater_equal_int16/model.onnx",
-    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_greater_equal_int16_expanded/model.onnx",
-    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_greater_equal_int8/model.onnx",
-    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_greater_equal_int8_expanded/model.onnx",
-    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_greater_equal_uint16/model.onnx",
-    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_greater_equal_uint16_expanded/model.onnx",
-    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_greater_equal_uint32/model.onnx",
-    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_greater_equal_uint32_expanded/model.onnx",
-    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_greater_equal_uint64/model.onnx",
-    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_greater_equal_uint64_expanded/model.onnx",
-    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_greater_equal_uint8/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_greater_equal_uint8_expanded/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_greater_int16/model.onnx",
-    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_greater_int8/model.onnx",
-    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_greater_uint16/model.onnx",
-    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_greater_uint32/model.onnx",
-    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_greater_uint64/model.onnx",
-    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_greater_uint8/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_gridsample/model.onnx",
@@ -2869,35 +2869,35 @@
   ],
   [
     "node/test_hammingwindow/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_hammingwindow_expanded/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_hammingwindow_symmetric/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_hammingwindow_symmetric_expanded/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_hannwindow/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_hannwindow_expanded/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_hannwindow_symmetric/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_hannwindow_symmetric_expanded/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_hardmax_axis_0/model.onnx",
@@ -2973,51 +2973,51 @@
   ],
   [
     "node/test_if/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for cond. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for cond. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_if_opt/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for cond. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for cond. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_if_seq/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for cond. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for cond. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_image_decoder_decode_bmp_rgb/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_image_decoder_decode_jpeg2k_rgb/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_image_decoder_decode_jpeg_bgr/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_image_decoder_decode_jpeg_grayscale/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_image_decoder_decode_jpeg_rgb/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_image_decoder_decode_png_rgb/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_image_decoder_decode_pnm_rgb/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_image_decoder_decode_tiff_rgb/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_image_decoder_decode_webp_rgb/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_instancenorm_epsilon/model.onnx",
@@ -3029,27 +3029,27 @@
   ],
   [
     "node/test_isinf/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_isinf_float16/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_isinf_negative/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_isinf_positive/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_isnan/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_isnan_float16/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_l1normalization_axis_0/model.onnx",
@@ -3325,99 +3325,99 @@
   ],
   [
     "node/test_less/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for less. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for less. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_less_bcast/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for less. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for less. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_less_equal/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for less_equal. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for less_equal. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_less_equal_bcast/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for less_equal. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for less_equal. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_less_equal_bcast_expanded/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for less_equal. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for less_equal. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_less_equal_expanded/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for less_equal. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for less_equal. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_less_equal_int16/model.onnx",
-    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_less_equal_int16_expanded/model.onnx",
-    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_less_equal_int8/model.onnx",
-    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_less_equal_int8_expanded/model.onnx",
-    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_less_equal_uint16/model.onnx",
-    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_less_equal_uint16_expanded/model.onnx",
-    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_less_equal_uint32/model.onnx",
-    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_less_equal_uint32_expanded/model.onnx",
-    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_less_equal_uint64/model.onnx",
-    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_less_equal_uint64_expanded/model.onnx",
-    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_less_equal_uint8/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_less_equal_uint8_expanded/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_less_int16/model.onnx",
-    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_less_int8/model.onnx",
-    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_less_uint16/model.onnx",
-    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_less_uint32/model.onnx",
-    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_less_uint64/model.onnx",
-    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_less_uint8/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_log/model.onnx",
@@ -3513,15 +3513,15 @@
   ],
   [
     "node/test_loop11/model.onnx",
-    "Unsupported elem_type 7 (INT64) for trip_count. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for trip_count. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_loop13_seq/model.onnx",
-    "Unsupported elem_type 7 (INT64) for trip_count. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for trip_count. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_loop16_seq_none/model.onnx",
-    "Unsupported elem_type 7 (INT64) for trip_count. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for trip_count. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_lpnormalization_default/model.onnx",
@@ -3581,7 +3581,7 @@
   ],
   [
     "node/test_lstm_with_peepholes/model.onnx",
-    "Unsupported elem_type 6 (INT32) for sequence_lens. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for sequence_lens. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_matmul_1d_1d/model.onnx",
@@ -3613,7 +3613,7 @@
   ],
   [
     "node/test_matmulinteger/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for A. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for A. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_max_example/model.onnx",
@@ -3621,7 +3621,7 @@
   ],
   [
     "node/test_max_float16/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for data_0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for data_0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_max_float32/model.onnx",
@@ -3629,23 +3629,23 @@
   ],
   [
     "node/test_max_float64/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for data_0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for data_0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_max_int16/model.onnx",
-    "Unsupported elem_type 5 (INT16) for data_0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 5 (INT16) for data_0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_max_int32/model.onnx",
-    "Unsupported elem_type 6 (INT32) for data_0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for data_0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_max_int64/model.onnx",
-    "Unsupported elem_type 7 (INT64) for data_0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for data_0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_max_int8/model.onnx",
-    "Unsupported elem_type 3 (INT8) for data_0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for data_0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_max_one_input/model.onnx",
@@ -3657,19 +3657,19 @@
   ],
   [
     "node/test_max_uint16/model.onnx",
-    "Unsupported elem_type 4 (UINT16) for data_0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 4 (UINT16) for data_0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_max_uint32/model.onnx",
-    "Unsupported elem_type 12 (UINT32) for data_0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 12 (UINT32) for data_0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_max_uint64/model.onnx",
-    "Unsupported elem_type 13 (UINT64) for data_0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 13 (UINT64) for data_0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_max_uint8/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for data_0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for data_0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_maxpool_1d_default/model.onnx",
@@ -3721,7 +3721,7 @@
   ],
   [
     "node/test_maxpool_2d_uint8/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_maxpool_3d_default/model.onnx",
@@ -3741,19 +3741,19 @@
   ],
   [
     "node/test_maxpool_with_argmax_2d_precomputed_pads/model.onnx",
-    "Unsupported elem_type 7 (INT64) for z. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for z. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_maxpool_with_argmax_2d_precomputed_strides/model.onnx",
-    "Unsupported elem_type 7 (INT64) for z. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for z. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_maxunpool_export_with_output_shape/model.onnx",
-    "Unsupported elem_type 7 (INT64) for xI. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for xI. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_maxunpool_export_without_output_shape/model.onnx",
-    "Unsupported elem_type 7 (INT64) for xI. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for xI. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_mean_example/model.onnx",
@@ -3769,7 +3769,7 @@
   ],
   [
     "node/test_melweightmatrix/model.onnx",
-    "Unsupported elem_type 6 (INT32) for num_mel_bins. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for num_mel_bins. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_min_example/model.onnx",
@@ -3777,7 +3777,7 @@
   ],
   [
     "node/test_min_float16/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for data_0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for data_0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_min_float32/model.onnx",
@@ -3785,23 +3785,23 @@
   ],
   [
     "node/test_min_float64/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for data_0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for data_0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_min_int16/model.onnx",
-    "Unsupported elem_type 5 (INT16) for data_0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 5 (INT16) for data_0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_min_int32/model.onnx",
-    "Unsupported elem_type 6 (INT32) for data_0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for data_0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_min_int64/model.onnx",
-    "Unsupported elem_type 7 (INT64) for data_0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for data_0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_min_int8/model.onnx",
-    "Unsupported elem_type 3 (INT8) for data_0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for data_0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_min_one_input/model.onnx",
@@ -3813,19 +3813,19 @@
   ],
   [
     "node/test_min_uint16/model.onnx",
-    "Unsupported elem_type 4 (UINT16) for data_0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 4 (UINT16) for data_0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_min_uint32/model.onnx",
-    "Unsupported elem_type 12 (UINT32) for data_0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 12 (UINT32) for data_0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_min_uint64/model.onnx",
-    "Unsupported elem_type 13 (UINT64) for data_0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 13 (UINT64) for data_0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_min_uint8/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for data_0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for data_0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_mish/model.onnx",
@@ -3837,15 +3837,15 @@
   ],
   [
     "node/test_mod_broadcast/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_mod_int64_fmod/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_mod_mixed_sign_float16/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 10 (FLOAT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_mod_mixed_sign_float32/model.onnx",
@@ -3853,47 +3853,47 @@
   ],
   [
     "node/test_mod_mixed_sign_float64/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_mod_mixed_sign_int16/model.onnx",
-    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_mod_mixed_sign_int32/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_mod_mixed_sign_int64/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_mod_mixed_sign_int8/model.onnx",
-    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_mod_uint16/model.onnx",
-    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_mod_uint32/model.onnx",
-    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_mod_uint64/model.onnx",
-    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_mod_uint8/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_momentum/model.onnx",
-    "Unsupported elem_type 7 (INT64) for T. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for T. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_momentum_multiple/model.onnx",
-    "Unsupported elem_type 7 (INT64) for T. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for T. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_mul/model.onnx",
@@ -3909,27 +3909,27 @@
   ],
   [
     "node/test_mul_int16/model.onnx",
-    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_mul_int8/model.onnx",
-    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_mul_uint16/model.onnx",
-    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_mul_uint32/model.onnx",
-    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_mul_uint64/model.onnx",
-    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_mul_uint8/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_mvn/model.onnx",
@@ -3953,207 +3953,207 @@
   ],
   [
     "node/test_nesterov_momentum/model.onnx",
-    "Unsupported elem_type 7 (INT64) for T. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for T. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NC/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NC_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1_ii/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1_ii_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1_mean_weight_negative_ii/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1_mean_weight_negative_ii_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1_weight/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1_weight_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1_weight_ii/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1_weight_ii_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1d2/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1d2_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1d2_no_weight_reduction_mean_ii/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1d2_no_weight_reduction_mean_ii_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1d2_reduction_mean/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1d2_reduction_mean_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1d2_reduction_sum/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1d2_reduction_sum_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight_reduction_mean/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight_reduction_mean_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight_reduction_sum/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight_reduction_sum_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight_reduction_sum_ii/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight_reduction_sum_ii_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1d2d3_none_no_weight_negative_ii/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1d2d3_sum_weight_high_ii/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1d2d3d4d5_mean_weight/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1d2d3d4d5_mean_weight_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1d2d3d4d5_none_no_weight/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nllloss_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for target. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nonmaxsuppression_center_point_box_format/model.onnx",
-    "Unsupported elem_type 7 (INT64) for max_output_boxes_per_class. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for max_output_boxes_per_class. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nonmaxsuppression_flipped_coordinates/model.onnx",
-    "Unsupported elem_type 7 (INT64) for max_output_boxes_per_class. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for max_output_boxes_per_class. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nonmaxsuppression_identical_boxes/model.onnx",
-    "Unsupported elem_type 7 (INT64) for max_output_boxes_per_class. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for max_output_boxes_per_class. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nonmaxsuppression_limit_output_size/model.onnx",
-    "Unsupported elem_type 7 (INT64) for max_output_boxes_per_class. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for max_output_boxes_per_class. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nonmaxsuppression_single_box/model.onnx",
-    "Unsupported elem_type 7 (INT64) for max_output_boxes_per_class. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for max_output_boxes_per_class. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nonmaxsuppression_suppress_by_IOU/model.onnx",
-    "Unsupported elem_type 7 (INT64) for max_output_boxes_per_class. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for max_output_boxes_per_class. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nonmaxsuppression_suppress_by_IOU_and_scores/model.onnx",
-    "Unsupported elem_type 7 (INT64) for max_output_boxes_per_class. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for max_output_boxes_per_class. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nonmaxsuppression_two_batches/model.onnx",
-    "Unsupported elem_type 7 (INT64) for max_output_boxes_per_class. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for max_output_boxes_per_class. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nonmaxsuppression_two_classes/model.onnx",
-    "Unsupported elem_type 7 (INT64) for max_output_boxes_per_class. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for max_output_boxes_per_class. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_nonzero_example/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for condition. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for condition. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_not_2d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_not_3d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_not_4d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_onehot_negative_indices/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_onehot_with_axis/model.onnx",
@@ -4165,7 +4165,7 @@
   ],
   [
     "node/test_onehot_without_axis/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_optional_get_element_optional_sequence/model.onnx",
@@ -4185,19 +4185,19 @@
   ],
   [
     "node/test_optional_has_element_empty_no_input_name_optional_input/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for output. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_optional_has_element_empty_no_input_name_tensor_input/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for output. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_optional_has_element_empty_no_input_optional_input/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for output. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_optional_has_element_empty_no_input_tensor_input/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for output. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for output. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_optional_has_element_empty_optional_input/model.onnx",
@@ -4213,35 +4213,35 @@
   ],
   [
     "node/test_or2d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_or3d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_or4d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_or_bcast3v1d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_or_bcast3v2d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_or_bcast4v2d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_or_bcast4v3d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_or_bcast4v4d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_pow/model.onnx",
@@ -4261,35 +4261,35 @@
   ],
   [
     "node/test_pow_types_float32_int32/model.onnx",
-    "Unsupported elem_type 6 (INT32) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_pow_types_float32_int64/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_pow_types_float32_uint32/model.onnx",
-    "Unsupported elem_type 12 (UINT32) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 12 (UINT32) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_pow_types_float32_uint64/model.onnx",
-    "Unsupported elem_type 13 (UINT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 13 (UINT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_pow_types_int32_float32/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_pow_types_int32_int32/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_pow_types_int64_float32/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_pow_types_int64_int64/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_prelu_broadcast/model.onnx",
@@ -4309,91 +4309,91 @@
   ],
   [
     "node/test_qlinearconv/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_qlinearmatmul_2D_int8_float16/model.onnx",
-    "Unsupported elem_type 3 (INT8) for a. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for a. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_qlinearmatmul_2D_int8_float32/model.onnx",
-    "Unsupported elem_type 3 (INT8) for a. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for a. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_qlinearmatmul_2D_uint8_float16/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for a. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for a. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_qlinearmatmul_2D_uint8_float32/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for a. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for a. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_qlinearmatmul_3D_int8_float16/model.onnx",
-    "Unsupported elem_type 3 (INT8) for a. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for a. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_qlinearmatmul_3D_int8_float32/model.onnx",
-    "Unsupported elem_type 3 (INT8) for a. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for a. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_qlinearmatmul_3D_uint8_float16/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for a. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for a. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_qlinearmatmul_3D_uint8_float32/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for a. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for a. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_quantizelinear/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for y_zero_point. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for y_zero_point. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_quantizelinear_axis/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for y_zero_point. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for y_zero_point. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_quantizelinear_blocked_asymmetric/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for y_zero_point. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for y_zero_point. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_quantizelinear_blocked_symmetric/model.onnx",
-    "Unsupported elem_type 5 (INT16) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 5 (INT16) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_quantizelinear_e4m3fn/model.onnx",
-    "Unsupported elem_type 17 (FLOAT8E4M3FN) for y_zero_point. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for y_zero_point. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_quantizelinear_e5m2/model.onnx",
-    "Unsupported elem_type 19 (FLOAT8E5M2) for y_zero_point. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 19 (FLOAT8E5M2) for y_zero_point. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_quantizelinear_float4e2m1/model.onnx",
-    "Unsupported elem_type 23 (FLOAT4E2M1) for y_zero_point. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 23 (FLOAT4E2M1) for y_zero_point. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_quantizelinear_int16/model.onnx",
-    "Unsupported elem_type 5 (INT16) for y_zero_point. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 5 (INT16) for y_zero_point. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_quantizelinear_int2/model.onnx",
-    "Unsupported elem_type 26 (INT2) for y_zero_point. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 26 (INT2) for y_zero_point. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_quantizelinear_int4/model.onnx",
-    "Unsupported elem_type 22 (INT4) for y_zero_point. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 22 (INT4) for y_zero_point. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_quantizelinear_uint16/model.onnx",
-    "Unsupported elem_type 4 (UINT16) for y_zero_point. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 4 (UINT16) for y_zero_point. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_quantizelinear_uint2/model.onnx",
-    "Unsupported elem_type 25 (UINT2) for y_zero_point. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 25 (UINT2) for y_zero_point. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_quantizelinear_uint4/model.onnx",
-    "Unsupported elem_type 21 (UINT4) for y_zero_point. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 21 (UINT4) for y_zero_point. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_range_float_type_positive_delta/model.onnx",
@@ -4405,11 +4405,11 @@
   ],
   [
     "node/test_range_int32_type_negative_delta/model.onnx",
-    "Unsupported elem_type 6 (INT32) for start. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for start. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_range_int32_type_negative_delta_expanded/model.onnx",
-    "Unsupported elem_type 6 (INT32) for start. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for start. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reciprocal/model.onnx",
@@ -4421,263 +4421,263 @@
   ],
   [
     "node/test_reduce_l1_default_axes_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l1_default_axes_keepdims_example_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l1_default_axes_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l1_default_axes_keepdims_random_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l1_do_not_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l1_do_not_keepdims_example_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l1_do_not_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l1_do_not_keepdims_random_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l1_empty_set/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l1_empty_set_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l1_keep_dims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l1_keep_dims_example_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l1_keep_dims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l1_keep_dims_random_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l1_negative_axes_keep_dims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l1_negative_axes_keep_dims_example_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l1_negative_axes_keep_dims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l1_negative_axes_keep_dims_random_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l2_default_axes_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l2_default_axes_keepdims_example_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l2_default_axes_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l2_default_axes_keepdims_random_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l2_do_not_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l2_do_not_keepdims_example_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l2_do_not_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l2_do_not_keepdims_random_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l2_empty_set/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l2_empty_set_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l2_keep_dims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l2_keep_dims_example_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l2_keep_dims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l2_keep_dims_random_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l2_negative_axes_keep_dims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l2_negative_axes_keep_dims_example_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l2_negative_axes_keep_dims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_l2_negative_axes_keep_dims_random_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_asc_axes/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_asc_axes_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_default/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_default_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_desc_axes/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_desc_axes_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_empty_set/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_empty_set_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_exp_default_axes_keepdims_example/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_exp_default_axes_keepdims_example_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_exp_default_axes_keepdims_random/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_exp_default_axes_keepdims_random_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_exp_do_not_keepdims_example/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_exp_do_not_keepdims_example_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_exp_do_not_keepdims_random/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_exp_do_not_keepdims_random_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_exp_empty_set/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_exp_empty_set_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_exp_keepdims_example/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_exp_keepdims_example_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_exp_keepdims_random/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_exp_keepdims_random_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_exp_negative_axes_keepdims_example/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_exp_negative_axes_keepdims_example_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_exp_negative_axes_keepdims_random/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_exp_negative_axes_keepdims_random_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_negative_axes/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_log_sum_negative_axes_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_max_bool_inputs/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_max_default_axes_keepdim_example/model.onnx",
@@ -4689,67 +4689,67 @@
   ],
   [
     "node/test_reduce_max_do_not_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_max_do_not_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_max_empty_set/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_max_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_max_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_max_negative_axes_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_max_negative_axes_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_mean_default_axes_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_mean_default_axes_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_mean_do_not_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_mean_do_not_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_mean_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_mean_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_mean_negative_axes_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_mean_negative_axes_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_min_bool_inputs/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for data. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for data. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_min_default_axes_keepdims_example/model.onnx",
@@ -4761,31 +4761,31 @@
   ],
   [
     "node/test_reduce_min_do_not_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_min_do_not_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_min_empty_set/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_min_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_min_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_min_negative_axes_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_min_negative_axes_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_prod_default_axes_keepdims_example/model.onnx",
@@ -4797,167 +4797,167 @@
   ],
   [
     "node/test_reduce_prod_do_not_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_prod_do_not_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_prod_empty_set/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_prod_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_prod_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_prod_negative_axes_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_prod_negative_axes_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_default_axes_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_default_axes_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_do_not_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_do_not_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_empty_axes_input_noop/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_empty_axes_input_noop_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_empty_set/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_empty_set_non_reduced_axis_zero/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_negative_axes_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_negative_axes_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_square_default_axes_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_square_default_axes_keepdims_example_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_square_default_axes_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_square_default_axes_keepdims_random_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_square_do_not_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_square_do_not_keepdims_example_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_square_do_not_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_square_do_not_keepdims_random_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_square_empty_set/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_square_empty_set_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_square_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_square_keepdims_example_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_square_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_square_keepdims_random_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_square_negative_axes_keepdims_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_square_negative_axes_keepdims_example_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_square_negative_axes_keepdims_random/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reduce_sum_square_negative_axes_keepdims_random_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reflect_pad/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_regex_full_match_basic/model.onnx",
-    "Unsupported elem_type 8 (STRING) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for X. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_regex_full_match_email_domain/model.onnx",
-    "Unsupported elem_type 8 (STRING) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for X. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_regex_full_match_empty/model.onnx",
-    "Unsupported elem_type 8 (STRING) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for X. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_relu/model.onnx",
@@ -4969,43 +4969,43 @@
   ],
   [
     "node/test_reshape_allowzero_reordered/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reshape_extended_dims/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reshape_negative_dim/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reshape_negative_extended_dims/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reshape_one_dim/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reshape_reduced_dims/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reshape_reordered_all_dims/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reshape_reordered_last_dims/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reshape_zero_and_negative_dim/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reshape_zero_dim/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_resize_downsample_scales_cubic/model.onnx",
@@ -5045,47 +5045,47 @@
   ],
   [
     "node/test_resize_downsample_sizes_cubic/model.onnx",
-    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_resize_downsample_sizes_cubic_antialias/model.onnx",
-    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_resize_downsample_sizes_linear_antialias/model.onnx",
-    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_resize_downsample_sizes_linear_pytorch_half_pixel/model.onnx",
-    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_resize_downsample_sizes_nearest/model.onnx",
-    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_resize_downsample_sizes_nearest_not_larger/model.onnx",
-    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_resize_downsample_sizes_nearest_not_smaller/model.onnx",
-    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_resize_tf_crop_and_resize/model.onnx",
-    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_resize_tf_crop_and_resize_axes_2_3/model.onnx",
-    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_resize_tf_crop_and_resize_axes_3_2/model.onnx",
-    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_resize_tf_crop_and_resize_extrapolation_value/model.onnx",
-    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_resize_upsample_scales_cubic/model.onnx",
@@ -5129,47 +5129,47 @@
   ],
   [
     "node/test_resize_upsample_sizes_cubic/model.onnx",
-    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_resize_upsample_sizes_nearest/model.onnx",
-    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_resize_upsample_sizes_nearest_axes_2_3/model.onnx",
-    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_resize_upsample_sizes_nearest_axes_3_2/model.onnx",
-    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_resize_upsample_sizes_nearest_ceil_half_pixel/model.onnx",
-    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_resize_upsample_sizes_nearest_floor_align_corners/model.onnx",
-    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_resize_upsample_sizes_nearest_not_larger/model.onnx",
-    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_resize_upsample_sizes_nearest_not_smaller/model.onnx",
-    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_resize_upsample_sizes_nearest_round_prefer_ceil_asymmetric/model.onnx",
-    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for sizes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reversesequence_batch/model.onnx",
-    "Unsupported elem_type 7 (INT64) for sequence_lens. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for sequence_lens. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_reversesequence_time/model.onnx",
-    "Unsupported elem_type 7 (INT64) for sequence_lens. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for sequence_lens. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_rms_normalization_2d_axis0/model.onnx",
@@ -5329,39 +5329,39 @@
   ],
   [
     "node/test_roialign_aligned_false/model.onnx",
-    "Unsupported elem_type 7 (INT64) for batch_indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for batch_indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_roialign_aligned_true/model.onnx",
-    "Unsupported elem_type 7 (INT64) for batch_indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for batch_indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_roialign_mode_max/model.onnx",
-    "Unsupported elem_type 7 (INT64) for batch_indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for batch_indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_rotary_embedding/model.onnx",
-    "Unsupported elem_type 7 (INT64) for position_ids. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for position_ids. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_rotary_embedding_3d_input/model.onnx",
-    "Unsupported elem_type 7 (INT64) for position_ids. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for position_ids. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_rotary_embedding_3d_input_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for position_ids. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for position_ids. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_rotary_embedding_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for position_ids. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for position_ids. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_rotary_embedding_interleaved/model.onnx",
-    "Unsupported elem_type 7 (INT64) for position_ids. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for position_ids. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_rotary_embedding_interleaved_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for position_ids. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for position_ids. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_rotary_embedding_no_position_ids/model.onnx",
@@ -5389,19 +5389,19 @@
   ],
   [
     "node/test_rotary_embedding_with_interleaved_rotary_dim/model.onnx",
-    "Unsupported elem_type 7 (INT64) for position_ids. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for position_ids. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_rotary_embedding_with_interleaved_rotary_dim_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for position_ids. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for position_ids. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_rotary_embedding_with_rotary_dim/model.onnx",
-    "Unsupported elem_type 7 (INT64) for position_ids. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for position_ids. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_rotary_embedding_with_rotary_dim_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for position_ids. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for position_ids. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_round/model.onnx",
@@ -5417,327 +5417,327 @@
   ],
   [
     "node/test_scatter_elements_with_axis/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_scatter_elements_with_duplicate_indices/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_scatter_elements_with_negative_indices/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_scatter_elements_with_reduction_max/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_scatter_elements_with_reduction_min/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_scatter_elements_without_axis/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_scatter_with_axis/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_scatter_without_axis/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_scatternd/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_scatternd_add/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_scatternd_max/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_scatternd_min/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_scatternd_multiply/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_3d/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_3d_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_3d_log_prob/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_3d_log_prob_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_log_prob/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_log_prob_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_no_weight_ii/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_log_prob/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_log_prob/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_no_weight_ii_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_no_weight_ii_log_prob/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_weight/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_weight_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_weight_ii/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_weight_ii_3d/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_weight_ii_3d_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_weight_ii_3d_log_prob/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_weight_ii_4d/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_weight_ii_4d_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_weight_ii_4d_log_prob/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_weight_ii_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_weight_ii_log_prob/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_weight_log_prob/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_mean_weight_log_prob_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_none/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_none_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_none_log_prob/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_none_log_prob_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_none_weights/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_none_weights_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_none_weights_log_prob/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_none_weights_log_prob_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_sum/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_sum_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_sum_log_prob/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sce_sum_log_prob_expanded/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_selu/model.onnx",
@@ -5821,47 +5821,47 @@
   ],
   [
     "node/test_shape/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_shape_clip_end/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_shape_clip_start/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_shape_end_1/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_shape_end_negative_1/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_shape_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_shape_start_1/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_shape_start_1_end_2/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_shape_start_1_end_negative_1/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_shape_start_greater_than_end/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_shape_start_negative_1/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_shrink_hard/model.onnx",
@@ -5921,43 +5921,43 @@
   ],
   [
     "node/test_size/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_size_example/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_slice/model.onnx",
-    "Unsupported elem_type 7 (INT64) for starts. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for starts. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_slice_default_axes/model.onnx",
-    "Unsupported elem_type 7 (INT64) for starts. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for starts. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_slice_default_steps/model.onnx",
-    "Unsupported elem_type 7 (INT64) for starts. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for starts. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_slice_end_out_of_bounds/model.onnx",
-    "Unsupported elem_type 7 (INT64) for starts. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for starts. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_slice_neg/model.onnx",
-    "Unsupported elem_type 7 (INT64) for starts. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for starts. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_slice_neg_steps/model.onnx",
-    "Unsupported elem_type 7 (INT64) for starts. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for starts. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_slice_negative_axes/model.onnx",
-    "Unsupported elem_type 7 (INT64) for starts. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for starts. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_slice_start_out_of_bounds/model.onnx",
-    "Unsupported elem_type 7 (INT64) for starts. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for starts. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_softmax_axis_0/model.onnx",
@@ -6117,11 +6117,11 @@
   ],
   [
     "node/test_split_to_sequence_1/model.onnx",
-    "Unsupported elem_type 7 (INT64) for split. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for split. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_split_to_sequence_2/model.onnx",
-    "Unsupported elem_type 7 (INT64) for split. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for split. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_split_to_sequence_nokeepdims/model.onnx",
@@ -6129,35 +6129,35 @@
   ],
   [
     "node/test_split_variable_parts_1d_opset13/model.onnx",
-    "Unsupported elem_type 7 (INT64) for split. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for split. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_split_variable_parts_1d_opset18/model.onnx",
-    "Unsupported elem_type 7 (INT64) for split. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for split. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_split_variable_parts_2d_opset13/model.onnx",
-    "Unsupported elem_type 7 (INT64) for split. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for split. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_split_variable_parts_2d_opset18/model.onnx",
-    "Unsupported elem_type 7 (INT64) for split. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for split. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_split_variable_parts_default_axis_opset13/model.onnx",
-    "Unsupported elem_type 7 (INT64) for split. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for split. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_split_variable_parts_default_axis_opset18/model.onnx",
-    "Unsupported elem_type 7 (INT64) for split. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for split. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_split_zero_size_splits_opset13/model.onnx",
-    "Unsupported elem_type 7 (INT64) for split. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for split. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_split_zero_size_splits_opset18/model.onnx",
-    "Unsupported elem_type 7 (INT64) for split. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for split. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sqrt/model.onnx",
@@ -6169,87 +6169,87 @@
   ],
   [
     "node/test_squeeze/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_squeeze_negative_axes/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_stft/model.onnx",
-    "Unsupported elem_type 7 (INT64) for frame_step. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for frame_step. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_stft_with_window/model.onnx",
-    "Unsupported elem_type 7 (INT64) for frame_step. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for frame_step. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_string_concat/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_string_concat_broadcasting/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_string_concat_empty_string/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_string_concat_utf8/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_string_concat_zero_dimensional/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_string_split_basic/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_string_split_consecutive_delimiters/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_string_split_empty_string_delimiter/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_string_split_empty_tensor/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_string_split_maxsplit/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_string_split_no_delimiter/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_strnormalizer_export_monday_casesensintive_lower/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_strnormalizer_export_monday_casesensintive_nochangecase/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_strnormalizer_export_monday_casesensintive_upper/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_strnormalizer_export_monday_empty_output/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_strnormalizer_export_monday_insensintive_upper_twodim/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_strnormalizer_nostopwords_nochangecase/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sub/model.onnx",
@@ -6265,27 +6265,27 @@
   ],
   [
     "node/test_sub_int16/model.onnx",
-    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 5 (INT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sub_int8/model.onnx",
-    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 3 (INT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sub_uint16/model.onnx",
-    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 4 (UINT16) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sub_uint32/model.onnx",
-    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 12 (UINT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sub_uint64/model.onnx",
-    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sub_uint8/model.onnx",
-    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 2 (UINT8) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_sum_example/model.onnx",
@@ -6325,43 +6325,43 @@
   ],
   [
     "node/test_tensorscatter/model.onnx",
-    "Unsupported elem_type 7 (INT64) for write_indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for write_indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_tensorscatter_3d/model.onnx",
-    "Unsupported elem_type 7 (INT64) for write_indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for write_indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_tensorscatter_circular/model.onnx",
-    "Unsupported elem_type 7 (INT64) for write_indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for write_indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_tfidfvectorizer_tf_batch_onlybigrams_skip0/model.onnx",
-    "Unsupported elem_type 6 (INT32) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for X. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_tfidfvectorizer_tf_batch_onlybigrams_skip5/model.onnx",
-    "Unsupported elem_type 6 (INT32) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for X. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_tfidfvectorizer_tf_batch_uniandbigrams_skip5/model.onnx",
-    "Unsupported elem_type 6 (INT32) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for X. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_tfidfvectorizer_tf_only_bigrams_skip0/model.onnx",
-    "Unsupported elem_type 6 (INT32) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for X. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_tfidfvectorizer_tf_onlybigrams_levelempty/model.onnx",
-    "Unsupported elem_type 6 (INT32) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for X. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_tfidfvectorizer_tf_onlybigrams_skip5/model.onnx",
-    "Unsupported elem_type 6 (INT32) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for X. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_tfidfvectorizer_tf_uniandbigrams_skip5/model.onnx",
-    "Unsupported elem_type 6 (INT32) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for X. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_thresholdedrelu/model.onnx",
@@ -6389,63 +6389,63 @@
   ],
   [
     "node/test_tile/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_tile_precomputed/model.onnx",
-    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for y. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_top_k/model.onnx",
-    "Unsupported elem_type 7 (INT64) for k. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for k. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_top_k_negative_axis/model.onnx",
-    "Unsupported elem_type 7 (INT64) for k. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for k. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_top_k_same_values/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_top_k_same_values_2d/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_top_k_same_values_largest/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_top_k_smallest/model.onnx",
-    "Unsupported elem_type 7 (INT64) for k. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for k. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_top_k_uint64/model.onnx",
-    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 13 (UINT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_training_dropout/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for t. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for t. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_training_dropout_default/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for t. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for t. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_training_dropout_default_mask/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for t. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for t. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_training_dropout_mask/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for t. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for t. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_training_dropout_zero_ratio/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for t. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for t. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_training_dropout_zero_ratio_mask/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for t. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for t. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_transpose_all_permutations_0/model.onnx",
@@ -6477,127 +6477,127 @@
   ],
   [
     "node/test_tril/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_tril_neg/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_tril_one_row_neg/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_tril_out_neg/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_tril_out_pos/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_tril_pos/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_tril_square/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_tril_square_neg/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_tril_zero/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_triu/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_triu_neg/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_triu_one_row/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_triu_out_neg_out/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_triu_out_pos/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_triu_pos/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_triu_square/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_triu_square_neg/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_triu_zero/model.onnx",
-    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_unique_length_1/model.onnx",
-    "Unsupported elem_type 7 (INT64) for X. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for X. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_unique_not_sorted_without_axis/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_unique_sorted_with_axis/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_unique_sorted_with_axis_3d/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_unique_sorted_with_negative_axis/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_unique_sorted_without_axis/model.onnx",
-    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for indices. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_unsqueeze_axis_0/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_unsqueeze_axis_1/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_unsqueeze_axis_2/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_unsqueeze_negative_axes/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_unsqueeze_three_axes/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_unsqueeze_two_axes/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_unsqueeze_unsorted_axes/model.onnx",
-    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for axes. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_upsample_nearest/model.onnx",
@@ -6605,47 +6605,47 @@
   ],
   [
     "node/test_where_example/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for condition. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for condition. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_where_long_example/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for condition. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for condition. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_wrap_pad/model.onnx",
-    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 6 (INT32) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_xor2d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_xor3d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_xor4d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_xor_bcast3v1d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_xor_bcast3v2d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_xor_bcast4v2d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_xor_bcast4v3d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "node/test_xor_bcast4v4d/model.onnx",
-    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 9 (BOOL) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "pytorch-converted/test_AvgPool1d/model.onnx",
@@ -6817,11 +6817,11 @@
   ],
   [
     "pytorch-converted/test_Embedding/model.onnx",
-    "Unsupported elem_type 7 (INT64) for 0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for 0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "pytorch-converted/test_Embedding_sparse/model.onnx",
-    "Unsupported elem_type 7 (INT64) for 0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for 0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "pytorch-converted/test_GLU/model.onnx",
@@ -6977,23 +6977,23 @@
   ],
   [
     "pytorch-operator/test_operator_add_broadcast/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for 0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for 0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "pytorch-operator/test_operator_add_size1_broadcast/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for 0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for 0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "pytorch-operator/test_operator_add_size1_right_broadcast/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for 0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for 0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "pytorch-operator/test_operator_add_size1_singleton_broadcast/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for 0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for 0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "pytorch-operator/test_operator_addconstant/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for 0. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 11 (DOUBLE) for 0. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "pytorch-operator/test_operator_addmm/model.onnx",
@@ -7117,19 +7117,19 @@
   ],
   [
     "simple/test_expand_shape_model1/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "simple/test_expand_shape_model2/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "simple/test_expand_shape_model3/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "simple/test_expand_shape_model4/model.onnx",
-    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for shape. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "simple/test_gradient_of_add/model.onnx",
@@ -7161,7 +7161,7 @@
   ],
   [
     "simple/test_sequence_model6/model.onnx",
-    "Unsupported elem_type 7 (INT64) for len. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 7 (INT64) for len. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "simple/test_sequence_model7/model.onnx",
@@ -7185,26 +7185,26 @@
   ],
   [
     "simple/test_strnorm_model_monday_casesensintive_lower/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "simple/test_strnorm_model_monday_casesensintive_nochangecase/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "simple/test_strnorm_model_monday_casesensintive_upper/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "simple/test_strnorm_model_monday_empty_output/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "simple/test_strnorm_model_monday_insensintive_upper_twodim/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ],
   [
     "simple/test_strnorm_model_nostopwords_nochangecase/model.onnx",
-    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT). Hint: export the model with float32 tensors."
+    "Unsupported elem_type 8 (STRING) for x. Supported elem_types: 1 (FLOAT)."
   ]
 ]


### PR DESCRIPTION
### Motivation

- Remove the trailing suggestion "Hint: export the model with float32 tensors." from unsupported elem_type error messages to reduce noise and match the canonical expected error strings.
- Ensure deterministic, compact error messages used in automated comparisons and test expectations.

### Description

- Drop the `"Hint: export the model with float32 tensors."` suffix from the `Unsupported elem_type` error in `_tensor_type` inside `src/onnx2c/onnx_import.py`.
- Update `tests/official_onnx_expected_errors.json` to remove the same hint from all expected error strings so tests align with the new message text.
- Apply small formatting adjustments to keep punctuation consistent after removing the hint.

### Testing

- Ran the test suite with `pytest -n auto -q`.
- Result: `51 passed` in `7.81s`.
- The previously failing `test_official_onnx_expected_errors` is now passing after aligning the expected strings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696319b61f9c8325a50722a58d29ce92)