### PR TITLE
codegen: add ConvOp output-dimension accessors and refresh ONNX support report

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 274 / 1802 official ONNX files.
+Support 281 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -8,15 +8,15 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 
 | File | Supported | Error |
 | --- | --- | --- |
-| `light/light_bvlc_alexnet.onnx` | ❌ | 'ConvOp' object has no attribute 'out_h' |
+| `light/light_bvlc_alexnet.onnx` | ✅ |  |
 | `light/light_densenet121.onnx` | ❌ | Unsupported op GlobalAveragePool |
-| `light/light_inception_v1.onnx` | ❌ | 'ConvOp' object has no attribute 'out_h' |
-| `light/light_inception_v2.onnx` | ❌ | 'ConvOp' object has no attribute 'out_h' |
-| `light/light_resnet50.onnx` | ❌ | 'ConvOp' object has no attribute 'out_h' |
-| `light/light_shufflenet.onnx` | ❌ | 'ConvOp' object has no attribute 'out_h' |
+| `light/light_inception_v1.onnx` | ✅ |  |
+| `light/light_inception_v2.onnx` | ✅ |  |
+| `light/light_resnet50.onnx` | ✅ |  |
+| `light/light_shufflenet.onnx` | ✅ |  |
 | `light/light_squeezenet.onnx` | ❌ | Unsupported op GlobalAveragePool |
-| `light/light_vgg19.onnx` | ❌ | 'ConvOp' object has no attribute 'out_h' |
-| `light/light_zfnet512.onnx` | ❌ | 'ConvOp' object has no attribute 'out_h' |
+| `light/light_vgg19.onnx` | ✅ |  |
+| `light/light_zfnet512.onnx` | ✅ |  |
 | `node/test_abs/model.onnx` | ✅ |  |
 | `node/test_acos/model.onnx` | ❌ | Unsupported op Acos |
 | `node/test_acos_example/model.onnx` | ❌ | Unsupported op Acos |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -48,7 +48,6 @@
 | ReduceMean axes input must be constant | 8 | ██ |
 | Unsupported op RotaryEmbedding | 8 | ██ |
 | Unsupported op Slice | 8 | ██ |
-| '*' object has no attribute '*' | 7 | █ |
 | Dynamic or zero dims are not supported | 7 | █ |
 | Unsupported op GatherElements | 7 | █ |
 | Unsupported op Hardmax | 7 | █ |

--- a/src/onnx2c/codegen/c_emitter.py
+++ b/src/onnx2c/codegen/c_emitter.py
@@ -93,6 +93,18 @@ class ConvOp:
     group: int
     dtype: str
 
+    @property
+    def out_h(self) -> int:
+        if self.spatial_rank < 1:
+            raise ValueError("Conv output height is undefined for spatial_rank < 1")
+        return self.out_spatial[0]
+
+    @property
+    def out_w(self) -> int:
+        if self.spatial_rank < 2:
+            raise ValueError("Conv output width is undefined for spatial_rank < 2")
+        return self.out_spatial[1]
+
 
 @dataclass(frozen=True)
 class AveragePoolOp:
@@ -1421,7 +1433,7 @@ class CEmitter:
         if isinstance(op, GemmOp):
             return (op.m, op.n)
         if isinstance(op, ConvOp):
-            return (op.batch, op.out_channels, op.out_h, op.out_w)
+            return (op.batch, op.out_channels, *op.out_spatial)
         if isinstance(op, AveragePoolOp):
             return (op.batch, op.channels, op.out_h, op.out_w)
         if isinstance(op, BatchNormOp):

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -1,7 +1,7 @@
 [
   [
     "light/light_bvlc_alexnet.onnx",
-    "'ConvOp' object has no attribute 'out_h'"
+    ""
   ],
   [
     "light/light_densenet121.onnx",
@@ -9,19 +9,19 @@
   ],
   [
     "light/light_inception_v1.onnx",
-    "'ConvOp' object has no attribute 'out_h'"
+    ""
   ],
   [
     "light/light_inception_v2.onnx",
-    "'ConvOp' object has no attribute 'out_h'"
+    ""
   ],
   [
     "light/light_resnet50.onnx",
-    "'ConvOp' object has no attribute 'out_h'"
+    ""
   ],
   [
     "light/light_shufflenet.onnx",
-    "'ConvOp' object has no attribute 'out_h'"
+    ""
   ],
   [
     "light/light_squeezenet.onnx",
@@ -29,11 +29,11 @@
   ],
   [
     "light/light_vgg19.onnx",
-    "'ConvOp' object has no attribute 'out_h'"
+    ""
   ],
   [
     "light/light_zfnet512.onnx",
-    "'ConvOp' object has no attribute 'out_h'"
+    ""
   ],
   [
     "node/test_abs/model.onnx",


### PR DESCRIPTION
### Motivation
- Avoid attribute errors when code expects `ConvOp.out_h`/`out_w` for convolution ops with non-2D spatial ranks.
- Make output-shape handling spatial-rank-agnostic so conv operators of arbitrary spatial rank are handled consistently.

### Description
- Add `ConvOp.out_h` and `ConvOp.out_w` property accessors that derive values from `out_spatial` and validate `spatial_rank` in `src/onnx2c/codegen/c_emitter.py`.
- Refresh the official ONNX support report and histogram by updating `OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`, and `tests/official_onnx_expected_errors.json` to reflect resolved Conv-related failures.
- Modified files: `src/onnx2c/codegen/c_emitter.py`, `OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`, and `tests/official_onnx_expected_errors.json`.

### Testing
- Ran `UPDATE_REFS=1 pytest -n auto -q` and the test suite completed successfully with `103 passed`.
- Updated official ONNX references were regenerated as part of the test run and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69643cedbebc83259f250acd796b4a61)