### PR TITLE
tests: enforce md test after json using pytest-order and remove custom reordering

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,23 +10,3 @@ if str(SRC_ROOT) not in sys.path:
 if str(TESTS_ROOT) not in sys.path:
     sys.path.insert(0, str(TESTS_ROOT))
 
-
-def pytest_collection_modifyitems(session, config, items):  # type: ignore[no-untyped-def]
-    json_test_suffix = "test_official_onnx_expected_errors"
-    md_test_suffix = "test_official_onnx_file_support_doc"
-
-    json_index = next(
-        (index for index, item in enumerate(items) if item.nodeid.endswith(json_test_suffix)),
-        None,
-    )
-    md_index = next(
-        (index for index, item in enumerate(items) if item.nodeid.endswith(md_test_suffix)),
-        None,
-    )
-    if json_index is None or md_index is None or json_index < md_index:
-        return
-
-    md_item = items.pop(md_index)
-    if md_index < json_index:
-        json_index -= 1
-    items.insert(json_index + 1, md_item)

--- a/tests/test_official_onnx_files.py
+++ b/tests/test_official_onnx_files.py
@@ -7,6 +7,7 @@ from collections import Counter
 from pathlib import Path
 
 import onnx
+import pytest
 
 from onnx2c.compiler import Compiler
 
@@ -1904,6 +1905,7 @@ def test_official_onnx_files() -> None:
     )
 
 
+@pytest.mark.order(1)
 def test_official_onnx_expected_errors() -> None:
     data_root = Path(__file__).resolve().parents[1] / "onnx-org" / "onnx" / "backend" / "test" / "data"
     expectations = _load_official_onnx_file_expectations()
@@ -1935,6 +1937,7 @@ def test_official_onnx_expected_errors() -> None:
         return
 
 
+@pytest.mark.order(after="test_official_onnx_expected_errors")
 def test_official_onnx_file_support_doc() -> None:
     expectations = _load_official_onnx_file_expectations()
     expected_markdown = _render_official_onnx_file_support_markdown(expectations)


### PR DESCRIPTION
### Motivation
- Ensure the generated markdown support document test runs after the JSON expectations test to keep golden/reference updates deterministic.
- Replace a custom test collection reordering hook with an explicit, declarative ordering mechanism provided by `pytest-order`.
- Reduce hidden test-ordering logic and rely on the test runner's ordering plugin for clarity and maintainability.

### Description
- Removed the custom `pytest_collection_modifyitems` function from `tests/conftest.py` that was manually reordering the two official ONNX tests.
- Added `import pytest` and applied `@pytest.mark.order(1)` to `test_official_onnx_expected_errors` in `tests/test_official_onnx_files.py`.
- Added `@pytest.mark.order(after="test_official_onnx_expected_errors")` to `test_official_onnx_file_support_doc` to guarantee it runs afterward.

### Testing
- Ran `pytest -q tests/test_official_onnx_files.py -k "official_onnx_expected_errors or official_onnx_file_support_doc"` and the focused suite passed.
- Test output: `2 passed, 1 deselected` and the run completed in `2.40s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696448bde13c8325b609fa287289fff2)