### PR TITLE
codegen: inline transpose kernel and add Transpose lowering

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 106 / 1802 official ONNX files.
+Support 124 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -524,9 +524,9 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_constantofshape_int_shape_zero/model.onnx` | ❌ | Dynamic or zero dims are not supported |
 | `node/test_constantofshape_int_zeros/model.onnx` | ❌ | ConstantOfShape expects matching dtypes, got int32, int64 |
 | `node/test_conv_with_autopad_same/model.onnx` | ❌ | Conv supports auto_pad=NOTSET only |
-| `node/test_conv_with_strides_and_asymmetric_padding/model.onnx` | ❌ | Unsupported op Conv |
-| `node/test_conv_with_strides_no_padding/model.onnx` | ❌ | Unsupported op Conv |
-| `node/test_conv_with_strides_padding/model.onnx` | ❌ | Unsupported op Conv |
+| `node/test_conv_with_strides_and_asymmetric_padding/model.onnx` | ✅ |  |
+| `node/test_conv_with_strides_no_padding/model.onnx` | ✅ |  |
+| `node/test_conv_with_strides_padding/model.onnx` | ✅ |  |
 | `node/test_convinteger_with_padding/model.onnx` | ❌ | Unsupported elem_type 2 (UINT8) for tensor 'x'. |
 | `node/test_convinteger_without_padding/model.onnx` | ❌ | Unsupported elem_type 2 (UINT8) for tensor 'x'. |
 | `node/test_convtranspose/model.onnx` | ❌ | Unsupported op ConvTranspose |
@@ -1620,13 +1620,13 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_training_dropout_mask/model.onnx` | ❌ | Only single-output graphs are supported |
 | `node/test_training_dropout_zero_ratio/model.onnx` | ❌ | Dropout expects matching dtypes, got bool, float |
 | `node/test_training_dropout_zero_ratio_mask/model.onnx` | ❌ | Only single-output graphs are supported |
-| `node/test_transpose_all_permutations_0/model.onnx` | ❌ | Unsupported op Transpose |
-| `node/test_transpose_all_permutations_1/model.onnx` | ❌ | Unsupported op Transpose |
-| `node/test_transpose_all_permutations_2/model.onnx` | ❌ | Unsupported op Transpose |
-| `node/test_transpose_all_permutations_3/model.onnx` | ❌ | Unsupported op Transpose |
-| `node/test_transpose_all_permutations_4/model.onnx` | ❌ | Unsupported op Transpose |
-| `node/test_transpose_all_permutations_5/model.onnx` | ❌ | Unsupported op Transpose |
-| `node/test_transpose_default/model.onnx` | ❌ | Unsupported op Transpose |
+| `node/test_transpose_all_permutations_0/model.onnx` | ✅ |  |
+| `node/test_transpose_all_permutations_1/model.onnx` | ✅ |  |
+| `node/test_transpose_all_permutations_2/model.onnx` | ✅ |  |
+| `node/test_transpose_all_permutations_3/model.onnx` | ✅ |  |
+| `node/test_transpose_all_permutations_4/model.onnx` | ✅ |  |
+| `node/test_transpose_all_permutations_5/model.onnx` | ✅ |  |
+| `node/test_transpose_default/model.onnx` | ✅ |  |
 | `node/test_tril/model.onnx` | ❌ | Unsupported op Trilu |
 | `node/test_tril_neg/model.onnx` | ❌ | Unsupported op Trilu |
 | `node/test_tril_one_row_neg/model.onnx` | ❌ | Unsupported op Trilu |
@@ -1683,32 +1683,32 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `pytorch-converted/test_BatchNorm3d_eval/model.onnx` | ❌ | Unsupported op BatchNormalization |
 | `pytorch-converted/test_BatchNorm3d_momentum_eval/model.onnx` | ❌ | Unsupported op BatchNormalization |
 | `pytorch-converted/test_ConstantPad2d/model.onnx` | ❌ | Unsupported op Pad |
-| `pytorch-converted/test_Conv1d/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv1d_dilated/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv1d_groups/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv1d_pad1/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv1d_pad1size1/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv1d_pad2/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv1d_pad2size1/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv1d_stride/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv2d/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv2d_depthwise/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv2d_depthwise_padded/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv2d_depthwise_strided/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv2d_depthwise_with_multiplier/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv2d_dilated/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv2d_groups/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv2d_groups_thnn/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv2d_no_bias/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv2d_padding/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv2d_strided/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv3d/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv3d_dilated/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv3d_dilated_strided/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv3d_groups/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv3d_no_bias/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv3d_stride/model.onnx` | ❌ | Unsupported op Conv |
-| `pytorch-converted/test_Conv3d_stride_padding/model.onnx` | ❌ | Unsupported op Conv |
+| `pytorch-converted/test_Conv1d/model.onnx` | ❌ | Conv expects 2D strides |
+| `pytorch-converted/test_Conv1d_dilated/model.onnx` | ❌ | Conv expects 2D strides |
+| `pytorch-converted/test_Conv1d_groups/model.onnx` | ❌ | Conv supports group=1 only |
+| `pytorch-converted/test_Conv1d_pad1/model.onnx` | ❌ | Conv expects 2D strides |
+| `pytorch-converted/test_Conv1d_pad1size1/model.onnx` | ❌ | Conv expects 2D strides |
+| `pytorch-converted/test_Conv1d_pad2/model.onnx` | ❌ | Conv expects 2D strides |
+| `pytorch-converted/test_Conv1d_pad2size1/model.onnx` | ❌ | Conv expects 2D strides |
+| `pytorch-converted/test_Conv1d_stride/model.onnx` | ❌ | Conv expects 2D strides |
+| `pytorch-converted/test_Conv2d/model.onnx` | ✅ |  |
+| `pytorch-converted/test_Conv2d_depthwise/model.onnx` | ❌ | Conv supports group=1 only |
+| `pytorch-converted/test_Conv2d_depthwise_padded/model.onnx` | ❌ | Conv supports group=1 only |
+| `pytorch-converted/test_Conv2d_depthwise_strided/model.onnx` | ❌ | Conv supports group=1 only |
+| `pytorch-converted/test_Conv2d_depthwise_with_multiplier/model.onnx` | ❌ | Conv supports group=1 only |
+| `pytorch-converted/test_Conv2d_dilated/model.onnx` | ✅ |  |
+| `pytorch-converted/test_Conv2d_groups/model.onnx` | ❌ | Conv supports group=1 only |
+| `pytorch-converted/test_Conv2d_groups_thnn/model.onnx` | ❌ | Conv supports group=1 only |
+| `pytorch-converted/test_Conv2d_no_bias/model.onnx` | ✅ |  |
+| `pytorch-converted/test_Conv2d_padding/model.onnx` | ✅ |  |
+| `pytorch-converted/test_Conv2d_strided/model.onnx` | ✅ |  |
+| `pytorch-converted/test_Conv3d/model.onnx` | ❌ | Conv expects 2D strides |
+| `pytorch-converted/test_Conv3d_dilated/model.onnx` | ❌ | Conv expects 2D strides |
+| `pytorch-converted/test_Conv3d_dilated_strided/model.onnx` | ❌ | Conv expects 2D strides |
+| `pytorch-converted/test_Conv3d_groups/model.onnx` | ❌ | Conv supports group=1 only |
+| `pytorch-converted/test_Conv3d_no_bias/model.onnx` | ❌ | Conv expects 2D strides |
+| `pytorch-converted/test_Conv3d_stride/model.onnx` | ❌ | Conv expects 2D strides |
+| `pytorch-converted/test_Conv3d_stride_padding/model.onnx` | ❌ | Conv expects 2D strides |
 | `pytorch-converted/test_ConvTranspose2d/model.onnx` | ❌ | Unsupported op ConvTranspose |
 | `pytorch-converted/test_ConvTranspose2d_no_bias/model.onnx` | ❌ | Unsupported op ConvTranspose |
 | `pytorch-converted/test_ELU/model.onnx` | ❌ | Unsupported op Elu |
@@ -1719,7 +1719,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `pytorch-converted/test_LeakyReLU/model.onnx` | ❌ | Unsupported op LeakyRelu |
 | `pytorch-converted/test_LeakyReLU_with_negval/model.onnx` | ❌ | Unsupported op LeakyRelu |
 | `pytorch-converted/test_Linear/model.onnx` | ❌ | Gemm must have 2 inputs and 1 output |
-| `pytorch-converted/test_Linear_no_bias/model.onnx` | ❌ | Unsupported op Transpose |
+| `pytorch-converted/test_Linear_no_bias/model.onnx` | ✅ |  |
 | `pytorch-converted/test_LogSoftmax/model.onnx` | ❌ | Unsupported op LogSoftmax |
 | `pytorch-converted/test_MaxPool1d/model.onnx` | ❌ | Unsupported op MaxPool |
 | `pytorch-converted/test_MaxPool1d_stride/model.onnx` | ❌ | Unsupported op MaxPool |
@@ -1762,7 +1762,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `pytorch-operator/test_operator_chunk/model.onnx` | ❌ | Only single-output graphs are supported |
 | `pytorch-operator/test_operator_clip/model.onnx` | ❌ | Unsupported op Clip |
 | `pytorch-operator/test_operator_concat2/model.onnx` | ❌ | Unsupported op Concat |
-| `pytorch-operator/test_operator_conv/model.onnx` | ❌ | Unsupported op Conv |
+| `pytorch-operator/test_operator_conv/model.onnx` | ✅ |  |
 | `pytorch-operator/test_operator_convtranspose/model.onnx` | ❌ | Unsupported op ConvTranspose |
 | `pytorch-operator/test_operator_exp/model.onnx` | ✅ |  |
 | `pytorch-operator/test_operator_flatten/model.onnx` | ❌ | Unsupported op Flatten |
@@ -1774,7 +1774,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `pytorch-operator/test_operator_non_float_params/model.onnx` | ✅ |  |
 | `pytorch-operator/test_operator_pad/model.onnx` | ❌ | Unsupported op Pad |
 | `pytorch-operator/test_operator_params/model.onnx` | ❌ | Unsupported op Sigmoid |
-| `pytorch-operator/test_operator_permute2/model.onnx` | ❌ | Unsupported op Transpose |
+| `pytorch-operator/test_operator_permute2/model.onnx` | ✅ |  |
 | `pytorch-operator/test_operator_pow/model.onnx` | ✅ |  |
 | `pytorch-operator/test_operator_reduced_mean/model.onnx` | ❌ | Unsupported op ReduceMean |
 | `pytorch-operator/test_operator_reduced_mean_keepdim/model.onnx` | ❌ | Unsupported op ReduceMean |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -12,7 +12,6 @@
 | Missing dtype for value '*' in op Resize. Hint: run ONNX shape inference or export with static shapes. | 39 | ████████ |
 | Missing elem_type for tensor '*' | 33 | ███████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████ |
-| Unsupported op Conv | 30 | ██████ |
 | Unsupported op Attention | 29 | ██████ |
 | Unsupported op CastLike | 29 | ██████ |
 | Unsupported op AveragePool | 25 | █████ |
@@ -37,6 +36,7 @@
 | Unsupported op ConvTranspose | 14 | ███ |
 | Unsupported op Concat | 13 | ███ |
 | Gemm must have 2 inputs and 1 output | 13 | ███ |
+| Conv expects 2D strides | 13 | ███ |
 | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 12 | ██ |
 | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 12 | ██ |
 | Less expects matching dtypes, got bool, float | 12 | ██ |
@@ -52,8 +52,8 @@
 | ReduceL1 expects matching dtypes, got float, int64 | 9 | ██ |
 | ReduceL2 expects matching dtypes, got float, int64 | 9 | ██ |
 | ReduceSumSquare expects matching dtypes, got float, int64 | 9 | ██ |
-| Unsupported op Transpose | 9 | ██ |
 | Unsupported op LpPool | 8 | ██ |
+| Conv supports group=1 only | 8 | ██ |
 | Unsupported op BatchNormalization | 7 | █ |
 | Dynamic or zero dims are not supported | 7 | █ |
 | Unsupported op Hardmax | 7 | █ |

--- a/templates/transpose_op.c.j2
+++ b/templates/transpose_op.c.j2
@@ -1,0 +1,41 @@
+static void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+    const int64_t input_shape[{{ rank }}] = { {{ input_shape | join(", ") }} };
+    const int64_t perm[{{ rank }}] = { {{ perm | join(", ") }} };
+    int64_t output_shape[{{ rank }}];
+    size_t input_strides[{{ rank }}];
+    size_t output_strides[{{ rank }}];
+    for (int64_t axis = 0; axis < {{ rank }}; ++axis) {
+        output_shape[axis] = input_shape[perm[axis]];
+    }
+    if ({{ rank }} > 0) {
+        input_strides[{{ rank }} - 1] = 1;
+        output_strides[{{ rank }} - 1] = 1;
+    }
+    for (int64_t axis = {{ rank }} - 1; axis > 0; --axis) {
+        input_strides[axis - 1] =
+            input_strides[axis] * (size_t)input_shape[axis];
+        output_strides[axis - 1] =
+            output_strides[axis] * (size_t)output_shape[axis];
+    }
+    size_t total = 1;
+    for (int64_t axis = 0; axis < {{ rank }}; ++axis) {
+        total *= (size_t)output_shape[axis];
+    }
+    const uint8_t *input_bytes = (const uint8_t *){{ input0 }};
+    uint8_t *output_bytes = (uint8_t *){{ output }};
+    for (size_t out_index = 0; out_index < total; ++out_index) {
+        size_t remaining = out_index;
+        size_t input_index = 0;
+        for (int64_t axis = 0; axis < {{ rank }}; ++axis) {
+            size_t coord = remaining / output_strides[axis];
+            remaining %= output_strides[axis];
+            input_index +=
+                coord * input_strides[(size_t)perm[axis]];
+        }
+        memcpy(
+            output_bytes + out_index * sizeof({{ c_type }}),
+            input_bytes + input_index * sizeof({{ c_type }}),
+            sizeof({{ c_type }})
+        );
+    }
+}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -6449,31 +6449,31 @@
   ],
   [
     "node/test_transpose_all_permutations_0/model.onnx",
-    "Unsupported op Transpose"
+    ""
   ],
   [
     "node/test_transpose_all_permutations_1/model.onnx",
-    "Unsupported op Transpose"
+    ""
   ],
   [
     "node/test_transpose_all_permutations_2/model.onnx",
-    "Unsupported op Transpose"
+    ""
   ],
   [
     "node/test_transpose_all_permutations_3/model.onnx",
-    "Unsupported op Transpose"
+    ""
   ],
   [
     "node/test_transpose_all_permutations_4/model.onnx",
-    "Unsupported op Transpose"
+    ""
   ],
   [
     "node/test_transpose_all_permutations_5/model.onnx",
-    "Unsupported op Transpose"
+    ""
   ],
   [
     "node/test_transpose_default/model.onnx",
-    "Unsupported op Transpose"
+    ""
   ],
   [
     "node/test_tril/model.onnx",
@@ -6845,7 +6845,7 @@
   ],
   [
     "pytorch-converted/test_Linear_no_bias/model.onnx",
-    "Unsupported op Transpose"
+    ""
   ],
   [
     "pytorch-converted/test_LogSoftmax/model.onnx",
@@ -7065,7 +7065,7 @@
   ],
   [
     "pytorch-operator/test_operator_permute2/model.onnx",
-    "Unsupported op Transpose"
+    ""
   ],
   [
     "pytorch-operator/test_operator_pow/model.onnx",

--- a/tests/test_endtoend_ops.py
+++ b/tests/test_endtoend_ops.py
@@ -431,6 +431,22 @@ OPERATOR_CASES = [
         "dtype": TensorProto.FLOAT,
         "attrs": {},
     },
+    {
+        "name": "TransposeNCHWToNHWC",
+        "op_type": "Transpose",
+        "input_shapes": [[1, 3, 4, 5]],
+        "output_shape": [1, 4, 5, 3],
+        "dtype": TensorProto.FLOAT,
+        "attrs": {"perm": [0, 2, 3, 1]},
+    },
+    {
+        "name": "TransposeNHWCToNCHW",
+        "op_type": "Transpose",
+        "input_shapes": [[1, 4, 5, 3]],
+        "output_shape": [1, 3, 4, 5],
+        "dtype": TensorProto.FLOAT,
+        "attrs": {"perm": [0, 3, 1, 2]},
+    },
 ]
 
 


### PR DESCRIPTION
### Motivation

- Add full support for the ONNX `Transpose` operator while avoiding a separate runtime helper by emitting the kernel inline.  
- Keep generated C minimal and portable by using a generic memcpy-based transpose implementation emitted per-op.  
- Support common layout permutations (e.g., NCHW ↔ NHWC) so models that rely on axis reordering can be lowered and emitted.  
- Update test coverage and official ONNX support references to prevent regressions.

### Description

- Introduce `TransposeOp` in the emitter data model and implement lowering via `Compiler._lower_transpose_op` with a helper `_resolve_transpose_perm` to validate and compute the permutation.  
- Add a `transpose_op.c.j2` template that inlines stride computation and a generic memcpy-based transpose loop into the emitted operator function.  
- Update the C emitter to render the transpose template and add required includes (`<stdint.h>`, `<string.h>`) when `TransposeOp` is present, and remove runtime helper injection and the separate `transpose.c`/runtime module.  
- Add end-to-end tests for NCHW→NHWC and NHWC→NCHW transpose cases and refresh official ONNX support/golden reference files.

### Testing

- Ran the test suite with refreshed references via `UPDATE_REFS=1 pytest -n auto -q`.  
- All automated tests completed successfully with `68 passed`.  
- The new transpose end-to-end tests executed as part of the operator tests and passed.  
- No automated test failures were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69639bd5c87c83259280061d0c655942)