### PR TITLE
lowering: add LRN operator support

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 215 / 1802 official ONNX files.
+Support 219 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -8,15 +8,15 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 
 | File | Supported | Error |
 | --- | --- | --- |
-| `light/light_bvlc_alexnet.onnx` | ❌ | Unsupported op LRN |
+| `light/light_bvlc_alexnet.onnx` | ❌ | Conv supports group=1 only |
 | `light/light_densenet121.onnx` | ❌ | Unsupported op GlobalAveragePool |
-| `light/light_inception_v1.onnx` | ❌ | Unsupported op LRN |
+| `light/light_inception_v1.onnx` | ✅ |  |
 | `light/light_inception_v2.onnx` | ✅ |  |
 | `light/light_resnet50.onnx` | ✅ |  |
 | `light/light_shufflenet.onnx` | ❌ | Conv supports group=1 only |
 | `light/light_squeezenet.onnx` | ❌ | Unsupported op GlobalAveragePool |
 | `light/light_vgg19.onnx` | ✅ |  |
-| `light/light_zfnet512.onnx` | ❌ | Unsupported op LRN |
+| `light/light_zfnet512.onnx` | ✅ |  |
 | `node/test_abs/model.onnx` | ✅ |  |
 | `node/test_acos/model.onnx` | ❌ | Unsupported op Acos |
 | `node/test_acos_example/model.onnx` | ❌ | Unsupported op Acos |
@@ -898,8 +898,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | `node/test_lppool_2d_same_upper/model.onnx` | ❌ | Unsupported op LpPool |
 | `node/test_lppool_2d_strides/model.onnx` | ❌ | Unsupported op LpPool |
 | `node/test_lppool_3d_default/model.onnx` | ❌ | Unsupported op LpPool |
-| `node/test_lrn/model.onnx` | ❌ | Unsupported op LRN |
-| `node/test_lrn_default/model.onnx` | ❌ | Unsupported op LRN |
+| `node/test_lrn/model.onnx` | ✅ |  |
+| `node/test_lrn_default/model.onnx` | ✅ |  |
 | `node/test_lstm_batchwise/model.onnx` | ❌ | Only single-output graphs are supported |
 | `node/test_lstm_defaults/model.onnx` | ❌ | Unsupported op LSTM |
 | `node/test_lstm_with_initial_bias/model.onnx` | ❌ | Unsupported op LSTM |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -40,9 +40,9 @@
 | Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 11 | ██ |
 | Unsupported op Pad | 11 | ██ |
 | Unsupported op Flatten | 11 | ██ |
+| Conv supports group=1 only | 10 | ██ |
 | Unsupported op ReduceMin | 10 | ██ |
 | Unsupported op Shape | 10 | ██ |
-| Conv supports group=1 only | 9 | ██ |
 | Unsupported op NonMaxSuppression | 9 | ██ |
 | Unsupported op ReduceL1 | 9 | ██ |
 | Unsupported op ReduceL2 | 9 | ██ |
@@ -66,7 +66,6 @@
 | Unsupported op LpNormalization | 6 | █ |
 | Unsupported op Mod | 6 | █ |
 | Unsupported op ScatterElements | 6 | █ |
-| Unsupported op LRN | 5 | █ |
 | AveragePool expects 2D kernel_shape | 5 | █ |
 | Unsupported op Elu | 5 | █ |
 | Unsupported op Col2Im | 5 | █ |

--- a/src/onnx2c/lowering/lrn.py
+++ b/src/onnx2c/lowering/lrn.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..codegen.c_emitter import LrnOp
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Node
+from .registry import register_lowering
+
+
+@dataclass(frozen=True)
+class LrnSpec:
+    shape: tuple[int, ...]
+    channels: int
+    size: int
+    half: int
+    alpha: float
+    beta: float
+    bias: float
+
+
+def _value_shape(graph: Graph, name: str, node: Node) -> tuple[int, ...]:
+    try:
+        return graph.find_value(name).type.shape
+    except KeyError as exc:
+        raise ShapeInferenceError(
+            f"Missing shape for value '{name}' in op {node.op_type}. "
+            "Hint: run ONNX shape inference or export with static shapes."
+        ) from exc
+
+
+def _value_dtype(graph: Graph, name: str, node: Node) -> str:
+    try:
+        return graph.find_value(name).type.dtype
+    except KeyError as exc:
+        raise ShapeInferenceError(
+            f"Missing dtype for value '{name}' in op {node.op_type}. "
+            "Hint: run ONNX shape inference or export with static shapes."
+        ) from exc
+
+
+def _node_dtype(graph: Graph, node: Node, *names: str) -> str:
+    dtypes = {_value_dtype(graph, name, node) for name in names}
+    if len(dtypes) != 1:
+        raise UnsupportedOpError(
+            f"{node.op_type} expects matching dtypes, got {', '.join(sorted(dtypes))}"
+        )
+    return next(iter(dtypes))
+
+
+def resolve_lrn_spec(graph: Graph, node: Node) -> LrnSpec:
+    if len(node.inputs) != 1 or len(node.outputs) != 1:
+        raise UnsupportedOpError("LRN must have 1 input and 1 output")
+    supported_attrs = {"alpha", "beta", "bias", "size"}
+    if set(node.attrs) - supported_attrs:
+        raise UnsupportedOpError("LRN has unsupported attributes")
+    size = int(node.attrs.get("size", 0))
+    if size <= 0:
+        raise UnsupportedOpError("LRN size must be a positive integer")
+    if size % 2 == 0:
+        raise UnsupportedOpError("LRN size must be odd")
+    alpha = float(node.attrs.get("alpha", 0.0001))
+    beta = float(node.attrs.get("beta", 0.75))
+    bias = float(node.attrs.get("bias", 1.0))
+    input_shape = _value_shape(graph, node.inputs[0], node)
+    if len(input_shape) < 2:
+        raise UnsupportedOpError("LRN expects input rank of at least 2")
+    output_shape = _value_shape(graph, node.outputs[0], node)
+    if output_shape != input_shape:
+        raise ShapeInferenceError(
+            "LRN output shape must match input shape, "
+            f"got {output_shape} for input {input_shape}"
+        )
+    return LrnSpec(
+        shape=input_shape,
+        channels=input_shape[1],
+        size=size,
+        half=size // 2,
+        alpha=alpha,
+        beta=beta,
+        bias=bias,
+    )
+
+
+@register_lowering("LRN")
+def lower_lrn(graph: Graph, node: Node) -> LrnOp:
+    op_dtype = _node_dtype(graph, node, *node.inputs, *node.outputs)
+    if op_dtype != "float":
+        raise UnsupportedOpError("LRN supports float inputs only")
+    spec = resolve_lrn_spec(graph, node)
+    return LrnOp(
+        input0=node.inputs[0],
+        output=node.outputs[0],
+        shape=spec.shape,
+        channels=spec.channels,
+        size=spec.size,
+        half=spec.half,
+        alpha=spec.alpha,
+        beta=spec.beta,
+        bias=spec.bias,
+        dtype=op_dtype,
+    )

--- a/templates/lrn_op.c.j2
+++ b/templates/lrn_op.c.j2
@@ -1,0 +1,20 @@
+void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+{% for dim in shape %}
+{{ loop_indents[loop.index0] }}for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+{% endfor %}
+{{ inner_indent }}size_t channel_start = {{ loop_vars[1] }} > {{ half }} ? {{ loop_vars[1] }} - {{ half }} : 0;
+{{ inner_indent }}size_t channel_end = {{ loop_vars[1] }} + {{ half }};
+{{ inner_indent }}if (channel_end >= {{ channels }}) {
+{{ inner_indent }}    channel_end = {{ channels }} - 1;
+{{ inner_indent }}}
+{{ inner_indent }}{{ c_type }} sum = {{ zero_literal }};
+{{ inner_indent }}for (size_t c = channel_start; c <= channel_end; ++c) {
+{{ inner_indent }}    {{ c_type }} val = {{ input0 }}[{{ loop_vars[0] }}][c]{% for var in loop_vars[2:] %}[{{ var }}]{% endfor %};
+{{ inner_indent }}    sum += val * val;
+{{ inner_indent }}}
+{{ inner_indent }}{{ c_type }} scale = {{ bias_literal }} + {{ alpha_div_size_literal }} * sum;
+{{ inner_indent }}{{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = {{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %} / powf(scale, {{ beta_literal }});
+{% for _ in shape %}
+{{ loop_indents[loop.revindex0] }}}
+{% endfor %}
+}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -1,7 +1,7 @@
 [
   [
     "light/light_bvlc_alexnet.onnx",
-    "Unsupported op LRN"
+    "Conv supports group=1 only"
   ],
   [
     "light/light_densenet121.onnx",
@@ -9,7 +9,7 @@
   ],
   [
     "light/light_inception_v1.onnx",
-    "Unsupported op LRN"
+    ""
   ],
   [
     "light/light_inception_v2.onnx",
@@ -33,7 +33,7 @@
   ],
   [
     "light/light_zfnet512.onnx",
-    "Unsupported op LRN"
+    ""
   ],
   [
     "node/test_abs/model.onnx",
@@ -3561,11 +3561,11 @@
   ],
   [
     "node/test_lrn/model.onnx",
-    "Unsupported op LRN"
+    ""
   ],
   [
     "node/test_lrn_default/model.onnx",
-    "Unsupported op LRN"
+    ""
   ],
   [
     "node/test_lstm_batchwise/model.onnx",


### PR DESCRIPTION
### Motivation
- Enable support for the ONNX `LRN` (Local Response Normalization) operator across the compiler pipeline to unblock models that include LRN nodes.
- Provide deterministic lowering, runtime evaluation and C code emission for `LRN` consistent with existing pass-based architecture.
- Keep operator-specific validation explicit and raise actionable errors for unsupported shapes/dtypes.
- Update the known-good support matrix to reflect newly supported files that contained `LRN`.

### Description
- Add a lowering pass `src/onnx2c/lowering/lrn.py` that validates attributes and shapes and registers `LRN` lowering via `register_lowering` and returns a `LrnOp` spec.
- Introduce `LrnOp` dataclass and integrate it into `CEmitter` so templates are loaded, rendered and `math.h` is included when needed, with a new `templates/lrn_op.c.j2` template for C emission.
- Wire runtime evaluation via `_apply_lrn` in `src/onnx2c/compiler.py` and handle `LRN` execution in the interpreter path, plus import/typing updates to propagate `LrnSpec`.
- Update support metadata and tests by adjusting `tests/official_onnx_expected_errors.json` and `OFFICIAL_ONNX_FILE_SUPPORT.md` entries for files that used `LRN`.

### Testing
- Ran the full pytest suite with updated golden references using `UPDATE_REFS=1 pytest -n auto -q`.
- Test run result: `92 passed` and completed in `17.78s`.
- Templates were exercised by the emitter during tests and `math.h` dependency was added conditionally where required.
- No failing automated tests remain after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6963fdef487c8325b32ad9b81d4202a1)