### PR TITLE
tests: order json expectations before markdown

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,3 +9,24 @@ if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 if str(TESTS_ROOT) not in sys.path:
     sys.path.insert(0, str(TESTS_ROOT))
+
+
+def pytest_collection_modifyitems(session, config, items):  # type: ignore[no-untyped-def]
+    json_test_suffix = "test_official_onnx_expected_errors"
+    md_test_suffix = "test_official_onnx_file_support_doc"
+
+    json_index = next(
+        (index for index, item in enumerate(items) if item.nodeid.endswith(json_test_suffix)),
+        None,
+    )
+    md_index = next(
+        (index for index, item in enumerate(items) if item.nodeid.endswith(md_test_suffix)),
+        None,
+    )
+    if json_index is None or md_index is None or json_index < md_index:
+        return
+
+    md_item = items.pop(md_index)
+    if md_index < json_index:
+        json_index -= 1
+    items.insert(json_index + 1, md_item)


### PR DESCRIPTION
### Motivation

- Ensure `test_official_onnx_expected_errors` runs before `test_official_onnx_file_support_doc` so JSON expectations are available when rendering or validating the markdown support doc.
- Avoid spurious test failures or nondeterministic behavior when running tests that update golden references with `UPDATE_REFS`.

### Description

- Add `pytest_collection_modifyitems` to `tests/conftest.py` to reorder collected tests by nodeid suffix.
- The hook locates items ending with `test_official_onnx_expected_errors` and `test_official_onnx_file_support_doc` and moves the markdown test to run immediately after the JSON expectations test.
- Uses `item.nodeid.endswith(...)` to find targets and updates the `items` list in-place to preserve deterministic collection order.
- Change is limited to `tests/conftest.py` and does not alter test logic.

### Testing

- Ran `UPDATE_REFS=1 pytest -n auto -q` to exercise the reference-update path and collection ordering.
- Test run succeeded with `63 passed in 9.40s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69638499eec88325b8f94daa9f035e9c)