### PR TITLE
deps: add pytest-order to CI requirements

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -12,6 +12,7 @@ Jinja2==3.1.6
 # Testing
 pytest==8.2.0
 pytest-xdist==3.6.1
+pytest-order==1.2.1
 hypothesis>=6.100.0
 expecttest>=0.1.6
 


### PR DESCRIPTION
### Motivation

- Make the `pytest-order` plugin available in CI so tests that use ordering markers or rely on deterministic sequencing run correctly.

### Description

- Add `pytest-order==1.2.1` to `requirements-ci.txt`.
- No other source files or behavior changes were made.

### Testing

- Ran `UPDATE_REFS=1 pytest -n auto -q` to exercise the full test suite.
- The test run completed with `103 passed in 21.20s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6964418d05b88325a5e8692c835b8682)