### PR TITLE
Support multi-output graphs in codegen

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -22,10 +22,10 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_acos_example/model.onnx | ❌ | Unsupported op Acos |
 | node/test_acosh/model.onnx | ❌ | Unsupported op Acosh |
 | node/test_acosh_example/model.onnx | ❌ | Unsupported op Acosh |
-| node/test_adagrad/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_adagrad_multiple/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_adam/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_adam_multiple/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_adagrad/model.onnx | ❌ | Unsupported op Adagrad |
+| node/test_adagrad_multiple/model.onnx | ❌ | Unsupported op Adagrad |
+| node/test_adam/model.onnx | ❌ | Unsupported op Adam |
+| node/test_adam_multiple/model.onnx | ❌ | Unsupported op Adam |
 | node/test_add/model.onnx | ✅ |  |
 | node/test_add_bcast/model.onnx | ✅ |  |
 | node/test_add_int16/model.onnx | ✅ |  |
@@ -113,7 +113,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_attention_3d_diff_heads_sizes_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_scaled_expanded_function_QIntermediate' |
 | node/test_attention_3d_diff_heads_sizes_softcap/model.onnx | ❌ | Unsupported op Attention |
 | node/test_attention_3d_diff_heads_sizes_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_softcap_expanded_function_QIntermediate' |
-| node/test_attention_3d_diff_heads_with_past_and_present/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_attention_3d_diff_heads_with_past_and_present/model.onnx | ❌ | Unsupported op Attention |
 | node/test_attention_3d_diff_heads_with_past_and_present_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_with_past_and_present_expanded_function_QIntermediate' |
 | node/test_attention_3d_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_expanded_function_QIntermediate' |
 | node/test_attention_3d_gqa/model.onnx | ❌ | Unsupported op Attention |
@@ -126,7 +126,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_attention_3d_gqa_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_gqa_scaled_expanded_function_QIntermediate' |
 | node/test_attention_3d_gqa_softcap/model.onnx | ❌ | Unsupported op Attention |
 | node/test_attention_3d_gqa_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_gqa_softcap_expanded_function_QIntermediate' |
-| node/test_attention_3d_gqa_with_past_and_present/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_attention_3d_gqa_with_past_and_present/model.onnx | ❌ | Unsupported op Attention |
 | node/test_attention_3d_gqa_with_past_and_present_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_gqa_with_past_and_present_expanded_function_QIntermediate' |
 | node/test_attention_3d_scaled/model.onnx | ❌ | Unsupported op Attention |
 | node/test_attention_3d_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_scaled_expanded_function_QIntermediate' |
@@ -134,15 +134,15 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_attention_3d_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_softcap_expanded_function_QIntermediate' |
 | node/test_attention_3d_transpose_verification/model.onnx | ❌ | Unsupported op Attention |
 | node/test_attention_3d_transpose_verification_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_transpose_verification_expanded_function_QIntermediate' |
-| node/test_attention_3d_with_past_and_present/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_attention_3d_with_past_and_present/model.onnx | ❌ | Unsupported op Attention |
 | node/test_attention_3d_with_past_and_present_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_expanded_function_QIntermediate' |
-| node/test_attention_3d_with_past_and_present_qk_matmul/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_attention_3d_with_past_and_present_qk_matmul_bias/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_attention_3d_with_past_and_present_qk_matmul/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_3d_with_past_and_present_qk_matmul_bias/model.onnx | ❌ | Unsupported op Attention |
 | node/test_attention_3d_with_past_and_present_qk_matmul_bias_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_qk_matmul_bias_expanded_function_QIntermediate' |
 | node/test_attention_3d_with_past_and_present_qk_matmul_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_qk_matmul_expanded_function_QIntermediate' |
-| node/test_attention_3d_with_past_and_present_qk_matmul_softcap/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_attention_3d_with_past_and_present_qk_matmul_softcap/model.onnx | ❌ | Unsupported op Attention |
 | node/test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded_function_QIntermediate' |
-| node/test_attention_3d_with_past_and_present_qk_matmul_softmax/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_attention_3d_with_past_and_present_qk_matmul_softmax/model.onnx | ❌ | Unsupported op Attention |
 | node/test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded_function_QIntermediate' |
 | node/test_attention_4d/model.onnx | ✅ |  |
 | node/test_attention_4d_attn_mask/model.onnx | ❌ | Unsupported op Attention |
@@ -173,11 +173,11 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_attention_4d_diff_heads_sizes_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_sizes_scaled_expanded_function_AttnBias' |
 | node/test_attention_4d_diff_heads_sizes_softcap/model.onnx | ❌ | Unsupported op Attention |
 | node/test_attention_4d_diff_heads_sizes_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_sizes_softcap_expanded_function_AttnBias' |
-| node/test_attention_4d_diff_heads_with_past_and_present/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_attention_4d_diff_heads_with_past_and_present/model.onnx | ❌ | Unsupported op Attention |
 | node/test_attention_4d_diff_heads_with_past_and_present_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_with_past_and_present_expanded_function_KExpanded' |
-| node/test_attention_4d_diff_heads_with_past_and_present_mask3d/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_attention_4d_diff_heads_with_past_and_present_mask3d/model.onnx | ❌ | Unsupported op Attention |
 | node/test_attention_4d_diff_heads_with_past_and_present_mask3d_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_with_past_and_present_mask3d_expanded_function_KExpanded' |
-| node/test_attention_4d_diff_heads_with_past_and_present_mask4d/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_attention_4d_diff_heads_with_past_and_present_mask4d/model.onnx | ❌ | Unsupported op Attention |
 | node/test_attention_4d_diff_heads_with_past_and_present_mask4d_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_with_past_and_present_mask4d_expanded_function_KExpanded' |
 | node/test_attention_4d_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_expanded_function_AttnBias' |
 | node/test_attention_4d_fp16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'Q'. |
@@ -192,7 +192,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_attention_4d_gqa_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_gqa_scaled_expanded_function_AttnBias' |
 | node/test_attention_4d_gqa_softcap/model.onnx | ❌ | Unsupported op Attention |
 | node/test_attention_4d_gqa_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_gqa_softcap_expanded_function_AttnBias' |
-| node/test_attention_4d_gqa_with_past_and_present/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_attention_4d_gqa_with_past_and_present/model.onnx | ❌ | Unsupported op Attention |
 | node/test_attention_4d_gqa_with_past_and_present_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_gqa_with_past_and_present_expanded_function_KExpanded' |
 | node/test_attention_4d_gqa_with_past_and_present_fp16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'Q'. |
 | node/test_attention_4d_gqa_with_past_and_present_fp16_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'Q'. |
@@ -200,27 +200,27 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_attention_4d_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_scaled_expanded_function_AttnBias' |
 | node/test_attention_4d_softcap/model.onnx | ❌ | Unsupported op Attention |
 | node/test_attention_4d_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_softcap_expanded_function_AttnBias' |
-| node/test_attention_4d_with_past_and_present/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_attention_4d_with_past_and_present/model.onnx | ❌ | Unsupported op Attention |
 | node/test_attention_4d_with_past_and_present_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_past_and_present_expanded_function_KExpanded' |
-| node/test_attention_4d_with_past_and_present_qk_matmul/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_attention_4d_with_past_and_present_qk_matmul_bias/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_attention_4d_with_past_and_present_qk_matmul/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_4d_with_past_and_present_qk_matmul_bias/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal/model.onnx | ❌ | Unsupported op Attention |
 | node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal_expanded_function_RangeRow' |
 | node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_expanded_function_KExpanded' |
-| node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal/model.onnx | ❌ | Unsupported op Attention |
 | node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal_expanded_function_RangeRow' |
 | node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_expanded_function_KExpanded' |
 | node/test_attention_4d_with_past_and_present_qk_matmul_bias_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_past_and_present_qk_matmul_bias_expanded_function_KExpanded' |
 | node/test_attention_4d_with_past_and_present_qk_matmul_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_past_and_present_qk_matmul_expanded_function_KExpanded' |
-| node/test_attention_4d_with_qk_matmul/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_attention_4d_with_qk_matmul_bias/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_attention_4d_with_qk_matmul/model.onnx | ❌ | Missing dtype for value '' in op Attention. Hint: run ONNX shape inference or export with static shapes. |
+| node/test_attention_4d_with_qk_matmul_bias/model.onnx | ❌ | Missing dtype for value '' in op Attention. Hint: run ONNX shape inference or export with static shapes. |
 | node/test_attention_4d_with_qk_matmul_bias_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_qk_matmul_bias_expanded_function_KExpanded' |
 | node/test_attention_4d_with_qk_matmul_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_qk_matmul_expanded_function_AttnBias' |
-| node/test_attention_4d_with_qk_matmul_softcap/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_attention_4d_with_qk_matmul_softcap/model.onnx | ❌ | Missing dtype for value '' in op Attention. Hint: run ONNX shape inference or export with static shapes. |
 | node/test_attention_4d_with_qk_matmul_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_qk_matmul_softcap_expanded_function_KExpanded' |
-| node/test_attention_4d_with_qk_matmul_softmax/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_attention_4d_with_qk_matmul_softmax/model.onnx | ❌ | Missing dtype for value '' in op Attention. Hint: run ONNX shape inference or export with static shapes. |
 | node/test_attention_4d_with_qk_matmul_softmax_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_qk_matmul_softmax_expanded_function_KExpanded' |
 | node/test_averagepool_1d_default/model.onnx | ❌ | AveragePool expects 2D kernel_shape |
 | node/test_averagepool_2d_ceil/model.onnx | ❌ | AveragePool supports ceil_mode=0 only |
@@ -247,9 +247,9 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_basic_deform_conv_with_padding/model.onnx | ❌ | Unsupported op DeformConv |
 | node/test_basic_deform_conv_without_padding/model.onnx | ❌ | Unsupported op DeformConv |
 | node/test_batchnorm_epsilon/model.onnx | ✅ |  |
-| node/test_batchnorm_epsilon_training_mode/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_batchnorm_epsilon_training_mode/model.onnx | ❌ | BatchNormalization must have 5 inputs and 1 output |
 | node/test_batchnorm_example/model.onnx | ✅ |  |
-| node/test_batchnorm_example_training_mode/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_batchnorm_example_training_mode/model.onnx | ❌ | BatchNormalization must have 5 inputs and 1 output |
 | node/test_bernoulli/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'x'. |
 | node/test_bernoulli_double/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'y'. |
 | node/test_bernoulli_double_expanded/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'y'. |
@@ -589,8 +589,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_div_uint64/model.onnx | ❌ | Unsupported elem_type 13 (UINT64) for tensor 'x'. |
 | node/test_div_uint8/model.onnx | ❌ | Unsupported elem_type 2 (UINT8) for tensor 'x'. |
 | node/test_dropout_default/model.onnx | ✅ |  |
-| node/test_dropout_default_mask/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_dropout_default_mask_ratio/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_dropout_default_mask/model.onnx | ❌ | Dropout mask output is not supported |
+| node/test_dropout_default_mask_ratio/model.onnx | ❌ | Dropout supports only the data input and 1 or 2 outputs |
 | node/test_dropout_default_old/model.onnx | ✅ |  |
 | node/test_dropout_default_ratio/model.onnx | ❌ | Dropout supports only the data input and 1 or 2 outputs |
 | node/test_dropout_random_old/model.onnx | ✅ |  |
@@ -721,7 +721,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_group_normalization_epsilon_expanded/model.onnx | ❌ | Dynamic dim for tensor 'GroupNormalization_test_group_normalization_epsilon_expanded_function_XReshaped' |
 | node/test_group_normalization_example/model.onnx | ❌ | Unsupported op GroupNormalization |
 | node/test_group_normalization_example_expanded/model.onnx | ❌ | Dynamic dim for tensor 'GroupNormalization_test_group_normalization_example_expanded_function_XReshaped' |
-| node/test_gru_batchwise/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_gru_batchwise/model.onnx | ❌ | Unsupported op GRU |
 | node/test_gru_defaults/model.onnx | ❌ | Unsupported op GRU |
 | node/test_gru_seq_length/model.onnx | ❌ | Unsupported op GRU |
 | node/test_gru_with_initial_bias/model.onnx | ❌ | Unsupported op GRU |
@@ -776,61 +776,61 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_l1normalization_axis_last/model.onnx | ❌ | Unsupported op LpNormalization |
 | node/test_l2normalization_axis_0/model.onnx | ❌ | Unsupported op LpNormalization |
 | node/test_l2normalization_axis_1/model.onnx | ❌ | Unsupported op LpNormalization |
-| node/test_layer_normalization_2d_axis0/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_layer_normalization_2d_axis0/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_2d_axis0_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis0_expanded_function_SuffixShape' |
 | node/test_layer_normalization_2d_axis0_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis0_expanded_function_SuffixShape' |
-| node/test_layer_normalization_2d_axis1/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_layer_normalization_2d_axis1/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_2d_axis1_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis1_expanded_function_SuffixShape' |
 | node/test_layer_normalization_2d_axis1_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis1_expanded_function_SuffixShape' |
-| node/test_layer_normalization_2d_axis_negative_1/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_layer_normalization_2d_axis_negative_1/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_2d_axis_negative_1_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis_negative_1_expanded_function_SuffixShape' |
 | node/test_layer_normalization_2d_axis_negative_1_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis_negative_1_expanded_function_SuffixShape' |
-| node/test_layer_normalization_2d_axis_negative_2/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_layer_normalization_2d_axis_negative_2/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_2d_axis_negative_2_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis_negative_2_expanded_function_SuffixShape' |
 | node/test_layer_normalization_2d_axis_negative_2_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis_negative_2_expanded_function_SuffixShape' |
-| node/test_layer_normalization_3d_axis0_epsilon/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_layer_normalization_3d_axis0_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_3d_axis0_epsilon_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis0_epsilon_expanded_function_SuffixShape' |
 | node/test_layer_normalization_3d_axis0_epsilon_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis0_epsilon_expanded_function_SuffixShape' |
-| node/test_layer_normalization_3d_axis1_epsilon/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_layer_normalization_3d_axis1_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_3d_axis1_epsilon_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis1_epsilon_expanded_function_SuffixShape' |
 | node/test_layer_normalization_3d_axis1_epsilon_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis1_epsilon_expanded_function_SuffixShape' |
-| node/test_layer_normalization_3d_axis2_epsilon/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_layer_normalization_3d_axis2_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_3d_axis2_epsilon_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis2_epsilon_expanded_function_SuffixShape' |
 | node/test_layer_normalization_3d_axis2_epsilon_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis2_epsilon_expanded_function_SuffixShape' |
-| node/test_layer_normalization_3d_axis_negative_1_epsilon/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_layer_normalization_3d_axis_negative_1_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_3d_axis_negative_1_epsilon_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis_negative_1_epsilon_expanded_function_SuffixShape' |
 | node/test_layer_normalization_3d_axis_negative_1_epsilon_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis_negative_1_epsilon_expanded_function_SuffixShape' |
-| node/test_layer_normalization_3d_axis_negative_2_epsilon/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_layer_normalization_3d_axis_negative_2_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_3d_axis_negative_2_epsilon_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis_negative_2_epsilon_expanded_function_SuffixShape' |
 | node/test_layer_normalization_3d_axis_negative_2_epsilon_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis_negative_2_epsilon_expanded_function_SuffixShape' |
-| node/test_layer_normalization_3d_axis_negative_3_epsilon/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_layer_normalization_3d_axis_negative_3_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_3d_axis_negative_3_epsilon_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis_negative_3_epsilon_expanded_function_SuffixShape' |
 | node/test_layer_normalization_3d_axis_negative_3_epsilon_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis_negative_3_epsilon_expanded_function_SuffixShape' |
-| node/test_layer_normalization_4d_axis0/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_layer_normalization_4d_axis0/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_4d_axis0_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis0_expanded_function_SuffixShape' |
 | node/test_layer_normalization_4d_axis0_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis0_expanded_function_SuffixShape' |
-| node/test_layer_normalization_4d_axis1/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_layer_normalization_4d_axis1/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_4d_axis1_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis1_expanded_function_SuffixShape' |
 | node/test_layer_normalization_4d_axis1_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis1_expanded_function_SuffixShape' |
-| node/test_layer_normalization_4d_axis2/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_layer_normalization_4d_axis2/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_4d_axis2_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis2_expanded_function_SuffixShape' |
 | node/test_layer_normalization_4d_axis2_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis2_expanded_function_SuffixShape' |
-| node/test_layer_normalization_4d_axis3/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_layer_normalization_4d_axis3/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_4d_axis3_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis3_expanded_function_SuffixShape' |
 | node/test_layer_normalization_4d_axis3_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis3_expanded_function_SuffixShape' |
-| node/test_layer_normalization_4d_axis_negative_1/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_layer_normalization_4d_axis_negative_1/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_4d_axis_negative_1_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis_negative_1_expanded_function_SuffixShape' |
 | node/test_layer_normalization_4d_axis_negative_1_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis_negative_1_expanded_function_SuffixShape' |
-| node/test_layer_normalization_4d_axis_negative_2/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_layer_normalization_4d_axis_negative_2/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_4d_axis_negative_2_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis_negative_2_expanded_function_SuffixShape' |
 | node/test_layer_normalization_4d_axis_negative_2_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis_negative_2_expanded_function_SuffixShape' |
-| node/test_layer_normalization_4d_axis_negative_3/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_layer_normalization_4d_axis_negative_3/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_4d_axis_negative_3_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis_negative_3_expanded_function_SuffixShape' |
 | node/test_layer_normalization_4d_axis_negative_3_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis_negative_3_expanded_function_SuffixShape' |
-| node/test_layer_normalization_4d_axis_negative_4/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_layer_normalization_4d_axis_negative_4/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_4d_axis_negative_4_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis_negative_4_expanded_function_SuffixShape' |
 | node/test_layer_normalization_4d_axis_negative_4_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis_negative_4_expanded_function_SuffixShape' |
-| node/test_layer_normalization_default_axis/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_layer_normalization_default_axis/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_default_axis_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_default_axis_expanded_function_SuffixShape' |
 | node/test_layer_normalization_default_axis_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_default_axis_expanded_function_SuffixShape' |
 | node/test_leakyrelu/model.onnx | ❌ | Unsupported op LeakyRelu |
@@ -886,7 +886,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_logsoftmax_negative_axis/model.onnx | ❌ | Unsupported op LogSoftmax |
 | node/test_logsoftmax_negative_axis_expanded/model.onnx | ✅ |  |
 | node/test_logsoftmax_negative_axis_expanded_ver18/model.onnx | ✅ |  |
-| node/test_loop11/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_loop11/model.onnx | ❌ | Unsupported op Loop |
 | node/test_loop13_seq/model.onnx | ❌ | Missing elem_type for tensor 'seq_empty' |
 | node/test_loop16_seq_none/model.onnx | ❌ | Missing elem_type for tensor 'opt_seq' |
 | node/test_lpnormalization_default/model.onnx | ❌ | Unsupported op LpNormalization |
@@ -900,7 +900,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_lppool_3d_default/model.onnx | ❌ | Unsupported op LpPool |
 | node/test_lrn/model.onnx | ✅ |  |
 | node/test_lrn_default/model.onnx | ✅ |  |
-| node/test_lstm_batchwise/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_lstm_batchwise/model.onnx | ❌ | Unsupported op LSTM |
 | node/test_lstm_defaults/model.onnx | ❌ | Unsupported op LSTM |
 | node/test_lstm_with_initial_bias/model.onnx | ❌ | Unsupported op LSTM |
 | node/test_lstm_with_peepholes/model.onnx | ❌ | Unsupported op LSTM |
@@ -943,8 +943,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_maxpool_3d_dilations/model.onnx | ✅ |  |
 | node/test_maxpool_3d_dilations_use_ref_impl/model.onnx | ✅ |  |
 | node/test_maxpool_3d_dilations_use_ref_impl_large/model.onnx | ✅ |  |
-| node/test_maxpool_with_argmax_2d_precomputed_pads/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_maxpool_with_argmax_2d_precomputed_strides/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_maxpool_with_argmax_2d_precomputed_pads/model.onnx | ❌ | MaxPool must have 1 input and 1 output |
+| node/test_maxpool_with_argmax_2d_precomputed_strides/model.onnx | ❌ | MaxPool must have 1 input and 1 output |
 | node/test_maxunpool_export_with_output_shape/model.onnx | ❌ | Unsupported op MaxUnpool |
 | node/test_maxunpool_export_without_output_shape/model.onnx | ❌ | Unsupported op MaxUnpool |
 | node/test_mean_example/model.onnx | ❌ | Mean must have 2 inputs and 1 output |
@@ -980,8 +980,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_mod_uint32/model.onnx | ❌ | Unsupported elem_type 12 (UINT32) for tensor 'x'. |
 | node/test_mod_uint64/model.onnx | ❌ | Unsupported elem_type 13 (UINT64) for tensor 'x'. |
 | node/test_mod_uint8/model.onnx | ❌ | Unsupported elem_type 2 (UINT8) for tensor 'x'. |
-| node/test_momentum/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_momentum_multiple/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_momentum/model.onnx | ❌ | Unsupported op Momentum |
+| node/test_momentum_multiple/model.onnx | ❌ | Unsupported op Momentum |
 | node/test_mul/model.onnx | ✅ |  |
 | node/test_mul_bcast/model.onnx | ✅ |  |
 | node/test_mul_example/model.onnx | ✅ |  |
@@ -996,7 +996,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_mvn_expanded_ver18/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_neg/model.onnx | ✅ |  |
 | node/test_neg_example/model.onnx | ✅ |  |
-| node/test_nesterov_momentum/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_nesterov_momentum/model.onnx | ❌ | Unsupported op Momentum |
 | node/test_nllloss_NC/model.onnx | ❌ | Unsupported op NegativeLogLikelihoodLoss |
 | node/test_nllloss_NC_expanded/model.onnx | ❌ | Unsupported op GatherElements |
 | node/test_nllloss_NCd1/model.onnx | ❌ | Scalar outputs are not supported |
@@ -1360,8 +1360,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_rotary_embedding_with_rotary_dim/model.onnx | ❌ | Unsupported op RotaryEmbedding |
 | node/test_rotary_embedding_with_rotary_dim_expanded/model.onnx | ❌ | Dynamic dim for tensor 'RotaryEmbedding_test_rotary_embedding_with_rotary_dim_expanded_function_CosCacheSliced' |
 | node/test_round/model.onnx | ❌ | Unsupported op Round |
-| node/test_scan9_sum/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_scan_sum/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_scan9_sum/model.onnx | ❌ | Unsupported op Scan |
+| node/test_scan_sum/model.onnx | ❌ | Unsupported op Scan |
 | node/test_scatter_elements_with_axis/model.onnx | ❌ | Unsupported op ScatterElements |
 | node/test_scatter_elements_with_duplicate_indices/model.onnx | ❌ | Unsupported op ScatterElements |
 | node/test_scatter_elements_with_negative_indices/model.onnx | ❌ | Unsupported op ScatterElements |
@@ -1377,72 +1377,72 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_scatternd_multiply/model.onnx | ❌ | Unsupported op ScatterND |
 | node/test_sce_NCd1_mean_weight_negative_ii/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx | ❌ | Scalar outputs are not supported |
-| node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx | ❌ | Scalar outputs are not supported |
+| node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_NCd1d2d3_none_no_weight_negative_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
 | node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
-| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
 | node/test_sce_NCd1d2d3_sum_weight_high_ii/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx | ❌ | Scalar outputs are not supported |
-| node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob/model.onnx | ❌ | Scalar outputs are not supported |
+| node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx | ❌ | Scalar outputs are not supported |
-| node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx | ❌ | Scalar outputs are not supported |
+| node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
 | node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
-| node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
 | node/test_sce_mean/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_mean_3d/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_mean_3d_expanded/model.onnx | ❌ | Scalar outputs are not supported |
-| node/test_sce_mean_3d_log_prob/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_sce_mean_3d_log_prob_expanded/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_sce_mean_3d_log_prob/model.onnx | ❌ | Scalar outputs are not supported |
+| node/test_sce_mean_3d_log_prob_expanded/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_mean_expanded/model.onnx | ❌ | Scalar outputs are not supported |
-| node/test_sce_mean_log_prob/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_sce_mean_log_prob_expanded/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_sce_mean_log_prob/model.onnx | ❌ | Scalar outputs are not supported |
+| node/test_sce_mean_log_prob_expanded/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_mean_no_weight_ii/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_mean_no_weight_ii_3d/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_mean_no_weight_ii_3d_expanded/model.onnx | ❌ | Scalar outputs are not supported |
-| node/test_sce_mean_no_weight_ii_3d_log_prob/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_sce_mean_no_weight_ii_3d_log_prob/model.onnx | ❌ | Scalar outputs are not supported |
+| node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_mean_no_weight_ii_4d/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_mean_no_weight_ii_4d_expanded/model.onnx | ❌ | Scalar outputs are not supported |
-| node/test_sce_mean_no_weight_ii_4d_log_prob/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_sce_mean_no_weight_ii_4d_log_prob/model.onnx | ❌ | Scalar outputs are not supported |
+| node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_mean_no_weight_ii_expanded/model.onnx | ❌ | Scalar outputs are not supported |
-| node/test_sce_mean_no_weight_ii_log_prob/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_sce_mean_no_weight_ii_log_prob/model.onnx | ❌ | Scalar outputs are not supported |
+| node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_mean_weight/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_mean_weight_expanded/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_mean_weight_ii/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_mean_weight_ii_3d/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_mean_weight_ii_3d_expanded/model.onnx | ❌ | Scalar outputs are not supported |
-| node/test_sce_mean_weight_ii_3d_log_prob/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_sce_mean_weight_ii_3d_log_prob/model.onnx | ❌ | Scalar outputs are not supported |
+| node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_mean_weight_ii_4d/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_mean_weight_ii_4d_expanded/model.onnx | ❌ | Scalar outputs are not supported |
-| node/test_sce_mean_weight_ii_4d_log_prob/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_sce_mean_weight_ii_4d_log_prob/model.onnx | ❌ | Scalar outputs are not supported |
+| node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_mean_weight_ii_expanded/model.onnx | ❌ | Scalar outputs are not supported |
-| node/test_sce_mean_weight_ii_log_prob/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_sce_mean_weight_log_prob/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_sce_mean_weight_log_prob_expanded/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_sce_mean_weight_ii_log_prob/model.onnx | ❌ | Scalar outputs are not supported |
+| node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx | ❌ | Scalar outputs are not supported |
+| node/test_sce_mean_weight_log_prob/model.onnx | ❌ | Scalar outputs are not supported |
+| node/test_sce_mean_weight_log_prob_expanded/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_none/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
 | node/test_sce_none_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
-| node/test_sce_none_log_prob/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_sce_none_log_prob_expanded/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_sce_none_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_none_log_prob_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
 | node/test_sce_none_weights/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
 | node/test_sce_none_weights_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
-| node/test_sce_none_weights_log_prob/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_sce_none_weights_log_prob_expanded/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_sce_none_weights_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_none_weights_log_prob_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
 | node/test_sce_sum/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_sce_sum_expanded/model.onnx | ❌ | Scalar outputs are not supported |
-| node/test_sce_sum_log_prob/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_sce_sum_log_prob_expanded/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_sce_sum_log_prob/model.onnx | ❌ | Scalar outputs are not supported |
+| node/test_sce_sum_log_prob_expanded/model.onnx | ❌ | Scalar outputs are not supported |
 | node/test_selu/model.onnx | ❌ | Unsupported op Selu |
 | node/test_selu_default/model.onnx | ❌ | Unsupported op Selu |
 | node/test_selu_default_expanded_ver18/model.onnx | ❌ | Unsupported op CastLike |
@@ -1481,7 +1481,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_sigmoid/model.onnx | ❌ | Unsupported op Sigmoid |
 | node/test_sigmoid_example/model.onnx | ❌ | Unsupported op Sigmoid |
 | node/test_sign/model.onnx | ❌ | Unsupported op Sign |
-| node/test_simple_rnn_batchwise/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_simple_rnn_batchwise/model.onnx | ❌ | Unsupported op RNN |
 | node/test_simple_rnn_defaults/model.onnx | ❌ | Unsupported op RNN |
 | node/test_simple_rnn_with_initial_bias/model.onnx | ❌ | Unsupported op RNN |
 | node/test_sin/model.onnx | ✅ |  |
@@ -1529,25 +1529,25 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_softsign_expanded_ver18/model.onnx | ❌ | Unsupported op CastLike |
 | node/test_spacetodepth/model.onnx | ❌ | Unsupported op SpaceToDepth |
 | node/test_spacetodepth_example/model.onnx | ❌ | Unsupported op SpaceToDepth |
-| node/test_split_1d_uneven_split_opset18/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_split_2d_uneven_split_opset18/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_split_equal_parts_1d_opset13/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_split_equal_parts_1d_opset18/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_split_equal_parts_2d/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_split_equal_parts_2d_opset13/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_split_equal_parts_default_axis_opset13/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_split_equal_parts_default_axis_opset18/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_split_1d_uneven_split_opset18/model.onnx | ❌ | Unsupported op Split |
+| node/test_split_2d_uneven_split_opset18/model.onnx | ❌ | Unsupported op Split |
+| node/test_split_equal_parts_1d_opset13/model.onnx | ❌ | Unsupported op Split |
+| node/test_split_equal_parts_1d_opset18/model.onnx | ❌ | Unsupported op Split |
+| node/test_split_equal_parts_2d/model.onnx | ❌ | Unsupported op Split |
+| node/test_split_equal_parts_2d_opset13/model.onnx | ❌ | Unsupported op Split |
+| node/test_split_equal_parts_default_axis_opset13/model.onnx | ❌ | Unsupported op Split |
+| node/test_split_equal_parts_default_axis_opset18/model.onnx | ❌ | Unsupported op Split |
 | node/test_split_to_sequence_1/model.onnx | ❌ | Missing elem_type for tensor 'seq' |
 | node/test_split_to_sequence_2/model.onnx | ❌ | Missing elem_type for tensor 'seq' |
 | node/test_split_to_sequence_nokeepdims/model.onnx | ❌ | Missing elem_type for tensor 'seq' |
-| node/test_split_variable_parts_1d_opset13/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_split_variable_parts_1d_opset18/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_split_variable_parts_2d_opset13/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_split_variable_parts_2d_opset18/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_split_variable_parts_default_axis_opset13/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_split_variable_parts_default_axis_opset18/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_split_zero_size_splits_opset13/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_split_zero_size_splits_opset18/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_split_variable_parts_1d_opset13/model.onnx | ❌ | Unsupported op Split |
+| node/test_split_variable_parts_1d_opset18/model.onnx | ❌ | Unsupported op Split |
+| node/test_split_variable_parts_2d_opset13/model.onnx | ❌ | Unsupported op Split |
+| node/test_split_variable_parts_2d_opset18/model.onnx | ❌ | Unsupported op Split |
+| node/test_split_variable_parts_default_axis_opset13/model.onnx | ❌ | Unsupported op Split |
+| node/test_split_variable_parts_default_axis_opset18/model.onnx | ❌ | Unsupported op Split |
+| node/test_split_zero_size_splits_opset13/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_split_zero_size_splits_opset18/model.onnx | ❌ | Dynamic or zero dims are not supported |
 | node/test_sqrt/model.onnx | ✅ |  |
 | node/test_sqrt_example/model.onnx | ✅ |  |
 | node/test_squeeze/model.onnx | ❌ | Unsupported op Squeeze |
@@ -1607,19 +1607,19 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_thresholdedrelu_expanded_ver18/model.onnx | ❌ | Unsupported op CastLike |
 | node/test_tile/model.onnx | ❌ | Unsupported op Tile |
 | node/test_tile_precomputed/model.onnx | ❌ | Unsupported op Tile |
-| node/test_top_k/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_top_k_negative_axis/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_top_k_same_values/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_top_k_same_values_2d/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_top_k_same_values_largest/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_top_k_smallest/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_top_k/model.onnx | ❌ | Unsupported op TopK |
+| node/test_top_k_negative_axis/model.onnx | ❌ | Unsupported op TopK |
+| node/test_top_k_same_values/model.onnx | ❌ | Unsupported op TopK |
+| node/test_top_k_same_values_2d/model.onnx | ❌ | Unsupported op TopK |
+| node/test_top_k_same_values_largest/model.onnx | ❌ | Unsupported op TopK |
+| node/test_top_k_smallest/model.onnx | ❌ | Unsupported op TopK |
 | node/test_top_k_uint64/model.onnx | ❌ | Unsupported elem_type 13 (UINT64) for tensor 'x'. |
 | node/test_training_dropout/model.onnx | ❌ | Dropout supports only the data input and 1 or 2 outputs |
 | node/test_training_dropout_default/model.onnx | ❌ | Dropout supports only the data input and 1 or 2 outputs |
-| node/test_training_dropout_default_mask/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_training_dropout_mask/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_training_dropout_default_mask/model.onnx | ❌ | Dropout supports only the data input and 1 or 2 outputs |
+| node/test_training_dropout_mask/model.onnx | ❌ | Dropout supports only the data input and 1 or 2 outputs |
 | node/test_training_dropout_zero_ratio/model.onnx | ❌ | Dropout supports only the data input and 1 or 2 outputs |
-| node/test_training_dropout_zero_ratio_mask/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_training_dropout_zero_ratio_mask/model.onnx | ❌ | Dropout supports only the data input and 1 or 2 outputs |
 | node/test_transpose_all_permutations_0/model.onnx | ✅ |  |
 | node/test_transpose_all_permutations_1/model.onnx | ✅ |  |
 | node/test_transpose_all_permutations_2/model.onnx | ✅ |  |
@@ -1645,12 +1645,12 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_triu_square/model.onnx | ❌ | Unsupported op Trilu |
 | node/test_triu_square_neg/model.onnx | ❌ | Unsupported op Trilu |
 | node/test_triu_zero/model.onnx | ❌ | Dynamic or zero dims are not supported |
-| node/test_unique_length_1/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_unique_not_sorted_without_axis/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_unique_sorted_with_axis/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_unique_sorted_with_axis_3d/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_unique_sorted_with_negative_axis/model.onnx | ❌ | Only single-output graphs are supported |
-| node/test_unique_sorted_without_axis/model.onnx | ❌ | Only single-output graphs are supported |
+| node/test_unique_length_1/model.onnx | ❌ | Unsupported op Unique |
+| node/test_unique_not_sorted_without_axis/model.onnx | ❌ | Unsupported op Unique |
+| node/test_unique_sorted_with_axis/model.onnx | ❌ | Unsupported op Unique |
+| node/test_unique_sorted_with_axis_3d/model.onnx | ❌ | Unsupported op Unique |
+| node/test_unique_sorted_with_negative_axis/model.onnx | ❌ | Unsupported op Unique |
+| node/test_unique_sorted_without_axis/model.onnx | ❌ | Unsupported op Unique |
 | node/test_unsqueeze_axis_0/model.onnx | ✅ |  |
 | node/test_unsqueeze_axis_1/model.onnx | ✅ |  |
 | node/test_unsqueeze_axis_2/model.onnx | ✅ |  |
@@ -1759,7 +1759,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | pytorch-operator/test_operator_addconstant/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for Constant '1'. |
 | pytorch-operator/test_operator_addmm/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_basic/model.onnx | ❌ | Unsupported op Sigmoid |
-| pytorch-operator/test_operator_chunk/model.onnx | ❌ | Only single-output graphs are supported |
+| pytorch-operator/test_operator_chunk/model.onnx | ❌ | Unsupported op Split |
 | pytorch-operator/test_operator_clip/model.onnx | ❌ | Unsupported op Clip |
 | pytorch-operator/test_operator_concat2/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_conv/model.onnx | ✅ |  |
@@ -1785,14 +1785,14 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | pytorch-operator/test_operator_selu/model.onnx | ❌ | Unsupported op Selu |
 | pytorch-operator/test_operator_sqrt/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_symbolic_override/model.onnx | ❌ | Unsupported op InstanceNormalization |
-| pytorch-operator/test_operator_symbolic_override_nested/model.onnx | ❌ | Only single-output graphs are supported |
+| pytorch-operator/test_operator_symbolic_override_nested/model.onnx | ❌ | Sum must have 2 inputs and 1 output |
 | pytorch-operator/test_operator_view/model.onnx | ❌ | Unsupported op Flatten |
 | simple/test_expand_shape_model1/model.onnx | ❌ | Unsupported op Expand |
 | simple/test_expand_shape_model2/model.onnx | ❌ | Unsupported op Expand |
 | simple/test_expand_shape_model3/model.onnx | ❌ | Unsupported op Expand |
 | simple/test_expand_shape_model4/model.onnx | ❌ | Unsupported op Expand |
-| simple/test_gradient_of_add/model.onnx | ❌ | Only single-output graphs are supported |
-| simple/test_gradient_of_add_and_mul/model.onnx | ❌ | Only single-output graphs are supported |
+| simple/test_gradient_of_add/model.onnx | ❌ | Scalar outputs are not supported |
+| simple/test_gradient_of_add_and_mul/model.onnx | ❌ | Scalar outputs are not supported |
 | simple/test_sequence_model1/model.onnx | ❌ | Dynamic dim for tensor 'out' |
 | simple/test_sequence_model2/model.onnx | ❌ | Missing elem_type for tensor 'seq_1' |
 | simple/test_sequence_model3/model.onnx | ❌ | Missing elem_type for tensor 'seq_1' |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -3,23 +3,25 @@
 | Error message | Count | Histogram |
 | --- | --- | --- |
 | Dynamic dim for tensor '*' | 146 | ██████████████████████████████ |
-| Only single-output graphs are supported | 129 | ███████████████████████████ |
-| Scalar outputs are not supported | 64 | █████████████ |
+| Scalar outputs are not supported | 92 | ███████████████████ |
 | Unsupported elem_type 10 (FLOAT16) for tensor '*'. | 60 | ████████████ |
 | Unsupported elem_type 11 (DOUBLE) for tensor '*'. | 53 | ███████████ |
 | Unsupported elem_type 2 (UINT8) for tensor '*'. | 50 | ██████████ |
+| Unsupported op Attention | 47 | ██████████ |
 | ReduceSum axes input must be constant | 43 | █████████ |
 | Unsupported op Resize | 39 | ████████ |
 | Missing elem_type for tensor '*' | 33 | ███████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████ |
-| Unsupported op Attention | 29 | ██████ |
 | Unsupported op CastLike | 29 | ██████ |
 | Unsupported elem_type 13 (UINT64) for tensor '*'. | 21 | ████ |
 | Unsupported elem_type 4 (UINT16) for tensor '*'. | 19 | ████ |
+| Unsupported op LayerNormalization | 19 | ████ |
 | Unsupported op RMSNormalization | 19 | ████ |
 | Unsupported op Less | 18 | ████ |
 | Unsupported op GridSample | 18 | ████ |
+| Unsupported op LogSoftmax | 18 | ████ |
 | Unsupported elem_type 12 (UINT32) for tensor '*'. | 17 | ███ |
+| Unsupported op Split | 17 | ███ |
 | Unsupported op ArgMax | 16 | ███ |
 | Unsupported op ArgMin | 16 | ███ |
 | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 16 | ███ |
@@ -30,7 +32,6 @@
 | Unsupported elem_type 25 (UINT2) for tensor '*'. | 14 | ███ |
 | Unsupported elem_type 21 (UINT4) for tensor '*'. | 14 | ███ |
 | Unsupported op ConvTranspose | 14 | ███ |
-| Unsupported op LogSoftmax | 14 | ███ |
 | Unsupported op Clip | 13 | ███ |
 | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 12 | ██ |
 | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 12 | ██ |
@@ -38,17 +39,19 @@
 | Unsupported op Pad | 11 | ██ |
 | Unsupported op Flatten | 11 | ██ |
 | Unsupported op Shape | 10 | ██ |
+| Dynamic or zero dims are not supported | 9 | ██ |
 | Unsupported op NonMaxSuppression | 9 | ██ |
 | ReduceL1 axes input must be constant | 9 | ██ |
 | ReduceL2 axes input must be constant | 9 | ██ |
 | ReduceSumSquare axes input must be constant | 9 | ██ |
 | Reshape requires a constant shape input | 9 | ██ |
+| Dropout supports only the data input and 1 or 2 outputs | 8 | ██ |
 | Unsupported op Greater | 8 | ██ |
 | Unsupported op LpPool | 8 | ██ |
 | ReduceMean axes input must be constant | 8 | ██ |
 | Unsupported op RotaryEmbedding | 8 | ██ |
+| Unsupported op SoftmaxCrossEntropyLoss | 8 | ██ |
 | Unsupported op Slice | 8 | ██ |
-| Dynamic or zero dims are not supported | 7 | █ |
 | Unsupported op GatherElements | 7 | █ |
 | Unsupported op Hardmax | 7 | █ |
 | ReduceMax axes input must be constant | 7 | █ |
@@ -64,6 +67,9 @@
 | Unsupported op LpNormalization | 6 | █ |
 | Unsupported op Mod | 6 | █ |
 | Unsupported op ScatterElements | 6 | █ |
+| Unsupported op TopK | 6 | █ |
+| Unsupported op Unique | 6 | █ |
+| Missing dtype for value '*' in op Attention. Hint: run ONNX shape inference or export with static shapes. | 5 | █ |
 | AveragePool expects 2D kernel_shape | 5 | █ |
 | Unsupported op Elu | 5 | █ |
 | Unsupported op Col2Im | 5 | █ |
@@ -76,40 +82,43 @@
 | Unsupported op AffineGrid | 4 | █ |
 | Unsupported op DeformConv | 4 | █ |
 | Unsupported op Compress | 4 | █ |
-| Dropout supports only the data input and 1 or 2 outputs | 4 | █ |
 | Unsupported op Equal | 4 | █ |
 | Unsupported op Gelu | 4 | █ |
 | Unsupported op GreaterOrEqual | 4 | █ |
+| Unsupported op GRU | 4 | █ |
 | Unsupported op HardSigmoid | 4 | █ |
 | Unsupported op LessOrEqual | 4 | █ |
+| Unsupported op LSTM | 4 | █ |
 | Unsupported op Max | 4 | █ |
 | Unsupported op Min | 4 | █ |
 | Unsupported op Softplus | 4 | █ |
 | Unsupported op OneHot | 4 | █ |
-| Unsupported op SoftmaxCrossEntropyLoss | 4 | █ |
+| Unsupported op RNN | 4 | █ |
 | Unsupported op Squeeze | 4 | █ |
 | Unsupported op Tile | 4 | █ |
 | AveragePool supports auto_pad=NOTSET only | 3 | █ |
 | Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 3 | █ |
 | Unsupported op Identity | 3 | █ |
 | Unsupported op GatherND | 3 | █ |
-| Unsupported op GRU | 3 | █ |
 | Unsupported op InstanceNormalization | 3 | █ |
 | Unsupported op IsInf | 3 | █ |
-| Unsupported op LSTM | 3 | █ |
+| Unsupported op Momentum | 3 | █ |
 | Unsupported op Cast | 3 | █ |
-| Unsupported op RNN | 3 | █ |
 | Unsupported op RoiAlign | 3 | █ |
 | Unsupported op Shrink | 3 | █ |
+| Sum must have 2 inputs and 1 output | 3 | █ |
 | Unsupported op TensorScatter | 3 | █ |
 | Unsupported op ThresholdedRelu | 3 | █ |
 | Unsupported op Acos | 2 | █ |
 | Unsupported op Acosh | 2 | █ |
+| Unsupported op Adagrad | 2 | █ |
+| Unsupported op Adam | 2 | █ |
 | Unsupported op Asin | 2 | █ |
 | Unsupported op Asinh | 2 | █ |
 | Unsupported op Atan | 2 | █ |
 | Attention expects matching dtypes, got bool, float | 2 | █ |
 | AveragePool supports ceil_mode=0 only | 2 | █ |
+| BatchNormalization must have 5 inputs and 1 output | 2 | █ |
 | Unsupported op BitwiseAnd | 2 | █ |
 | Unsupported op BitwiseOr | 2 | █ |
 | Unsupported op BitwiseXor | 2 | █ |
@@ -124,6 +133,7 @@
 | Unsupported op HammingWindow | 2 | █ |
 | Unsupported op HannWindow | 2 | █ |
 | Max must have 2 inputs and 1 output | 2 | █ |
+| MaxPool must have 1 input and 1 output | 2 | █ |
 | Unsupported op MaxUnpool | 2 | █ |
 | Mean must have 2 inputs and 1 output | 2 | █ |
 | Min must have 2 inputs and 1 output | 2 | █ |
@@ -135,19 +145,17 @@
 | Unsupported op Range | 2 | █ |
 | Unsupported op Reciprocal | 2 | █ |
 | Unsupported op ReverseSequence | 2 | █ |
+| Unsupported op Scan | 2 | █ |
 | Unsupported op Scatter | 2 | █ |
 | Unsupported op Sign | 2 | █ |
 | Unsupported op Sinh | 2 | █ |
 | Unsupported op Softsign | 2 | █ |
 | Unsupported op SpaceToDepth | 2 | █ |
 | Unsupported op STFT | 2 | █ |
-| Sum must have 2 inputs and 1 output | 2 | █ |
 | Unsupported op Where | 2 | █ |
-| Unsupported op Split | 2 | █ |
 | Unsupported op ArrayFeatureExtractor | 1 | █ |
 | Unsupported op Binarizer | 1 | █ |
 | Unsupported op TreeEnsemble | 1 | █ |
-| Missing dtype for value '*' in op Attention. Hint: run ONNX shape inference or export with static shapes. | 1 | █ |
 | Unsupported op Bernoulli | 1 | █ |
 | Unsupported op RandomUniformLike | 1 | █ |
 | Unsupported op BitwiseNot | 1 | █ |
@@ -155,12 +163,14 @@
 | Graph must contain at least one node | 1 | █ |
 | Unsupported op DequantizeLinear | 1 | █ |
 | Unsupported op Det | 1 | █ |
+| Dropout mask output is not supported | 1 | █ |
 | Unsupported op Erf | 1 | █ |
 | Gemm bias input must be rank 1 or 2, got () | 1 | █ |
 | Gemm bias input must be broadcastable to output shape, got (1,) vs (3, 3) | 1 | █ |
 | Unsupported op HardSwish | 1 | █ |
 | Unsupported op If | 1 | █ |
 | Unsupported op IsNaN | 1 | █ |
+| Unsupported op Loop | 1 | █ |
 | MatMul supports 2D inputs only, got (4,) x (2, 4, 1) | 1 | █ |
 | MatMul supports 2D inputs only, got (2, 3, 4) x (2, 4, 3) | 1 | █ |
 | MatMul supports 2D inputs only, got (1, 2, 3, 4) x (1, 2, 4, 3) | 1 | █ |

--- a/templates/testbench.c.j2
+++ b/templates/testbench.c.j2
@@ -25,9 +25,11 @@ int main(void) {
         {{ input.name }}_ptr[i] = {{ input.random_expr }};
     }
 {% endfor %}
+{% for output in outputs %}
     {{ output.c_type }} {{ output.name }}{{ output.array_suffix }};
     {{ output.c_type }} *{{ output.name }}_ptr = ({{ output.c_type }} *){{ output.name }};
-    {{ model_name }}({% for input in inputs %}{{ input.name }}, {% endfor %}{{ output.name }});
+{% endfor %}
+    {{ model_name }}({% for input in inputs %}{{ input.name }}, {% endfor %}{% for output in outputs %}{{ output.name }}{% if not loop.last %}, {% endif %}{% endfor %});
     printf("{\"inputs\":{");
 {% for input in inputs %}
 {% if not loop.first %}
@@ -53,7 +55,12 @@ int main(void) {
 {% endfor %}
     printf("]}");
 {% endfor %}
-    printf("},\"output\":{\"name\":\"{{ output.name }}\",\"shape\":[{{ output.shape_literal }}],\"data\":");
+    printf("},\"outputs\":{");
+{% for output in outputs %}
+{% if not loop.first %}
+    printf(",");
+{% endif %}
+    printf("\"{{ output.name }}\":{\"shape\":[{{ output.shape_literal }}],\"data\":");
     printf("[");
 {% for depth in range(output.rank) %}
 {{ output.loop_indents[depth] }}for (size_t {{ output.loop_vars[depth] }} = 0; {{ output.loop_vars[depth] }} < {{ output.shape[depth] }}; ++{{ output.loop_vars[depth] }}) {
@@ -71,6 +78,8 @@ int main(void) {
 {% endif %}
 {{ output.loop_indents[depth] }}}
 {% endfor %}
-    printf("]}}\n");
+    printf("]}");
+{% endfor %}
+    printf("}}\n");
     return 0;
 }

--- a/tests/golden/add_model_testbench.c
+++ b/tests/golden/add_model_testbench.c
@@ -98,7 +98,8 @@ int main(void) {
         printf("]");
     }
     printf("]}");
-    printf("},\"output\":{\"name\":\"out\",\"shape\":[2,3,4],\"data\":");
+    printf("},\"outputs\":{");
+    printf("\"out\":{\"shape\":[2,3,4],\"data\":");
     printf("[");
     for (size_t i0 = 0; i0 < 2; ++i0) {
         if (i0) {
@@ -120,6 +121,7 @@ int main(void) {
         }
         printf("]");
     }
-    printf("]}}\n");
+    printf("]}");
+    printf("}}\n");
     return 0;
 }

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -57,19 +57,19 @@
   ],
   [
     "node/test_adagrad/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Adagrad"
   ],
   [
     "node/test_adagrad_multiple/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Adagrad"
   ],
   [
     "node/test_adam/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Adam"
   ],
   [
     "node/test_adam_multiple/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Adam"
   ],
   [
     "node/test_add/model.onnx",
@@ -421,7 +421,7 @@
   ],
   [
     "node/test_attention_3d_diff_heads_with_past_and_present/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Attention"
   ],
   [
     "node/test_attention_3d_diff_heads_with_past_and_present_expanded/model.onnx",
@@ -473,7 +473,7 @@
   ],
   [
     "node/test_attention_3d_gqa_with_past_and_present/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Attention"
   ],
   [
     "node/test_attention_3d_gqa_with_past_and_present_expanded/model.onnx",
@@ -505,7 +505,7 @@
   ],
   [
     "node/test_attention_3d_with_past_and_present/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Attention"
   ],
   [
     "node/test_attention_3d_with_past_and_present_expanded/model.onnx",
@@ -513,11 +513,11 @@
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Attention"
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_bias/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Attention"
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_bias_expanded/model.onnx",
@@ -529,7 +529,7 @@
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_softcap/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Attention"
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded/model.onnx",
@@ -537,7 +537,7 @@
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_softmax/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Attention"
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded/model.onnx",
@@ -661,7 +661,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Attention"
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_expanded/model.onnx",
@@ -669,7 +669,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_mask3d/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Attention"
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_mask3d_expanded/model.onnx",
@@ -677,7 +677,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_mask4d/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Attention"
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_mask4d_expanded/model.onnx",
@@ -737,7 +737,7 @@
   ],
   [
     "node/test_attention_4d_gqa_with_past_and_present/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Attention"
   ],
   [
     "node/test_attention_4d_gqa_with_past_and_present_expanded/model.onnx",
@@ -769,7 +769,7 @@
   ],
   [
     "node/test_attention_4d_with_past_and_present/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Attention"
   ],
   [
     "node/test_attention_4d_with_past_and_present_expanded/model.onnx",
@@ -777,19 +777,19 @@
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Attention"
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Attention"
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Attention"
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Attention"
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal_expanded/model.onnx",
@@ -801,11 +801,11 @@
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Attention"
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Attention"
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal_expanded/model.onnx",
@@ -825,11 +825,11 @@
   ],
   [
     "node/test_attention_4d_with_qk_matmul/model.onnx",
-    "Only single-output graphs are supported"
+    "Missing dtype for value '' in op Attention. Hint: run ONNX shape inference or export with static shapes."
   ],
   [
     "node/test_attention_4d_with_qk_matmul_bias/model.onnx",
-    "Only single-output graphs are supported"
+    "Missing dtype for value '' in op Attention. Hint: run ONNX shape inference or export with static shapes."
   ],
   [
     "node/test_attention_4d_with_qk_matmul_bias_expanded/model.onnx",
@@ -841,7 +841,7 @@
   ],
   [
     "node/test_attention_4d_with_qk_matmul_softcap/model.onnx",
-    "Only single-output graphs are supported"
+    "Missing dtype for value '' in op Attention. Hint: run ONNX shape inference or export with static shapes."
   ],
   [
     "node/test_attention_4d_with_qk_matmul_softcap_expanded/model.onnx",
@@ -849,7 +849,7 @@
   ],
   [
     "node/test_attention_4d_with_qk_matmul_softmax/model.onnx",
-    "Only single-output graphs are supported"
+    "Missing dtype for value '' in op Attention. Hint: run ONNX shape inference or export with static shapes."
   ],
   [
     "node/test_attention_4d_with_qk_matmul_softmax_expanded/model.onnx",
@@ -957,7 +957,7 @@
   ],
   [
     "node/test_batchnorm_epsilon_training_mode/model.onnx",
-    "Only single-output graphs are supported"
+    "BatchNormalization must have 5 inputs and 1 output"
   ],
   [
     "node/test_batchnorm_example/model.onnx",
@@ -965,7 +965,7 @@
   ],
   [
     "node/test_batchnorm_example_training_mode/model.onnx",
-    "Only single-output graphs are supported"
+    "BatchNormalization must have 5 inputs and 1 output"
   ],
   [
     "node/test_bernoulli/model.onnx",
@@ -2325,11 +2325,11 @@
   ],
   [
     "node/test_dropout_default_mask/model.onnx",
-    "Only single-output graphs are supported"
+    "Dropout mask output is not supported"
   ],
   [
     "node/test_dropout_default_mask_ratio/model.onnx",
-    "Only single-output graphs are supported"
+    "Dropout supports only the data input and 1 or 2 outputs"
   ],
   [
     "node/test_dropout_default_old/model.onnx",
@@ -2853,7 +2853,7 @@
   ],
   [
     "node/test_gru_batchwise/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op GRU"
   ],
   [
     "node/test_gru_defaults/model.onnx",
@@ -3073,7 +3073,7 @@
   ],
   [
     "node/test_layer_normalization_2d_axis0/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op LayerNormalization"
   ],
   [
     "node/test_layer_normalization_2d_axis0_expanded/model.onnx",
@@ -3085,7 +3085,7 @@
   ],
   [
     "node/test_layer_normalization_2d_axis1/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op LayerNormalization"
   ],
   [
     "node/test_layer_normalization_2d_axis1_expanded/model.onnx",
@@ -3097,7 +3097,7 @@
   ],
   [
     "node/test_layer_normalization_2d_axis_negative_1/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op LayerNormalization"
   ],
   [
     "node/test_layer_normalization_2d_axis_negative_1_expanded/model.onnx",
@@ -3109,7 +3109,7 @@
   ],
   [
     "node/test_layer_normalization_2d_axis_negative_2/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op LayerNormalization"
   ],
   [
     "node/test_layer_normalization_2d_axis_negative_2_expanded/model.onnx",
@@ -3121,7 +3121,7 @@
   ],
   [
     "node/test_layer_normalization_3d_axis0_epsilon/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op LayerNormalization"
   ],
   [
     "node/test_layer_normalization_3d_axis0_epsilon_expanded/model.onnx",
@@ -3133,7 +3133,7 @@
   ],
   [
     "node/test_layer_normalization_3d_axis1_epsilon/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op LayerNormalization"
   ],
   [
     "node/test_layer_normalization_3d_axis1_epsilon_expanded/model.onnx",
@@ -3145,7 +3145,7 @@
   ],
   [
     "node/test_layer_normalization_3d_axis2_epsilon/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op LayerNormalization"
   ],
   [
     "node/test_layer_normalization_3d_axis2_epsilon_expanded/model.onnx",
@@ -3157,7 +3157,7 @@
   ],
   [
     "node/test_layer_normalization_3d_axis_negative_1_epsilon/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op LayerNormalization"
   ],
   [
     "node/test_layer_normalization_3d_axis_negative_1_epsilon_expanded/model.onnx",
@@ -3169,7 +3169,7 @@
   ],
   [
     "node/test_layer_normalization_3d_axis_negative_2_epsilon/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op LayerNormalization"
   ],
   [
     "node/test_layer_normalization_3d_axis_negative_2_epsilon_expanded/model.onnx",
@@ -3181,7 +3181,7 @@
   ],
   [
     "node/test_layer_normalization_3d_axis_negative_3_epsilon/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op LayerNormalization"
   ],
   [
     "node/test_layer_normalization_3d_axis_negative_3_epsilon_expanded/model.onnx",
@@ -3193,7 +3193,7 @@
   ],
   [
     "node/test_layer_normalization_4d_axis0/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op LayerNormalization"
   ],
   [
     "node/test_layer_normalization_4d_axis0_expanded/model.onnx",
@@ -3205,7 +3205,7 @@
   ],
   [
     "node/test_layer_normalization_4d_axis1/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op LayerNormalization"
   ],
   [
     "node/test_layer_normalization_4d_axis1_expanded/model.onnx",
@@ -3217,7 +3217,7 @@
   ],
   [
     "node/test_layer_normalization_4d_axis2/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op LayerNormalization"
   ],
   [
     "node/test_layer_normalization_4d_axis2_expanded/model.onnx",
@@ -3229,7 +3229,7 @@
   ],
   [
     "node/test_layer_normalization_4d_axis3/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op LayerNormalization"
   ],
   [
     "node/test_layer_normalization_4d_axis3_expanded/model.onnx",
@@ -3241,7 +3241,7 @@
   ],
   [
     "node/test_layer_normalization_4d_axis_negative_1/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op LayerNormalization"
   ],
   [
     "node/test_layer_normalization_4d_axis_negative_1_expanded/model.onnx",
@@ -3253,7 +3253,7 @@
   ],
   [
     "node/test_layer_normalization_4d_axis_negative_2/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op LayerNormalization"
   ],
   [
     "node/test_layer_normalization_4d_axis_negative_2_expanded/model.onnx",
@@ -3265,7 +3265,7 @@
   ],
   [
     "node/test_layer_normalization_4d_axis_negative_3/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op LayerNormalization"
   ],
   [
     "node/test_layer_normalization_4d_axis_negative_3_expanded/model.onnx",
@@ -3277,7 +3277,7 @@
   ],
   [
     "node/test_layer_normalization_4d_axis_negative_4/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op LayerNormalization"
   ],
   [
     "node/test_layer_normalization_4d_axis_negative_4_expanded/model.onnx",
@@ -3289,7 +3289,7 @@
   ],
   [
     "node/test_layer_normalization_default_axis/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op LayerNormalization"
   ],
   [
     "node/test_layer_normalization_default_axis_expanded/model.onnx",
@@ -3513,7 +3513,7 @@
   ],
   [
     "node/test_loop11/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Loop"
   ],
   [
     "node/test_loop13_seq/model.onnx",
@@ -3569,7 +3569,7 @@
   ],
   [
     "node/test_lstm_batchwise/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op LSTM"
   ],
   [
     "node/test_lstm_defaults/model.onnx",
@@ -3741,11 +3741,11 @@
   ],
   [
     "node/test_maxpool_with_argmax_2d_precomputed_pads/model.onnx",
-    "Only single-output graphs are supported"
+    "MaxPool must have 1 input and 1 output"
   ],
   [
     "node/test_maxpool_with_argmax_2d_precomputed_strides/model.onnx",
-    "Only single-output graphs are supported"
+    "MaxPool must have 1 input and 1 output"
   ],
   [
     "node/test_maxunpool_export_with_output_shape/model.onnx",
@@ -3889,11 +3889,11 @@
   ],
   [
     "node/test_momentum/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Momentum"
   ],
   [
     "node/test_momentum_multiple/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Momentum"
   ],
   [
     "node/test_mul/model.onnx",
@@ -3953,7 +3953,7 @@
   ],
   [
     "node/test_nesterov_momentum/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Momentum"
   ],
   [
     "node/test_nllloss_NC/model.onnx",
@@ -5409,11 +5409,11 @@
   ],
   [
     "node/test_scan9_sum/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Scan"
   ],
   [
     "node/test_scan_sum/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Scan"
   ],
   [
     "node/test_scatter_elements_with_axis/model.onnx",
@@ -5477,11 +5477,11 @@
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii/model.onnx",
@@ -5493,11 +5493,11 @@
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op SoftmaxCrossEntropyLoss"
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op LogSoftmax"
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii/model.onnx",
@@ -5509,11 +5509,11 @@
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx",
@@ -5525,11 +5525,11 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx",
@@ -5541,11 +5541,11 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op SoftmaxCrossEntropyLoss"
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op LogSoftmax"
   ],
   [
     "node/test_sce_mean/model.onnx",
@@ -5561,11 +5561,11 @@
   ],
   [
     "node/test_sce_mean_3d_log_prob/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_mean_3d_log_prob_expanded/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_mean_expanded/model.onnx",
@@ -5573,11 +5573,11 @@
   ],
   [
     "node/test_sce_mean_log_prob/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_mean_log_prob_expanded/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_mean_no_weight_ii/model.onnx",
@@ -5593,11 +5593,11 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_log_prob/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d/model.onnx",
@@ -5609,11 +5609,11 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_log_prob/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_mean_no_weight_ii_expanded/model.onnx",
@@ -5621,11 +5621,11 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_log_prob/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_mean_weight/model.onnx",
@@ -5649,11 +5649,11 @@
   ],
   [
     "node/test_sce_mean_weight_ii_3d_log_prob/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_mean_weight_ii_4d/model.onnx",
@@ -5665,11 +5665,11 @@
   ],
   [
     "node/test_sce_mean_weight_ii_4d_log_prob/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_mean_weight_ii_expanded/model.onnx",
@@ -5677,19 +5677,19 @@
   ],
   [
     "node/test_sce_mean_weight_ii_log_prob/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_mean_weight_log_prob/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_mean_weight_log_prob_expanded/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_none/model.onnx",
@@ -5701,11 +5701,11 @@
   ],
   [
     "node/test_sce_none_log_prob/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op SoftmaxCrossEntropyLoss"
   ],
   [
     "node/test_sce_none_log_prob_expanded/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op LogSoftmax"
   ],
   [
     "node/test_sce_none_weights/model.onnx",
@@ -5717,11 +5717,11 @@
   ],
   [
     "node/test_sce_none_weights_log_prob/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op SoftmaxCrossEntropyLoss"
   ],
   [
     "node/test_sce_none_weights_log_prob_expanded/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op LogSoftmax"
   ],
   [
     "node/test_sce_sum/model.onnx",
@@ -5733,11 +5733,11 @@
   ],
   [
     "node/test_sce_sum_log_prob/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_sce_sum_log_prob_expanded/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "node/test_selu/model.onnx",
@@ -5893,7 +5893,7 @@
   ],
   [
     "node/test_simple_rnn_batchwise/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op RNN"
   ],
   [
     "node/test_simple_rnn_defaults/model.onnx",
@@ -6085,35 +6085,35 @@
   ],
   [
     "node/test_split_1d_uneven_split_opset18/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Split"
   ],
   [
     "node/test_split_2d_uneven_split_opset18/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Split"
   ],
   [
     "node/test_split_equal_parts_1d_opset13/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Split"
   ],
   [
     "node/test_split_equal_parts_1d_opset18/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Split"
   ],
   [
     "node/test_split_equal_parts_2d/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Split"
   ],
   [
     "node/test_split_equal_parts_2d_opset13/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Split"
   ],
   [
     "node/test_split_equal_parts_default_axis_opset13/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Split"
   ],
   [
     "node/test_split_equal_parts_default_axis_opset18/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Split"
   ],
   [
     "node/test_split_to_sequence_1/model.onnx",
@@ -6129,35 +6129,35 @@
   ],
   [
     "node/test_split_variable_parts_1d_opset13/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Split"
   ],
   [
     "node/test_split_variable_parts_1d_opset18/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Split"
   ],
   [
     "node/test_split_variable_parts_2d_opset13/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Split"
   ],
   [
     "node/test_split_variable_parts_2d_opset18/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Split"
   ],
   [
     "node/test_split_variable_parts_default_axis_opset13/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Split"
   ],
   [
     "node/test_split_variable_parts_default_axis_opset18/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Split"
   ],
   [
     "node/test_split_zero_size_splits_opset13/model.onnx",
-    "Only single-output graphs are supported"
+    "Dynamic or zero dims are not supported"
   ],
   [
     "node/test_split_zero_size_splits_opset18/model.onnx",
-    "Only single-output graphs are supported"
+    "Dynamic or zero dims are not supported"
   ],
   [
     "node/test_sqrt/model.onnx",
@@ -6397,27 +6397,27 @@
   ],
   [
     "node/test_top_k/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op TopK"
   ],
   [
     "node/test_top_k_negative_axis/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op TopK"
   ],
   [
     "node/test_top_k_same_values/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op TopK"
   ],
   [
     "node/test_top_k_same_values_2d/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op TopK"
   ],
   [
     "node/test_top_k_same_values_largest/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op TopK"
   ],
   [
     "node/test_top_k_smallest/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op TopK"
   ],
   [
     "node/test_top_k_uint64/model.onnx",
@@ -6433,11 +6433,11 @@
   ],
   [
     "node/test_training_dropout_default_mask/model.onnx",
-    "Only single-output graphs are supported"
+    "Dropout supports only the data input and 1 or 2 outputs"
   ],
   [
     "node/test_training_dropout_mask/model.onnx",
-    "Only single-output graphs are supported"
+    "Dropout supports only the data input and 1 or 2 outputs"
   ],
   [
     "node/test_training_dropout_zero_ratio/model.onnx",
@@ -6445,7 +6445,7 @@
   ],
   [
     "node/test_training_dropout_zero_ratio_mask/model.onnx",
-    "Only single-output graphs are supported"
+    "Dropout supports only the data input and 1 or 2 outputs"
   ],
   [
     "node/test_transpose_all_permutations_0/model.onnx",
@@ -6549,27 +6549,27 @@
   ],
   [
     "node/test_unique_length_1/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Unique"
   ],
   [
     "node/test_unique_not_sorted_without_axis/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Unique"
   ],
   [
     "node/test_unique_sorted_with_axis/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Unique"
   ],
   [
     "node/test_unique_sorted_with_axis_3d/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Unique"
   ],
   [
     "node/test_unique_sorted_with_negative_axis/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Unique"
   ],
   [
     "node/test_unique_sorted_without_axis/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Unique"
   ],
   [
     "node/test_unsqueeze_axis_0/model.onnx",
@@ -7005,7 +7005,7 @@
   ],
   [
     "pytorch-operator/test_operator_chunk/model.onnx",
-    "Only single-output graphs are supported"
+    "Unsupported op Split"
   ],
   [
     "pytorch-operator/test_operator_clip/model.onnx",
@@ -7109,7 +7109,7 @@
   ],
   [
     "pytorch-operator/test_operator_symbolic_override_nested/model.onnx",
-    "Only single-output graphs are supported"
+    "Sum must have 2 inputs and 1 output"
   ],
   [
     "pytorch-operator/test_operator_view/model.onnx",
@@ -7133,11 +7133,11 @@
   ],
   [
     "simple/test_gradient_of_add/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "simple/test_gradient_of_add_and_mul/model.onnx",
-    "Only single-output graphs are supported"
+    "Scalar outputs are not supported"
   ],
   [
     "simple/test_sequence_model1/model.onnx",

--- a/tests/test_endtoend_features.py
+++ b/tests/test_endtoend_features.py
@@ -127,7 +127,7 @@ def test_initializer_weights_emitted_as_static_arrays() -> None:
     model, weights = _make_add_initializer_model()
     payload, generated = _compile_and_run_testbench(model)
     assert "static const float weight" in generated
-    output_data = np.array(payload["output"]["data"], dtype=np.float32)
+    output_data = np.array(payload["outputs"]["out"]["data"], dtype=np.float32)
     assert output_data.shape == weights.shape
     with tempfile.TemporaryDirectory() as temp_dir:
         model_path = Path(temp_dir) / "add_init.onnx"

--- a/tests/test_multi_output.py
+++ b/tests/test_multi_output.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from onnx import TensorProto, helper
+
+from onnx2c.compiler import Compiler, CompilerOptions
+
+
+def test_multi_output_graph_compile_and_run() -> None:
+    input_info = helper.make_tensor_value_info(
+        "in0", TensorProto.FLOAT, [2, 2]
+    )
+    add_output = helper.make_tensor_value_info(
+        "out_add", TensorProto.FLOAT, [2, 2]
+    )
+    mul_output = helper.make_tensor_value_info(
+        "out_mul", TensorProto.FLOAT, [2, 2]
+    )
+    add_node = helper.make_node(
+        "Add", inputs=["in0", "in0"], outputs=["out_add"]
+    )
+    mul_node = helper.make_node(
+        "Mul", inputs=["in0", "in0"], outputs=["out_mul"]
+    )
+    graph = helper.make_graph(
+        [add_node, mul_node],
+        "multi_output",
+        [input_info],
+        [add_output, mul_output],
+    )
+    model = helper.make_model(graph)
+    compiler = Compiler(
+        CompilerOptions(template_dir=Path("templates"), model_name="multi")
+    )
+    generated = compiler.compile(model)
+    assert "void multi(" in generated
+    assert "out_add[2][2]" in generated
+    assert "out_mul[2][2]" in generated
+    inputs = {"in0": np.ones((2, 2), dtype=np.float32)}
+    outputs = compiler.run(model, inputs)
+    np.testing.assert_allclose(outputs["out_add"], 2.0, rtol=1e-6, atol=1e-6)
+    np.testing.assert_allclose(outputs["out_mul"], 1.0, rtol=1e-6, atol=1e-6)


### PR DESCRIPTION
### Motivation

- Enable compiling ONNX graphs that produce multiple outputs instead of only single-output graphs. 
- Update the generated C testbench format to include multiple outputs so verification can check all outputs. 
- Keep runtime `Compiler.run()` and CLI verification consistent with the multi-output testbench JSON. 
- Refresh golden/reference artifacts and expected-error mappings to reflect the new testbench format.

### Description

- Extended `LoweredModel` to carry `output_names`, `output_shapes`, and `output_dtypes` instead of a single output descriptor and updated lowering in `Compiler._lower_model` to populate them. 
- Updated the C emitter (`src/onnx2c/codegen/c_emitter.py`) to: accept multiple outputs when emitting the wrapper function signature, reserve temporary buffers only for intermediate (non-output) values, and produce a testbench payload for multiple outputs. 
- Changed the testbench template (`templates/testbench.c.j2`) to emit an `"outputs"` object (mapping output name -> {shape,data}) and fixed JSON closing so the payload is valid. 
- Updated CLI verification in `src/onnx2c/cli.py` to parse and validate multiple outputs from the testbench JSON, and added/updated tests and golden files (`tests/test_multi_output.py`, `tests/golden/add_model_testbench.c`) and support metadata (`tests/official_onnx_expected_errors.json`, `OFFICIAL_ONNX_FILE_SUPPORT*`) to match the new format.

### Testing

- Ran the targeted unit test: `pytest -n auto -q tests/test_multi_output.py` which passed (1 test, 6.01s). 
- Ran the full test suite with reference updates: `UPDATE_REFS=1 pytest -n auto -q` which completed successfully (105 passed, 21.75s) and updated golden/testbench references accordingly. 
- Verified that generated C signatures now include all output buffers and that the testbench JSON contains the `outputs` mapping expected by the CLI verifier. 
- Updated golden artifacts and expected-error files to reflect behavior and message changes introduced by multi-output handling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696452c4d7748325887e9c98c95e24c5)