### PR TITLE
Add BatchNormalization lowering and codegen support

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 184 / 1802 official ONNX files.
+Support 191 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -9,11 +9,11 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | File | Supported | Error |
 | --- | --- | --- |
 | `light/light_bvlc_alexnet.onnx` | ❌ | Unsupported op LRN |
-| `light/light_densenet121.onnx` | ❌ | Unsupported op BatchNormalization |
+| `light/light_densenet121.onnx` | ❌ | Unsupported op Unsqueeze |
 | `light/light_inception_v1.onnx` | ❌ | Unsupported op LRN |
-| `light/light_inception_v2.onnx` | ❌ | Unsupported op BatchNormalization |
-| `light/light_resnet50.onnx` | ❌ | Unsupported op BatchNormalization |
-| `light/light_shufflenet.onnx` | ❌ | Unsupported op BatchNormalization |
+| `light/light_inception_v2.onnx` | ❌ | Unsupported op Unsqueeze |
+| `light/light_resnet50.onnx` | ❌ | Unsupported op Reshape |
+| `light/light_shufflenet.onnx` | ❌ | Conv supports group=1 only |
 | `light/light_squeezenet.onnx` | ❌ | Unsupported op Dropout |
 | `light/light_vgg19.onnx` | ❌ | Unsupported op Reshape |
 | `light/light_zfnet512.onnx` | ❌ | Unsupported op LRN |
@@ -246,9 +246,9 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_basic_conv_without_padding/model.onnx` | ✅ |  |
 | `node/test_basic_deform_conv_with_padding/model.onnx` | ❌ | Unsupported op DeformConv |
 | `node/test_basic_deform_conv_without_padding/model.onnx` | ❌ | Unsupported op DeformConv |
-| `node/test_batchnorm_epsilon/model.onnx` | ❌ | Unsupported op BatchNormalization |
+| `node/test_batchnorm_epsilon/model.onnx` | ✅ |  |
 | `node/test_batchnorm_epsilon_training_mode/model.onnx` | ❌ | Only single-output graphs are supported |
-| `node/test_batchnorm_example/model.onnx` | ❌ | Unsupported op BatchNormalization |
+| `node/test_batchnorm_example/model.onnx` | ✅ |  |
 | `node/test_batchnorm_example_training_mode/model.onnx` | ❌ | Only single-output graphs are supported |
 | `node/test_bernoulli/model.onnx` | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'x'. |
 | `node/test_bernoulli_double/model.onnx` | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'y'. |
@@ -1677,11 +1677,11 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `pytorch-converted/test_AvgPool3d/model.onnx` | ❌ | AveragePool expects 2D kernel_shape |
 | `pytorch-converted/test_AvgPool3d_stride/model.onnx` | ❌ | AveragePool expects 2D kernel_shape |
 | `pytorch-converted/test_AvgPool3d_stride1_pad0_gpu_input/model.onnx` | ❌ | AveragePool expects 2D kernel_shape |
-| `pytorch-converted/test_BatchNorm1d_3d_input_eval/model.onnx` | ❌ | Unsupported op BatchNormalization |
-| `pytorch-converted/test_BatchNorm2d_eval/model.onnx` | ❌ | Unsupported op BatchNormalization |
-| `pytorch-converted/test_BatchNorm2d_momentum_eval/model.onnx` | ❌ | Unsupported op BatchNormalization |
-| `pytorch-converted/test_BatchNorm3d_eval/model.onnx` | ❌ | Unsupported op BatchNormalization |
-| `pytorch-converted/test_BatchNorm3d_momentum_eval/model.onnx` | ❌ | Unsupported op BatchNormalization |
+| `pytorch-converted/test_BatchNorm1d_3d_input_eval/model.onnx` | ✅ |  |
+| `pytorch-converted/test_BatchNorm2d_eval/model.onnx` | ✅ |  |
+| `pytorch-converted/test_BatchNorm2d_momentum_eval/model.onnx` | ✅ |  |
+| `pytorch-converted/test_BatchNorm3d_eval/model.onnx` | ✅ |  |
+| `pytorch-converted/test_BatchNorm3d_momentum_eval/model.onnx` | ✅ |  |
 | `pytorch-converted/test_ConstantPad2d/model.onnx` | ❌ | Unsupported op Pad |
 | `pytorch-converted/test_Conv1d/model.onnx` | ❌ | Conv expects 2D strides |
 | `pytorch-converted/test_Conv1d_dilated/model.onnx` | ❌ | Conv expects 2D strides |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -20,8 +20,9 @@
 | Unsupported op RMSNormalization | 19 | ████ |
 | Unsupported op Less | 18 | ████ |
 | Unsupported op GridSample | 18 | ████ |
+| Unsupported op Reshape | 17 | ███ |
 | Unsupported elem_type 12 (UINT32) for tensor '*'. | 17 | ███ |
-| Unsupported op Reshape | 16 | ███ |
+| Unsupported op Unsqueeze | 16 | ███ |
 | Unsupported op ArgMax | 16 | ███ |
 | Unsupported op ArgMin | 16 | ███ |
 | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 16 | ███ |
@@ -32,20 +33,19 @@
 | Unsupported elem_type 25 (UINT2) for tensor '*'. | 14 | ███ |
 | Unsupported elem_type 21 (UINT4) for tensor '*'. | 14 | ███ |
 | Unsupported op ConvTranspose | 14 | ███ |
-| Unsupported op Unsqueeze | 14 | ███ |
 | Unsupported op Clip | 13 | ███ |
 | Gemm must have 2 inputs and 1 output | 13 | ███ |
 | Conv expects 2D strides | 13 | ███ |
 | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 12 | ██ |
 | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 12 | ██ |
 | Unsupported op ReduceMean | 12 | ██ |
-| Unsupported op BatchNormalization | 11 | ██ |
 | Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 11 | ██ |
 | Unsupported op Pad | 11 | ██ |
 | Unsupported op Flatten | 11 | ██ |
 | Unsupported op LogSoftmax | 10 | ██ |
 | Unsupported op ReduceMin | 10 | ██ |
 | Unsupported op Shape | 10 | ██ |
+| Conv supports group=1 only | 9 | ██ |
 | Unsupported op NonMaxSuppression | 9 | ██ |
 | Unsupported op ReduceL1 | 9 | ██ |
 | Unsupported op ReduceL2 | 9 | ██ |
@@ -56,7 +56,6 @@
 | Unsupported op LpPool | 8 | ██ |
 | Unsupported op RotaryEmbedding | 8 | ██ |
 | Unsupported op Slice | 8 | ██ |
-| Conv supports group=1 only | 8 | ██ |
 | Dynamic or zero dims are not supported | 7 | █ |
 | Unsupported op Hardmax | 7 | █ |
 | Unsupported op TfIdfVectorizer | 7 | █ |

--- a/src/onnx2c/lowering/batch_normalization.py
+++ b/src/onnx2c/lowering/batch_normalization.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..codegen.c_emitter import BatchNormOp
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Node
+from .registry import register_lowering
+
+
+@dataclass(frozen=True)
+class _BatchNormSpec:
+    shape: tuple[int, ...]
+    channels: int
+    epsilon: float
+
+
+def _value_shape(graph: Graph, name: str, node: Node) -> tuple[int, ...]:
+    try:
+        return graph.find_value(name).type.shape
+    except KeyError as exc:
+        raise ShapeInferenceError(
+            f"Missing shape for value '{name}' in op {node.op_type}. "
+            "Hint: run ONNX shape inference or export with static shapes."
+        ) from exc
+
+
+def _value_dtype(graph: Graph, name: str, node: Node) -> str:
+    try:
+        return graph.find_value(name).type.dtype
+    except KeyError as exc:
+        raise ShapeInferenceError(
+            f"Missing dtype for value '{name}' in op {node.op_type}. "
+            "Hint: run ONNX shape inference or export with static shapes."
+        ) from exc
+
+
+def _node_dtype(graph: Graph, node: Node, *names: str) -> str:
+    dtypes = {_value_dtype(graph, name, node) for name in names}
+    if len(dtypes) != 1:
+        raise UnsupportedOpError(
+            f"{node.op_type} expects matching dtypes, got {', '.join(sorted(dtypes))}"
+        )
+    return next(iter(dtypes))
+
+
+def _resolve_batch_norm_spec(graph: Graph, node: Node) -> _BatchNormSpec:
+    if len(node.inputs) != 5 or len(node.outputs) != 1:
+        raise UnsupportedOpError(
+            "BatchNormalization must have 5 inputs and 1 output"
+        )
+    supported_attrs = {
+        "epsilon",
+        "is_test",
+        "momentum",
+        "spatial",
+        "training_mode",
+    }
+    if set(node.attrs) - supported_attrs:
+        raise UnsupportedOpError("BatchNormalization has unsupported attributes")
+    is_test = int(node.attrs.get("is_test", 1))
+    if is_test != 1:
+        raise UnsupportedOpError("BatchNormalization supports is_test=1 only")
+    training_mode = int(node.attrs.get("training_mode", 0))
+    if training_mode != 0:
+        raise UnsupportedOpError("BatchNormalization supports training_mode=0 only")
+    spatial = int(node.attrs.get("spatial", 1))
+    if spatial != 1:
+        raise UnsupportedOpError("BatchNormalization supports spatial=1 only")
+    epsilon = float(node.attrs.get("epsilon", 1e-5))
+    input_shape = _value_shape(graph, node.inputs[0], node)
+    if len(input_shape) < 2:
+        raise UnsupportedOpError(
+            "BatchNormalization expects input rank of at least 2"
+        )
+    channels = input_shape[1]
+    for name in node.inputs[1:]:
+        shape = _value_shape(graph, name, node)
+        if shape != (channels,):
+            raise ShapeInferenceError(
+                "BatchNormalization parameter shape must be "
+                f"({channels},), got {shape}"
+            )
+    output_shape = _value_shape(graph, node.outputs[0], node)
+    if output_shape != input_shape:
+        raise ShapeInferenceError(
+            "BatchNormalization output shape must match input shape, "
+            f"got {output_shape}"
+        )
+    return _BatchNormSpec(
+        shape=input_shape,
+        channels=channels,
+        epsilon=epsilon,
+    )
+
+
+@register_lowering("BatchNormalization")
+def lower_batch_normalization(graph: Graph, node: Node) -> BatchNormOp:
+    op_dtype = _node_dtype(graph, node, *node.inputs, *node.outputs)
+    if op_dtype != "float":
+        raise UnsupportedOpError("BatchNormalization supports float inputs only")
+    spec = _resolve_batch_norm_spec(graph, node)
+    return BatchNormOp(
+        input0=node.inputs[0],
+        scale=node.inputs[1],
+        bias=node.inputs[2],
+        mean=node.inputs[3],
+        variance=node.inputs[4],
+        output=node.outputs[0],
+        shape=spec.shape,
+        channels=spec.channels,
+        epsilon=spec.epsilon,
+        dtype=op_dtype,
+    )

--- a/templates/batch_norm_op.c.j2
+++ b/templates/batch_norm_op.c.j2
@@ -1,0 +1,11 @@
+void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix }}, const {{ c_type }} {{ scale }}{{ scale_suffix }}, const {{ c_type }} {{ bias }}{{ bias_suffix }}, const {{ c_type }} {{ mean }}{{ mean_suffix }}, const {{ c_type }} {{ variance }}{{ variance_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+{% for dim in shape %}
+{{ loop_indents[loop.index0] }}for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+{% endfor %}
+{{ inner_indent }}size_t c = {{ loop_vars[1] }};
+{{ inner_indent }}{{ c_type }} denom = sqrtf({{ variance }}[c] + {{ epsilon_literal }});
+{{ inner_indent }}{{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = ({{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %} - {{ mean }}[c]) / denom * {{ scale }}[c] + {{ bias }}[c];
+{% for _ in shape %}
+{{ loop_indents[loop.revindex0] }}}
+{% endfor %}
+}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -5,7 +5,7 @@
   ],
   [
     "light/light_densenet121.onnx",
-    "Unsupported op BatchNormalization"
+    "Unsupported op Unsqueeze"
   ],
   [
     "light/light_inception_v1.onnx",
@@ -13,15 +13,15 @@
   ],
   [
     "light/light_inception_v2.onnx",
-    "Unsupported op BatchNormalization"
+    "Unsupported op Unsqueeze"
   ],
   [
     "light/light_resnet50.onnx",
-    "Unsupported op BatchNormalization"
+    "Unsupported op Reshape"
   ],
   [
     "light/light_shufflenet.onnx",
-    "Unsupported op BatchNormalization"
+    "Conv supports group=1 only"
   ],
   [
     "light/light_squeezenet.onnx",
@@ -953,7 +953,7 @@
   ],
   [
     "node/test_batchnorm_epsilon/model.onnx",
-    "Unsupported op BatchNormalization"
+    ""
   ],
   [
     "node/test_batchnorm_epsilon_training_mode/model.onnx",
@@ -961,7 +961,7 @@
   ],
   [
     "node/test_batchnorm_example/model.onnx",
-    "Unsupported op BatchNormalization"
+    ""
   ],
   [
     "node/test_batchnorm_example_training_mode/model.onnx",
@@ -6677,23 +6677,23 @@
   ],
   [
     "pytorch-converted/test_BatchNorm1d_3d_input_eval/model.onnx",
-    "Unsupported op BatchNormalization"
+    ""
   ],
   [
     "pytorch-converted/test_BatchNorm2d_eval/model.onnx",
-    "Unsupported op BatchNormalization"
+    ""
   ],
   [
     "pytorch-converted/test_BatchNorm2d_momentum_eval/model.onnx",
-    "Unsupported op BatchNormalization"
+    ""
   ],
   [
     "pytorch-converted/test_BatchNorm3d_eval/model.onnx",
-    "Unsupported op BatchNormalization"
+    ""
   ],
   [
     "pytorch-converted/test_BatchNorm3d_momentum_eval/model.onnx",
-    "Unsupported op BatchNormalization"
+    ""
   ],
   [
     "pytorch-converted/test_ConstantPad2d/model.onnx",


### PR DESCRIPTION
### Motivation

- Support the ONNX `BatchNormalization` operator for inference so models using BatchNorm can be lowered and compiled to C.
- Keep the compiler pass-based and deterministic by implementing lowering + codegen rather than special-casing in codegen paths.
- Provide a runtime execution path for `BatchNormalization` to allow local numeric verification against NumPy/ORT.
- Update official ONNX support expectations and golden references to reflect newly supported BatchNorm cases.

### Description

- Add a lowering implementation `src/onnx2c/lowering/batch_normalization.py` that validates inference-only attributes and registers `BatchNormalization` via the lowering registry using `@register_lowering`.
- Wire BatchNorm into the compiler and runtime in `src/onnx2c/compiler.py` so the operator is lowered into a `BatchNormOp` and executed by `Compiler.run` for verification.
- Add a `BatchNormOp` dataclass and codegen wiring in `src/onnx2c/codegen/c_emitter.py`, plus a dedicated template `templates/batch_norm_op.c.j2` that emits the C kernel (uses `sqrtf` and per-channel params).
- Add tests in `tests/test_endtoend_ops.py` (a NumPy-based runtime check `test_batchnorm_run_matches_numpy` and an ORT comparison `test_batchnorm_op_matches_onnxruntime`) and refresh official support docs/golden references under `tests/` and `OFFICIAL_ONNX_FILE_SUPPORT*`.

### Testing

- Ran the full test suite with reference updates: `UPDATE_REFS=1 pytest -n auto -q` and all tests passed (`84 passed in 17.26s`).
- Updated and validated the official ONNX support doc generation: `UPDATE_REFS=1 pytest -q tests/test_official_onnx_files.py::test_official_onnx_file_support_doc` which passed (`1 passed in 0.66s`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6963df01009c8325b3964743307cdc4d)