### PR TITLE
docs: rename and expand README to 'emmtrix ONNX to C compiler'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,49 @@
-# emx-onnx2c
+# emmtrix ONNX to C compiler
 
-## CLI
+`emmtrix ONNX to C compiler` compiles ONNX models into portable, deterministic C code. The
+generated C is designed to be readable, stable across runs, and easy to embed in
+larger projects without heavy runtime dependencies.
+
+## Goals
+
+- Correctness-first compilation with outputs comparable to ONNX Runtime.
+- Deterministic and reproducible C code generation.
+- Clean, pass-based compiler architecture (import → normalize → optimize → lower → emit).
+- Minimal C runtime with explicit, predictable data movement.
+
+## Non-goals
+
+- Aggressive performance optimizations in generated C.
+- Implicit runtime dependencies or dynamic loading.
+- Training/backpropagation support.
+
+## Features
+
+- CLI for ONNX-to-C compilation and verification.
+- Deterministic codegen with explicit tensor shapes and loop nests.
+- Minimal C runtime templates in `templates/`.
+- ONNX Runtime comparison for end-to-end validation.
+- Official ONNX operator coverage tracking.
+
+## Requirements
+
+- Python 3.9+
+- `onnx` for compilation
+- Optional for verification:
+  - `onnxruntime`
+  - `numpy`
+  - A C compiler (uses `cc`, `gcc`, or `clang`, or `CC`/`--cc`)
+
+Install dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements-ci.txt
+pip install -e .
+```
+
+## Quickstart
 
 Compile an ONNX model into a C source file:
 
@@ -14,16 +57,55 @@ Verify an ONNX model end-to-end against ONNX Runtime:
 python -m onnx2c verify path/to/model.onnx
 ```
 
+## CLI Reference
+
+`onnx2c` provides two subcommands: `compile` and `verify`.
+
+### `compile`
+
+```bash
+python -m onnx2c compile <model.onnx> <output.c> [options]
+```
+
+Options:
+
+- `--template-dir`: Directory containing the C templates (default: `templates`).
+- `--model-name`: Override the generated model name (default: output file stem).
+- `--emit-testbench`: Emit a JSON-producing `main()` testbench for validation.
+
+### `verify`
+
+```bash
+python -m onnx2c verify <model.onnx> [options]
+```
+
+Options:
+
+- `--template-dir`: Directory containing the C templates (default: `templates`).
+- `--model-name`: Override the generated model name (default: model file stem).
+- `--cc`: Explicit C compiler command for building the testbench binary.
+
+## Output
+
+The compiler emits a single C source file that includes:
+
+- A generated entry point that mirrors the ONNX graph inputs/outputs.
+- Tensor buffers for constants and temporaries.
+- A lightweight runtime implemented via templates in `templates/`.
+
 ## Official ONNX test coverage
 
 See [`OFFICIAL_ONNX_FILE_SUPPORT.md`](OFFICIAL_ONNX_FILE_SUPPORT.md) for the generated support matrix.
 
-### CLI Parameters
+## Project layout
 
-The CLI currently exposes a single `compile` command with the following parameters:
+- `src/onnx2c`: Compiler package.
+- `templates/`: C templates and runtime snippets.
+- `tests/`: Pytest-based tests and ONNX fixtures.
+- `onnx2c-org/`, `emx-pytorch2c-org/`: Reference implementations for semantics.
 
-- `model` (positional): Path to the ONNX model file to compile.
-- `output` (positional): Output path for the generated C source file.
-- `--template-dir`: Directory containing the C templates. Defaults to `templates`.
-- `--model-name`: Overrides the generated model name. Defaults to the output file stem.
-- `--emit-testbench`: Emits a JSON-producing `main()` testbench for validation.
+## Tests
+
+```bash
+UPDATE_REFS=1 pytest -n auto -q
+```


### PR DESCRIPTION
### Motivation

- Rename the project heading and description to `emmtrix ONNX to C compiler` as requested.
- Provide a clearer project overview including goals and non-goals to explain design intent.
- Improve onboarding by documenting the CLI usage and options for `compile` and `verify`.
- Surface testing guidance and project layout so contributors can run and update references reproducibly.

### Description

- Updated the README heading and opening description to `emmtrix ONNX to C compiler`.
- Expanded the README with `Goals`, `Non-goals`, `Features`, `Requirements`, `Quickstart`, `CLI Reference`, `Output`, `Project layout`, and `Tests` sections.
- Documented the `compile` and `verify` subcommands and options such as `--template-dir`, `--model-name`, `--emit-testbench`, and `--cc`.
- Added the recommended test command `UPDATE_REFS=1 pytest -n auto -q` to the `Tests` section.

### Testing

- Ran the test suite with `UPDATE_REFS=1 pytest -n auto -q` as part of the change workflow.
- Automated tests completed with `109 passed` in `21.08s`.
- No automated test failures were observed.
- This change is documentation-only and does not modify runtime code paths exercised by the tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69646b2648488325b520cf3d7fc2b154)