### PR TITLE
Validate Conv kernel_shape and refresh ONNX support refs

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 104 / 1802 official ONNX files.
+Support 106 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -242,8 +242,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_averagepool_3d_dilations_large_count_include_pad_is_1_ceil_mode_is_False/model.onnx` | ❌ | Unsupported op AveragePool |
 | `node/test_averagepool_3d_dilations_large_count_include_pad_is_1_ceil_mode_is_True/model.onnx` | ❌ | Unsupported op AveragePool |
 | `node/test_averagepool_3d_dilations_small/model.onnx` | ❌ | Unsupported op AveragePool |
-| `node/test_basic_conv_with_padding/model.onnx` | ❌ | Unsupported op Conv |
-| `node/test_basic_conv_without_padding/model.onnx` | ❌ | Unsupported op Conv |
+| `node/test_basic_conv_with_padding/model.onnx` | ✅ |  |
+| `node/test_basic_conv_without_padding/model.onnx` | ✅ |  |
 | `node/test_basic_deform_conv_with_padding/model.onnx` | ❌ | Unsupported op DeformConv |
 | `node/test_basic_deform_conv_without_padding/model.onnx` | ❌ | Unsupported op DeformConv |
 | `node/test_batchnorm_epsilon/model.onnx` | ❌ | Unsupported op BatchNormalization |
@@ -523,7 +523,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_constantofshape_float_ones/model.onnx` | ❌ | ConstantOfShape expects matching dtypes, got float, int64 |
 | `node/test_constantofshape_int_shape_zero/model.onnx` | ❌ | Dynamic or zero dims are not supported |
 | `node/test_constantofshape_int_zeros/model.onnx` | ❌ | ConstantOfShape expects matching dtypes, got int32, int64 |
-| `node/test_conv_with_autopad_same/model.onnx` | ❌ | Unsupported op Conv |
+| `node/test_conv_with_autopad_same/model.onnx` | ❌ | Conv supports auto_pad=NOTSET only |
 | `node/test_conv_with_strides_and_asymmetric_padding/model.onnx` | ❌ | Unsupported op Conv |
 | `node/test_conv_with_strides_no_padding/model.onnx` | ❌ | Unsupported op Conv |
 | `node/test_conv_with_strides_padding/model.onnx` | ❌ | Unsupported op Conv |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -10,9 +10,9 @@
 | Unsupported elem_type 2 (UINT8) for tensor '*'. | 50 | ██████████ |
 | ReduceSum expects matching dtypes, got float, int64 | 43 | █████████ |
 | Missing dtype for value '*' in op Resize. Hint: run ONNX shape inference or export with static shapes. | 39 | ████████ |
-| Unsupported op Conv | 33 | ███████ |
 | Missing elem_type for tensor '*' | 33 | ███████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████ |
+| Unsupported op Conv | 30 | ██████ |
 | Unsupported op Attention | 29 | ██████ |
 | Unsupported op CastLike | 29 | ██████ |
 | Unsupported op AveragePool | 25 | █████ |
@@ -174,6 +174,7 @@
 | Unsupported op Celu | 1 | █ |
 | Graph must contain at least one node | 1 | █ |
 | ConstantOfShape expects matching dtypes, got int32, int64 | 1 | █ |
+| Conv supports auto_pad=NOTSET only | 1 | █ |
 | DequantizeLinear expects matching dtypes, got float, int16 | 1 | █ |
 | Unsupported op Det | 1 | █ |
 | Equal expects matching dtypes, got bool, int16 | 1 | █ |

--- a/templates/conv_op.c.j2
+++ b/templates/conv_op.c.j2
@@ -1,0 +1,27 @@
+void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix }}, const {{ c_type }} {{ weights }}{{ weight_suffix }},{% if bias %} const {{ c_type }} {{ bias }}{{ bias_suffix }},{% endif %} {{ c_type }} {{ output }}{{ output_suffix }}) {
+    for (size_t n = 0; n < {{ batch }}; ++n) {
+        for (size_t oc = 0; oc < {{ out_channels }}; ++oc) {
+            for (size_t oh = 0; oh < {{ out_h }}; ++oh) {
+                for (size_t ow = 0; ow < {{ out_w }}; ++ow) {
+                    {{ c_type }} acc = {% if bias %}{{ bias }}[oc]{% else %}{{ zero_literal }}{% endif %};
+                    for (size_t ic = 0; ic < {{ in_channels }}; ++ic) {
+                        for (size_t kh = 0; kh < {{ kernel_h }}; ++kh) {
+                            const int ih = (int)(oh * {{ stride_h }} + kh * {{ dilation_h }}) - {{ pad_top }};
+                            if (ih < 0 || ih >= {{ in_h }}) {
+                                continue;
+                            }
+                            for (size_t kw = 0; kw < {{ kernel_w }}; ++kw) {
+                                const int iw = (int)(ow * {{ stride_w }} + kw * {{ dilation_w }}) - {{ pad_left }};
+                                if (iw < 0 || iw >= {{ in_w }}) {
+                                    continue;
+                                }
+                                acc += {{ input0 }}[n][ic][ih][iw] * {{ weights }}[oc][ic][kh][kw];
+                            }
+                        }
+                    }
+                    {{ output }}[n][oc][oh][ow] = acc;
+                }
+            }
+        }
+    }
+}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -937,11 +937,11 @@
   ],
   [
     "node/test_basic_conv_with_padding/model.onnx",
-    "Unsupported op Conv"
+    ""
   ],
   [
     "node/test_basic_conv_without_padding/model.onnx",
-    "Unsupported op Conv"
+    ""
   ],
   [
     "node/test_basic_deform_conv_with_padding/model.onnx",
@@ -2061,19 +2061,19 @@
   ],
   [
     "node/test_conv_with_autopad_same/model.onnx",
-    "Unsupported op Conv"
+    "Conv supports auto_pad=NOTSET only"
   ],
   [
     "node/test_conv_with_strides_and_asymmetric_padding/model.onnx",
-    "Unsupported op Conv"
+    ""
   ],
   [
     "node/test_conv_with_strides_no_padding/model.onnx",
-    "Unsupported op Conv"
+    ""
   ],
   [
     "node/test_conv_with_strides_padding/model.onnx",
-    "Unsupported op Conv"
+    ""
   ],
   [
     "node/test_convinteger_with_padding/model.onnx",
@@ -6701,107 +6701,107 @@
   ],
   [
     "pytorch-converted/test_Conv1d/model.onnx",
-    "Unsupported op Conv"
+    "Conv expects 2D strides"
   ],
   [
     "pytorch-converted/test_Conv1d_dilated/model.onnx",
-    "Unsupported op Conv"
+    "Conv expects 2D strides"
   ],
   [
     "pytorch-converted/test_Conv1d_groups/model.onnx",
-    "Unsupported op Conv"
+    "Conv supports group=1 only"
   ],
   [
     "pytorch-converted/test_Conv1d_pad1/model.onnx",
-    "Unsupported op Conv"
+    "Conv expects 2D strides"
   ],
   [
     "pytorch-converted/test_Conv1d_pad1size1/model.onnx",
-    "Unsupported op Conv"
+    "Conv expects 2D strides"
   ],
   [
     "pytorch-converted/test_Conv1d_pad2/model.onnx",
-    "Unsupported op Conv"
+    "Conv expects 2D strides"
   ],
   [
     "pytorch-converted/test_Conv1d_pad2size1/model.onnx",
-    "Unsupported op Conv"
+    "Conv expects 2D strides"
   ],
   [
     "pytorch-converted/test_Conv1d_stride/model.onnx",
-    "Unsupported op Conv"
+    "Conv expects 2D strides"
   ],
   [
     "pytorch-converted/test_Conv2d/model.onnx",
-    "Unsupported op Conv"
+    ""
   ],
   [
     "pytorch-converted/test_Conv2d_depthwise/model.onnx",
-    "Unsupported op Conv"
+    "Conv supports group=1 only"
   ],
   [
     "pytorch-converted/test_Conv2d_depthwise_padded/model.onnx",
-    "Unsupported op Conv"
+    "Conv supports group=1 only"
   ],
   [
     "pytorch-converted/test_Conv2d_depthwise_strided/model.onnx",
-    "Unsupported op Conv"
+    "Conv supports group=1 only"
   ],
   [
     "pytorch-converted/test_Conv2d_depthwise_with_multiplier/model.onnx",
-    "Unsupported op Conv"
+    "Conv supports group=1 only"
   ],
   [
     "pytorch-converted/test_Conv2d_dilated/model.onnx",
-    "Unsupported op Conv"
+    ""
   ],
   [
     "pytorch-converted/test_Conv2d_groups/model.onnx",
-    "Unsupported op Conv"
+    "Conv supports group=1 only"
   ],
   [
     "pytorch-converted/test_Conv2d_groups_thnn/model.onnx",
-    "Unsupported op Conv"
+    "Conv supports group=1 only"
   ],
   [
     "pytorch-converted/test_Conv2d_no_bias/model.onnx",
-    "Unsupported op Conv"
+    ""
   ],
   [
     "pytorch-converted/test_Conv2d_padding/model.onnx",
-    "Unsupported op Conv"
+    ""
   ],
   [
     "pytorch-converted/test_Conv2d_strided/model.onnx",
-    "Unsupported op Conv"
+    ""
   ],
   [
     "pytorch-converted/test_Conv3d/model.onnx",
-    "Unsupported op Conv"
+    "Conv expects 2D strides"
   ],
   [
     "pytorch-converted/test_Conv3d_dilated/model.onnx",
-    "Unsupported op Conv"
+    "Conv expects 2D strides"
   ],
   [
     "pytorch-converted/test_Conv3d_dilated_strided/model.onnx",
-    "Unsupported op Conv"
+    "Conv expects 2D strides"
   ],
   [
     "pytorch-converted/test_Conv3d_groups/model.onnx",
-    "Unsupported op Conv"
+    "Conv supports group=1 only"
   ],
   [
     "pytorch-converted/test_Conv3d_no_bias/model.onnx",
-    "Unsupported op Conv"
+    "Conv expects 2D strides"
   ],
   [
     "pytorch-converted/test_Conv3d_stride/model.onnx",
-    "Unsupported op Conv"
+    "Conv expects 2D strides"
   ],
   [
     "pytorch-converted/test_Conv3d_stride_padding/model.onnx",
-    "Unsupported op Conv"
+    "Conv expects 2D strides"
   ],
   [
     "pytorch-converted/test_ConvTranspose2d/model.onnx",
@@ -7017,7 +7017,7 @@
   ],
   [
     "pytorch-operator/test_operator_conv/model.onnx",
-    "Unsupported op Conv"
+    ""
   ],
   [
     "pytorch-operator/test_operator_convtranspose/model.onnx",


### PR DESCRIPTION
### Motivation
- Ensure Conv node attribute `kernel_shape` is consistent with the provided weight tensor to avoid silent shape mismatches.
- Improve Conv handling and shape validation in the compiler so more ONNX Conv testcases are recognized and validated.
- Keep generated C code able to emit and run Conv kernels for end-to-end verification.

### Description
- Add validation for `kernel_shape` in `_resolve_conv_spec` to require a 2D `kernel_shape` and ensure it matches the weight shape in `src/onnx2c/compiler.py`.
- Integrate Conv into lowering, runtime evaluation, and codegen by adding `ConvOp`, `_lower_conv_op`, `_apply_conv`, and wiring the new `conv_op.c.j2` template into `CEmitter`.
- Add an end-to-end Conv test in `tests/test_endtoend_ops.py` and update `tests/official_onnx_expected_errors.json` and OFFICIAL_ONNX support docs/histogram to reflect the new Conv coverage.

### Testing
- Ran `pytest -n auto -q` initially which revealed failures related to updated Conv handling (failing expected-error references).
- Updated `tests/official_onnx_expected_errors.json` and refreshed support docs to match the new validation behavior.
- Ran `UPDATE_REFS=1 pytest -n auto -q` to regenerate refs and then ran the full test suite, which completed successfully (`66 passed`).
- Verified the new Conv end-to-end verification exercised the generated `conv_op.c.j2` emission and runtime path via the existing `verify` flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69638a8ea3648325ad489b08d978bc4a)