### PR TITLE
compiler: support Gemm bias input

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 199 / 1802 official ONNX files.
+Support 200 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -11,11 +11,11 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `light/light_bvlc_alexnet.onnx` | ❌ | Unsupported op LRN |
 | `light/light_densenet121.onnx` | ❌ | Unsupported op GlobalAveragePool |
 | `light/light_inception_v1.onnx` | ❌ | Unsupported op LRN |
-| `light/light_inception_v2.onnx` | ❌ | Gemm must have 2 inputs and 1 output |
-| `light/light_resnet50.onnx` | ❌ | Gemm must have 2 inputs and 1 output |
+| `light/light_inception_v2.onnx` | ❌ | Gemm only supports alpha=1, beta=1, transA=0, transB=0 |
+| `light/light_resnet50.onnx` | ❌ | Gemm only supports alpha=1, beta=1, transA=0, transB=0 |
 | `light/light_shufflenet.onnx` | ❌ | Conv supports group=1 only |
 | `light/light_squeezenet.onnx` | ❌ | Unsupported op Dropout |
-| `light/light_vgg19.onnx` | ❌ | Gemm must have 2 inputs and 1 output |
+| `light/light_vgg19.onnx` | ❌ | Gemm only supports alpha=1, beta=1, transA=0, transB=0 |
 | `light/light_zfnet512.onnx` | ❌ | Unsupported op LRN |
 | `node/test_abs/model.onnx` | ✅ |  |
 | `node/test_acos/model.onnx` | ❌ | Unsupported op Acos |
@@ -660,17 +660,17 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_gelu_tanh_1_expanded/model.onnx` | ❌ | Unsupported op CastLike |
 | `node/test_gelu_tanh_2/model.onnx` | ❌ | Unsupported op Gelu |
 | `node/test_gelu_tanh_2_expanded/model.onnx` | ❌ | Unsupported op CastLike |
-| `node/test_gemm_all_attributes/model.onnx` | ❌ | Gemm must have 2 inputs and 1 output |
-| `node/test_gemm_alpha/model.onnx` | ❌ | Gemm must have 2 inputs and 1 output |
-| `node/test_gemm_beta/model.onnx` | ❌ | Gemm must have 2 inputs and 1 output |
-| `node/test_gemm_default_matrix_bias/model.onnx` | ❌ | Gemm must have 2 inputs and 1 output |
+| `node/test_gemm_all_attributes/model.onnx` | ❌ | Gemm only supports alpha=1, beta=1, transA=0, transB=0 |
+| `node/test_gemm_alpha/model.onnx` | ❌ | Gemm only supports alpha=1, beta=1, transA=0, transB=0 |
+| `node/test_gemm_beta/model.onnx` | ❌ | Gemm only supports alpha=1, beta=1, transA=0, transB=0 |
+| `node/test_gemm_default_matrix_bias/model.onnx` | ✅ |  |
 | `node/test_gemm_default_no_bias/model.onnx` | ✅ |  |
-| `node/test_gemm_default_scalar_bias/model.onnx` | ❌ | Gemm must have 2 inputs and 1 output |
-| `node/test_gemm_default_single_elem_vector_bias/model.onnx` | ❌ | Gemm must have 2 inputs and 1 output |
-| `node/test_gemm_default_vector_bias/model.onnx` | ❌ | Gemm must have 2 inputs and 1 output |
-| `node/test_gemm_default_zero_bias/model.onnx` | ❌ | Gemm must have 2 inputs and 1 output |
-| `node/test_gemm_transposeA/model.onnx` | ❌ | Gemm must have 2 inputs and 1 output |
-| `node/test_gemm_transposeB/model.onnx` | ❌ | Gemm must have 2 inputs and 1 output |
+| `node/test_gemm_default_scalar_bias/model.onnx` | ❌ | Gemm bias input must match output shape, got () vs (2, 4) |
+| `node/test_gemm_default_single_elem_vector_bias/model.onnx` | ❌ | Gemm bias input must match output shape, got (1,) vs (3, 3) |
+| `node/test_gemm_default_vector_bias/model.onnx` | ❌ | Gemm bias input must match output shape, got (1, 4) vs (2, 4) |
+| `node/test_gemm_default_zero_bias/model.onnx` | ❌ | Gemm bias input must match output shape, got (1, 4) vs (3, 4) |
+| `node/test_gemm_transposeA/model.onnx` | ❌ | Gemm only supports alpha=1, beta=1, transA=0, transB=0 |
+| `node/test_gemm_transposeB/model.onnx` | ❌ | Gemm only supports alpha=1, beta=1, transA=0, transB=0 |
 | `node/test_globalaveragepool/model.onnx` | ❌ | Unsupported op GlobalAveragePool |
 | `node/test_globalaveragepool_precomputed/model.onnx` | ❌ | Unsupported op GlobalAveragePool |
 | `node/test_globalmaxpool/model.onnx` | ❌ | Unsupported op GlobalMaxPool |
@@ -1718,7 +1718,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `pytorch-converted/test_GLU_dim/model.onnx` | ❌ | Unsupported op Split |
 | `pytorch-converted/test_LeakyReLU/model.onnx` | ❌ | Unsupported op LeakyRelu |
 | `pytorch-converted/test_LeakyReLU_with_negval/model.onnx` | ❌ | Unsupported op LeakyRelu |
-| `pytorch-converted/test_Linear/model.onnx` | ❌ | Gemm must have 2 inputs and 1 output |
+| `pytorch-converted/test_Linear/model.onnx` | ❌ | Gemm only supports alpha=1, beta=1, transA=0, transB=0 |
 | `pytorch-converted/test_Linear_no_bias/model.onnx` | ✅ |  |
 | `pytorch-converted/test_LogSoftmax/model.onnx` | ❌ | Unsupported op LogSoftmax |
 | `pytorch-converted/test_MaxPool1d/model.onnx` | ✅ |  |
@@ -1757,7 +1757,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `pytorch-operator/test_operator_add_size1_right_broadcast/model.onnx` | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor '0'. |
 | `pytorch-operator/test_operator_add_size1_singleton_broadcast/model.onnx` | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor '0'. |
 | `pytorch-operator/test_operator_addconstant/model.onnx` | ❌ | Unsupported elem_type 11 (DOUBLE) for Constant '1'. |
-| `pytorch-operator/test_operator_addmm/model.onnx` | ❌ | Gemm must have 2 inputs and 1 output |
+| `pytorch-operator/test_operator_addmm/model.onnx` | ❌ | Gemm bias input must match output shape, got (4,) vs (2, 4) |
 | `pytorch-operator/test_operator_basic/model.onnx` | ❌ | Unsupported op Sigmoid |
 | `pytorch-operator/test_operator_chunk/model.onnx` | ❌ | Only single-output graphs are supported |
 | `pytorch-operator/test_operator_clip/model.onnx` | ❌ | Unsupported op Clip |
@@ -1770,7 +1770,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `pytorch-operator/test_operator_max/model.onnx` | ✅ |  |
 | `pytorch-operator/test_operator_maxpool/model.onnx` | ✅ |  |
 | `pytorch-operator/test_operator_min/model.onnx` | ✅ |  |
-| `pytorch-operator/test_operator_mm/model.onnx` | ❌ | Gemm must have 2 inputs and 1 output |
+| `pytorch-operator/test_operator_mm/model.onnx` | ❌ | Gemm only supports alpha=1, beta=1, transA=0, transB=0 |
 | `pytorch-operator/test_operator_non_float_params/model.onnx` | ✅ |  |
 | `pytorch-operator/test_operator_pad/model.onnx` | ❌ | Unsupported op Pad |
 | `pytorch-operator/test_operator_params/model.onnx` | ❌ | Unsupported op Sigmoid |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -21,7 +21,6 @@
 | Unsupported op Less | 18 | ████ |
 | Unsupported op GridSample | 18 | ████ |
 | Unsupported elem_type 12 (UINT32) for tensor '*'. | 17 | ███ |
-| Gemm must have 2 inputs and 1 output | 16 | ███ |
 | Unsupported op ArgMax | 16 | ███ |
 | Unsupported op ArgMin | 16 | ███ |
 | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 16 | ███ |
@@ -41,6 +40,7 @@
 | Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 11 | ██ |
 | Unsupported op Pad | 11 | ██ |
 | Unsupported op Flatten | 11 | ██ |
+| Gemm only supports alpha=1, beta=1, transA=0, transB=0 | 10 | ██ |
 | Unsupported op ReduceMin | 10 | ██ |
 | Unsupported op Shape | 10 | ██ |
 | Conv supports group=1 only | 9 | ██ |
@@ -162,6 +162,10 @@
 | Unsupported op DequantizeLinear | 1 | █ |
 | Unsupported op Det | 1 | █ |
 | Unsupported op Erf | 1 | █ |
+| Gemm bias input must match output shape, got () vs (2, 4) | 1 | █ |
+| Gemm bias input must match output shape, got (1,) vs (3, 3) | 1 | █ |
+| Gemm bias input must match output shape, got (1, 4) vs (2, 4) | 1 | █ |
+| Gemm bias input must match output shape, got (1, 4) vs (3, 4) | 1 | █ |
 | Unsupported op HardSwish | 1 | █ |
 | Unsupported op If | 1 | █ |
 | Unsupported op IsNaN | 1 | █ |
@@ -180,3 +184,4 @@
 | Unsupported op Swish | 1 | █ |
 | Unsupported op Upsample | 1 | █ |
 | Unsupported elem_type 11 (DOUBLE) for Constant '*'. | 1 | █ |
+| Gemm bias input must match output shape, got (4,) vs (2, 4) | 1 | █ |

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -13,11 +13,11 @@
   ],
   [
     "light/light_inception_v2.onnx",
-    "Gemm must have 2 inputs and 1 output"
+    "Gemm only supports alpha=1, beta=1, transA=0, transB=0"
   ],
   [
     "light/light_resnet50.onnx",
-    "Gemm must have 2 inputs and 1 output"
+    "Gemm only supports alpha=1, beta=1, transA=0, transB=0"
   ],
   [
     "light/light_shufflenet.onnx",
@@ -29,7 +29,7 @@
   ],
   [
     "light/light_vgg19.onnx",
-    "Gemm must have 2 inputs and 1 output"
+    "Gemm only supports alpha=1, beta=1, transA=0, transB=0"
   ],
   [
     "light/light_zfnet512.onnx",
@@ -2609,19 +2609,19 @@
   ],
   [
     "node/test_gemm_all_attributes/model.onnx",
-    "Gemm must have 2 inputs and 1 output"
+    "Gemm only supports alpha=1, beta=1, transA=0, transB=0"
   ],
   [
     "node/test_gemm_alpha/model.onnx",
-    "Gemm must have 2 inputs and 1 output"
+    "Gemm only supports alpha=1, beta=1, transA=0, transB=0"
   ],
   [
     "node/test_gemm_beta/model.onnx",
-    "Gemm must have 2 inputs and 1 output"
+    "Gemm only supports alpha=1, beta=1, transA=0, transB=0"
   ],
   [
     "node/test_gemm_default_matrix_bias/model.onnx",
-    "Gemm must have 2 inputs and 1 output"
+    ""
   ],
   [
     "node/test_gemm_default_no_bias/model.onnx",
@@ -2629,27 +2629,27 @@
   ],
   [
     "node/test_gemm_default_scalar_bias/model.onnx",
-    "Gemm must have 2 inputs and 1 output"
+    "Gemm bias input must match output shape, got () vs (2, 4)"
   ],
   [
     "node/test_gemm_default_single_elem_vector_bias/model.onnx",
-    "Gemm must have 2 inputs and 1 output"
+    "Gemm bias input must match output shape, got (1,) vs (3, 3)"
   ],
   [
     "node/test_gemm_default_vector_bias/model.onnx",
-    "Gemm must have 2 inputs and 1 output"
+    "Gemm bias input must match output shape, got (1, 4) vs (2, 4)"
   ],
   [
     "node/test_gemm_default_zero_bias/model.onnx",
-    "Gemm must have 2 inputs and 1 output"
+    "Gemm bias input must match output shape, got (1, 4) vs (3, 4)"
   ],
   [
     "node/test_gemm_transposeA/model.onnx",
-    "Gemm must have 2 inputs and 1 output"
+    "Gemm only supports alpha=1, beta=1, transA=0, transB=0"
   ],
   [
     "node/test_gemm_transposeB/model.onnx",
-    "Gemm must have 2 inputs and 1 output"
+    "Gemm only supports alpha=1, beta=1, transA=0, transB=0"
   ],
   [
     "node/test_globalaveragepool/model.onnx",
@@ -6841,7 +6841,7 @@
   ],
   [
     "pytorch-converted/test_Linear/model.onnx",
-    "Gemm must have 2 inputs and 1 output"
+    "Gemm only supports alpha=1, beta=1, transA=0, transB=0"
   ],
   [
     "pytorch-converted/test_Linear_no_bias/model.onnx",
@@ -6997,7 +6997,7 @@
   ],
   [
     "pytorch-operator/test_operator_addmm/model.onnx",
-    "Gemm must have 2 inputs and 1 output"
+    "Gemm bias input must match output shape, got (4,) vs (2, 4)"
   ],
   [
     "pytorch-operator/test_operator_basic/model.onnx",
@@ -7049,7 +7049,7 @@
   ],
   [
     "pytorch-operator/test_operator_mm/model.onnx",
-    "Gemm must have 2 inputs and 1 output"
+    "Gemm only supports alpha=1, beta=1, transA=0, transB=0"
   ],
   [
     "pytorch-operator/test_operator_non_float_params/model.onnx",


### PR DESCRIPTION
### Motivation
- Gemm nodes can include an optional bias input which the compiler previously rejected because it required exactly 2 inputs. 
- The change aims to correctly handle Gemm with 2 or 3 inputs while preserving existing attribute constraints (`alpha`, `beta`, `transA`, `transB`).

### Description
- Allow `Gemm` to have 2 or 3 inputs by relaxing validation in `_validate_gemm` to accept `{2, 3}` inputs and still enforce attribute limits. 
- Add `_lower_gemm_ops` which lowers `Gemm` to a `MatMul` (and an `Add` `BinaryOp` when a bias is present) with shape validation and deterministic temporary output naming via `_unique_value_name`.
- Update the eager interpreter in `run()` to apply an optional bias after the matmul with shape checks and to raise a `ShapeInferenceError` on mismatch. 
- Update official support reports / expected-error baselines to reflect the new Gemm behavior and new bias-related error messages.

### Testing
- Ran the full pytest suite with reference updates: `UPDATE_REFS=1 pytest -n auto -q`. 
- All tests passed: `87 passed` in `18.75s`. 
- Golden/expected-error fixtures were updated to reflect the new behavior and remain consistent with the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6963e971263c832584ea14370757d888)