### PR TITLE
Add AveragePool lowering, runtime, and C codegen with tests

### DIFF
--- a/src/onnx2c/lowering/__init__.py
+++ b/src/onnx2c/lowering/__init__.py
@@ -1,0 +1,3 @@
+from .registry import get_lowering, register_lowering
+
+__all__ = ["get_lowering", "register_lowering"]

--- a/src/onnx2c/lowering/average_pool.py
+++ b/src/onnx2c/lowering/average_pool.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..codegen.c_emitter import AveragePoolOp
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Node
+from .registry import register_lowering
+
+
+@dataclass(frozen=True)
+class _AveragePoolSpec:
+    batch: int
+    channels: int
+    in_h: int
+    in_w: int
+    out_h: int
+    out_w: int
+    kernel_h: int
+    kernel_w: int
+    stride_h: int
+    stride_w: int
+    pad_top: int
+    pad_left: int
+    pad_bottom: int
+    pad_right: int
+    count_include_pad: bool
+
+
+def _value_shape(graph: Graph, name: str, node: Node) -> tuple[int, ...]:
+    try:
+        return graph.find_value(name).type.shape
+    except KeyError as exc:
+        raise ShapeInferenceError(
+            f"Missing shape for value '{name}' in op {node.op_type}. "
+            "Hint: run ONNX shape inference or export with static shapes."
+        ) from exc
+
+
+def _value_dtype(graph: Graph, name: str, node: Node) -> str:
+    try:
+        return graph.find_value(name).type.dtype
+    except KeyError as exc:
+        raise ShapeInferenceError(
+            f"Missing dtype for value '{name}' in op {node.op_type}. "
+            "Hint: run ONNX shape inference or export with static shapes."
+        ) from exc
+
+
+def _resolve_average_pool_spec(graph: Graph, node: Node) -> _AveragePoolSpec:
+    if len(node.inputs) != 1 or len(node.outputs) != 1:
+        raise UnsupportedOpError("AveragePool must have 1 input and 1 output")
+    supported_attrs = {
+        "auto_pad",
+        "ceil_mode",
+        "count_include_pad",
+        "kernel_shape",
+        "pads",
+        "strides",
+    }
+    if set(node.attrs) - supported_attrs:
+        raise UnsupportedOpError("AveragePool has unsupported attributes")
+    auto_pad = node.attrs.get("auto_pad", b"NOTSET")
+    if isinstance(auto_pad, bytes):
+        auto_pad = auto_pad.decode("utf-8", errors="ignore")
+    if auto_pad not in ("", "NOTSET"):
+        raise UnsupportedOpError("AveragePool supports auto_pad=NOTSET only")
+    ceil_mode = int(node.attrs.get("ceil_mode", 0))
+    if ceil_mode != 0:
+        raise UnsupportedOpError("AveragePool supports ceil_mode=0 only")
+    count_include_pad = int(node.attrs.get("count_include_pad", 0))
+    if count_include_pad not in (0, 1):
+        raise UnsupportedOpError("AveragePool supports count_include_pad 0 or 1")
+    kernel_shape = node.attrs.get("kernel_shape")
+    if kernel_shape is None:
+        raise UnsupportedOpError("AveragePool requires kernel_shape")
+    kernel_shape = tuple(int(value) for value in kernel_shape)
+    if len(kernel_shape) != 2:
+        raise UnsupportedOpError("AveragePool expects 2D kernel_shape")
+    kernel_h, kernel_w = kernel_shape
+    strides = tuple(int(value) for value in node.attrs.get("strides", (1, 1)))
+    if len(strides) != 2:
+        raise UnsupportedOpError("AveragePool expects 2D strides")
+    pads = tuple(int(value) for value in node.attrs.get("pads", (0, 0, 0, 0)))
+    if len(pads) != 4:
+        raise UnsupportedOpError("AveragePool expects 4D pads")
+    pad_top, pad_left, pad_bottom, pad_right = pads
+    input_shape = _value_shape(graph, node.inputs[0], node)
+    if len(input_shape) != 4:
+        raise UnsupportedOpError("AveragePool supports NCHW 2D inputs only")
+    batch, channels, in_h, in_w = input_shape
+    stride_h, stride_w = strides
+    out_h = (in_h + pad_top + pad_bottom - kernel_h) // stride_h + 1
+    out_w = (in_w + pad_left + pad_right - kernel_w) // stride_w + 1
+    if out_h <= 0 or out_w <= 0:
+        raise ShapeInferenceError("AveragePool output shape must be positive")
+    output_shape = _value_shape(graph, node.outputs[0], node)
+    expected_output_shape = (batch, channels, out_h, out_w)
+    if output_shape != expected_output_shape:
+        raise ShapeInferenceError(
+            "AveragePool output shape must be "
+            f"{expected_output_shape}, got {output_shape}"
+        )
+    return _AveragePoolSpec(
+        batch=batch,
+        channels=channels,
+        in_h=in_h,
+        in_w=in_w,
+        out_h=out_h,
+        out_w=out_w,
+        kernel_h=kernel_h,
+        kernel_w=kernel_w,
+        stride_h=stride_h,
+        stride_w=stride_w,
+        pad_top=pad_top,
+        pad_left=pad_left,
+        pad_bottom=pad_bottom,
+        pad_right=pad_right,
+        count_include_pad=bool(count_include_pad),
+    )
+
+
+@register_lowering("AveragePool")
+def lower_average_pool(graph: Graph, node: Node) -> AveragePoolOp:
+    op_dtype = _value_dtype(graph, node.inputs[0], node)
+    output_dtype = _value_dtype(graph, node.outputs[0], node)
+    if op_dtype != output_dtype:
+        raise UnsupportedOpError(
+            "AveragePool expects matching input/output dtypes, "
+            f"got {op_dtype} and {output_dtype}"
+        )
+    if op_dtype != "float":
+        raise UnsupportedOpError("AveragePool supports float inputs only")
+    spec = _resolve_average_pool_spec(graph, node)
+    return AveragePoolOp(
+        input0=node.inputs[0],
+        output=node.outputs[0],
+        batch=spec.batch,
+        channels=spec.channels,
+        in_h=spec.in_h,
+        in_w=spec.in_w,
+        out_h=spec.out_h,
+        out_w=spec.out_w,
+        kernel_h=spec.kernel_h,
+        kernel_w=spec.kernel_w,
+        stride_h=spec.stride_h,
+        stride_w=spec.stride_w,
+        pad_top=spec.pad_top,
+        pad_left=spec.pad_left,
+        pad_bottom=spec.pad_bottom,
+        pad_right=spec.pad_right,
+        count_include_pad=spec.count_include_pad,
+        dtype=op_dtype,
+    )

--- a/src/onnx2c/lowering/registry.py
+++ b/src/onnx2c/lowering/registry.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+
+from ..ir.model import Graph, Node
+
+LoweredOp = TypeVar("LoweredOp")
+
+_LOWERING_REGISTRY: dict[str, Callable[[Graph, Node], object]] = {}
+
+
+def register_lowering(
+    op_type: str,
+) -> Callable[[Callable[[Graph, Node], LoweredOp]], Callable[[Graph, Node], LoweredOp]]:
+    def decorator(
+        func: Callable[[Graph, Node], LoweredOp],
+    ) -> Callable[[Graph, Node], LoweredOp]:
+        _LOWERING_REGISTRY[op_type] = func
+        return func
+
+    return decorator
+
+
+def get_lowering(op_type: str) -> Callable[[Graph, Node], object] | None:
+    return _LOWERING_REGISTRY.get(op_type)

--- a/templates/average_pool_op.c.j2
+++ b/templates/average_pool_op.c.j2
@@ -1,0 +1,33 @@
+void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+    for (size_t n = 0; n < {{ batch }}; ++n) {
+        for (size_t c = 0; c < {{ channels }}; ++c) {
+            for (size_t oh = 0; oh < {{ out_h }}; ++oh) {
+                for (size_t ow = 0; ow < {{ out_w }}; ++ow) {
+                    {{ c_type }} acc = {{ zero_literal }};
+                    size_t count = 0;
+                    for (size_t kh = 0; kh < {{ kernel_h }}; ++kh) {
+                        const int ih = (int)(oh * {{ stride_h }} + kh) - {{ pad_top }};
+                        if (ih < 0 || ih >= {{ in_h }}) {
+                            if ({{ count_include_pad }}) {
+                                count += {{ kernel_w }};
+                            }
+                            continue;
+                        }
+                        for (size_t kw = 0; kw < {{ kernel_w }}; ++kw) {
+                            const int iw = (int)(ow * {{ stride_w }} + kw) - {{ pad_left }};
+                            if (iw < 0 || iw >= {{ in_w }}) {
+                                if ({{ count_include_pad }}) {
+                                    count += 1;
+                                }
+                                continue;
+                            }
+                            acc += {{ input0 }}[n][c][ih][iw];
+                            count += 1;
+                        }
+                    }
+                    {{ output }}[n][c][oh][ow] = count ? acc / ({{ c_type }})count : {{ zero_literal }};
+                }
+            }
+        }
+    }
+}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -857,83 +857,83 @@
   ],
   [
     "node/test_averagepool_1d_default/model.onnx",
-    "Unsupported op AveragePool"
+    "AveragePool expects 2D kernel_shape"
   ],
   [
     "node/test_averagepool_2d_ceil/model.onnx",
-    "Unsupported op AveragePool"
+    "AveragePool supports ceil_mode=0 only"
   ],
   [
     "node/test_averagepool_2d_ceil_last_window_starts_on_pad/model.onnx",
-    "Unsupported op AveragePool"
+    "AveragePool supports ceil_mode=0 only"
   ],
   [
     "node/test_averagepool_2d_default/model.onnx",
-    "Unsupported op AveragePool"
+    ""
   ],
   [
     "node/test_averagepool_2d_dilations/model.onnx",
-    "Unsupported op AveragePool"
+    "AveragePool has unsupported attributes"
   ],
   [
     "node/test_averagepool_2d_pads/model.onnx",
-    "Unsupported op AveragePool"
+    ""
   ],
   [
     "node/test_averagepool_2d_pads_count_include_pad/model.onnx",
-    "Unsupported op AveragePool"
+    ""
   ],
   [
     "node/test_averagepool_2d_precomputed_pads/model.onnx",
-    "Unsupported op AveragePool"
+    ""
   ],
   [
     "node/test_averagepool_2d_precomputed_pads_count_include_pad/model.onnx",
-    "Unsupported op AveragePool"
+    ""
   ],
   [
     "node/test_averagepool_2d_precomputed_same_upper/model.onnx",
-    "Unsupported op AveragePool"
+    "AveragePool supports auto_pad=NOTSET only"
   ],
   [
     "node/test_averagepool_2d_precomputed_strides/model.onnx",
-    "Unsupported op AveragePool"
+    ""
   ],
   [
     "node/test_averagepool_2d_same_lower/model.onnx",
-    "Unsupported op AveragePool"
+    "AveragePool supports auto_pad=NOTSET only"
   ],
   [
     "node/test_averagepool_2d_same_upper/model.onnx",
-    "Unsupported op AveragePool"
+    "AveragePool supports auto_pad=NOTSET only"
   ],
   [
     "node/test_averagepool_2d_strides/model.onnx",
-    "Unsupported op AveragePool"
+    ""
   ],
   [
     "node/test_averagepool_3d_default/model.onnx",
-    "Unsupported op AveragePool"
+    "AveragePool expects 2D kernel_shape"
   ],
   [
     "node/test_averagepool_3d_dilations_large_count_include_pad_is_0_ceil_mode_is_False/model.onnx",
-    "Unsupported op AveragePool"
+    "AveragePool has unsupported attributes"
   ],
   [
     "node/test_averagepool_3d_dilations_large_count_include_pad_is_0_ceil_mode_is_True/model.onnx",
-    "Unsupported op AveragePool"
+    "AveragePool has unsupported attributes"
   ],
   [
     "node/test_averagepool_3d_dilations_large_count_include_pad_is_1_ceil_mode_is_False/model.onnx",
-    "Unsupported op AveragePool"
+    "AveragePool has unsupported attributes"
   ],
   [
     "node/test_averagepool_3d_dilations_large_count_include_pad_is_1_ceil_mode_is_True/model.onnx",
-    "Unsupported op AveragePool"
+    "AveragePool has unsupported attributes"
   ],
   [
     "node/test_averagepool_3d_dilations_small/model.onnx",
-    "Unsupported op AveragePool"
+    "AveragePool has unsupported attributes"
   ],
   [
     "node/test_basic_conv_with_padding/model.onnx",
@@ -6657,23 +6657,23 @@
   ],
   [
     "pytorch-converted/test_AvgPool2d/model.onnx",
-    "Unsupported op AveragePool"
+    ""
   ],
   [
     "pytorch-converted/test_AvgPool2d_stride/model.onnx",
-    "Unsupported op AveragePool"
+    ""
   ],
   [
     "pytorch-converted/test_AvgPool3d/model.onnx",
-    "Unsupported op AveragePool"
+    "AveragePool expects 2D kernel_shape"
   ],
   [
     "pytorch-converted/test_AvgPool3d_stride/model.onnx",
-    "Unsupported op AveragePool"
+    "AveragePool expects 2D kernel_shape"
   ],
   [
     "pytorch-converted/test_AvgPool3d_stride1_pad0_gpu_input/model.onnx",
-    "Unsupported op AveragePool"
+    "AveragePool expects 2D kernel_shape"
   ],
   [
     "pytorch-converted/test_BatchNorm1d_3d_input_eval/model.onnx",


### PR DESCRIPTION
### Motivation
- Add support for the ONNX `AveragePool` op across lowering, interpreter, and C code emission to increase operator coverage.  
- Make lowering extensible via a registry so new op lowerings can be registered without editing the core `Compiler` logic.  
- Emit deterministic, minimal C for `AveragePool` using the existing templating/codegen approach.  
- Verify correctness by running end-to-end comparisons against ONNX Runtime (ORT).

### Description
- Introduce a lowering registry and AveragePool lowering implementation in `src/onnx2c/lowering/` and expose `get_lowering`/`register_lowering`.  
- Implement `AveragePool` lowering (`src/onnx2c/lowering/average_pool.py`) that validates attrs/shapes and returns a new `AveragePoolOp` IR type.  
- Add runtime evaluation `_apply_average_pool` in `src/onnx2c/compiler.py` and wire lowering lookup into `_lower_model` and runtime `run` so `AveragePool` is handled uniformly.  
- Extend the C emitter with `AveragePoolOp` support and a new Jinja2 template `templates/average_pool_op.c.j2`, and add end-to-end tests and expected-error snapshot adjustments in `tests/test_endtoend_ops.py` and `tests/official_onnx_expected_errors.json`.

### Testing
- Ran the full test suite (golden refs update): `UPDATE_REFS=1 pytest -n auto -q`.  
- Result: `80 passed in 24.62s`.  
- The new tests cover several `AveragePool` configurations (kernel/stride/pads and `count_include_pad`) and exercise both lowering and C code emission.  
- Updated official ONNX expected-error snapshots to reflect `AveragePool` validation messages instead of unconditional `Unsupported op` errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6963d2eecfcc8325b1ba6950fc3f4aec)