### PR TITLE
core: add double (float64) dtype support

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 302 / 1802 official ONNX files.
+Support 310 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -49,7 +49,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_ai_onnx_ml_label_encoder_tensor_mapping/model.onnx | ❌ | Unsupported elem_type 8 (STRING) for tensor 'X'. |
 | node/test_ai_onnx_ml_label_encoder_tensor_value_only_mapping/model.onnx | ❌ | Unsupported elem_type 8 (STRING) for tensor 'X'. |
 | node/test_ai_onnx_ml_tree_ensemble_set_membership/model.onnx | ❌ | Unsupported op TreeEnsemble |
-| node/test_ai_onnx_ml_tree_ensemble_single_tree/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'X'. |
+| node/test_ai_onnx_ml_tree_ensemble_single_tree/model.onnx | ❌ | Unsupported op TreeEnsemble |
 | node/test_and2d/model.onnx | ✅ |  |
 | node/test_and3d/model.onnx | ✅ |  |
 | node/test_and4d/model.onnx | ✅ |  |
@@ -250,10 +250,10 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_batchnorm_epsilon_training_mode/model.onnx | ❌ | BatchNormalization must have 5 inputs and 1 output |
 | node/test_batchnorm_example/model.onnx | ✅ |  |
 | node/test_batchnorm_example_training_mode/model.onnx | ❌ | BatchNormalization must have 5 inputs and 1 output |
-| node/test_bernoulli/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'x'. |
-| node/test_bernoulli_double/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'y'. |
-| node/test_bernoulli_double_expanded/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'y'. |
-| node/test_bernoulli_expanded/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'x'. |
+| node/test_bernoulli/model.onnx | ❌ | Unsupported op Bernoulli |
+| node/test_bernoulli_double/model.onnx | ❌ | Unsupported op Bernoulli |
+| node/test_bernoulli_double_expanded/model.onnx | ❌ | Unsupported op RandomUniformLike |
+| node/test_bernoulli_expanded/model.onnx | ❌ | Unsupported op RandomUniformLike |
 | node/test_bernoulli_seed/model.onnx | ❌ | Unsupported op Bernoulli |
 | node/test_bernoulli_seed_expanded/model.onnx | ❌ | Unsupported op RandomUniformLike |
 | node/test_bitshift_left_uint16/model.onnx | ❌ | Unsupported op BitShift |
@@ -284,8 +284,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_blackmanwindow_symmetric/model.onnx | ❌ | Unsupported op BlackmanWindow |
 | node/test_blackmanwindow_symmetric_expanded/model.onnx | ❌ | Dynamic dim for tensor 'BlackmanWindow_test_blackmanwindow_symmetric_expanded_function_Range' |
 | node/test_cast_BFLOAT16_to_FLOAT/model.onnx | ❌ | Unsupported elem_type 16 (BFLOAT16) for tensor 'input'. |
-| node/test_cast_DOUBLE_to_FLOAT/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'input'. |
-| node/test_cast_DOUBLE_to_FLOAT16/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'input'. |
+| node/test_cast_DOUBLE_to_FLOAT/model.onnx | ❌ | Unsupported op Cast |
+| node/test_cast_DOUBLE_to_FLOAT16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'output'. |
 | node/test_cast_FLOAT16_to_DOUBLE/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
 | node/test_cast_FLOAT16_to_FLOAT/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
 | node/test_cast_FLOAT16_to_FLOAT4E2M1/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
@@ -308,7 +308,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_cast_FLOAT8E5M2_to_FLOAT/model.onnx | ❌ | Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'input'. |
 | node/test_cast_FLOAT8E5M2_to_FLOAT16/model.onnx | ❌ | Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'input'. |
 | node/test_cast_FLOAT_to_BFLOAT16/model.onnx | ❌ | Unsupported elem_type 16 (BFLOAT16) for tensor 'output'. |
-| node/test_cast_FLOAT_to_DOUBLE/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'output'. |
+| node/test_cast_FLOAT_to_DOUBLE/model.onnx | ❌ | Unsupported op Cast |
 | node/test_cast_FLOAT_to_FLOAT16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'output'. |
 | node/test_cast_FLOAT_to_FLOAT4E2M1/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'output'. |
 | node/test_cast_FLOAT_to_FLOAT8E4M3FN/model.onnx | ❌ | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'output'. |
@@ -345,10 +345,10 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_cast_no_saturate_FLOAT_to_FLOAT8E5M2FNUZ/model.onnx | ❌ | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor 'output'. |
 | node/test_castlike_BFLOAT16_to_FLOAT/model.onnx | ❌ | Unsupported elem_type 16 (BFLOAT16) for tensor 'input'. |
 | node/test_castlike_BFLOAT16_to_FLOAT_expanded/model.onnx | ❌ | Unsupported elem_type 16 (BFLOAT16) for tensor 'input'. |
-| node/test_castlike_DOUBLE_to_FLOAT/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'input'. |
-| node/test_castlike_DOUBLE_to_FLOAT16/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'input'. |
-| node/test_castlike_DOUBLE_to_FLOAT16_expanded/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'input'. |
-| node/test_castlike_DOUBLE_to_FLOAT_expanded/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'input'. |
+| node/test_castlike_DOUBLE_to_FLOAT/model.onnx | ❌ | Unsupported op CastLike |
+| node/test_castlike_DOUBLE_to_FLOAT16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'like'. |
+| node/test_castlike_DOUBLE_to_FLOAT16_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'like'. |
+| node/test_castlike_DOUBLE_to_FLOAT_expanded/model.onnx | ❌ | Unsupported op Cast |
 | node/test_castlike_FLOAT16_to_DOUBLE/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
 | node/test_castlike_FLOAT16_to_DOUBLE_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
 | node/test_castlike_FLOAT16_to_FLOAT/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
@@ -393,8 +393,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_castlike_FLOAT8E5M2_to_FLOAT_expanded/model.onnx | ❌ | Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'input'. |
 | node/test_castlike_FLOAT_to_BFLOAT16/model.onnx | ❌ | Unsupported elem_type 16 (BFLOAT16) for tensor 'like'. |
 | node/test_castlike_FLOAT_to_BFLOAT16_expanded/model.onnx | ❌ | Unsupported elem_type 16 (BFLOAT16) for tensor 'like'. |
-| node/test_castlike_FLOAT_to_DOUBLE/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'like'. |
-| node/test_castlike_FLOAT_to_DOUBLE_expanded/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'like'. |
+| node/test_castlike_FLOAT_to_DOUBLE/model.onnx | ❌ | Unsupported op CastLike |
+| node/test_castlike_FLOAT_to_DOUBLE_expanded/model.onnx | ❌ | Unsupported op Cast |
 | node/test_castlike_FLOAT_to_FLOAT16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'like'. |
 | node/test_castlike_FLOAT_to_FLOAT16_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'like'. |
 | node/test_castlike_FLOAT_to_FLOAT4E2M1/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'like'. |
@@ -544,15 +544,15 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_cos_example/model.onnx | ✅ |  |
 | node/test_cosh/model.onnx | ❌ | Unsupported op Cosh |
 | node/test_cosh_example/model.onnx | ❌ | Unsupported op Cosh |
-| node/test_cumsum_1d/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'x'. |
-| node/test_cumsum_1d_exclusive/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'x'. |
+| node/test_cumsum_1d/model.onnx | ❌ | Unsupported op CumSum |
+| node/test_cumsum_1d_exclusive/model.onnx | ❌ | Unsupported op CumSum |
 | node/test_cumsum_1d_int32_exclusive/model.onnx | ❌ | Unsupported op CumSum |
-| node/test_cumsum_1d_reverse/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'x'. |
-| node/test_cumsum_1d_reverse_exclusive/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'x'. |
-| node/test_cumsum_2d_axis_0/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'x'. |
-| node/test_cumsum_2d_axis_1/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'x'. |
+| node/test_cumsum_1d_reverse/model.onnx | ❌ | Unsupported op CumSum |
+| node/test_cumsum_1d_reverse_exclusive/model.onnx | ❌ | Unsupported op CumSum |
+| node/test_cumsum_2d_axis_0/model.onnx | ❌ | Unsupported op CumSum |
+| node/test_cumsum_2d_axis_1/model.onnx | ❌ | Unsupported op CumSum |
 | node/test_cumsum_2d_int32/model.onnx | ❌ | Unsupported op CumSum |
-| node/test_cumsum_2d_negative_axis/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'x'. |
+| node/test_cumsum_2d_negative_axis/model.onnx | ❌ | Unsupported op CumSum |
 | node/test_deform_conv_with_mask_bias/model.onnx | ❌ | Unsupported op DeformConv |
 | node/test_deform_conv_with_multiple_offset_groups/model.onnx | ❌ | Unsupported op DeformConv |
 | node/test_depthtospace_crd_mode_example/model.onnx | ❌ | Unsupported op DepthToSpace |
@@ -601,12 +601,12 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_dynamicquantizelinear_min_adjusted/model.onnx | ❌ | Unsupported op DynamicQuantizeLinear |
 | node/test_dynamicquantizelinear_min_adjusted_expanded/model.onnx | ❌ | Unsupported op Clip |
 | node/test_edge_pad/model.onnx | ❌ | Unsupported op Pad |
-| node/test_einsum_batch_diagonal/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'x'. |
-| node/test_einsum_batch_matmul/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'x'. |
-| node/test_einsum_inner_prod/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'x'. |
-| node/test_einsum_scalar/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'x'. |
-| node/test_einsum_sum/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'x'. |
-| node/test_einsum_transpose/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'x'. |
+| node/test_einsum_batch_diagonal/model.onnx | ❌ | Unsupported op Einsum |
+| node/test_einsum_batch_matmul/model.onnx | ❌ | Unsupported op Einsum |
+| node/test_einsum_inner_prod/model.onnx | ❌ | Unsupported op Einsum |
+| node/test_einsum_scalar/model.onnx | ❌ | Unsupported op Einsum |
+| node/test_einsum_sum/model.onnx | ❌ | Unsupported op Einsum |
+| node/test_einsum_transpose/model.onnx | ❌ | Unsupported op Einsum |
 | node/test_elu/model.onnx | ❌ | Unsupported op Elu |
 | node/test_elu_default/model.onnx | ❌ | Unsupported op Elu |
 | node/test_elu_default_expanded_ver18/model.onnx | ❌ | Unsupported op CastLike |
@@ -629,7 +629,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_expand_dim_changed/model.onnx | ❌ | Unsupported op Expand |
 | node/test_expand_dim_unchanged/model.onnx | ❌ | Unsupported op Expand |
 | node/test_eyelike_populate_off_main_diagonal/model.onnx | ❌ | Unsupported op EyeLike |
-| node/test_eyelike_with_dtype/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'y'. |
+| node/test_eyelike_with_dtype/model.onnx | ❌ | Unsupported op EyeLike |
 | node/test_eyelike_without_dtype/model.onnx | ❌ | Unsupported op EyeLike |
 | node/test_flatten_axis0/model.onnx | ❌ | Unsupported op Flatten |
 | node/test_flatten_axis1/model.onnx | ❌ | Unsupported op Flatten |
@@ -915,7 +915,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_max_example/model.onnx | ❌ | Max must have 2 inputs and 1 output |
 | node/test_max_float16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'data_0'. |
 | node/test_max_float32/model.onnx | ✅ |  |
-| node/test_max_float64/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'data_0'. |
+| node/test_max_float64/model.onnx | ✅ |  |
 | node/test_max_int16/model.onnx | ❌ | Unsupported op Max |
 | node/test_max_int32/model.onnx | ❌ | Unsupported op Max |
 | node/test_max_int64/model.onnx | ❌ | Unsupported op Max |
@@ -954,7 +954,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_min_example/model.onnx | ❌ | Min must have 2 inputs and 1 output |
 | node/test_min_float16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'data_0'. |
 | node/test_min_float32/model.onnx | ✅ |  |
-| node/test_min_float64/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'data_0'. |
+| node/test_min_float64/model.onnx | ✅ |  |
 | node/test_min_int16/model.onnx | ❌ | Unsupported op Min |
 | node/test_min_int32/model.onnx | ❌ | Unsupported op Min |
 | node/test_min_int64/model.onnx | ❌ | Unsupported op Min |
@@ -971,7 +971,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_mod_int64_fmod/model.onnx | ❌ | Unsupported op Mod |
 | node/test_mod_mixed_sign_float16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'x'. |
 | node/test_mod_mixed_sign_float32/model.onnx | ✅ |  |
-| node/test_mod_mixed_sign_float64/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'x'. |
+| node/test_mod_mixed_sign_float64/model.onnx | ✅ |  |
 | node/test_mod_mixed_sign_int16/model.onnx | ❌ | Unsupported op Mod |
 | node/test_mod_mixed_sign_int32/model.onnx | ❌ | Unsupported op Mod |
 | node/test_mod_mixed_sign_int64/model.onnx | ❌ | Unsupported op Mod |
@@ -1157,24 +1157,24 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_log_sum_desc_axes_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
 | node/test_reduce_log_sum_empty_set/model.onnx | ❌ | ReduceLogSum axes input must be constant |
 | node/test_reduce_log_sum_empty_set_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_log_sum_exp_default_axes_keepdims_example/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'data'. |
-| node/test_reduce_log_sum_exp_default_axes_keepdims_example_expanded/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'data'. |
-| node/test_reduce_log_sum_exp_default_axes_keepdims_random/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'data'. |
-| node/test_reduce_log_sum_exp_default_axes_keepdims_random_expanded/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'data'. |
-| node/test_reduce_log_sum_exp_do_not_keepdims_example/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'data'. |
-| node/test_reduce_log_sum_exp_do_not_keepdims_example_expanded/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'data'. |
-| node/test_reduce_log_sum_exp_do_not_keepdims_random/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'data'. |
-| node/test_reduce_log_sum_exp_do_not_keepdims_random_expanded/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'data'. |
+| node/test_reduce_log_sum_exp_default_axes_keepdims_example/model.onnx | ❌ | ReduceLogSumExp axes input must be constant |
+| node/test_reduce_log_sum_exp_default_axes_keepdims_example_expanded/model.onnx | ❌ | Unsupported op Cast |
+| node/test_reduce_log_sum_exp_default_axes_keepdims_random/model.onnx | ❌ | ReduceLogSumExp axes input must be constant |
+| node/test_reduce_log_sum_exp_default_axes_keepdims_random_expanded/model.onnx | ❌ | Unsupported op Cast |
+| node/test_reduce_log_sum_exp_do_not_keepdims_example/model.onnx | ❌ | ReduceLogSumExp axes input must be constant |
+| node/test_reduce_log_sum_exp_do_not_keepdims_example_expanded/model.onnx | ❌ | Unsupported op Cast |
+| node/test_reduce_log_sum_exp_do_not_keepdims_random/model.onnx | ❌ | ReduceLogSumExp axes input must be constant |
+| node/test_reduce_log_sum_exp_do_not_keepdims_random_expanded/model.onnx | ❌ | Unsupported op Cast |
 | node/test_reduce_log_sum_exp_empty_set/model.onnx | ❌ | ReduceLogSumExp axes input must be constant |
-| node/test_reduce_log_sum_exp_empty_set_expanded/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'ReduceLogSumExp_test_reduce_log_sum_exp_empty_set_expanded_function_data_double'. |
-| node/test_reduce_log_sum_exp_keepdims_example/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'data'. |
-| node/test_reduce_log_sum_exp_keepdims_example_expanded/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'data'. |
-| node/test_reduce_log_sum_exp_keepdims_random/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'data'. |
-| node/test_reduce_log_sum_exp_keepdims_random_expanded/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'data'. |
-| node/test_reduce_log_sum_exp_negative_axes_keepdims_example/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'data'. |
-| node/test_reduce_log_sum_exp_negative_axes_keepdims_example_expanded/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'data'. |
-| node/test_reduce_log_sum_exp_negative_axes_keepdims_random/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'data'. |
-| node/test_reduce_log_sum_exp_negative_axes_keepdims_random_expanded/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'data'. |
+| node/test_reduce_log_sum_exp_empty_set_expanded/model.onnx | ❌ | Unsupported op Cast |
+| node/test_reduce_log_sum_exp_keepdims_example/model.onnx | ❌ | ReduceLogSumExp axes input must be constant |
+| node/test_reduce_log_sum_exp_keepdims_example_expanded/model.onnx | ❌ | Unsupported op Cast |
+| node/test_reduce_log_sum_exp_keepdims_random/model.onnx | ❌ | ReduceLogSumExp axes input must be constant |
+| node/test_reduce_log_sum_exp_keepdims_random_expanded/model.onnx | ❌ | Unsupported op Cast |
+| node/test_reduce_log_sum_exp_negative_axes_keepdims_example/model.onnx | ❌ | ReduceLogSumExp axes input must be constant |
+| node/test_reduce_log_sum_exp_negative_axes_keepdims_example_expanded/model.onnx | ❌ | Unsupported op Cast |
+| node/test_reduce_log_sum_exp_negative_axes_keepdims_random/model.onnx | ❌ | ReduceLogSumExp axes input must be constant |
+| node/test_reduce_log_sum_exp_negative_axes_keepdims_random_expanded/model.onnx | ❌ | Unsupported op Cast |
 | node/test_reduce_log_sum_negative_axes/model.onnx | ❌ | ReduceLogSum axes input must be constant |
 | node/test_reduce_log_sum_negative_axes_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
 | node/test_reduce_max_bool_inputs/model.onnx | ❌ | ReduceMax does not support dtype bool |
@@ -1752,11 +1752,11 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | pytorch-converted/test_log_softmax_lastdim/model.onnx | ❌ | Unsupported op LogSoftmax |
 | pytorch-converted/test_softmax_functional_dim3/model.onnx | ✅ |  |
 | pytorch-converted/test_softmax_lastdim/model.onnx | ✅ |  |
-| pytorch-operator/test_operator_add_broadcast/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor '0'. |
-| pytorch-operator/test_operator_add_size1_broadcast/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor '0'. |
-| pytorch-operator/test_operator_add_size1_right_broadcast/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor '0'. |
-| pytorch-operator/test_operator_add_size1_singleton_broadcast/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor '0'. |
-| pytorch-operator/test_operator_addconstant/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for Constant '1'. |
+| pytorch-operator/test_operator_add_broadcast/model.onnx | ✅ |  |
+| pytorch-operator/test_operator_add_size1_broadcast/model.onnx | ✅ |  |
+| pytorch-operator/test_operator_add_size1_right_broadcast/model.onnx | ✅ |  |
+| pytorch-operator/test_operator_add_size1_singleton_broadcast/model.onnx | ✅ |  |
+| pytorch-operator/test_operator_addconstant/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_addmm/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_basic/model.onnx | ❌ | Unsupported op Sigmoid |
 | pytorch-operator/test_operator_chunk/model.onnx | ❌ | Unsupported op Split |
@@ -1799,7 +1799,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | simple/test_sequence_model4/model.onnx | ❌ | Dynamic dim for tensor 'out' |
 | simple/test_sequence_model5/model.onnx | ❌ | Missing elem_type for tensor 'seq_1' |
 | simple/test_sequence_model6/model.onnx | ❌ | Missing elem_type for tensor 'seq_1' |
-| simple/test_sequence_model7/model.onnx | ❌ | Unsupported elem_type 11 (DOUBLE) for tensor 'X'. |
+| simple/test_sequence_model7/model.onnx | ❌ | Missing elem_type for tensor 'seq_1' |
 | simple/test_sequence_model8/model.onnx | ❌ | Dynamic dim for tensor 'X' |
 | simple/test_shrink/model.onnx | ❌ | Unsupported op Shrink |
 | simple/test_sign_model/model.onnx | ❌ | Unsupported op Sign |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -3,17 +3,17 @@
 | Error message | Count | Histogram |
 | --- | --- | --- |
 | Dynamic dim for tensor '*' | 146 | ██████████████████████████████ |
-| Unsupported elem_type 10 (FLOAT16) for tensor '*'. | 62 | █████████████ |
-| Unsupported elem_type 11 (DOUBLE) for tensor '*'. | 53 | ███████████ |
+| Unsupported elem_type 10 (FLOAT16) for tensor '*'. | 65 | █████████████ |
 | Unsupported op Attention | 47 | ██████████ |
 | Unsupported op LogSoftmax | 44 | █████████ |
 | ReduceSum axes input must be constant | 43 | █████████ |
 | Unsupported op Resize | 39 | ████████ |
+| Missing elem_type for tensor '*' | 34 | ███████ |
 | Unsupported op SoftmaxCrossEntropyLoss | 34 | ███████ |
-| Missing elem_type for tensor '*' | 33 | ███████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████ |
-| Unsupported op CastLike | 29 | ██████ |
+| Unsupported op CastLike | 31 | ██████ |
 | Unsupported op Less | 26 | █████ |
+| Unsupported op Cast | 22 | █████ |
 | Unsupported op LayerNormalization | 19 | ████ |
 | Unsupported op RMSNormalization | 19 | ████ |
 | Unsupported op GridSample | 18 | ████ |
@@ -40,11 +40,12 @@
 | Unsupported op Mod | 10 | ██ |
 | Unsupported op Shape | 10 | ██ |
 | Dynamic or zero dims are not supported | 9 | ██ |
+| Unsupported op CumSum | 9 | ██ |
 | Unsupported op ImageDecoder | 9 | ██ |
-| Unsupported op Cast | 9 | ██ |
 | Unsupported op NonMaxSuppression | 9 | ██ |
 | ReduceL1 axes input must be constant | 9 | ██ |
 | ReduceL2 axes input must be constant | 9 | ██ |
+| ReduceLogSumExp axes input must be constant | 9 | ██ |
 | ReduceSumSquare axes input must be constant | 9 | ██ |
 | Reshape requires a constant shape input | 9 | ██ |
 | Unsupported op BitShift | 8 | ██ |
@@ -69,6 +70,7 @@
 | Unsupported op CenterCropPad | 6 | █ |
 | Unsupported op DFT | 6 | █ |
 | Unsupported op Div | 6 | █ |
+| Unsupported op Einsum | 6 | █ |
 | Unsupported op Expand | 6 | █ |
 | Unsupported op Gather | 6 | █ |
 | Unsupported op LpNormalization | 6 | █ |
@@ -103,10 +105,13 @@
 | Unsupported op Squeeze | 4 | █ |
 | Unsupported op Tile | 4 | █ |
 | AveragePool supports auto_pad=NOTSET only | 3 | █ |
+| Unsupported op Bernoulli | 3 | █ |
+| Unsupported op RandomUniformLike | 3 | █ |
 | Unsupported op BitwiseNot | 3 | █ |
 | Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 3 | █ |
 | Unsupported op Identity | 3 | █ |
 | Unsupported op DynamicQuantizeLinear | 3 | █ |
+| Unsupported op EyeLike | 3 | █ |
 | Unsupported op GatherND | 3 | █ |
 | Unsupported op InstanceNormalization | 3 | █ |
 | Unsupported op IsInf | 3 | █ |
@@ -120,6 +125,7 @@
 | Unsupported op Acosh | 2 | █ |
 | Unsupported op Adagrad | 2 | █ |
 | Unsupported op Adam | 2 | █ |
+| Unsupported op TreeEnsemble | 2 | █ |
 | Unsupported op Asin | 2 | █ |
 | Unsupported op Asinh | 2 | █ |
 | Unsupported op Atan | 2 | █ |
@@ -129,10 +135,8 @@
 | Unsupported op BlackmanWindow | 2 | █ |
 | Unsupported op ConvInteger | 2 | █ |
 | Unsupported op Cosh | 2 | █ |
-| Unsupported op CumSum | 2 | █ |
 | Unsupported op DepthToSpace | 2 | █ |
 | Unsupported op Det | 2 | █ |
-| Unsupported op EyeLike | 2 | █ |
 | Unsupported op GlobalMaxPool | 2 | █ |
 | Unsupported op GroupNormalization | 2 | █ |
 | Unsupported op HammingWindow | 2 | █ |
@@ -160,9 +164,6 @@
 | Unsupported op Gradient | 2 | █ |
 | Unsupported op ArrayFeatureExtractor | 1 | █ |
 | Unsupported op Binarizer | 1 | █ |
-| Unsupported op TreeEnsemble | 1 | █ |
-| Unsupported op Bernoulli | 1 | █ |
-| Unsupported op RandomUniformLike | 1 | █ |
 | Unsupported op Celu | 1 | █ |
 | Graph must contain at least one node | 1 | █ |
 | Dropout mask output is not supported | 1 | █ |
@@ -188,11 +189,9 @@
 | Pow expects matching dtypes, got float, uint32 | 1 | █ |
 | Pow expects matching dtypes, got float, uint64 | 1 | █ |
 | Unsupported op QLinearConv | 1 | █ |
-| ReduceLogSumExp axes input must be constant | 1 | █ |
 | ReduceMax does not support dtype bool | 1 | █ |
 | ReduceMin does not support dtype bool | 1 | █ |
 | Unsupported op Round | 1 | █ |
 | Unsupported op Swish | 1 | █ |
 | Unsupported op Upsample | 1 | █ |
-| Unsupported elem_type 11 (DOUBLE) for Constant '*'. | 1 | █ |
 | Gemm bias input must be broadcastable to output shape, got (1,) vs (2, 4) | 1 | █ |

--- a/src/onnx2c/cli.py
+++ b/src/onnx2c/cli.py
@@ -209,7 +209,7 @@ def _handle_verify(args: argparse.Namespace) -> int:
                 raise AssertionError(f"Missing output {value.name} in testbench data")
             info = output_dtypes[value.name]
             output_data = np.array(output_payload["data"], dtype=info.np_dtype)
-            if value.type.dtype == "float":
+            if np.issubdtype(info.np_dtype, np.floating):
                 np.testing.assert_allclose(
                     output_data, ort_out, rtol=1e-4, atol=1e-5
                 )

--- a/src/onnx2c/dtypes.py
+++ b/src/onnx2c/dtypes.py
@@ -18,6 +18,7 @@ class DTypeInfo:
 
 ONNX_TO_DTYPE = {
     onnx.TensorProto.FLOAT: "float",
+    onnx.TensorProto.DOUBLE: "double",
     onnx.TensorProto.BOOL: "bool",
     onnx.TensorProto.UINT8: "uint8",
     onnx.TensorProto.UINT16: "uint16",
@@ -36,6 +37,14 @@ DTYPE_INFO = {
         c_type="float",
         np_dtype=np.dtype("float32"),
         zero_literal="0.0f",
+        min_literal="-INFINITY",
+        max_literal="INFINITY",
+    ),
+    "double": DTypeInfo(
+        name="double",
+        c_type="double",
+        np_dtype=np.dtype("float64"),
+        zero_literal="0.0",
         min_literal="-INFINITY",
         max_literal="INFINITY",
     ),

--- a/src/onnx2c/lowering/average_pool.py
+++ b/src/onnx2c/lowering/average_pool.py
@@ -164,8 +164,10 @@ def lower_average_pool(graph: Graph, node: Node) -> AveragePoolOp:
             "AveragePool expects matching input/output dtypes, "
             f"got {op_dtype} and {output_dtype}"
         )
-    if op_dtype != "float":
-        raise UnsupportedOpError("AveragePool supports float inputs only")
+    if op_dtype not in {"float", "double"}:
+        raise UnsupportedOpError(
+            "AveragePool supports float and double inputs only"
+        )
     spec = _resolve_average_pool_spec(graph, node)
     return AveragePoolOp(
         input0=node.inputs[0],
@@ -198,8 +200,10 @@ def lower_global_average_pool(graph: Graph, node: Node) -> AveragePoolOp:
             "GlobalAveragePool expects matching input/output dtypes, "
             f"got {op_dtype} and {output_dtype}"
         )
-    if op_dtype != "float":
-        raise UnsupportedOpError("GlobalAveragePool supports float inputs only")
+    if op_dtype not in {"float", "double"}:
+        raise UnsupportedOpError(
+            "GlobalAveragePool supports float and double inputs only"
+        )
     spec = _resolve_global_average_pool_spec(graph, node)
     return AveragePoolOp(
         input0=node.inputs[0],

--- a/src/onnx2c/lowering/batch_normalization.py
+++ b/src/onnx2c/lowering/batch_normalization.py
@@ -97,8 +97,10 @@ def _resolve_batch_norm_spec(graph: Graph, node: Node) -> _BatchNormSpec:
 @register_lowering("BatchNormalization")
 def lower_batch_normalization(graph: Graph, node: Node) -> BatchNormOp:
     op_dtype = _node_dtype(graph, node, *node.inputs, *node.outputs)
-    if op_dtype != "float":
-        raise UnsupportedOpError("BatchNormalization supports float inputs only")
+    if op_dtype not in {"float", "double"}:
+        raise UnsupportedOpError(
+            "BatchNormalization supports float and double inputs only"
+        )
     spec = _resolve_batch_norm_spec(graph, node)
     return BatchNormOp(
         input0=node.inputs[0],

--- a/src/onnx2c/lowering/lrn.py
+++ b/src/onnx2c/lowering/lrn.py
@@ -85,8 +85,8 @@ def resolve_lrn_spec(graph: Graph, node: Node) -> LrnSpec:
 @register_lowering("LRN")
 def lower_lrn(graph: Graph, node: Node) -> LrnOp:
     op_dtype = _node_dtype(graph, node, *node.inputs, *node.outputs)
-    if op_dtype != "float":
-        raise UnsupportedOpError("LRN supports float inputs only")
+    if op_dtype not in {"float", "double"}:
+        raise UnsupportedOpError("LRN supports float and double inputs only")
     spec = resolve_lrn_spec(graph, node)
     return LrnOp(
         input0=node.inputs[0],

--- a/src/onnx2c/lowering/reduce.py
+++ b/src/onnx2c/lowering/reduce.py
@@ -177,6 +177,7 @@ def _resolve_reduce_spec(graph: Graph, node: Node) -> _ReduceSpec | None:
 def _reduce_dtype_supported(dtype: str) -> bool:
     return dtype in {
         "float",
+        "double",
         "int64",
         "int32",
         "int16",
@@ -202,9 +203,12 @@ def lower_reduce(graph: Graph, node: Node) -> ReduceOp | ReshapeOp:
         raise UnsupportedOpError(
             f"{node.op_type} does not support dtype {op_dtype}"
         )
-    if node.op_type in REDUCE_OUTPUTS_FLOAT_ONLY and op_dtype != "float":
+    if node.op_type in REDUCE_OUTPUTS_FLOAT_ONLY and op_dtype not in {
+        "float",
+        "double",
+    }:
         raise UnsupportedOpError(
-            f"{node.op_type} supports float inputs only"
+            f"{node.op_type} supports float and double inputs only"
         )
     spec = _resolve_reduce_spec(graph, node)
     if spec is None:

--- a/src/onnx2c/onnx_import.py
+++ b/src/onnx2c/onnx_import.py
@@ -20,6 +20,8 @@ def _normalize_initializer_data(dtype: str, data: object) -> np.ndarray:
         array = np.array(data)
     if dtype == "float" and array.dtype != "float32":
         array = array.astype("float32", copy=False)
+    if dtype == "double" and array.dtype != "float64":
+        array = array.astype("float64", copy=False)
     if dtype == "bool" and array.dtype != "bool":
         array = array.astype("bool", copy=False)
     if dtype == "uint64" and array.dtype != "uint64":

--- a/templates/attention_op.c.j2
+++ b/templates/attention_op.c.j2
@@ -28,12 +28,12 @@ void {{ op_name }}(const {{ c_type }} {{ input_q }}{{ input_q_suffix }},
                 for (int ki = 0; ki < {{ kv_seq }}; ++ki) {
                     {{ c_type }} weight = {{ zero_literal }};
                     if (!({{ is_causal }} && ki > qi)) {
-                        weight = expf(scores[ki] - max_score);
+                        weight = {{ exp_fn }}(scores[ki] - max_score);
                     }
                     weights[ki] = weight;
                     sum += weight;
                 }
-                {{ c_type }} inv_sum = sum == {{ zero_literal }} ? {{ zero_literal }} : ({{ c_type }})1.0f / sum;
+                {{ c_type }} inv_sum = sum == {{ zero_literal }} ? {{ zero_literal }} : ({{ c_type }}){{ one_literal }} / sum;
                 for (int vd = 0; vd < {{ v_head_size }}; ++vd) {
                     {{ c_type }} acc = {{ zero_literal }};
                     for (int ki = 0; ki < {{ kv_seq }}; ++ki) {

--- a/templates/batch_norm_op.c.j2
+++ b/templates/batch_norm_op.c.j2
@@ -3,7 +3,7 @@ void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix }}, const {{ c
 {{ loop_indents[loop.index0] }}for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
 {{ inner_indent }}size_t c = {{ loop_vars[1] }};
-{{ inner_indent }}{{ c_type }} denom = sqrtf({{ variance }}[c] + {{ epsilon_literal }});
+{{ inner_indent }}{{ c_type }} denom = {{ sqrt_fn }}({{ variance }}[c] + {{ epsilon_literal }});
 {{ inner_indent }}{{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = ({{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %} - {{ mean }}[c]) / denom * {{ scale }}[c] + {{ bias }}[c];
 {% for _ in shape %}
 {{ loop_indents[loop.revindex0] }}}

--- a/templates/lrn_op.c.j2
+++ b/templates/lrn_op.c.j2
@@ -13,7 +13,7 @@ void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix }}, {{ c_type 
 {{ inner_indent }}    sum += val * val;
 {{ inner_indent }}}
 {{ inner_indent }}{{ c_type }} scale = {{ bias_literal }} + {{ alpha_div_size_literal }} * sum;
-{{ inner_indent }}{{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = {{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %} / powf(scale, {{ beta_literal }});
+{{ inner_indent }}{{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = {{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %} / {{ pow_fn }}(scale, {{ beta_literal }});
 {% for _ in shape %}
 {{ loop_indents[loop.revindex0] }}}
 {% endfor %}

--- a/templates/softmax_op.c.j2
+++ b/templates/softmax_op.c.j2
@@ -16,7 +16,7 @@ void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ array_suffix }}, {{ c_type 
             }
             {{ c_type }} sum = 0;
             for (size_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
-                {{ c_type }} value = expf(input_flat[base + axis_idx * inner] - max_value);
+                {{ c_type }} value = {{ exp_fn }}(input_flat[base + axis_idx * inner] - max_value);
                 output_flat[base + axis_idx * inner] = value;
                 sum += value;
             }

--- a/templates/testbench.c.j2
+++ b/templates/testbench.c.j2
@@ -13,6 +13,10 @@ static float rng_next_float(void) {
     return (float)((double)rng_next_u64() * (1.0 / 18446744073709551616.0));
 }
 
+static double rng_next_double(void) {
+    return (double)rng_next_u64() * (1.0 / 18446744073709551616.0);
+}
+
 static int64_t rng_next_i64(void) {
     return (int64_t)rng_next_u64();
 }

--- a/tests/golden/add_model_testbench.c
+++ b/tests/golden/add_model_testbench.c
@@ -32,6 +32,10 @@ static float rng_next_float(void) {
     return (float)((double)rng_next_u64() * (1.0 / 18446744073709551616.0));
 }
 
+static double rng_next_double(void) {
+    return (double)rng_next_u64() * (1.0 / 18446744073709551616.0);
+}
+
 static int64_t rng_next_i64(void) {
     return (int64_t)rng_next_u64();
 }

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -165,7 +165,7 @@
   ],
   [
     "node/test_ai_onnx_ml_tree_ensemble_single_tree/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'X'."
+    "Unsupported op TreeEnsemble"
   ],
   [
     "node/test_and2d/model.onnx",
@@ -969,19 +969,19 @@
   ],
   [
     "node/test_bernoulli/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'x'."
+    "Unsupported op Bernoulli"
   ],
   [
     "node/test_bernoulli_double/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'y'."
+    "Unsupported op Bernoulli"
   ],
   [
     "node/test_bernoulli_double_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'y'."
+    "Unsupported op RandomUniformLike"
   ],
   [
     "node/test_bernoulli_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'x'."
+    "Unsupported op RandomUniformLike"
   ],
   [
     "node/test_bernoulli_seed/model.onnx",
@@ -1105,11 +1105,11 @@
   ],
   [
     "node/test_cast_DOUBLE_to_FLOAT/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'input'."
+    "Unsupported op Cast"
   ],
   [
     "node/test_cast_DOUBLE_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'input'."
+    "Unsupported elem_type 10 (FLOAT16) for tensor 'output'."
   ],
   [
     "node/test_cast_FLOAT16_to_DOUBLE/model.onnx",
@@ -1201,7 +1201,7 @@
   ],
   [
     "node/test_cast_FLOAT_to_DOUBLE/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'output'."
+    "Unsupported op Cast"
   ],
   [
     "node/test_cast_FLOAT_to_FLOAT16/model.onnx",
@@ -1349,19 +1349,19 @@
   ],
   [
     "node/test_castlike_DOUBLE_to_FLOAT/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'input'."
+    "Unsupported op CastLike"
   ],
   [
     "node/test_castlike_DOUBLE_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'input'."
+    "Unsupported elem_type 10 (FLOAT16) for tensor 'like'."
   ],
   [
     "node/test_castlike_DOUBLE_to_FLOAT16_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'input'."
+    "Unsupported elem_type 10 (FLOAT16) for tensor 'like'."
   ],
   [
     "node/test_castlike_DOUBLE_to_FLOAT_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'input'."
+    "Unsupported op Cast"
   ],
   [
     "node/test_castlike_FLOAT16_to_DOUBLE/model.onnx",
@@ -1541,11 +1541,11 @@
   ],
   [
     "node/test_castlike_FLOAT_to_DOUBLE/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'like'."
+    "Unsupported op CastLike"
   ],
   [
     "node/test_castlike_FLOAT_to_DOUBLE_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'like'."
+    "Unsupported op Cast"
   ],
   [
     "node/test_castlike_FLOAT_to_FLOAT16/model.onnx",
@@ -2145,11 +2145,11 @@
   ],
   [
     "node/test_cumsum_1d/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'x'."
+    "Unsupported op CumSum"
   ],
   [
     "node/test_cumsum_1d_exclusive/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'x'."
+    "Unsupported op CumSum"
   ],
   [
     "node/test_cumsum_1d_int32_exclusive/model.onnx",
@@ -2157,19 +2157,19 @@
   ],
   [
     "node/test_cumsum_1d_reverse/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'x'."
+    "Unsupported op CumSum"
   ],
   [
     "node/test_cumsum_1d_reverse_exclusive/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'x'."
+    "Unsupported op CumSum"
   ],
   [
     "node/test_cumsum_2d_axis_0/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'x'."
+    "Unsupported op CumSum"
   ],
   [
     "node/test_cumsum_2d_axis_1/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'x'."
+    "Unsupported op CumSum"
   ],
   [
     "node/test_cumsum_2d_int32/model.onnx",
@@ -2177,7 +2177,7 @@
   ],
   [
     "node/test_cumsum_2d_negative_axis/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'x'."
+    "Unsupported op CumSum"
   ],
   [
     "node/test_deform_conv_with_mask_bias/model.onnx",
@@ -2373,27 +2373,27 @@
   ],
   [
     "node/test_einsum_batch_diagonal/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'x'."
+    "Unsupported op Einsum"
   ],
   [
     "node/test_einsum_batch_matmul/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'x'."
+    "Unsupported op Einsum"
   ],
   [
     "node/test_einsum_inner_prod/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'x'."
+    "Unsupported op Einsum"
   ],
   [
     "node/test_einsum_scalar/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'x'."
+    "Unsupported op Einsum"
   ],
   [
     "node/test_einsum_sum/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'x'."
+    "Unsupported op Einsum"
   ],
   [
     "node/test_einsum_transpose/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'x'."
+    "Unsupported op Einsum"
   ],
   [
     "node/test_elu/model.onnx",
@@ -2485,7 +2485,7 @@
   ],
   [
     "node/test_eyelike_with_dtype/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'y'."
+    "Unsupported op EyeLike"
   ],
   [
     "node/test_eyelike_without_dtype/model.onnx",
@@ -3629,7 +3629,7 @@
   ],
   [
     "node/test_max_float64/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'data_0'."
+    ""
   ],
   [
     "node/test_max_int16/model.onnx",
@@ -3785,7 +3785,7 @@
   ],
   [
     "node/test_min_float64/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'data_0'."
+    ""
   ],
   [
     "node/test_min_int16/model.onnx",
@@ -3853,7 +3853,7 @@
   ],
   [
     "node/test_mod_mixed_sign_float64/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'x'."
+    ""
   ],
   [
     "node/test_mod_mixed_sign_int16/model.onnx",
@@ -4597,35 +4597,35 @@
   ],
   [
     "node/test_reduce_log_sum_exp_default_axes_keepdims_example/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'data'."
+    "ReduceLogSumExp axes input must be constant"
   ],
   [
     "node/test_reduce_log_sum_exp_default_axes_keepdims_example_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'data'."
+    "Unsupported op Cast"
   ],
   [
     "node/test_reduce_log_sum_exp_default_axes_keepdims_random/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'data'."
+    "ReduceLogSumExp axes input must be constant"
   ],
   [
     "node/test_reduce_log_sum_exp_default_axes_keepdims_random_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'data'."
+    "Unsupported op Cast"
   ],
   [
     "node/test_reduce_log_sum_exp_do_not_keepdims_example/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'data'."
+    "ReduceLogSumExp axes input must be constant"
   ],
   [
     "node/test_reduce_log_sum_exp_do_not_keepdims_example_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'data'."
+    "Unsupported op Cast"
   ],
   [
     "node/test_reduce_log_sum_exp_do_not_keepdims_random/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'data'."
+    "ReduceLogSumExp axes input must be constant"
   ],
   [
     "node/test_reduce_log_sum_exp_do_not_keepdims_random_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'data'."
+    "Unsupported op Cast"
   ],
   [
     "node/test_reduce_log_sum_exp_empty_set/model.onnx",
@@ -4633,39 +4633,39 @@
   ],
   [
     "node/test_reduce_log_sum_exp_empty_set_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'ReduceLogSumExp_test_reduce_log_sum_exp_empty_set_expanded_function_data_double'."
+    "Unsupported op Cast"
   ],
   [
     "node/test_reduce_log_sum_exp_keepdims_example/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'data'."
+    "ReduceLogSumExp axes input must be constant"
   ],
   [
     "node/test_reduce_log_sum_exp_keepdims_example_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'data'."
+    "Unsupported op Cast"
   ],
   [
     "node/test_reduce_log_sum_exp_keepdims_random/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'data'."
+    "ReduceLogSumExp axes input must be constant"
   ],
   [
     "node/test_reduce_log_sum_exp_keepdims_random_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'data'."
+    "Unsupported op Cast"
   ],
   [
     "node/test_reduce_log_sum_exp_negative_axes_keepdims_example/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'data'."
+    "ReduceLogSumExp axes input must be constant"
   ],
   [
     "node/test_reduce_log_sum_exp_negative_axes_keepdims_example_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'data'."
+    "Unsupported op Cast"
   ],
   [
     "node/test_reduce_log_sum_exp_negative_axes_keepdims_random/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'data'."
+    "ReduceLogSumExp axes input must be constant"
   ],
   [
     "node/test_reduce_log_sum_exp_negative_axes_keepdims_random_expanded/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'data'."
+    "Unsupported op Cast"
   ],
   [
     "node/test_reduce_log_sum_negative_axes/model.onnx",
@@ -6977,23 +6977,23 @@
   ],
   [
     "pytorch-operator/test_operator_add_broadcast/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor '0'."
+    ""
   ],
   [
     "pytorch-operator/test_operator_add_size1_broadcast/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor '0'."
+    ""
   ],
   [
     "pytorch-operator/test_operator_add_size1_right_broadcast/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor '0'."
+    ""
   ],
   [
     "pytorch-operator/test_operator_add_size1_singleton_broadcast/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor '0'."
+    ""
   ],
   [
     "pytorch-operator/test_operator_addconstant/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for Constant '1'."
+    ""
   ],
   [
     "pytorch-operator/test_operator_addmm/model.onnx",
@@ -7165,7 +7165,7 @@
   ],
   [
     "simple/test_sequence_model7/model.onnx",
-    "Unsupported elem_type 11 (DOUBLE) for tensor 'X'."
+    "Missing elem_type for tensor 'seq_1'"
   ],
   [
     "simple/test_sequence_model8/model.onnx",


### PR DESCRIPTION
### Motivation

- Add support for ONNX `DOUBLE` / C `double` so models and initializers using float64 are handled end-to-end.
- Extend operators and lowering paths that were restricted to `float32` to accept `double` where semantics and math exist.
- Keep codegen deterministic while emitting the correct C math functions and literals for both `float` and `double`.

### Description

- Register `onnx.TensorProto.DOUBLE` and a `double` entry in `DTYPE_INFO`, and normalize initializer arrays to `float64` in `_normalize_initializer_data`.
- Allow `double` in dtype checks (`_ensure_supported_dtype`, lowering guards and compiler checks) and adapt runtime evaluation (Gemm, Conv, Softmax, Attention, LRN, AveragePool, Reduce paths) to accept `double` where appropriate.
- Introduce float/double-aware formatting and math dispatch in the compiler and C emitter (`_format_double`, `_format_floating`, `_math_fn`, function/literal selection), update templates to call the selected math functions and use correct literals, and add `rng_next_double` to testbench generation.
- Make test verification dtype-aware by using `np.issubdtype(..., np.floating)` in the CLI and update golden/support artifacts to reflect double support.

### Testing

- Ran the full test suite with reference updates: `UPDATE_REFS=1 pytest -n auto -q` and all tests passed (109 passed in 16.03s).
- Golden/testbench artifacts were regenerated as part of the run to reflect the new `double`-aware outputs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69645f7d4d408325823c287e0420e744)