### PR TITLE
Add GlobalAveragePool support

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 281 / 1802 official ONNX files.
+Support 285 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -9,12 +9,12 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | File | Supported | Error |
 | --- | --- | --- |
 | light/light_bvlc_alexnet.onnx | ✅ |  |
-| light/light_densenet121.onnx | ❌ | Unsupported op GlobalAveragePool |
+| light/light_densenet121.onnx | ✅ |  |
 | light/light_inception_v1.onnx | ✅ |  |
 | light/light_inception_v2.onnx | ✅ |  |
 | light/light_resnet50.onnx | ✅ |  |
 | light/light_shufflenet.onnx | ✅ |  |
-| light/light_squeezenet.onnx | ❌ | Unsupported op GlobalAveragePool |
+| light/light_squeezenet.onnx | ✅ |  |
 | light/light_vgg19.onnx | ✅ |  |
 | light/light_zfnet512.onnx | ✅ |  |
 | node/test_abs/model.onnx | ✅ |  |
@@ -671,8 +671,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_gemm_default_zero_bias/model.onnx | ✅ |  |
 | node/test_gemm_transposeA/model.onnx | ✅ |  |
 | node/test_gemm_transposeB/model.onnx | ✅ |  |
-| node/test_globalaveragepool/model.onnx | ❌ | Unsupported op GlobalAveragePool |
-| node/test_globalaveragepool_precomputed/model.onnx | ❌ | Unsupported op GlobalAveragePool |
+| node/test_globalaveragepool/model.onnx | ✅ |  |
+| node/test_globalaveragepool_precomputed/model.onnx | ✅ |  |
 | node/test_globalmaxpool/model.onnx | ❌ | Unsupported op GlobalMaxPool |
 | node/test_globalmaxpool_precomputed/model.onnx | ❌ | Unsupported op GlobalMaxPool |
 | node/test_greater/model.onnx | ❌ | Unsupported op Greater |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -73,7 +73,6 @@
 | Unsupported op ScatterND | 5 | █ |
 | Unsupported op Selu | 5 | █ |
 | Unsupported op Sigmoid | 5 | █ |
-| Unsupported op GlobalAveragePool | 4 | █ |
 | Unsupported op AffineGrid | 4 | █ |
 | Unsupported op DeformConv | 4 | █ |
 | Unsupported op Compress | 4 | █ |

--- a/src/onnx2c/compiler.py
+++ b/src/onnx2c/compiler.py
@@ -34,7 +34,10 @@ from .dtypes import ONNX_TO_DTYPE, dtype_info
 from .errors import CodegenError, ShapeInferenceError, UnsupportedOpError
 from .ir.model import Graph, Initializer, Node
 from .lowering import get_lowering
-from .lowering.average_pool import lower_average_pool
+from .lowering.average_pool import (
+    lower_average_pool,
+    lower_global_average_pool,
+)
 from .lowering.batch_normalization import lower_batch_normalization
 from .lowering.constant_of_shape import lower_constant_of_shape
 from .lowering.lrn import LrnSpec, resolve_lrn_spec
@@ -323,6 +326,11 @@ class Compiler:
                 continue
             if node.op_type == "AveragePool":
                 op = lower_average_pool(graph, node)
+                data = values[node.inputs[0]]
+                values[node.outputs[0]] = _apply_average_pool(op, data)
+                continue
+            if node.op_type == "GlobalAveragePool":
+                op = lower_global_average_pool(graph, node)
                 data = values[node.inputs[0]]
                 values[node.outputs[0]] = _apply_average_pool(op, data)
                 continue

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -5,7 +5,7 @@
   ],
   [
     "light/light_densenet121.onnx",
-    "Unsupported op GlobalAveragePool"
+    ""
   ],
   [
     "light/light_inception_v1.onnx",
@@ -25,7 +25,7 @@
   ],
   [
     "light/light_squeezenet.onnx",
-    "Unsupported op GlobalAveragePool"
+    ""
   ],
   [
     "light/light_vgg19.onnx",
@@ -2653,11 +2653,11 @@
   ],
   [
     "node/test_globalaveragepool/model.onnx",
-    "Unsupported op GlobalAveragePool"
+    ""
   ],
   [
     "node/test_globalaveragepool_precomputed/model.onnx",
-    "Unsupported op GlobalAveragePool"
+    ""
   ],
   [
     "node/test_globalmaxpool/model.onnx",

--- a/tests/test_endtoend_ops.py
+++ b/tests/test_endtoend_ops.py
@@ -1065,6 +1065,17 @@ def test_average_pool_matches_onnxruntime(case: dict[str, object]) -> None:
     _run_cli_verify(model)
 
 
+def test_global_average_pool_matches_onnxruntime() -> None:
+    input_shape = [1, 2, 4, 3]
+    model = _make_operator_model(
+        op_type="GlobalAveragePool",
+        input_shapes=[input_shape],
+        output_shape=[input_shape[0], input_shape[1], 1, 1],
+        dtype=TensorProto.FLOAT,
+    )
+    _run_cli_verify(model)
+
+
 def test_constant_op_matches_onnxruntime() -> None:
     model = _make_constant_add_model()
     _run_cli_verify(model)


### PR DESCRIPTION
### Motivation
- Add support for the ONNX `GlobalAveragePool` operator so models that use it can be lowered and executed by the compiler. 
- Reuse the existing `AveragePool` lowering/kernel to keep runtime and codegen surface small and deterministic. 
- Update official support metadata so golden/reference runs reflect the new operator coverage. 

### Description
- Add `_resolve_global_average_pool_spec` and `lower_global_average_pool` in `src/onnx2c/lowering/average_pool.py` to validate shapes/attrs and produce an `AveragePoolOp` for global pooling. 
- Register `GlobalAveragePool` lowering and return an `AveragePoolOp` configured with kernel equal to the full spatial extent. 
- Wire runtime lowering path in `src/onnx2c/compiler.py` to call `lower_global_average_pool` and execute via the existing `_apply_average_pool` path. 
- Add an end-to-end verification test `test_global_average_pool_matches_onnxruntime` in `tests/test_endtoend_ops.py` and update `tests/official_onnx_expected_errors.json`, `OFFICIAL_ONNX_FILE_SUPPORT.md`, and histogram to mark GlobalAveragePool as supported. 

### Testing
- Ran the full test suite with updated golden refs via `UPDATE_REFS=1 pytest -n auto -q`. 
- All automated tests passed: `104 passed in 14.87s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6964500c80088325b0ec785519976f47)