### PR TITLE
onnx-import: import ONNX Constant as Initializer and normalize initializer dtypes

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 103 / 1802 official ONNX files.
+Support 104 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -458,7 +458,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_ceil/model.onnx` | ✅ |  |
 | `node/test_ceil_example/model.onnx` | ✅ |  |
 | `node/test_celu/model.onnx` | ❌ | Unsupported op Celu |
-| `node/test_celu_expanded/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_celu_expanded/model.onnx` | ❌ | Unsupported op Elu |
 | `node/test_center_crop_pad_crop/model.onnx` | ❌ | CenterCropPad expects matching dtypes, got float, int64 |
 | `node/test_center_crop_pad_crop_and_pad/model.onnx` | ❌ | CenterCropPad expects matching dtypes, got float, int64 |
 | `node/test_center_crop_pad_crop_and_pad_expanded/model.onnx` | ❌ | Dynamic dim for tensor 'CenterCropPad_test_center_crop_pad_crop_and_pad_expanded_function_padded_input' |
@@ -516,7 +516,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_concat_3d_axis_negative_1/model.onnx` | ❌ | Unsupported op Concat |
 | `node/test_concat_3d_axis_negative_2/model.onnx` | ❌ | Unsupported op Concat |
 | `node/test_concat_3d_axis_negative_3/model.onnx` | ❌ | Unsupported op Concat |
-| `node/test_constant/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_constant/model.onnx` | ❌ | Graph must contain at least one node |
 | `node/test_constant_pad/model.onnx` | ❌ | Pad expects matching dtypes, got float, int64 |
 | `node/test_constant_pad_axes/model.onnx` | ❌ | Pad expects matching dtypes, got float, int64 |
 | `node/test_constant_pad_negative_axes/model.onnx` | ❌ | Pad expects matching dtypes, got float, int64 |
@@ -609,10 +609,10 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_einsum_transpose/model.onnx` | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'x'. |
 | `node/test_elu/model.onnx` | ❌ | Unsupported op Elu |
 | `node/test_elu_default/model.onnx` | ❌ | Unsupported op Elu |
-| `node/test_elu_default_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_elu_default_expanded_ver18/model.onnx` | ❌ | Unsupported op CastLike |
 | `node/test_elu_example/model.onnx` | ❌ | Unsupported op Elu |
-| `node/test_elu_example_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
-| `node/test_elu_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_elu_example_expanded_ver18/model.onnx` | ❌ | Unsupported op CastLike |
+| `node/test_elu_expanded_ver18/model.onnx` | ❌ | Unsupported op CastLike |
 | `node/test_equal/model.onnx` | ❌ | Equal expects matching dtypes, got bool, int32 |
 | `node/test_equal_bcast/model.onnx` | ❌ | Equal expects matching dtypes, got bool, int32 |
 | `node/test_equal_int16/model.onnx` | ❌ | Equal expects matching dtypes, got bool, int16 |
@@ -653,13 +653,13 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_gathernd_example_int32/model.onnx` | ❌ | GatherND expects matching dtypes, got int32, int64 |
 | `node/test_gathernd_example_int32_batch_dim1/model.onnx` | ❌ | GatherND expects matching dtypes, got int32, int64 |
 | `node/test_gelu_default_1/model.onnx` | ❌ | Unsupported op Gelu |
-| `node/test_gelu_default_1_expanded/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_gelu_default_1_expanded/model.onnx` | ❌ | Unsupported op CastLike |
 | `node/test_gelu_default_2/model.onnx` | ❌ | Unsupported op Gelu |
-| `node/test_gelu_default_2_expanded/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_gelu_default_2_expanded/model.onnx` | ❌ | Unsupported op CastLike |
 | `node/test_gelu_tanh_1/model.onnx` | ❌ | Unsupported op Gelu |
-| `node/test_gelu_tanh_1_expanded/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_gelu_tanh_1_expanded/model.onnx` | ❌ | Unsupported op CastLike |
 | `node/test_gelu_tanh_2/model.onnx` | ❌ | Unsupported op Gelu |
-| `node/test_gelu_tanh_2_expanded/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_gelu_tanh_2_expanded/model.onnx` | ❌ | Unsupported op CastLike |
 | `node/test_gemm_all_attributes/model.onnx` | ❌ | Gemm must have 2 inputs and 1 output |
 | `node/test_gemm_alpha/model.onnx` | ❌ | Gemm must have 2 inputs and 1 output |
 | `node/test_gemm_beta/model.onnx` | ❌ | Gemm must have 2 inputs and 1 output |
@@ -742,10 +742,10 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_hardmax_one_hot/model.onnx` | ❌ | Unsupported op Hardmax |
 | `node/test_hardsigmoid/model.onnx` | ❌ | Unsupported op HardSigmoid |
 | `node/test_hardsigmoid_default/model.onnx` | ❌ | Unsupported op HardSigmoid |
-| `node/test_hardsigmoid_default_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_hardsigmoid_default_expanded_ver18/model.onnx` | ❌ | Unsupported op CastLike |
 | `node/test_hardsigmoid_example/model.onnx` | ❌ | Unsupported op HardSigmoid |
-| `node/test_hardsigmoid_example_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
-| `node/test_hardsigmoid_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_hardsigmoid_example_expanded_ver18/model.onnx` | ❌ | Unsupported op CastLike |
+| `node/test_hardsigmoid_expanded_ver18/model.onnx` | ❌ | Unsupported op CastLike |
 | `node/test_hardswish/model.onnx` | ❌ | Unsupported op HardSwish |
 | `node/test_hardswish_expanded/model.onnx` | ❌ | Unsupported op HardSigmoid |
 | `node/test_identity/model.onnx` | ❌ | Unsupported op Identity |
@@ -835,10 +835,10 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_layer_normalization_default_axis_expanded_ver18/model.onnx` | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_default_axis_expanded_function_SuffixShape' |
 | `node/test_leakyrelu/model.onnx` | ❌ | Unsupported op LeakyRelu |
 | `node/test_leakyrelu_default/model.onnx` | ❌ | Unsupported op LeakyRelu |
-| `node/test_leakyrelu_default_expanded/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_leakyrelu_default_expanded/model.onnx` | ❌ | Unsupported op CastLike |
 | `node/test_leakyrelu_example/model.onnx` | ❌ | Unsupported op LeakyRelu |
-| `node/test_leakyrelu_example_expanded/model.onnx` | ❌ | Unsupported op Constant |
-| `node/test_leakyrelu_expanded/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_leakyrelu_example_expanded/model.onnx` | ❌ | Unsupported op CastLike |
+| `node/test_leakyrelu_expanded/model.onnx` | ❌ | Unsupported op CastLike |
 | `node/test_less/model.onnx` | ❌ | Less expects matching dtypes, got bool, float |
 | `node/test_less_bcast/model.onnx` | ❌ | Less expects matching dtypes, got bool, float |
 | `node/test_less_equal/model.onnx` | ❌ | LessOrEqual expects matching dtypes, got bool, float |
@@ -866,26 +866,26 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_log/model.onnx` | ✅ |  |
 | `node/test_log_example/model.onnx` | ✅ |  |
 | `node/test_logsoftmax_axis_0/model.onnx` | ❌ | Unsupported op LogSoftmax |
-| `node/test_logsoftmax_axis_0_expanded/model.onnx` | ❌ | Unsupported op Constant |
-| `node/test_logsoftmax_axis_0_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_logsoftmax_axis_0_expanded/model.onnx` | ❌ | Unsupported op ReduceMax |
+| `node/test_logsoftmax_axis_0_expanded_ver18/model.onnx` | ❌ | ReduceMax expects matching dtypes, got float, int64 |
 | `node/test_logsoftmax_axis_1/model.onnx` | ❌ | Unsupported op LogSoftmax |
-| `node/test_logsoftmax_axis_1_expanded/model.onnx` | ❌ | Unsupported op Constant |
-| `node/test_logsoftmax_axis_1_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_logsoftmax_axis_1_expanded/model.onnx` | ❌ | Unsupported op ReduceMax |
+| `node/test_logsoftmax_axis_1_expanded_ver18/model.onnx` | ❌ | ReduceMax expects matching dtypes, got float, int64 |
 | `node/test_logsoftmax_axis_2/model.onnx` | ❌ | Unsupported op LogSoftmax |
-| `node/test_logsoftmax_axis_2_expanded/model.onnx` | ❌ | Unsupported op Constant |
-| `node/test_logsoftmax_axis_2_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_logsoftmax_axis_2_expanded/model.onnx` | ❌ | Unsupported op ReduceMax |
+| `node/test_logsoftmax_axis_2_expanded_ver18/model.onnx` | ❌ | ReduceMax expects matching dtypes, got float, int64 |
 | `node/test_logsoftmax_default_axis/model.onnx` | ❌ | Unsupported op LogSoftmax |
-| `node/test_logsoftmax_default_axis_expanded/model.onnx` | ❌ | Unsupported op Constant |
-| `node/test_logsoftmax_default_axis_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_logsoftmax_default_axis_expanded/model.onnx` | ❌ | Unsupported op ReduceMax |
+| `node/test_logsoftmax_default_axis_expanded_ver18/model.onnx` | ❌ | ReduceMax expects matching dtypes, got float, int64 |
 | `node/test_logsoftmax_example_1/model.onnx` | ❌ | Unsupported op LogSoftmax |
-| `node/test_logsoftmax_example_1_expanded/model.onnx` | ❌ | Unsupported op Constant |
-| `node/test_logsoftmax_example_1_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_logsoftmax_example_1_expanded/model.onnx` | ❌ | Unsupported op ReduceMax |
+| `node/test_logsoftmax_example_1_expanded_ver18/model.onnx` | ❌ | ReduceMax expects matching dtypes, got float, int64 |
 | `node/test_logsoftmax_large_number/model.onnx` | ❌ | Unsupported op LogSoftmax |
-| `node/test_logsoftmax_large_number_expanded/model.onnx` | ❌ | Unsupported op Constant |
-| `node/test_logsoftmax_large_number_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_logsoftmax_large_number_expanded/model.onnx` | ❌ | Unsupported op ReduceMax |
+| `node/test_logsoftmax_large_number_expanded_ver18/model.onnx` | ❌ | ReduceMax expects matching dtypes, got float, int64 |
 | `node/test_logsoftmax_negative_axis/model.onnx` | ❌ | Unsupported op LogSoftmax |
-| `node/test_logsoftmax_negative_axis_expanded/model.onnx` | ❌ | Unsupported op Constant |
-| `node/test_logsoftmax_negative_axis_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_logsoftmax_negative_axis_expanded/model.onnx` | ❌ | Unsupported op ReduceMax |
+| `node/test_logsoftmax_negative_axis_expanded_ver18/model.onnx` | ❌ | ReduceMax expects matching dtypes, got float, int64 |
 | `node/test_loop11/model.onnx` | ❌ | Only single-output graphs are supported |
 | `node/test_loop13_seq/model.onnx` | ❌ | Missing elem_type for tensor 'seq_empty' |
 | `node/test_loop16_seq_none/model.onnx` | ❌ | Missing elem_type for tensor 'opt_seq' |
@@ -992,13 +992,13 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_mul_uint64/model.onnx` | ❌ | Unsupported elem_type 13 (UINT64) for tensor 'x'. |
 | `node/test_mul_uint8/model.onnx` | ❌ | Unsupported elem_type 2 (UINT8) for tensor 'x'. |
 | `node/test_mvn/model.onnx` | ❌ | Unsupported op MeanVarianceNormalization |
-| `node/test_mvn_expanded/model.onnx` | ❌ | Unsupported op Constant |
-| `node/test_mvn_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_mvn_expanded/model.onnx` | ❌ | Unsupported op ReduceMean |
+| `node/test_mvn_expanded_ver18/model.onnx` | ❌ | ReduceMean expects matching dtypes, got float, int64 |
 | `node/test_neg/model.onnx` | ✅ |  |
 | `node/test_neg_example/model.onnx` | ✅ |  |
 | `node/test_nesterov_momentum/model.onnx` | ❌ | Only single-output graphs are supported |
 | `node/test_nllloss_NC/model.onnx` | ❌ | NegativeLogLikelihoodLoss expects matching dtypes, got float, int64 |
-| `node/test_nllloss_NC_expanded/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_nllloss_NC_expanded/model.onnx` | ❌ | Unsupported op Unsqueeze |
 | `node/test_nllloss_NCd1/model.onnx` | ❌ | Scalar outputs are not supported |
 | `node/test_nllloss_NCd1_expanded/model.onnx` | ❌ | Scalar outputs are not supported |
 | `node/test_nllloss_NCd1_ii/model.onnx` | ❌ | Scalar outputs are not supported |
@@ -1010,7 +1010,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_nllloss_NCd1_weight_ii/model.onnx` | ❌ | Scalar outputs are not supported |
 | `node/test_nllloss_NCd1_weight_ii_expanded/model.onnx` | ❌ | Scalar outputs are not supported |
 | `node/test_nllloss_NCd1d2/model.onnx` | ❌ | NegativeLogLikelihoodLoss expects matching dtypes, got float, int64 |
-| `node/test_nllloss_NCd1d2_expanded/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_nllloss_NCd1d2_expanded/model.onnx` | ❌ | Unsupported op Unsqueeze |
 | `node/test_nllloss_NCd1d2_no_weight_reduction_mean_ii/model.onnx` | ❌ | Scalar outputs are not supported |
 | `node/test_nllloss_NCd1d2_no_weight_reduction_mean_ii_expanded/model.onnx` | ❌ | Scalar outputs are not supported |
 | `node/test_nllloss_NCd1d2_reduction_mean/model.onnx` | ❌ | Scalar outputs are not supported |
@@ -1018,7 +1018,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_nllloss_NCd1d2_reduction_sum/model.onnx` | ❌ | Scalar outputs are not supported |
 | `node/test_nllloss_NCd1d2_reduction_sum_expanded/model.onnx` | ❌ | Scalar outputs are not supported |
 | `node/test_nllloss_NCd1d2_with_weight/model.onnx` | ❌ | NegativeLogLikelihoodLoss expects matching dtypes, got float, int64 |
-| `node/test_nllloss_NCd1d2_with_weight_expanded/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_nllloss_NCd1d2_with_weight_expanded/model.onnx` | ❌ | Unsupported op Unsqueeze |
 | `node/test_nllloss_NCd1d2_with_weight_reduction_mean/model.onnx` | ❌ | Scalar outputs are not supported |
 | `node/test_nllloss_NCd1d2_with_weight_reduction_mean_expanded/model.onnx` | ❌ | Scalar outputs are not supported |
 | `node/test_nllloss_NCd1d2_with_weight_reduction_sum/model.onnx` | ❌ | Scalar outputs are not supported |
@@ -1026,13 +1026,13 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_nllloss_NCd1d2_with_weight_reduction_sum_ii/model.onnx` | ❌ | Scalar outputs are not supported |
 | `node/test_nllloss_NCd1d2_with_weight_reduction_sum_ii_expanded/model.onnx` | ❌ | Scalar outputs are not supported |
 | `node/test_nllloss_NCd1d2d3_none_no_weight_negative_ii/model.onnx` | ❌ | NegativeLogLikelihoodLoss expects matching dtypes, got float, int64 |
-| `node/test_nllloss_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_nllloss_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx` | ❌ | Unsupported op Unsqueeze |
 | `node/test_nllloss_NCd1d2d3_sum_weight_high_ii/model.onnx` | ❌ | Scalar outputs are not supported |
 | `node/test_nllloss_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx` | ❌ | Scalar outputs are not supported |
 | `node/test_nllloss_NCd1d2d3d4d5_mean_weight/model.onnx` | ❌ | Scalar outputs are not supported |
 | `node/test_nllloss_NCd1d2d3d4d5_mean_weight_expanded/model.onnx` | ❌ | Scalar outputs are not supported |
 | `node/test_nllloss_NCd1d2d3d4d5_none_no_weight/model.onnx` | ❌ | NegativeLogLikelihoodLoss expects matching dtypes, got float, int64 |
-| `node/test_nllloss_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_nllloss_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx` | ❌ | Unsupported op Unsqueeze |
 | `node/test_nonmaxsuppression_center_point_box_format/model.onnx` | ❌ | NonMaxSuppression expects matching dtypes, got float, int64 |
 | `node/test_nonmaxsuppression_flipped_coordinates/model.onnx` | ❌ | NonMaxSuppression expects matching dtypes, got float, int64 |
 | `node/test_nonmaxsuppression_identical_boxes/model.onnx` | ❌ | NonMaxSuppression expects matching dtypes, got float, int64 |
@@ -1082,9 +1082,9 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_pow_types_int64_float32/model.onnx` | ❌ | Pow expects matching dtypes, got float, int64 |
 | `node/test_pow_types_int64_int64/model.onnx` | ❌ | Unsupported op Pow |
 | `node/test_prelu_broadcast/model.onnx` | ✅ |  |
-| `node/test_prelu_broadcast_expanded/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_prelu_broadcast_expanded/model.onnx` | ❌ | Unsupported op CastLike |
 | `node/test_prelu_example/model.onnx` | ✅ |  |
-| `node/test_prelu_example_expanded/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_prelu_example_expanded/model.onnx` | ❌ | Unsupported op CastLike |
 | `node/test_qlinearconv/model.onnx` | ❌ | Unsupported elem_type 2 (UINT8) for tensor 'x'. |
 | `node/test_qlinearmatmul_2D_int8_float16/model.onnx` | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'a_scale'. |
 | `node/test_qlinearmatmul_2D_int8_float32/model.onnx` | ❌ | QLinearMatMul expects matching dtypes, got float, int8 |
@@ -1249,7 +1249,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_regex_full_match_email_domain/model.onnx` | ❌ | Unsupported elem_type 8 (STRING) for tensor 'X'. |
 | `node/test_regex_full_match_empty/model.onnx` | ❌ | Unsupported elem_type 8 (STRING) for tensor 'X'. |
 | `node/test_relu/model.onnx` | ✅ |  |
-| `node/test_relu_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_relu_expanded_ver18/model.onnx` | ❌ | Unsupported op CastLike |
 | `node/test_reshape_allowzero_reordered/model.onnx` | ❌ | Dynamic or zero dims are not supported |
 | `node/test_reshape_extended_dims/model.onnx` | ❌ | Reshape expects matching dtypes, got float, int64 |
 | `node/test_reshape_negative_dim/model.onnx` | ❌ | Reshape expects matching dtypes, got float, int64 |
@@ -1380,7 +1380,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx` | ❌ | Only single-output graphs are supported |
 | `node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx` | ❌ | Only single-output graphs are supported |
 | `node/test_sce_NCd1d2d3_none_no_weight_negative_ii/model.onnx` | ❌ | SoftmaxCrossEntropyLoss expects matching dtypes, got float, int64 |
-| `node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx` | ❌ | Reshape expects matching dtypes, got float, int64 |
 | `node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob/model.onnx` | ❌ | Only single-output graphs are supported |
 | `node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx` | ❌ | Only single-output graphs are supported |
 | `node/test_sce_NCd1d2d3_sum_weight_high_ii/model.onnx` | ❌ | Scalar outputs are not supported |
@@ -1392,7 +1392,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx` | ❌ | Only single-output graphs are supported |
 | `node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx` | ❌ | Only single-output graphs are supported |
 | `node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx` | ❌ | SoftmaxCrossEntropyLoss expects matching dtypes, got float, int64 |
-| `node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx` | ❌ | Reshape expects matching dtypes, got float, int64 |
 | `node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx` | ❌ | Only single-output graphs are supported |
 | `node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx` | ❌ | Only single-output graphs are supported |
 | `node/test_sce_mean/model.onnx` | ❌ | Scalar outputs are not supported |
@@ -1432,11 +1432,11 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_sce_mean_weight_log_prob/model.onnx` | ❌ | Only single-output graphs are supported |
 | `node/test_sce_mean_weight_log_prob_expanded/model.onnx` | ❌ | Only single-output graphs are supported |
 | `node/test_sce_none/model.onnx` | ❌ | SoftmaxCrossEntropyLoss expects matching dtypes, got float, int64 |
-| `node/test_sce_none_expanded/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_sce_none_expanded/model.onnx` | ❌ | Reshape expects matching dtypes, got float, int64 |
 | `node/test_sce_none_log_prob/model.onnx` | ❌ | Only single-output graphs are supported |
 | `node/test_sce_none_log_prob_expanded/model.onnx` | ❌ | Only single-output graphs are supported |
 | `node/test_sce_none_weights/model.onnx` | ❌ | SoftmaxCrossEntropyLoss expects matching dtypes, got float, int64 |
-| `node/test_sce_none_weights_expanded/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_sce_none_weights_expanded/model.onnx` | ❌ | Reshape expects matching dtypes, got float, int64 |
 | `node/test_sce_none_weights_log_prob/model.onnx` | ❌ | Only single-output graphs are supported |
 | `node/test_sce_none_weights_log_prob_expanded/model.onnx` | ❌ | Only single-output graphs are supported |
 | `node/test_sce_sum/model.onnx` | ❌ | Scalar outputs are not supported |
@@ -1445,10 +1445,10 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_sce_sum_log_prob_expanded/model.onnx` | ❌ | Only single-output graphs are supported |
 | `node/test_selu/model.onnx` | ❌ | Unsupported op Selu |
 | `node/test_selu_default/model.onnx` | ❌ | Unsupported op Selu |
-| `node/test_selu_default_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_selu_default_expanded_ver18/model.onnx` | ❌ | Unsupported op CastLike |
 | `node/test_selu_example/model.onnx` | ❌ | Unsupported op Selu |
-| `node/test_selu_example_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
-| `node/test_selu_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_selu_example_expanded_ver18/model.onnx` | ❌ | Unsupported op CastLike |
+| `node/test_selu_expanded_ver18/model.onnx` | ❌ | Unsupported op CastLike |
 | `node/test_sequence_insert_at_back/model.onnx` | ❌ | Missing elem_type for tensor 'sequence' |
 | `node/test_sequence_insert_at_front/model.onnx` | ❌ | Missing elem_type for tensor 'sequence' |
 | `node/test_sequence_map_add_1_sequence_1_tensor/model.onnx` | ❌ | Missing elem_type for tensor 'x0' |
@@ -1475,9 +1475,9 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_shape_start_greater_than_end/model.onnx` | ❌ | Dynamic or zero dims are not supported |
 | `node/test_shape_start_negative_1/model.onnx` | ❌ | Shape expects matching dtypes, got float, int64 |
 | `node/test_shrink_hard/model.onnx` | ❌ | Unsupported op Shrink |
-| `node/test_shrink_hard_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_shrink_hard_expanded_ver18/model.onnx` | ❌ | Unsupported op CastLike |
 | `node/test_shrink_soft/model.onnx` | ❌ | Unsupported op Shrink |
-| `node/test_shrink_soft_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_shrink_soft_expanded_ver18/model.onnx` | ❌ | Unsupported op CastLike |
 | `node/test_sigmoid/model.onnx` | ❌ | Unsupported op Sigmoid |
 | `node/test_sigmoid_example/model.onnx` | ❌ | Unsupported op Sigmoid |
 | `node/test_sign/model.onnx` | ❌ | Unsupported op Sign |
@@ -1499,34 +1499,34 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_slice_negative_axes/model.onnx` | ❌ | Slice expects matching dtypes, got float, int64 |
 | `node/test_slice_start_out_of_bounds/model.onnx` | ❌ | Dynamic or zero dims are not supported |
 | `node/test_softmax_axis_0/model.onnx` | ❌ | Unsupported op Softmax |
-| `node/test_softmax_axis_0_expanded/model.onnx` | ❌ | Unsupported op Constant |
-| `node/test_softmax_axis_0_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_softmax_axis_0_expanded/model.onnx` | ❌ | Unsupported op ReduceMax |
+| `node/test_softmax_axis_0_expanded_ver18/model.onnx` | ❌ | ReduceMax expects matching dtypes, got float, int64 |
 | `node/test_softmax_axis_1/model.onnx` | ❌ | Unsupported op Softmax |
-| `node/test_softmax_axis_1_expanded/model.onnx` | ❌ | Unsupported op Constant |
-| `node/test_softmax_axis_1_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_softmax_axis_1_expanded/model.onnx` | ❌ | Unsupported op ReduceMax |
+| `node/test_softmax_axis_1_expanded_ver18/model.onnx` | ❌ | ReduceMax expects matching dtypes, got float, int64 |
 | `node/test_softmax_axis_2/model.onnx` | ❌ | Unsupported op Softmax |
-| `node/test_softmax_axis_2_expanded/model.onnx` | ❌ | Unsupported op Constant |
-| `node/test_softmax_axis_2_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_softmax_axis_2_expanded/model.onnx` | ❌ | Unsupported op ReduceMax |
+| `node/test_softmax_axis_2_expanded_ver18/model.onnx` | ❌ | ReduceMax expects matching dtypes, got float, int64 |
 | `node/test_softmax_default_axis/model.onnx` | ❌ | Unsupported op Softmax |
-| `node/test_softmax_default_axis_expanded/model.onnx` | ❌ | Unsupported op Constant |
-| `node/test_softmax_default_axis_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_softmax_default_axis_expanded/model.onnx` | ❌ | Unsupported op ReduceMax |
+| `node/test_softmax_default_axis_expanded_ver18/model.onnx` | ❌ | ReduceMax expects matching dtypes, got float, int64 |
 | `node/test_softmax_example/model.onnx` | ❌ | Unsupported op Softmax |
-| `node/test_softmax_example_expanded/model.onnx` | ❌ | Unsupported op Constant |
-| `node/test_softmax_example_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_softmax_example_expanded/model.onnx` | ❌ | Unsupported op ReduceMax |
+| `node/test_softmax_example_expanded_ver18/model.onnx` | ❌ | ReduceMax expects matching dtypes, got float, int64 |
 | `node/test_softmax_large_number/model.onnx` | ❌ | Unsupported op Softmax |
-| `node/test_softmax_large_number_expanded/model.onnx` | ❌ | Unsupported op Constant |
-| `node/test_softmax_large_number_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_softmax_large_number_expanded/model.onnx` | ❌ | Unsupported op ReduceMax |
+| `node/test_softmax_large_number_expanded_ver18/model.onnx` | ❌ | ReduceMax expects matching dtypes, got float, int64 |
 | `node/test_softmax_negative_axis/model.onnx` | ❌ | Unsupported op Softmax |
-| `node/test_softmax_negative_axis_expanded/model.onnx` | ❌ | Unsupported op Constant |
-| `node/test_softmax_negative_axis_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_softmax_negative_axis_expanded/model.onnx` | ❌ | Unsupported op ReduceMax |
+| `node/test_softmax_negative_axis_expanded_ver18/model.onnx` | ❌ | ReduceMax expects matching dtypes, got float, int64 |
 | `node/test_softplus/model.onnx` | ❌ | Unsupported op Softplus |
 | `node/test_softplus_example/model.onnx` | ❌ | Unsupported op Softplus |
-| `node/test_softplus_example_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
-| `node/test_softplus_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_softplus_example_expanded_ver18/model.onnx` | ❌ | Unsupported op CastLike |
+| `node/test_softplus_expanded_ver18/model.onnx` | ❌ | Unsupported op CastLike |
 | `node/test_softsign/model.onnx` | ❌ | Unsupported op Softsign |
 | `node/test_softsign_example/model.onnx` | ❌ | Unsupported op Softsign |
-| `node/test_softsign_example_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
-| `node/test_softsign_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_softsign_example_expanded_ver18/model.onnx` | ❌ | Unsupported op CastLike |
+| `node/test_softsign_expanded_ver18/model.onnx` | ❌ | Unsupported op CastLike |
 | `node/test_spacetodepth/model.onnx` | ❌ | Unsupported op SpaceToDepth |
 | `node/test_spacetodepth_example/model.onnx` | ❌ | Unsupported op SpaceToDepth |
 | `node/test_split_1d_uneven_split_opset18/model.onnx` | ❌ | Only single-output graphs are supported |
@@ -1584,7 +1584,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_sum_one_input/model.onnx` | ❌ | Sum must have 2 inputs and 1 output |
 | `node/test_sum_two_inputs/model.onnx` | ✅ |  |
 | `node/test_swish/model.onnx` | ❌ | Unsupported op Swish |
-| `node/test_swish_expanded/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_swish_expanded/model.onnx` | ❌ | Unsupported op CastLike |
 | `node/test_tan/model.onnx` | ✅ |  |
 | `node/test_tan_example/model.onnx` | ✅ |  |
 | `node/test_tanh/model.onnx` | ✅ |  |
@@ -1601,10 +1601,10 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_tfidfvectorizer_tf_uniandbigrams_skip5/model.onnx` | ❌ | TfIdfVectorizer expects matching dtypes, got float, int32 |
 | `node/test_thresholdedrelu/model.onnx` | ❌ | Unsupported op ThresholdedRelu |
 | `node/test_thresholdedrelu_default/model.onnx` | ❌ | Unsupported op ThresholdedRelu |
-| `node/test_thresholdedrelu_default_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_thresholdedrelu_default_expanded_ver18/model.onnx` | ❌ | Unsupported op CastLike |
 | `node/test_thresholdedrelu_example/model.onnx` | ❌ | Unsupported op ThresholdedRelu |
-| `node/test_thresholdedrelu_example_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
-| `node/test_thresholdedrelu_expanded_ver18/model.onnx` | ❌ | Unsupported op Constant |
+| `node/test_thresholdedrelu_example_expanded_ver18/model.onnx` | ❌ | Unsupported op CastLike |
+| `node/test_thresholdedrelu_expanded_ver18/model.onnx` | ❌ | Unsupported op CastLike |
 | `node/test_tile/model.onnx` | ❌ | Tile expects matching dtypes, got float, int64 |
 | `node/test_tile_precomputed/model.onnx` | ❌ | Tile expects matching dtypes, got float, int64 |
 | `node/test_top_k/model.onnx` | ❌ | Only single-output graphs are supported |
@@ -1735,8 +1735,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `pytorch-converted/test_PReLU_2d_multiparam/model.onnx` | ✅ |  |
 | `pytorch-converted/test_PReLU_3d/model.onnx` | ✅ |  |
 | `pytorch-converted/test_PReLU_3d_multiparam/model.onnx` | ✅ |  |
-| `pytorch-converted/test_PixelShuffle/model.onnx` | ❌ | Unsupported op Constant |
-| `pytorch-converted/test_PoissonNLLLLoss_no_reduce/model.onnx` | ❌ | Unsupported op Constant |
+| `pytorch-converted/test_PixelShuffle/model.onnx` | ❌ | Reshape expects matching dtypes, got float, int64 |
+| `pytorch-converted/test_PoissonNLLLLoss_no_reduce/model.onnx` | ✅ |  |
 | `pytorch-converted/test_ReLU/model.onnx` | ✅ |  |
 | `pytorch-converted/test_ReflectionPad2d/model.onnx` | ❌ | Unsupported op Pad |
 | `pytorch-converted/test_ReplicationPad2d/model.onnx` | ❌ | Unsupported op Pad |
@@ -1745,7 +1745,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `pytorch-converted/test_Softmax/model.onnx` | ❌ | Unsupported op Softmax |
 | `pytorch-converted/test_Softmin/model.onnx` | ❌ | Unsupported op Softmax |
 | `pytorch-converted/test_Softplus/model.onnx` | ❌ | Unsupported op Softplus |
-| `pytorch-converted/test_Softsign/model.onnx` | ❌ | Unsupported op Constant |
+| `pytorch-converted/test_Softsign/model.onnx` | ❌ | Scalar outputs are not supported |
 | `pytorch-converted/test_Tanh/model.onnx` | ✅ |  |
 | `pytorch-converted/test_ZeroPad2d/model.onnx` | ❌ | Unsupported op Pad |
 | `pytorch-converted/test_log_softmax_dim3/model.onnx` | ❌ | Unsupported op LogSoftmax |
@@ -1756,7 +1756,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `pytorch-operator/test_operator_add_size1_broadcast/model.onnx` | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor '0'. |
 | `pytorch-operator/test_operator_add_size1_right_broadcast/model.onnx` | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor '0'. |
 | `pytorch-operator/test_operator_add_size1_singleton_broadcast/model.onnx` | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor '0'. |
-| `pytorch-operator/test_operator_addconstant/model.onnx` | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor '0'. |
+| `pytorch-operator/test_operator_addconstant/model.onnx` | ❌ | Unsupported elem_type 11 (DOUBLE) for Constant '1'. |
 | `pytorch-operator/test_operator_addmm/model.onnx` | ❌ | Gemm must have 2 inputs and 1 output |
 | `pytorch-operator/test_operator_basic/model.onnx` | ❌ | Unsupported op Sigmoid |
 | `pytorch-operator/test_operator_chunk/model.onnx` | ❌ | Only single-output graphs are supported |
@@ -1770,7 +1770,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `pytorch-operator/test_operator_max/model.onnx` | ✅ |  |
 | `pytorch-operator/test_operator_maxpool/model.onnx` | ❌ | Unsupported op MaxPool |
 | `pytorch-operator/test_operator_min/model.onnx` | ✅ |  |
-| `pytorch-operator/test_operator_mm/model.onnx` | ❌ | Unsupported op Constant |
+| `pytorch-operator/test_operator_mm/model.onnx` | ❌ | Gemm must have 2 inputs and 1 output |
 | `pytorch-operator/test_operator_non_float_params/model.onnx` | ✅ |  |
 | `pytorch-operator/test_operator_pad/model.onnx` | ❌ | Unsupported op Pad |
 | `pytorch-operator/test_operator_params/model.onnx` | ❌ | Unsupported op Sigmoid |
@@ -1780,8 +1780,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `pytorch-operator/test_operator_reduced_mean_keepdim/model.onnx` | ❌ | Unsupported op ReduceMean |
 | `pytorch-operator/test_operator_reduced_sum/model.onnx` | ❌ | Unsupported op ReduceSum |
 | `pytorch-operator/test_operator_reduced_sum_keepdim/model.onnx` | ❌ | Unsupported op ReduceSum |
-| `pytorch-operator/test_operator_repeat/model.onnx` | ❌ | Unsupported op Constant |
-| `pytorch-operator/test_operator_repeat_dim_overflow/model.onnx` | ❌ | Unsupported op Constant |
+| `pytorch-operator/test_operator_repeat/model.onnx` | ❌ | Tile expects matching dtypes, got float, int64 |
+| `pytorch-operator/test_operator_repeat_dim_overflow/model.onnx` | ❌ | Reshape expects matching dtypes, got float, int64 |
 | `pytorch-operator/test_operator_selu/model.onnx` | ❌ | Unsupported op Selu |
 | `pytorch-operator/test_operator_sqrt/model.onnx` | ✅ |  |
 | `pytorch-operator/test_operator_symbolic_override/model.onnx` | ❌ | Unsupported op InstanceNormalization |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -4,10 +4,9 @@
 | --- | --- | --- |
 | Dynamic dim for tensor '*' | 146 | ██████████████████████████████ |
 | Only single-output graphs are supported | 129 | ███████████████████████████ |
-| Unsupported op Constant | 76 | ████████████████ |
-| Scalar outputs are not supported | 61 | █████████████ |
+| Scalar outputs are not supported | 62 | █████████████ |
 | Unsupported elem_type 10 (FLOAT16) for tensor '*'. | 60 | ████████████ |
-| Unsupported elem_type 11 (DOUBLE) for tensor '*'. | 54 | ███████████ |
+| Unsupported elem_type 11 (DOUBLE) for tensor '*'. | 53 | ███████████ |
 | Unsupported elem_type 2 (UINT8) for tensor '*'. | 50 | ██████████ |
 | ReduceSum expects matching dtypes, got float, int64 | 43 | █████████ |
 | Missing dtype for value '*' in op Resize. Hint: run ONNX shape inference or export with static shapes. | 39 | ████████ |
@@ -15,9 +14,11 @@
 | Missing elem_type for tensor '*' | 33 | ███████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████ |
 | Unsupported op Attention | 29 | ██████ |
+| Unsupported op CastLike | 29 | ██████ |
 | Unsupported op AveragePool | 25 | █████ |
 | Unsupported op MaxPool | 25 | █████ |
 | Unsupported elem_type 13 (UINT64) for tensor '*'. | 21 | ████ |
+| ReduceMax expects matching dtypes, got float, int64 | 21 | ████ |
 | Unsupported elem_type 4 (UINT16) for tensor '*'. | 19 | ████ |
 | Unsupported op RMSNormalization | 19 | ████ |
 | Unsupported op GridSample | 18 | ████ |
@@ -25,7 +26,9 @@
 | ArgMax expects matching dtypes, got float, int64 | 16 | ███ |
 | ArgMin expects matching dtypes, got float, int64 | 16 | ███ |
 | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 16 | ███ |
+| Unsupported op ReduceMax | 16 | ███ |
 | Unsupported op Trilu | 16 | ███ |
+| Reshape expects matching dtypes, got float, int64 | 15 | ███ |
 | Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 14 | ███ |
 | Unsupported elem_type 26 (INT2) for tensor '*'. | 14 | ███ |
 | Unsupported elem_type 22 (INT4) for tensor '*'. | 14 | ███ |
@@ -33,10 +36,10 @@
 | Unsupported elem_type 21 (UINT4) for tensor '*'. | 14 | ███ |
 | Unsupported op ConvTranspose | 14 | ███ |
 | Unsupported op Concat | 13 | ███ |
+| Gemm must have 2 inputs and 1 output | 13 | ███ |
 | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 12 | ██ |
 | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 12 | ██ |
 | Less expects matching dtypes, got bool, float | 12 | ██ |
-| Gemm must have 2 inputs and 1 output | 12 | ██ |
 | Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 11 | ██ |
 | Unsupported op Flatten | 11 | ██ |
 | Unsupported op Softmax | 11 | ██ |
@@ -44,18 +47,17 @@
 | Unsupported op LogSoftmax | 10 | ██ |
 | Shape expects matching dtypes, got float, int64 | 10 | ██ |
 | Unsupported op Clip | 9 | ██ |
+| ReduceMean expects matching dtypes, got float, int64 | 9 | ██ |
 | NonMaxSuppression expects matching dtypes, got float, int64 | 9 | ██ |
 | ReduceL1 expects matching dtypes, got float, int64 | 9 | ██ |
 | ReduceL2 expects matching dtypes, got float, int64 | 9 | ██ |
 | ReduceSumSquare expects matching dtypes, got float, int64 | 9 | ██ |
-| Reshape expects matching dtypes, got float, int64 | 9 | ██ |
 | Unsupported op Transpose | 9 | ██ |
 | Unsupported op LpPool | 8 | ██ |
-| ReduceMean expects matching dtypes, got float, int64 | 8 | ██ |
 | Unsupported op BatchNormalization | 7 | █ |
 | Dynamic or zero dims are not supported | 7 | █ |
 | Unsupported op Hardmax | 7 | █ |
-| ReduceMax expects matching dtypes, got float, int64 | 7 | █ |
+| Unsupported op Unsqueeze | 7 | █ |
 | ReduceMin expects matching dtypes, got float, int64 | 7 | █ |
 | ReduceProd expects matching dtypes, got float, int64 | 7 | █ |
 | Slice expects matching dtypes, got float, int64 | 7 | █ |
@@ -68,6 +70,7 @@
 | Unsupported op LpNormalization | 6 | █ |
 | Unsupported op Mod | 6 | █ |
 | ScatterElements expects matching dtypes, got float, int64 | 6 | █ |
+| Unsupported op Elu | 5 | █ |
 | Col2Im expects matching dtypes, got float, int64 | 5 | █ |
 | Unsupported op LeakyRelu | 5 | █ |
 | NegativeLogLikelihoodLoss expects matching dtypes, got float, int64 | 5 | █ |
@@ -83,7 +86,6 @@
 | Less expects matching dtypes, got bool, int8 | 4 | █ |
 | Compress expects matching dtypes, got bool, float | 4 | █ |
 | Unsupported op Dropout | 4 | █ |
-| Unsupported op Elu | 4 | █ |
 | Unsupported op Gelu | 4 | █ |
 | Greater expects matching dtypes, got bool, float | 4 | █ |
 | Unsupported op HardSigmoid | 4 | █ |
@@ -102,12 +104,14 @@
 | Unsupported op InstanceNormalization | 3 | █ |
 | IsInf expects matching dtypes, got bool, float | 3 | █ |
 | Missing dtype for value '*' in op LSTM. Hint: run ONNX shape inference or export with static shapes. | 3 | █ |
+| Unsupported op ReduceMean | 3 | █ |
 | Missing dtype for value '*' in op RNN. Hint: run ONNX shape inference or export with static shapes. | 3 | █ |
 | RoiAlign expects matching dtypes, got float, int64 | 3 | █ |
 | Unsupported op RotaryEmbedding | 3 | █ |
 | Unsupported op Shrink | 3 | █ |
 | TensorScatter expects matching dtypes, got float, int64 | 3 | █ |
 | Unsupported op ThresholdedRelu | 3 | █ |
+| Tile expects matching dtypes, got float, int64 | 3 | █ |
 | Dropout expects matching dtypes, got bool, float | 3 | █ |
 | Unsupported op Acos | 2 | █ |
 | Unsupported op Acosh | 2 | █ |
@@ -148,7 +152,6 @@
 | QuantizeLinear expects matching dtypes, got float, int16 | 2 | █ |
 | Unsupported op Range | 2 | █ |
 | Unsupported op Reciprocal | 2 | █ |
-| Unsupported op ReduceMax | 2 | █ |
 | Unsupported op ReduceMin | 2 | █ |
 | Unsupported op ReduceProd | 2 | █ |
 | ReverseSequence expects matching dtypes, got float, int64 | 2 | █ |
@@ -159,10 +162,7 @@
 | Unsupported op SpaceToDepth | 2 | █ |
 | Squeeze expects matching dtypes, got float, int64 | 2 | █ |
 | Sum must have 2 inputs and 1 output | 2 | █ |
-| Tile expects matching dtypes, got float, int64 | 2 | █ |
-| Unsupported op Unsqueeze | 2 | █ |
 | Unsupported op Split | 2 | █ |
-| Unsupported op ReduceMean | 2 | █ |
 | Unsupported op ReduceSum | 2 | █ |
 | ArrayFeatureExtractor expects matching dtypes, got float, int64 | 1 | █ |
 | Unsupported op Binarizer | 1 | █ |
@@ -172,6 +172,7 @@
 | Unsupported op RandomUniformLike | 1 | █ |
 | Unsupported op BitwiseNot | 1 | █ |
 | Unsupported op Celu | 1 | █ |
+| Graph must contain at least one node | 1 | █ |
 | ConstantOfShape expects matching dtypes, got int32, int64 | 1 | █ |
 | DequantizeLinear expects matching dtypes, got float, int16 | 1 | █ |
 | Unsupported op Det | 1 | █ |
@@ -212,4 +213,5 @@
 | Unsupported op Upsample | 1 | █ |
 | Where expects matching dtypes, got bool, float | 1 | █ |
 | Where expects matching dtypes, got bool, int64 | 1 | █ |
+| Unsupported elem_type 11 (DOUBLE) for Constant '*'. | 1 | █ |
 | Unsupported op Slice | 1 | █ |

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -1801,7 +1801,7 @@
   ],
   [
     "node/test_celu_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op Elu"
   ],
   [
     "node/test_center_crop_pad_crop/model.onnx",
@@ -2033,7 +2033,7 @@
   ],
   [
     "node/test_constant/model.onnx",
-    "Unsupported op Constant"
+    "Graph must contain at least one node"
   ],
   [
     "node/test_constant_pad/model.onnx",
@@ -2405,7 +2405,7 @@
   ],
   [
     "node/test_elu_default_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_elu_example/model.onnx",
@@ -2413,11 +2413,11 @@
   ],
   [
     "node/test_elu_example_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_elu_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_equal/model.onnx",
@@ -2581,7 +2581,7 @@
   ],
   [
     "node/test_gelu_default_1_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_gelu_default_2/model.onnx",
@@ -2589,7 +2589,7 @@
   ],
   [
     "node/test_gelu_default_2_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_gelu_tanh_1/model.onnx",
@@ -2597,7 +2597,7 @@
   ],
   [
     "node/test_gelu_tanh_1_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_gelu_tanh_2/model.onnx",
@@ -2605,7 +2605,7 @@
   ],
   [
     "node/test_gelu_tanh_2_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_gemm_all_attributes/model.onnx",
@@ -2937,7 +2937,7 @@
   ],
   [
     "node/test_hardsigmoid_default_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_hardsigmoid_example/model.onnx",
@@ -2945,11 +2945,11 @@
   ],
   [
     "node/test_hardsigmoid_example_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_hardsigmoid_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_hardswish/model.onnx",
@@ -3309,7 +3309,7 @@
   ],
   [
     "node/test_leakyrelu_default_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_leakyrelu_example/model.onnx",
@@ -3317,11 +3317,11 @@
   ],
   [
     "node/test_leakyrelu_example_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_leakyrelu_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_less/model.onnx",
@@ -3433,11 +3433,11 @@
   ],
   [
     "node/test_logsoftmax_axis_0_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op ReduceMax"
   ],
   [
     "node/test_logsoftmax_axis_0_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "ReduceMax expects matching dtypes, got float, int64"
   ],
   [
     "node/test_logsoftmax_axis_1/model.onnx",
@@ -3445,11 +3445,11 @@
   ],
   [
     "node/test_logsoftmax_axis_1_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op ReduceMax"
   ],
   [
     "node/test_logsoftmax_axis_1_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "ReduceMax expects matching dtypes, got float, int64"
   ],
   [
     "node/test_logsoftmax_axis_2/model.onnx",
@@ -3457,11 +3457,11 @@
   ],
   [
     "node/test_logsoftmax_axis_2_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op ReduceMax"
   ],
   [
     "node/test_logsoftmax_axis_2_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "ReduceMax expects matching dtypes, got float, int64"
   ],
   [
     "node/test_logsoftmax_default_axis/model.onnx",
@@ -3469,11 +3469,11 @@
   ],
   [
     "node/test_logsoftmax_default_axis_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op ReduceMax"
   ],
   [
     "node/test_logsoftmax_default_axis_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "ReduceMax expects matching dtypes, got float, int64"
   ],
   [
     "node/test_logsoftmax_example_1/model.onnx",
@@ -3481,11 +3481,11 @@
   ],
   [
     "node/test_logsoftmax_example_1_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op ReduceMax"
   ],
   [
     "node/test_logsoftmax_example_1_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "ReduceMax expects matching dtypes, got float, int64"
   ],
   [
     "node/test_logsoftmax_large_number/model.onnx",
@@ -3493,11 +3493,11 @@
   ],
   [
     "node/test_logsoftmax_large_number_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op ReduceMax"
   ],
   [
     "node/test_logsoftmax_large_number_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "ReduceMax expects matching dtypes, got float, int64"
   ],
   [
     "node/test_logsoftmax_negative_axis/model.onnx",
@@ -3505,11 +3505,11 @@
   ],
   [
     "node/test_logsoftmax_negative_axis_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op ReduceMax"
   ],
   [
     "node/test_logsoftmax_negative_axis_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "ReduceMax expects matching dtypes, got float, int64"
   ],
   [
     "node/test_loop11/model.onnx",
@@ -3937,11 +3937,11 @@
   ],
   [
     "node/test_mvn_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op ReduceMean"
   ],
   [
     "node/test_mvn_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "ReduceMean expects matching dtypes, got float, int64"
   ],
   [
     "node/test_neg/model.onnx",
@@ -3961,7 +3961,7 @@
   ],
   [
     "node/test_nllloss_NC_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op Unsqueeze"
   ],
   [
     "node/test_nllloss_NCd1/model.onnx",
@@ -4009,7 +4009,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op Unsqueeze"
   ],
   [
     "node/test_nllloss_NCd1d2_no_weight_reduction_mean_ii/model.onnx",
@@ -4041,7 +4041,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op Unsqueeze"
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight_reduction_mean/model.onnx",
@@ -4073,7 +4073,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op Unsqueeze"
   ],
   [
     "node/test_nllloss_NCd1d2d3_sum_weight_high_ii/model.onnx",
@@ -4097,7 +4097,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op Unsqueeze"
   ],
   [
     "node/test_nonmaxsuppression_center_point_box_format/model.onnx",
@@ -4297,7 +4297,7 @@
   ],
   [
     "node/test_prelu_broadcast_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_prelu_example/model.onnx",
@@ -4305,7 +4305,7 @@
   ],
   [
     "node/test_prelu_example_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_qlinearconv/model.onnx",
@@ -4965,7 +4965,7 @@
   ],
   [
     "node/test_relu_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_reshape_allowzero_reordered/model.onnx",
@@ -5489,7 +5489,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Reshape expects matching dtypes, got float, int64"
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob/model.onnx",
@@ -5537,7 +5537,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Reshape expects matching dtypes, got float, int64"
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx",
@@ -5697,7 +5697,7 @@
   ],
   [
     "node/test_sce_none_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Reshape expects matching dtypes, got float, int64"
   ],
   [
     "node/test_sce_none_log_prob/model.onnx",
@@ -5713,7 +5713,7 @@
   ],
   [
     "node/test_sce_none_weights_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Reshape expects matching dtypes, got float, int64"
   ],
   [
     "node/test_sce_none_weights_log_prob/model.onnx",
@@ -5749,7 +5749,7 @@
   ],
   [
     "node/test_selu_default_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_selu_example/model.onnx",
@@ -5757,11 +5757,11 @@
   ],
   [
     "node/test_selu_example_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_selu_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_sequence_insert_at_back/model.onnx",
@@ -5869,7 +5869,7 @@
   ],
   [
     "node/test_shrink_hard_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_shrink_soft/model.onnx",
@@ -5877,7 +5877,7 @@
   ],
   [
     "node/test_shrink_soft_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_sigmoid/model.onnx",
@@ -5965,11 +5965,11 @@
   ],
   [
     "node/test_softmax_axis_0_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op ReduceMax"
   ],
   [
     "node/test_softmax_axis_0_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "ReduceMax expects matching dtypes, got float, int64"
   ],
   [
     "node/test_softmax_axis_1/model.onnx",
@@ -5977,11 +5977,11 @@
   ],
   [
     "node/test_softmax_axis_1_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op ReduceMax"
   ],
   [
     "node/test_softmax_axis_1_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "ReduceMax expects matching dtypes, got float, int64"
   ],
   [
     "node/test_softmax_axis_2/model.onnx",
@@ -5989,11 +5989,11 @@
   ],
   [
     "node/test_softmax_axis_2_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op ReduceMax"
   ],
   [
     "node/test_softmax_axis_2_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "ReduceMax expects matching dtypes, got float, int64"
   ],
   [
     "node/test_softmax_default_axis/model.onnx",
@@ -6001,11 +6001,11 @@
   ],
   [
     "node/test_softmax_default_axis_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op ReduceMax"
   ],
   [
     "node/test_softmax_default_axis_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "ReduceMax expects matching dtypes, got float, int64"
   ],
   [
     "node/test_softmax_example/model.onnx",
@@ -6013,11 +6013,11 @@
   ],
   [
     "node/test_softmax_example_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op ReduceMax"
   ],
   [
     "node/test_softmax_example_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "ReduceMax expects matching dtypes, got float, int64"
   ],
   [
     "node/test_softmax_large_number/model.onnx",
@@ -6025,11 +6025,11 @@
   ],
   [
     "node/test_softmax_large_number_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op ReduceMax"
   ],
   [
     "node/test_softmax_large_number_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "ReduceMax expects matching dtypes, got float, int64"
   ],
   [
     "node/test_softmax_negative_axis/model.onnx",
@@ -6037,11 +6037,11 @@
   ],
   [
     "node/test_softmax_negative_axis_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op ReduceMax"
   ],
   [
     "node/test_softmax_negative_axis_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "ReduceMax expects matching dtypes, got float, int64"
   ],
   [
     "node/test_softplus/model.onnx",
@@ -6053,11 +6053,11 @@
   ],
   [
     "node/test_softplus_example_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_softplus_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_softsign/model.onnx",
@@ -6069,11 +6069,11 @@
   ],
   [
     "node/test_softsign_example_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_softsign_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_spacetodepth/model.onnx",
@@ -6305,7 +6305,7 @@
   ],
   [
     "node/test_swish_expanded/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_tan/model.onnx",
@@ -6373,7 +6373,7 @@
   ],
   [
     "node/test_thresholdedrelu_default_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_thresholdedrelu_example/model.onnx",
@@ -6381,11 +6381,11 @@
   ],
   [
     "node/test_thresholdedrelu_example_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_thresholdedrelu_expanded_ver18/model.onnx",
-    "Unsupported op Constant"
+    "Unsupported op CastLike"
   ],
   [
     "node/test_tile/model.onnx",
@@ -6909,11 +6909,11 @@
   ],
   [
     "pytorch-converted/test_PixelShuffle/model.onnx",
-    "Unsupported op Constant"
+    "Reshape expects matching dtypes, got float, int64"
   ],
   [
     "pytorch-converted/test_PoissonNLLLLoss_no_reduce/model.onnx",
-    "Unsupported op Constant"
+    ""
   ],
   [
     "pytorch-converted/test_ReLU/model.onnx",
@@ -6949,7 +6949,7 @@
   ],
   [
     "pytorch-converted/test_Softsign/model.onnx",
-    "Unsupported op Constant"
+    "Scalar outputs are not supported"
   ],
   [
     "pytorch-converted/test_Tanh/model.onnx",
@@ -6993,7 +6993,7 @@
   ],
   [
     "pytorch-operator/test_operator_addconstant/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor '0'."
+    "Unsupported elem_type 11 (DOUBLE) for Constant '1'."
   ],
   [
     "pytorch-operator/test_operator_addmm/model.onnx",
@@ -7049,7 +7049,7 @@
   ],
   [
     "pytorch-operator/test_operator_mm/model.onnx",
-    "Unsupported op Constant"
+    "Gemm must have 2 inputs and 1 output"
   ],
   [
     "pytorch-operator/test_operator_non_float_params/model.onnx",
@@ -7089,11 +7089,11 @@
   ],
   [
     "pytorch-operator/test_operator_repeat/model.onnx",
-    "Unsupported op Constant"
+    "Tile expects matching dtypes, got float, int64"
   ],
   [
     "pytorch-operator/test_operator_repeat_dim_overflow/model.onnx",
-    "Unsupported op Constant"
+    "Reshape expects matching dtypes, got float, int64"
   ],
   [
     "pytorch-operator/test_operator_selu/model.onnx",

--- a/tests/test_onnx_import.py
+++ b/tests/test_onnx_import.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import numpy as np
+import onnx
+
+from onnx import TensorProto, helper
+
+from onnx2c.onnx_import import import_onnx
+
+
+def _make_constant_model() -> tuple[onnx.ModelProto, np.ndarray]:
+    const_values = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+    tensor = helper.make_tensor(
+        "const_tensor",
+        TensorProto.FLOAT,
+        dims=const_values.shape,
+        vals=const_values.flatten().tolist(),
+    )
+    node = helper.make_node("Constant", inputs=[], outputs=["const_out"], value=tensor)
+    output = helper.make_tensor_value_info(
+        "const_out", TensorProto.FLOAT, const_values.shape
+    )
+    graph = helper.make_graph([node], "const_graph", [], [output])
+    model = helper.make_model(
+        graph,
+        producer_name="onnx2c",
+        opset_imports=[helper.make_operatorsetid("", 13)],
+    )
+    model.ir_version = 7
+    onnx.checker.check_model(model)
+    return model, const_values
+
+
+def test_import_constant_creates_initializer() -> None:
+    model, const_values = _make_constant_model()
+    graph = import_onnx(model)
+    assert not graph.nodes
+    assert len(graph.initializers) == 1
+    initializer = graph.initializers[0]
+    assert initializer.name == "const_out"
+    np.testing.assert_array_equal(initializer.data, const_values)


### PR DESCRIPTION
### Motivation

- Treat ONNX `Constant` nodes as true graph initializers so constant values are available to lowering and codegen.
- Centralize dtype conversion/normalization for initializers to ensure deterministic downstream behavior.
- Improve end-to-end correctness and verification for models that rely on `Constant` nodes.

### Description

- Add `_normalize_initializer_data` to centralize conversion and dtype normalization for initializer/constant data. 
- Add `_constant_initializer` to extract `Constant` node attributes and produce `Initializer` objects, and update `import_onnx` to convert `Constant` nodes into initializers and omit them from the runtime node list. 
- Add unit test `tests/test_onnx_import.py::test_import_constant_creates_initializer` and end-to-end test `tests/test_endtoend_ops.py::test_constant_op_matches_onnxruntime` to verify Constant import behavior. 
- Refresh official ONNX support snapshots (`OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`) and update `tests/official_onnx_expected_errors.json` to reflect the new import behavior.

### Testing

- Ran `pytest -n auto -q` which initially failed due to a documentation snapshot mismatch (1 failed, 64 passed). 
- Re-ran tests with updated references using `UPDATE_REFS=1 pytest -n auto -q` which completed successfully (`65 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69637dba2f70832591c0e1e3cbb5260e)