### PR TITLE
Add support for ConstantOfShape (lowering, runtime, and C codegen)

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 182 / 1802 official ONNX files.
+Support 184 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -8,15 +8,15 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 
 | File | Supported | Error |
 | --- | --- | --- |
-| `light/light_bvlc_alexnet.onnx` | ❌ | Unsupported op ConstantOfShape |
-| `light/light_densenet121.onnx` | ❌ | Unsupported op ConstantOfShape |
-| `light/light_inception_v1.onnx` | ❌ | Unsupported op ConstantOfShape |
-| `light/light_inception_v2.onnx` | ❌ | Unsupported op ConstantOfShape |
-| `light/light_resnet50.onnx` | ❌ | Unsupported op ConstantOfShape |
-| `light/light_shufflenet.onnx` | ❌ | Unsupported op ConstantOfShape |
-| `light/light_squeezenet.onnx` | ❌ | Unsupported op ConstantOfShape |
-| `light/light_vgg19.onnx` | ❌ | Unsupported op ConstantOfShape |
-| `light/light_zfnet512.onnx` | ❌ | Unsupported op ConstantOfShape |
+| `light/light_bvlc_alexnet.onnx` | ❌ | Unsupported op LRN |
+| `light/light_densenet121.onnx` | ❌ | Unsupported op BatchNormalization |
+| `light/light_inception_v1.onnx` | ❌ | Unsupported op LRN |
+| `light/light_inception_v2.onnx` | ❌ | Unsupported op BatchNormalization |
+| `light/light_resnet50.onnx` | ❌ | Unsupported op BatchNormalization |
+| `light/light_shufflenet.onnx` | ❌ | Unsupported op BatchNormalization |
+| `light/light_squeezenet.onnx` | ❌ | Unsupported op Dropout |
+| `light/light_vgg19.onnx` | ❌ | Unsupported op Reshape |
+| `light/light_zfnet512.onnx` | ❌ | Unsupported op LRN |
 | `node/test_abs/model.onnx` | ✅ |  |
 | `node/test_acos/model.onnx` | ❌ | Unsupported op Acos |
 | `node/test_acos_example/model.onnx` | ❌ | Unsupported op Acos |
@@ -520,9 +520,9 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_constant_pad/model.onnx` | ❌ | Unsupported op Pad |
 | `node/test_constant_pad_axes/model.onnx` | ❌ | Unsupported op Pad |
 | `node/test_constant_pad_negative_axes/model.onnx` | ❌ | Unsupported op Pad |
-| `node/test_constantofshape_float_ones/model.onnx` | ❌ | Unsupported op ConstantOfShape |
+| `node/test_constantofshape_float_ones/model.onnx` | ✅ |  |
 | `node/test_constantofshape_int_shape_zero/model.onnx` | ❌ | Dynamic or zero dims are not supported |
-| `node/test_constantofshape_int_zeros/model.onnx` | ❌ | Unsupported op ConstantOfShape |
+| `node/test_constantofshape_int_zeros/model.onnx` | ✅ |  |
 | `node/test_conv_with_autopad_same/model.onnx` | ❌ | Conv supports auto_pad=NOTSET only |
 | `node/test_conv_with_strides_and_asymmetric_padding/model.onnx` | ✅ |  |
 | `node/test_conv_with_strides_no_padding/model.onnx` | ✅ |  |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -21,11 +21,11 @@
 | Unsupported op Less | 18 | ████ |
 | Unsupported op GridSample | 18 | ████ |
 | Unsupported elem_type 12 (UINT32) for tensor '*'. | 17 | ███ |
+| Unsupported op Reshape | 16 | ███ |
 | Unsupported op ArgMax | 16 | ███ |
 | Unsupported op ArgMin | 16 | ███ |
 | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 16 | ███ |
 | Unsupported op Trilu | 16 | ███ |
-| Unsupported op Reshape | 15 | ███ |
 | Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 14 | ███ |
 | Unsupported elem_type 26 (INT2) for tensor '*'. | 14 | ███ |
 | Unsupported elem_type 22 (INT4) for tensor '*'. | 14 | ███ |
@@ -39,7 +39,7 @@
 | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 12 | ██ |
 | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 12 | ██ |
 | Unsupported op ReduceMean | 12 | ██ |
-| Unsupported op ConstantOfShape | 11 | ██ |
+| Unsupported op BatchNormalization | 11 | ██ |
 | Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 11 | ██ |
 | Unsupported op Pad | 11 | ██ |
 | Unsupported op Flatten | 11 | ██ |
@@ -51,14 +51,13 @@
 | Unsupported op ReduceL2 | 9 | ██ |
 | Unsupported op ReduceProd | 9 | ██ |
 | Unsupported op ReduceSumSquare | 9 | ██ |
+| Unsupported op Dropout | 8 | ██ |
 | Unsupported op Greater | 8 | ██ |
 | Unsupported op LpPool | 8 | ██ |
 | Unsupported op RotaryEmbedding | 8 | ██ |
 | Unsupported op Slice | 8 | ██ |
 | Conv supports group=1 only | 8 | ██ |
-| Unsupported op BatchNormalization | 7 | █ |
 | Dynamic or zero dims are not supported | 7 | █ |
-| Unsupported op Dropout | 7 | █ |
 | Unsupported op Hardmax | 7 | █ |
 | Unsupported op TfIdfVectorizer | 7 | █ |
 | AveragePool has unsupported attributes | 6 | █ |
@@ -70,6 +69,7 @@
 | Unsupported op LpNormalization | 6 | █ |
 | Unsupported op Mod | 6 | █ |
 | Unsupported op ScatterElements | 6 | █ |
+| Unsupported op LRN | 5 | █ |
 | AveragePool expects 2D kernel_shape | 5 | █ |
 | Unsupported op Elu | 5 | █ |
 | Unsupported op Col2Im | 5 | █ |
@@ -128,7 +128,6 @@
 | Unsupported op GroupNormalization | 2 | █ |
 | Unsupported op HammingWindow | 2 | █ |
 | Unsupported op HannWindow | 2 | █ |
-| Unsupported op LRN | 2 | █ |
 | Max must have 2 inputs and 1 output | 2 | █ |
 | Unsupported op MaxUnpool | 2 | █ |
 | Mean must have 2 inputs and 1 output | 2 | █ |

--- a/src/onnx2c/codegen/__init__.py
+++ b/src/onnx2c/codegen/__init__.py
@@ -1,9 +1,18 @@
-from .c_emitter import BinaryOp, CEmitter, ConstTensor, LoweredModel, MatMulOp, UnaryOp
+from .c_emitter import (
+    BinaryOp,
+    CEmitter,
+    ConstTensor,
+    ConstantOfShapeOp,
+    LoweredModel,
+    MatMulOp,
+    UnaryOp,
+)
 
 __all__ = [
     "BinaryOp",
     "CEmitter",
     "ConstTensor",
+    "ConstantOfShapeOp",
     "LoweredModel",
     "MatMulOp",
     "UnaryOp",

--- a/src/onnx2c/lowering/constant_of_shape.py
+++ b/src/onnx2c/lowering/constant_of_shape.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from onnx import numpy_helper
+
+from ..codegen.c_emitter import ConstantOfShapeOp
+from ..dtypes import ONNX_TO_DTYPE
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Node
+from .registry import register_lowering
+
+
+def _value_shape(graph: Graph, name: str, node: Node) -> tuple[int, ...]:
+    try:
+        return graph.find_value(name).type.shape
+    except KeyError as exc:
+        raise ShapeInferenceError(
+            f"Missing shape for value '{name}' in op {node.op_type}. "
+            "Hint: run ONNX shape inference or export with static shapes."
+        ) from exc
+
+
+def _value_dtype(graph: Graph, name: str, node: Node) -> str:
+    try:
+        return graph.find_value(name).type.dtype
+    except KeyError as exc:
+        raise ShapeInferenceError(
+            f"Missing dtype for value '{name}' in op {node.op_type}. "
+            "Hint: run ONNX shape inference or export with static shapes."
+        ) from exc
+
+
+def _parse_value_attr(node: Node) -> tuple[str, float | int | bool]:
+    value_attr = node.attrs.get("value")
+    if value_attr is None:
+        return "float", 0.0
+    dtype = ONNX_TO_DTYPE.get(value_attr.data_type)
+    if dtype is None:
+        raise UnsupportedOpError(
+            f"ConstantOfShape has unsupported value dtype {value_attr.data_type}"
+        )
+    data = numpy_helper.to_array(value_attr)
+    if data.size != 1:
+        raise UnsupportedOpError("ConstantOfShape value must be a scalar")
+    return dtype, data.reshape(-1)[0].item()
+
+
+@register_lowering("ConstantOfShape")
+def lower_constant_of_shape(graph: Graph, node: Node) -> ConstantOfShapeOp:
+    if len(node.inputs) != 1 or len(node.outputs) != 1:
+        raise UnsupportedOpError("ConstantOfShape must have 1 input and 1 output")
+    input_shape = _value_shape(graph, node.inputs[0], node)
+    if len(input_shape) != 1:
+        raise UnsupportedOpError("ConstantOfShape expects a 1D shape input")
+    output_shape = _value_shape(graph, node.outputs[0], node)
+    if input_shape[0] != len(output_shape):
+        raise ShapeInferenceError(
+            "ConstantOfShape input length must match output rank"
+        )
+    for dim in output_shape:
+        if dim <= 0:
+            raise ShapeInferenceError("Dynamic or zero dims are not supported")
+    input_dtype = _value_dtype(graph, node.inputs[0], node)
+    if input_dtype != "int64":
+        raise UnsupportedOpError(
+            f"ConstantOfShape expects int64 shape input, got {input_dtype}"
+        )
+    output_dtype = _value_dtype(graph, node.outputs[0], node)
+    value_dtype, value = _parse_value_attr(node)
+    if output_dtype != value_dtype:
+        raise UnsupportedOpError(
+            "ConstantOfShape output dtype must match value dtype, "
+            f"got {output_dtype} and {value_dtype}"
+        )
+    return ConstantOfShapeOp(
+        input0=node.inputs[0],
+        output=node.outputs[0],
+        input_shape=input_shape,
+        shape=output_shape,
+        value=value,
+        dtype=output_dtype,
+        input_dtype=input_dtype,
+    )

--- a/templates/constant_of_shape_op.c.j2
+++ b/templates/constant_of_shape_op.c.j2
@@ -1,0 +1,10 @@
+void {{ op_name }}(const {{ input_c_type }} {{ input0 }}{{ input_suffix }}, {{ c_type }} {{ output }}{{ array_suffix }}) {
+    (void){{ input0 }};
+{% for dim in shape %}
+{{ loop_indents[loop.index0] }}for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+{% endfor %}
+{{ inner_indent }}{{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = {{ value_literal }};
+{% for _ in shape %}
+{{ loop_indents[loop.revindex0] }}}
+{% endfor %}
+}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -1,39 +1,39 @@
 [
   [
     "light/light_bvlc_alexnet.onnx",
-    "Unsupported op ConstantOfShape"
+    "Unsupported op LRN"
   ],
   [
     "light/light_densenet121.onnx",
-    "Unsupported op ConstantOfShape"
+    "Unsupported op BatchNormalization"
   ],
   [
     "light/light_inception_v1.onnx",
-    "Unsupported op ConstantOfShape"
+    "Unsupported op LRN"
   ],
   [
     "light/light_inception_v2.onnx",
-    "Unsupported op ConstantOfShape"
+    "Unsupported op BatchNormalization"
   ],
   [
     "light/light_resnet50.onnx",
-    "Unsupported op ConstantOfShape"
+    "Unsupported op BatchNormalization"
   ],
   [
     "light/light_shufflenet.onnx",
-    "Unsupported op ConstantOfShape"
+    "Unsupported op BatchNormalization"
   ],
   [
     "light/light_squeezenet.onnx",
-    "Unsupported op ConstantOfShape"
+    "Unsupported op Dropout"
   ],
   [
     "light/light_vgg19.onnx",
-    "Unsupported op ConstantOfShape"
+    "Unsupported op Reshape"
   ],
   [
     "light/light_zfnet512.onnx",
-    "Unsupported op ConstantOfShape"
+    "Unsupported op LRN"
   ],
   [
     "node/test_abs/model.onnx",
@@ -2049,7 +2049,7 @@
   ],
   [
     "node/test_constantofshape_float_ones/model.onnx",
-    "Unsupported op ConstantOfShape"
+    ""
   ],
   [
     "node/test_constantofshape_int_shape_zero/model.onnx",
@@ -2057,7 +2057,7 @@
   ],
   [
     "node/test_constantofshape_int_zeros/model.onnx",
-    "Unsupported op ConstantOfShape"
+    ""
   ],
   [
     "node/test_conv_with_autopad_same/model.onnx",

--- a/tests/test_constant_of_shape.py
+++ b/tests/test_constant_of_shape.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import numpy as np
+import onnx
+
+from onnx import TensorProto, helper
+
+from onnx2c.compiler import Compiler
+
+
+def _make_constant_of_shape_model() -> onnx.ModelProto:
+    shape_values = np.array([2, 2], dtype=np.int64)
+    shape_tensor = helper.make_tensor(
+        "shape",
+        TensorProto.INT64,
+        dims=shape_values.shape,
+        vals=shape_values.tolist(),
+    )
+    value_tensor = helper.make_tensor(
+        "fill",
+        TensorProto.FLOAT,
+        dims=[1],
+        vals=[2.5],
+    )
+    output = helper.make_tensor_value_info(
+        "out", TensorProto.FLOAT, shape_values.tolist()
+    )
+    node = helper.make_node(
+        "ConstantOfShape",
+        inputs=["shape"],
+        outputs=[output.name],
+        value=value_tensor,
+    )
+    graph = helper.make_graph(
+        [node],
+        "constant_of_shape_graph",
+        [],
+        [output],
+        initializer=[shape_tensor],
+    )
+    model = helper.make_model(
+        graph,
+        producer_name="onnx2c",
+        opset_imports=[helper.make_operatorsetid("", 13)],
+    )
+    model.ir_version = 7
+    onnx.checker.check_model(model)
+    return model
+
+
+def test_constant_of_shape_run() -> None:
+    model = _make_constant_of_shape_model()
+    compiler = Compiler()
+    outputs = compiler.run(model, {})
+    expected = np.full((2, 2), 2.5, dtype=np.float32)
+    np.testing.assert_allclose(outputs["out"], expected)


### PR DESCRIPTION
### Motivation

- Implement full support for the ONNX `ConstantOfShape` operator so models using it can be compiled and executed.
- Emit deterministic C for `ConstantOfShape` instances and handle constant-only graphs (no model inputs) in wrapper signatures.
- Provide lowering-level validation and clear error messages for unsupported shapes and dtypes.
- Add tests to ensure runtime correctness and to keep golden/official ONNX support references up to date.

### Description

- Added a lowering for `ConstantOfShape` in `src/onnx2c/lowering/constant_of_shape.py` with shape/dtype validation and registration via the lowering registry.
- Extended compiler runtime (`src/onnx2c/compiler.py`) to execute `ConstantOfShape` nodes when running models without emitting C.
- Added `ConstantOfShapeOp` dataclass and integrated it into the C emitter (`src/onnx2c/codegen/c_emitter.py`), including a Jinja2 template `templates/constant_of_shape_op.c.j2` to generate C code that fills the output tensor with the specified value.
- Updated wrapper signature generation to support models with no inputs, added includes/dtype handling for shape/value dtypes, and exported the new op in `src/onnx2c/codegen/__init__.py`.
- Added unit and end-to-end tests: `tests/test_constant_of_shape.py` and a CLI verification case in `tests/test_endtoend_ops.py`.
- Updated official ONNX expectations and support docs / references (`tests/official_onnx_expected_errors.json`, `OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`) to reflect now-supported `ConstantOfShape` cases.

### Testing

- Ran the full test suite with updated references using `UPDATE_REFS=1 pytest -n auto -q` and refreshed golden/expectation files as needed.
- Test run result: `82 passed` in `11.74s` (full suite with reference updates).
- Added a new unit test `tests/test_constant_of_shape.py` which verifies `Compiler.run` produces the expected filled tensor (passed).
- Added an end-to-end verification case in `tests/test_endtoend_ops.py` that compiles and verifies a `ConstantOfShape` model (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6963d8a1436c8325b3c8e4e9e9b7bdbd)