### PR TITLE
Add Transpose op support and refresh official ONNX expectations

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 128 / 1802 official ONNX files.
+Support 137 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -1620,13 +1620,13 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_training_dropout_mask/model.onnx` | ❌ | Only single-output graphs are supported |
 | `node/test_training_dropout_zero_ratio/model.onnx` | ❌ | Dropout expects matching dtypes, got bool, float |
 | `node/test_training_dropout_zero_ratio_mask/model.onnx` | ❌ | Only single-output graphs are supported |
-| `node/test_transpose_all_permutations_0/model.onnx` | ❌ | Unsupported op Transpose |
-| `node/test_transpose_all_permutations_1/model.onnx` | ❌ | Unsupported op Transpose |
-| `node/test_transpose_all_permutations_2/model.onnx` | ❌ | Unsupported op Transpose |
-| `node/test_transpose_all_permutations_3/model.onnx` | ❌ | Unsupported op Transpose |
-| `node/test_transpose_all_permutations_4/model.onnx` | ❌ | Unsupported op Transpose |
-| `node/test_transpose_all_permutations_5/model.onnx` | ❌ | Unsupported op Transpose |
-| `node/test_transpose_default/model.onnx` | ❌ | Unsupported op Transpose |
+| `node/test_transpose_all_permutations_0/model.onnx` | ✅ |  |
+| `node/test_transpose_all_permutations_1/model.onnx` | ✅ |  |
+| `node/test_transpose_all_permutations_2/model.onnx` | ✅ |  |
+| `node/test_transpose_all_permutations_3/model.onnx` | ✅ |  |
+| `node/test_transpose_all_permutations_4/model.onnx` | ✅ |  |
+| `node/test_transpose_all_permutations_5/model.onnx` | ✅ |  |
+| `node/test_transpose_default/model.onnx` | ✅ |  |
 | `node/test_tril/model.onnx` | ❌ | Unsupported op Trilu |
 | `node/test_tril_neg/model.onnx` | ❌ | Unsupported op Trilu |
 | `node/test_tril_one_row_neg/model.onnx` | ❌ | Unsupported op Trilu |
@@ -1719,7 +1719,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `pytorch-converted/test_LeakyReLU/model.onnx` | ❌ | Unsupported op LeakyRelu |
 | `pytorch-converted/test_LeakyReLU_with_negval/model.onnx` | ❌ | Unsupported op LeakyRelu |
 | `pytorch-converted/test_Linear/model.onnx` | ❌ | Gemm must have 2 inputs and 1 output |
-| `pytorch-converted/test_Linear_no_bias/model.onnx` | ❌ | Unsupported op Transpose |
+| `pytorch-converted/test_Linear_no_bias/model.onnx` | ✅ |  |
 | `pytorch-converted/test_LogSoftmax/model.onnx` | ❌ | Unsupported op LogSoftmax |
 | `pytorch-converted/test_MaxPool1d/model.onnx` | ❌ | Unsupported op MaxPool |
 | `pytorch-converted/test_MaxPool1d_stride/model.onnx` | ❌ | Unsupported op MaxPool |
@@ -1774,7 +1774,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `pytorch-operator/test_operator_non_float_params/model.onnx` | ✅ |  |
 | `pytorch-operator/test_operator_pad/model.onnx` | ❌ | Unsupported op Pad |
 | `pytorch-operator/test_operator_params/model.onnx` | ❌ | Unsupported op Sigmoid |
-| `pytorch-operator/test_operator_permute2/model.onnx` | ❌ | Unsupported op Transpose |
+| `pytorch-operator/test_operator_permute2/model.onnx` | ✅ |  |
 | `pytorch-operator/test_operator_pow/model.onnx` | ✅ |  |
 | `pytorch-operator/test_operator_reduced_mean/model.onnx` | ❌ | Unsupported op ReduceMean |
 | `pytorch-operator/test_operator_reduced_mean_keepdim/model.onnx` | ❌ | Unsupported op ReduceMean |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -51,7 +51,6 @@
 | ReduceL1 expects matching dtypes, got float, int64 | 9 | ██ |
 | ReduceL2 expects matching dtypes, got float, int64 | 9 | ██ |
 | ReduceSumSquare expects matching dtypes, got float, int64 | 9 | ██ |
-| Unsupported op Transpose | 9 | ██ |
 | Unsupported op LpPool | 8 | ██ |
 | Conv supports group=1 only | 8 | ██ |
 | Unsupported op BatchNormalization | 7 | █ |

--- a/templates/transpose_op.c.j2
+++ b/templates/transpose_op.c.j2
@@ -1,0 +1,9 @@
+void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+{% for dim in output_shape %}
+{{ loop_indents[loop.index0] }}for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+{% endfor %}
+{{ inner_indent }}{{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = {{ input0 }}{% for var in input_indices %}[{{ var }}]{% endfor %};
+{% for _ in output_shape %}
+{{ loop_indents[loop.revindex0] }}}
+{% endfor %}
+}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -6449,31 +6449,31 @@
   ],
   [
     "node/test_transpose_all_permutations_0/model.onnx",
-    "Unsupported op Transpose"
+    ""
   ],
   [
     "node/test_transpose_all_permutations_1/model.onnx",
-    "Unsupported op Transpose"
+    ""
   ],
   [
     "node/test_transpose_all_permutations_2/model.onnx",
-    "Unsupported op Transpose"
+    ""
   ],
   [
     "node/test_transpose_all_permutations_3/model.onnx",
-    "Unsupported op Transpose"
+    ""
   ],
   [
     "node/test_transpose_all_permutations_4/model.onnx",
-    "Unsupported op Transpose"
+    ""
   ],
   [
     "node/test_transpose_all_permutations_5/model.onnx",
-    "Unsupported op Transpose"
+    ""
   ],
   [
     "node/test_transpose_default/model.onnx",
-    "Unsupported op Transpose"
+    ""
   ],
   [
     "node/test_tril/model.onnx",
@@ -6845,7 +6845,7 @@
   ],
   [
     "pytorch-converted/test_Linear_no_bias/model.onnx",
-    "Unsupported op Transpose"
+    ""
   ],
   [
     "pytorch-converted/test_LogSoftmax/model.onnx",
@@ -7065,7 +7065,7 @@
   ],
   [
     "pytorch-operator/test_operator_permute2/model.onnx",
-    "Unsupported op Transpose"
+    ""
   ],
   [
     "pytorch-operator/test_operator_pow/model.onnx",


### PR DESCRIPTION
### Motivation

- Implement native support for the ONNX `Transpose` operator so models using transpose can be lowered, executed in Python runner, and emitted as C code. 
- Keep codegen deterministic and templated by adding a dedicated transpose kernel template to the emitter. 
- Update the official ONNX support expectations and histogram to reflect the new operator coverage after regenerating references. 
- Ensure the change is covered by the repository's automated tests and reference regeneration workflow.

### Description

- Add `TransposeOp` dataclass and wire it into the lowered IR and emitter (`src/onnx2c/codegen/c_emitter.py`).
- Add lowering and runtime evaluation for `Transpose` in the compiler (`src/onnx2c/compiler.py`) with shape/perm validation and dtype propagation.
- Add a Jinja2 template `templates/transpose_op.c.j2` and integrate it into the emitter so `Transpose` kernels are emitted as C functions.
- Refresh `tests/official_onnx_expected_errors.json`, `OFFICIAL_ONNX_FILE_SUPPORT.md`, and `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md` to reflect new support counts and regenerated references.

### Testing

- Ran the full test suite with reference regeneration using `UPDATE_REFS=1 pytest -n auto -q`, which completed successfully with `69 passed` in `13.60s`.
- Ran the official ONNX support doc regeneration test `UPDATE_REFS=1 pytest tests/test_official_onnx_files.py::test_official_onnx_file_support_doc -q`, which passed `1 passed` in `0.67s`.
- The changes were exercised by the repository's official ONNX files expectations update, and the generated support documents/histogram were updated accordingly.
- No additional failing automated tests remain after the updates (all targeted tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6963c8dff3b08325b89af485766c8728)