### PR TITLE
attention: implement full Attention operator support (masks, GQA, KV cache, softcap, qk outputs)

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 310 / 1802 official ONNX files.
+Support 364 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -98,129 +98,129 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_atan_example/model.onnx | ❌ | Unsupported op Atan |
 | node/test_atanh/model.onnx | ✅ |  |
 | node/test_atanh_example/model.onnx | ✅ |  |
-| node/test_attention_3d/model.onnx | ❌ | Unsupported op Attention |
-| node/test_attention_3d_attn_mask/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_3d/model.onnx | ✅ |  |
+| node/test_attention_3d_attn_mask/model.onnx | ✅ |  |
 | node/test_attention_3d_attn_mask_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_attn_mask_expanded_function_QIntermediate' |
-| node/test_attention_3d_causal/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_3d_causal/model.onnx | ✅ |  |
 | node/test_attention_3d_causal_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_causal_expanded_function_QIntermediate' |
-| node/test_attention_3d_diff_heads_sizes/model.onnx | ❌ | Unsupported op Attention |
-| node/test_attention_3d_diff_heads_sizes_attn_mask/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_3d_diff_heads_sizes/model.onnx | ✅ |  |
+| node/test_attention_3d_diff_heads_sizes_attn_mask/model.onnx | ✅ |  |
 | node/test_attention_3d_diff_heads_sizes_attn_mask_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_attn_mask_expanded_function_QIntermediate' |
-| node/test_attention_3d_diff_heads_sizes_causal/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_3d_diff_heads_sizes_causal/model.onnx | ✅ |  |
 | node/test_attention_3d_diff_heads_sizes_causal_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_causal_expanded_function_QIntermediate' |
 | node/test_attention_3d_diff_heads_sizes_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_expanded_function_QIntermediate' |
-| node/test_attention_3d_diff_heads_sizes_scaled/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_3d_diff_heads_sizes_scaled/model.onnx | ✅ |  |
 | node/test_attention_3d_diff_heads_sizes_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_scaled_expanded_function_QIntermediate' |
-| node/test_attention_3d_diff_heads_sizes_softcap/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_3d_diff_heads_sizes_softcap/model.onnx | ✅ |  |
 | node/test_attention_3d_diff_heads_sizes_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_softcap_expanded_function_QIntermediate' |
-| node/test_attention_3d_diff_heads_with_past_and_present/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_3d_diff_heads_with_past_and_present/model.onnx | ✅ |  |
 | node/test_attention_3d_diff_heads_with_past_and_present_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_with_past_and_present_expanded_function_QIntermediate' |
 | node/test_attention_3d_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_expanded_function_QIntermediate' |
-| node/test_attention_3d_gqa/model.onnx | ❌ | Unsupported op Attention |
-| node/test_attention_3d_gqa_attn_mask/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_3d_gqa/model.onnx | ✅ |  |
+| node/test_attention_3d_gqa_attn_mask/model.onnx | ✅ |  |
 | node/test_attention_3d_gqa_attn_mask_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_gqa_attn_mask_expanded_function_QIntermediate' |
-| node/test_attention_3d_gqa_causal/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_3d_gqa_causal/model.onnx | ✅ |  |
 | node/test_attention_3d_gqa_causal_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_gqa_causal_expanded_function_QIntermediate' |
 | node/test_attention_3d_gqa_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_gqa_expanded_function_QIntermediate' |
-| node/test_attention_3d_gqa_scaled/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_3d_gqa_scaled/model.onnx | ✅ |  |
 | node/test_attention_3d_gqa_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_gqa_scaled_expanded_function_QIntermediate' |
-| node/test_attention_3d_gqa_softcap/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_3d_gqa_softcap/model.onnx | ✅ |  |
 | node/test_attention_3d_gqa_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_gqa_softcap_expanded_function_QIntermediate' |
-| node/test_attention_3d_gqa_with_past_and_present/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_3d_gqa_with_past_and_present/model.onnx | ✅ |  |
 | node/test_attention_3d_gqa_with_past_and_present_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_gqa_with_past_and_present_expanded_function_QIntermediate' |
-| node/test_attention_3d_scaled/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_3d_scaled/model.onnx | ✅ |  |
 | node/test_attention_3d_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_scaled_expanded_function_QIntermediate' |
-| node/test_attention_3d_softcap/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_3d_softcap/model.onnx | ✅ |  |
 | node/test_attention_3d_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_softcap_expanded_function_QIntermediate' |
-| node/test_attention_3d_transpose_verification/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_3d_transpose_verification/model.onnx | ✅ |  |
 | node/test_attention_3d_transpose_verification_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_transpose_verification_expanded_function_QIntermediate' |
-| node/test_attention_3d_with_past_and_present/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_3d_with_past_and_present/model.onnx | ✅ |  |
 | node/test_attention_3d_with_past_and_present_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_expanded_function_QIntermediate' |
-| node/test_attention_3d_with_past_and_present_qk_matmul/model.onnx | ❌ | Unsupported op Attention |
-| node/test_attention_3d_with_past_and_present_qk_matmul_bias/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_3d_with_past_and_present_qk_matmul/model.onnx | ✅ |  |
+| node/test_attention_3d_with_past_and_present_qk_matmul_bias/model.onnx | ✅ |  |
 | node/test_attention_3d_with_past_and_present_qk_matmul_bias_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_qk_matmul_bias_expanded_function_QIntermediate' |
 | node/test_attention_3d_with_past_and_present_qk_matmul_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_qk_matmul_expanded_function_QIntermediate' |
-| node/test_attention_3d_with_past_and_present_qk_matmul_softcap/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_3d_with_past_and_present_qk_matmul_softcap/model.onnx | ✅ |  |
 | node/test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded_function_QIntermediate' |
-| node/test_attention_3d_with_past_and_present_qk_matmul_softmax/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_3d_with_past_and_present_qk_matmul_softmax/model.onnx | ✅ |  |
 | node/test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded_function_QIntermediate' |
 | node/test_attention_4d/model.onnx | ✅ |  |
-| node/test_attention_4d_attn_mask/model.onnx | ❌ | Unsupported op Attention |
-| node/test_attention_4d_attn_mask_3d/model.onnx | ❌ | Unsupported op Attention |
-| node/test_attention_4d_attn_mask_3d_causal/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_4d_attn_mask/model.onnx | ✅ |  |
+| node/test_attention_4d_attn_mask_3d/model.onnx | ✅ |  |
+| node/test_attention_4d_attn_mask_3d_causal/model.onnx | ✅ |  |
 | node/test_attention_4d_attn_mask_3d_causal_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_attn_mask_3d_causal_expanded_function_RangeRow' |
 | node/test_attention_4d_attn_mask_3d_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_attn_mask_3d_expanded_function_KExpanded' |
-| node/test_attention_4d_attn_mask_4d/model.onnx | ❌ | Unsupported op Attention |
-| node/test_attention_4d_attn_mask_4d_causal/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_4d_attn_mask_4d/model.onnx | ✅ |  |
+| node/test_attention_4d_attn_mask_4d_causal/model.onnx | ✅ |  |
 | node/test_attention_4d_attn_mask_4d_causal_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_attn_mask_4d_causal_expanded_function_RangeRow' |
 | node/test_attention_4d_attn_mask_4d_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_attn_mask_4d_expanded_function_KExpanded' |
-| node/test_attention_4d_attn_mask_bool/model.onnx | ❌ | Attention expects matching dtypes, got bool, float |
-| node/test_attention_4d_attn_mask_bool_4d/model.onnx | ❌ | Attention expects matching dtypes, got bool, float |
+| node/test_attention_4d_attn_mask_bool/model.onnx | ✅ |  |
+| node/test_attention_4d_attn_mask_bool_4d/model.onnx | ✅ |  |
 | node/test_attention_4d_attn_mask_bool_4d_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_attn_mask_bool_4d_expanded_function_KExpanded' |
 | node/test_attention_4d_attn_mask_bool_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_attn_mask_bool_expanded_function_KExpanded' |
 | node/test_attention_4d_attn_mask_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_attn_mask_expanded_function_KExpanded' |
 | node/test_attention_4d_causal/model.onnx | ✅ |  |
 | node/test_attention_4d_causal_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_causal_expanded_function_AttnBias' |
-| node/test_attention_4d_diff_heads_mask4d_padded_kv/model.onnx | ❌ | Missing dtype for value '' in op Attention. Hint: run ONNX shape inference or export with static shapes. |
+| node/test_attention_4d_diff_heads_mask4d_padded_kv/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_mask4d_padded_kv_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_mask4d_padded_kv_expanded_function_AttnBias' |
 | node/test_attention_4d_diff_heads_sizes/model.onnx | ✅ |  |
-| node/test_attention_4d_diff_heads_sizes_attn_mask/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_4d_diff_heads_sizes_attn_mask/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_sizes_attn_mask_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_sizes_attn_mask_expanded_function_KExpanded' |
 | node/test_attention_4d_diff_heads_sizes_causal/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_sizes_causal_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_sizes_causal_expanded_function_AttnBias' |
 | node/test_attention_4d_diff_heads_sizes_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_sizes_expanded_function_AttnBias' |
 | node/test_attention_4d_diff_heads_sizes_scaled/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_sizes_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_sizes_scaled_expanded_function_AttnBias' |
-| node/test_attention_4d_diff_heads_sizes_softcap/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_4d_diff_heads_sizes_softcap/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_sizes_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_sizes_softcap_expanded_function_AttnBias' |
-| node/test_attention_4d_diff_heads_with_past_and_present/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_4d_diff_heads_with_past_and_present/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_with_past_and_present_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_with_past_and_present_expanded_function_KExpanded' |
-| node/test_attention_4d_diff_heads_with_past_and_present_mask3d/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_4d_diff_heads_with_past_and_present_mask3d/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_with_past_and_present_mask3d_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_with_past_and_present_mask3d_expanded_function_KExpanded' |
-| node/test_attention_4d_diff_heads_with_past_and_present_mask4d/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_4d_diff_heads_with_past_and_present_mask4d/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_with_past_and_present_mask4d_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_with_past_and_present_mask4d_expanded_function_KExpanded' |
 | node/test_attention_4d_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_expanded_function_AttnBias' |
 | node/test_attention_4d_fp16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'Q'. |
 | node/test_attention_4d_fp16_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'Q'. |
-| node/test_attention_4d_gqa/model.onnx | ❌ | Unsupported op Attention |
-| node/test_attention_4d_gqa_attn_mask/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_4d_gqa/model.onnx | ✅ |  |
+| node/test_attention_4d_gqa_attn_mask/model.onnx | ✅ |  |
 | node/test_attention_4d_gqa_attn_mask_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_gqa_attn_mask_expanded_function_KExpanded' |
-| node/test_attention_4d_gqa_causal/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_4d_gqa_causal/model.onnx | ✅ |  |
 | node/test_attention_4d_gqa_causal_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_gqa_causal_expanded_function_AttnBias' |
 | node/test_attention_4d_gqa_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_gqa_expanded_function_AttnBias' |
-| node/test_attention_4d_gqa_scaled/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_4d_gqa_scaled/model.onnx | ✅ |  |
 | node/test_attention_4d_gqa_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_gqa_scaled_expanded_function_AttnBias' |
-| node/test_attention_4d_gqa_softcap/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_4d_gqa_softcap/model.onnx | ✅ |  |
 | node/test_attention_4d_gqa_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_gqa_softcap_expanded_function_AttnBias' |
-| node/test_attention_4d_gqa_with_past_and_present/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_4d_gqa_with_past_and_present/model.onnx | ✅ |  |
 | node/test_attention_4d_gqa_with_past_and_present_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_gqa_with_past_and_present_expanded_function_KExpanded' |
 | node/test_attention_4d_gqa_with_past_and_present_fp16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'Q'. |
 | node/test_attention_4d_gqa_with_past_and_present_fp16_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'Q'. |
 | node/test_attention_4d_scaled/model.onnx | ✅ |  |
 | node/test_attention_4d_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_scaled_expanded_function_AttnBias' |
-| node/test_attention_4d_softcap/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_4d_softcap/model.onnx | ✅ |  |
 | node/test_attention_4d_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_softcap_expanded_function_AttnBias' |
-| node/test_attention_4d_with_past_and_present/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_4d_with_past_and_present/model.onnx | ✅ |  |
 | node/test_attention_4d_with_past_and_present_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_past_and_present_expanded_function_KExpanded' |
-| node/test_attention_4d_with_past_and_present_qk_matmul/model.onnx | ❌ | Unsupported op Attention |
-| node/test_attention_4d_with_past_and_present_qk_matmul_bias/model.onnx | ❌ | Unsupported op Attention |
-| node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask/model.onnx | ❌ | Unsupported op Attention |
-| node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_4d_with_past_and_present_qk_matmul/model.onnx | ✅ |  |
+| node/test_attention_4d_with_past_and_present_qk_matmul_bias/model.onnx | ✅ |  |
+| node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask/model.onnx | ✅ |  |
+| node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal/model.onnx | ✅ |  |
 | node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal_expanded_function_RangeRow' |
 | node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_expanded_function_KExpanded' |
-| node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask/model.onnx | ❌ | Unsupported op Attention |
-| node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal/model.onnx | ❌ | Unsupported op Attention |
+| node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask/model.onnx | ✅ |  |
+| node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal/model.onnx | ✅ |  |
 | node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal_expanded_function_RangeRow' |
 | node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_expanded_function_KExpanded' |
 | node/test_attention_4d_with_past_and_present_qk_matmul_bias_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_past_and_present_qk_matmul_bias_expanded_function_KExpanded' |
 | node/test_attention_4d_with_past_and_present_qk_matmul_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_past_and_present_qk_matmul_expanded_function_KExpanded' |
-| node/test_attention_4d_with_qk_matmul/model.onnx | ❌ | Missing dtype for value '' in op Attention. Hint: run ONNX shape inference or export with static shapes. |
-| node/test_attention_4d_with_qk_matmul_bias/model.onnx | ❌ | Missing dtype for value '' in op Attention. Hint: run ONNX shape inference or export with static shapes. |
+| node/test_attention_4d_with_qk_matmul/model.onnx | ✅ |  |
+| node/test_attention_4d_with_qk_matmul_bias/model.onnx | ✅ |  |
 | node/test_attention_4d_with_qk_matmul_bias_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_qk_matmul_bias_expanded_function_KExpanded' |
 | node/test_attention_4d_with_qk_matmul_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_qk_matmul_expanded_function_AttnBias' |
-| node/test_attention_4d_with_qk_matmul_softcap/model.onnx | ❌ | Missing dtype for value '' in op Attention. Hint: run ONNX shape inference or export with static shapes. |
+| node/test_attention_4d_with_qk_matmul_softcap/model.onnx | ✅ |  |
 | node/test_attention_4d_with_qk_matmul_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_qk_matmul_softcap_expanded_function_KExpanded' |
-| node/test_attention_4d_with_qk_matmul_softmax/model.onnx | ❌ | Missing dtype for value '' in op Attention. Hint: run ONNX shape inference or export with static shapes. |
+| node/test_attention_4d_with_qk_matmul_softmax/model.onnx | ✅ |  |
 | node/test_attention_4d_with_qk_matmul_softmax_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_qk_matmul_softmax_expanded_function_KExpanded' |
 | node/test_averagepool_1d_default/model.onnx | ❌ | AveragePool expects 2D kernel_shape |
 | node/test_averagepool_2d_ceil/model.onnx | ❌ | AveragePool supports ceil_mode=0 only |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -4,7 +4,6 @@
 | --- | --- | --- |
 | Dynamic dim for tensor '*' | 146 | ██████████████████████████████ |
 | Unsupported elem_type 10 (FLOAT16) for tensor '*'. | 65 | █████████████ |
-| Unsupported op Attention | 47 | ██████████ |
 | Unsupported op LogSoftmax | 44 | █████████ |
 | ReduceSum axes input must be constant | 43 | █████████ |
 | Unsupported op Resize | 39 | ████████ |
@@ -77,7 +76,6 @@
 | Unsupported op QuantizeLinear | 6 | █ |
 | Unsupported op ScatterElements | 6 | █ |
 | Unsupported op Unique | 6 | █ |
-| Missing dtype for value '*' in op Attention. Hint: run ONNX shape inference or export with static shapes. | 5 | █ |
 | AveragePool expects 2D kernel_shape | 5 | █ |
 | Unsupported op Elu | 5 | █ |
 | Unsupported op Col2Im | 5 | █ |
@@ -129,7 +127,6 @@
 | Unsupported op Asin | 2 | █ |
 | Unsupported op Asinh | 2 | █ |
 | Unsupported op Atan | 2 | █ |
-| Attention expects matching dtypes, got bool, float | 2 | █ |
 | AveragePool supports ceil_mode=0 only | 2 | █ |
 | BatchNormalization must have 5 inputs and 1 output | 2 | █ |
 | Unsupported op BlackmanWindow | 2 | █ |

--- a/templates/attention_op.c.j2
+++ b/templates/attention_op.c.j2
@@ -1,45 +1,199 @@
 void {{ op_name }}(const {{ c_type }} {{ input_q }}{{ input_q_suffix }},
                    const {{ c_type }} {{ input_k }}{{ input_k_suffix }},
-                   const {{ c_type }} {{ input_v }}{{ input_v_suffix }},
-                   {{ c_type }} {{ output }}{{ output_suffix }}) {
+                   const {{ c_type }} {{ input_v }}{{ input_v_suffix }}{% if input_attn_mask %},
+                   const {% if mask_is_bool %}bool{% else %}{{ c_type }}{% endif %} {{ input_attn_mask }}{{ input_mask_suffix }}{% endif %}{% if input_past_key %},
+                   const {{ c_type }} {{ input_past_key }}{{ input_past_key_suffix }}{% endif %}{% if input_past_value %},
+                   const {{ c_type }} {{ input_past_value }}{{ input_past_value_suffix }}{% endif %}{% if input_nonpad_kv_seqlen %},
+                   const {{ nonpad_c_type }} {{ input_nonpad_kv_seqlen }}{{ input_nonpad_suffix }}{% endif %},
+                   {{ c_type }} {{ output }}{{ output_suffix }}{% if output_present_key %},
+                   {{ c_type }} {{ output_present_key }}{{ output_present_key_suffix }}{% endif %}{% if output_present_value %},
+                   {{ c_type }} {{ output_present_value }}{{ output_present_value_suffix }}{% endif %}{% if output_qk_matmul %},
+                   {{ c_type }} {{ output_qk_matmul }}{{ output_qk_matmul_suffix }}{% endif %}) {
     const {{ c_type }} scale = {{ scale_literal }};
+    const {{ c_type }} softcap = {{ softcap_literal }};
+    {% if output_present_key %}
     for (int b = 0; b < {{ batch }}; ++b) {
-        for (int h = 0; h < {{ heads }}; ++h) {
-            for (int qi = 0; qi < {{ q_seq }}; ++qi) {
-                {{ c_type }} scores[{{ kv_seq }}];
-                {{ c_type }} max_score = -INFINITY;
-                for (int ki = 0; ki < {{ kv_seq }}; ++ki) {
-                    {{ c_type }} score = {{ zero_literal }};
-                    if ({{ is_causal }} && ki > qi) {
-                        score = -INFINITY;
-                    } else {
-                        for (int d = 0; d < {{ qk_head_size }}; ++d) {
-                            score += {{ input_q }}[b][h][qi][d] * {{ input_k }}[b][h][ki][d];
-                        }
-                        score *= scale;
+        for (int h = 0; h < {{ kv_heads }}; ++h) {
+            for (int ki = 0; ki < {{ total_seq }}; ++ki) {
+                if (ki < {{ past_seq }}) {
+                    for (int d = 0; d < {{ qk_head_size }}; ++d) {
+                        {{ output_present_key }}[b][h][ki][d] = {{ input_past_key }}[b][h][ki][d];
                     }
-                    scores[ki] = score;
-                    if (score > max_score) {
-                        max_score = score;
+                } else {
+                    int k_index = ki - {{ past_seq }};
+                    for (int d = 0; d < {{ qk_head_size }}; ++d) {
+                        {% if k_rank == 4 %}
+                        {{ output_present_key }}[b][h][ki][d] = {{ input_k }}[b][h][k_index][d];
+                        {% else %}
+                        {{ output_present_key }}[b][h][ki][d] = {{ input_k }}[b][k_index][h * {{ qk_head_size }} + d];
+                        {% endif %}
                     }
                 }
-                {{ c_type }} weights[{{ kv_seq }}];
+            }
+        }
+    }
+    {% endif %}
+    {% if output_present_value %}
+    for (int b = 0; b < {{ batch }}; ++b) {
+        for (int h = 0; h < {{ kv_heads }}; ++h) {
+            for (int ki = 0; ki < {{ total_seq }}; ++ki) {
+                if (ki < {{ past_seq }}) {
+                    for (int d = 0; d < {{ v_head_size }}; ++d) {
+                        {{ output_present_value }}[b][h][ki][d] = {{ input_past_value }}[b][h][ki][d];
+                    }
+                } else {
+                    int v_index = ki - {{ past_seq }};
+                    for (int d = 0; d < {{ v_head_size }}; ++d) {
+                        {% if v_rank == 4 %}
+                        {{ output_present_value }}[b][h][ki][d] = {{ input_v }}[b][h][v_index][d];
+                        {% else %}
+                        {{ output_present_value }}[b][h][ki][d] = {{ input_v }}[b][v_index][h * {{ v_head_size }} + d];
+                        {% endif %}
+                    }
+                }
+            }
+        }
+    }
+    {% endif %}
+    for (int b = 0; b < {{ batch }}; ++b) {
+        for (int h = 0; h < {{ q_heads }}; ++h) {
+            int kv_head = h / {{ head_group_size }};
+            for (int qi = 0; qi < {{ q_seq }}; ++qi) {
+                {{ c_type }} scores[{{ total_seq }}];
+                {{ c_type }} max_score = {{ min_literal }};
+                for (int ki = 0; ki < {{ total_seq }}; ++ki) {
+                    {{ c_type }} score = {{ zero_literal }};
+                    int k_index = ki - {{ past_seq }};
+                    for (int d = 0; d < {{ qk_head_size }}; ++d) {
+                        {{ c_type }} q_val;
+                        {{ c_type }} k_val;
+                        {% if q_rank == 4 %}
+                        q_val = {{ input_q }}[b][h][qi][d];
+                        {% else %}
+                        q_val = {{ input_q }}[b][qi][h * {{ qk_head_size }} + d];
+                        {% endif %}
+                        {% if input_past_key %}
+                        if (ki < {{ past_seq }}) {
+                            k_val = {{ input_past_key }}[b][kv_head][ki][d];
+                        } else {
+                            {% if k_rank == 4 %}
+                            k_val = {{ input_k }}[b][kv_head][k_index][d];
+                            {% else %}
+                            k_val = {{ input_k }}[b][k_index][kv_head * {{ qk_head_size }} + d];
+                            {% endif %}
+                        }
+                        {% else %}
+                        {% if k_rank == 4 %}
+                        k_val = {{ input_k }}[b][kv_head][k_index][d];
+                        {% else %}
+                        k_val = {{ input_k }}[b][k_index][kv_head * {{ qk_head_size }} + d];
+                        {% endif %}
+                        {% endif %}
+                        score += q_val * k_val;
+                    }
+                    score *= scale;
+                    {{ c_type }} bias = {{ zero_literal }};
+                    {% if input_attn_mask %}
+                    if (ki >= {{ mask_kv_seq }}) {
+                        bias = {{ min_literal }};
+                    } else {
+                        int mask_q = {{ '0' if mask_broadcast_q_seq else 'qi' }};
+                        {% if mask_rank == 2 %}
+                        {% if mask_is_bool %}
+                        bias = {{ input_attn_mask }}[mask_q][ki] ? {{ zero_literal }} : {{ min_literal }};
+                        {% else %}
+                        bias = {{ input_attn_mask }}[mask_q][ki];
+                        {% endif %}
+                        {% elif mask_rank == 3 %}
+                        int mask_b = {{ '0' if mask_broadcast_batch else 'b' }};
+                        {% if mask_is_bool %}
+                        bias = {{ input_attn_mask }}[mask_b][mask_q][ki] ? {{ zero_literal }} : {{ min_literal }};
+                        {% else %}
+                        bias = {{ input_attn_mask }}[mask_b][mask_q][ki];
+                        {% endif %}
+                        {% else %}
+                        int mask_b = {{ '0' if mask_broadcast_batch else 'b' }};
+                        int mask_h = {{ '0' if mask_broadcast_heads else 'h' }};
+                        {% if mask_is_bool %}
+                        bias = {{ input_attn_mask }}[mask_b][mask_h][mask_q][ki] ? {{ zero_literal }} : {{ min_literal }};
+                        {% else %}
+                        bias = {{ input_attn_mask }}[mask_b][mask_h][mask_q][ki];
+                        {% endif %}
+                        {% endif %}
+                    }
+                    {% endif %}
+                    {% if input_nonpad_kv_seqlen %}
+                    if (ki >= {{ input_nonpad_kv_seqlen }}[b]) {
+                        bias = {{ min_literal }};
+                    }
+                    {% endif %}
+                    if ({{ is_causal }} && ki > qi + {{ past_seq }}) {
+                        bias = {{ min_literal }};
+                    }
+                    {{ c_type }} score_bias = score + bias;
+                    {{ c_type }} score_softcap = score_bias;
+                    if (softcap != {{ zero_literal }}) {
+                        score_softcap = softcap * {{ tanh_fn }}(score_bias / softcap);
+                    }
+                    {% if output_qk_matmul %}
+                    if ({{ qk_matmul_output_mode }} == 0) {
+                        {{ output_qk_matmul }}[b][h][qi][ki] = score;
+                    } else if ({{ qk_matmul_output_mode }} == 1) {
+                        {{ output_qk_matmul }}[b][h][qi][ki] = score_bias;
+                    } else if ({{ qk_matmul_output_mode }} == 2) {
+                        {{ output_qk_matmul }}[b][h][qi][ki] = score_softcap;
+                    }
+                    {% endif %}
+                    scores[ki] = score_softcap;
+                    if (score_softcap > max_score) {
+                        max_score = score_softcap;
+                    }
+                }
+                {{ c_type }} weights[{{ total_seq }}];
                 {{ c_type }} sum = {{ zero_literal }};
-                for (int ki = 0; ki < {{ kv_seq }}; ++ki) {
+                for (int ki = 0; ki < {{ total_seq }}; ++ki) {
                     {{ c_type }} weight = {{ zero_literal }};
-                    if (!({{ is_causal }} && ki > qi)) {
+                    if (max_score != {{ min_literal }}) {
                         weight = {{ exp_fn }}(scores[ki] - max_score);
                     }
                     weights[ki] = weight;
                     sum += weight;
                 }
                 {{ c_type }} inv_sum = sum == {{ zero_literal }} ? {{ zero_literal }} : ({{ c_type }}){{ one_literal }} / sum;
+                {% if output_qk_matmul %}
+                if ({{ qk_matmul_output_mode }} == 3) {
+                    for (int ki = 0; ki < {{ total_seq }}; ++ki) {
+                        {{ output_qk_matmul }}[b][h][qi][ki] = weights[ki] * inv_sum;
+                    }
+                }
+                {% endif %}
                 for (int vd = 0; vd < {{ v_head_size }}; ++vd) {
                     {{ c_type }} acc = {{ zero_literal }};
-                    for (int ki = 0; ki < {{ kv_seq }}; ++ki) {
-                        acc += weights[ki] * inv_sum * {{ input_v }}[b][h][ki][vd];
+                    for (int ki = 0; ki < {{ total_seq }}; ++ki) {
+                        {{ c_type }} weight = weights[ki] * inv_sum;
+                        {% if input_past_value %}
+                        if (ki < {{ past_seq }}) {
+                            acc += weight * {{ input_past_value }}[b][kv_head][ki][vd];
+                        } else {
+                            {% if v_rank == 4 %}
+                            acc += weight * {{ input_v }}[b][kv_head][ki - {{ past_seq }}][vd];
+                            {% else %}
+                            acc += weight * {{ input_v }}[b][ki - {{ past_seq }}][kv_head * {{ v_head_size }} + vd];
+                            {% endif %}
+                        }
+                        {% else %}
+                        {% if v_rank == 4 %}
+                        acc += weight * {{ input_v }}[b][kv_head][ki][vd];
+                        {% else %}
+                        acc += weight * {{ input_v }}[b][ki][kv_head * {{ v_head_size }} + vd];
+                        {% endif %}
+                        {% endif %}
                     }
+                    {% if output_rank == 4 %}
                     {{ output }}[b][h][qi][vd] = acc;
+                    {% else %}
+                    {{ output }}[b][qi][h * {{ v_head_size }} + vd] = acc;
+                    {% endif %}
                 }
             }
         }

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -361,11 +361,11 @@
   ],
   [
     "node/test_attention_3d/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_3d_attn_mask/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_3d_attn_mask_expanded/model.onnx",
@@ -373,7 +373,7 @@
   ],
   [
     "node/test_attention_3d_causal/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_3d_causal_expanded/model.onnx",
@@ -381,11 +381,11 @@
   ],
   [
     "node/test_attention_3d_diff_heads_sizes/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_attn_mask/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_attn_mask_expanded/model.onnx",
@@ -393,7 +393,7 @@
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_causal/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_causal_expanded/model.onnx",
@@ -405,7 +405,7 @@
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_scaled/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_scaled_expanded/model.onnx",
@@ -413,7 +413,7 @@
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_softcap/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_softcap_expanded/model.onnx",
@@ -421,7 +421,7 @@
   ],
   [
     "node/test_attention_3d_diff_heads_with_past_and_present/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_3d_diff_heads_with_past_and_present_expanded/model.onnx",
@@ -433,11 +433,11 @@
   ],
   [
     "node/test_attention_3d_gqa/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_3d_gqa_attn_mask/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_3d_gqa_attn_mask_expanded/model.onnx",
@@ -445,7 +445,7 @@
   ],
   [
     "node/test_attention_3d_gqa_causal/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_3d_gqa_causal_expanded/model.onnx",
@@ -457,7 +457,7 @@
   ],
   [
     "node/test_attention_3d_gqa_scaled/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_3d_gqa_scaled_expanded/model.onnx",
@@ -465,7 +465,7 @@
   ],
   [
     "node/test_attention_3d_gqa_softcap/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_3d_gqa_softcap_expanded/model.onnx",
@@ -473,7 +473,7 @@
   ],
   [
     "node/test_attention_3d_gqa_with_past_and_present/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_3d_gqa_with_past_and_present_expanded/model.onnx",
@@ -481,7 +481,7 @@
   ],
   [
     "node/test_attention_3d_scaled/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_3d_scaled_expanded/model.onnx",
@@ -489,7 +489,7 @@
   ],
   [
     "node/test_attention_3d_softcap/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_3d_softcap_expanded/model.onnx",
@@ -497,7 +497,7 @@
   ],
   [
     "node/test_attention_3d_transpose_verification/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_3d_transpose_verification_expanded/model.onnx",
@@ -505,7 +505,7 @@
   ],
   [
     "node/test_attention_3d_with_past_and_present/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_3d_with_past_and_present_expanded/model.onnx",
@@ -513,11 +513,11 @@
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_bias/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_bias_expanded/model.onnx",
@@ -529,7 +529,7 @@
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_softcap/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded/model.onnx",
@@ -537,7 +537,7 @@
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_softmax/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded/model.onnx",
@@ -549,15 +549,15 @@
   ],
   [
     "node/test_attention_4d_attn_mask/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_4d_attn_mask_3d/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_4d_attn_mask_3d_causal/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_4d_attn_mask_3d_causal_expanded/model.onnx",
@@ -569,11 +569,11 @@
   ],
   [
     "node/test_attention_4d_attn_mask_4d/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_4d_attn_mask_4d_causal/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_4d_attn_mask_4d_causal_expanded/model.onnx",
@@ -585,11 +585,11 @@
   ],
   [
     "node/test_attention_4d_attn_mask_bool/model.onnx",
-    "Attention expects matching dtypes, got bool, float"
+    ""
   ],
   [
     "node/test_attention_4d_attn_mask_bool_4d/model.onnx",
-    "Attention expects matching dtypes, got bool, float"
+    ""
   ],
   [
     "node/test_attention_4d_attn_mask_bool_4d_expanded/model.onnx",
@@ -613,7 +613,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_mask4d_padded_kv/model.onnx",
-    "Missing dtype for value '' in op Attention. Hint: run ONNX shape inference or export with static shapes."
+    ""
   ],
   [
     "node/test_attention_4d_diff_heads_mask4d_padded_kv_expanded/model.onnx",
@@ -625,7 +625,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_attn_mask/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_attn_mask_expanded/model.onnx",
@@ -653,7 +653,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_softcap/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_softcap_expanded/model.onnx",
@@ -661,7 +661,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_expanded/model.onnx",
@@ -669,7 +669,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_mask3d/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_mask3d_expanded/model.onnx",
@@ -677,7 +677,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_mask4d/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_mask4d_expanded/model.onnx",
@@ -697,11 +697,11 @@
   ],
   [
     "node/test_attention_4d_gqa/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_4d_gqa_attn_mask/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_4d_gqa_attn_mask_expanded/model.onnx",
@@ -709,7 +709,7 @@
   ],
   [
     "node/test_attention_4d_gqa_causal/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_4d_gqa_causal_expanded/model.onnx",
@@ -721,7 +721,7 @@
   ],
   [
     "node/test_attention_4d_gqa_scaled/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_4d_gqa_scaled_expanded/model.onnx",
@@ -729,7 +729,7 @@
   ],
   [
     "node/test_attention_4d_gqa_softcap/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_4d_gqa_softcap_expanded/model.onnx",
@@ -737,7 +737,7 @@
   ],
   [
     "node/test_attention_4d_gqa_with_past_and_present/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_4d_gqa_with_past_and_present_expanded/model.onnx",
@@ -761,7 +761,7 @@
   ],
   [
     "node/test_attention_4d_softcap/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_4d_softcap_expanded/model.onnx",
@@ -769,7 +769,7 @@
   ],
   [
     "node/test_attention_4d_with_past_and_present/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_4d_with_past_and_present_expanded/model.onnx",
@@ -777,19 +777,19 @@
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal_expanded/model.onnx",
@@ -801,11 +801,11 @@
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal/model.onnx",
-    "Unsupported op Attention"
+    ""
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal_expanded/model.onnx",
@@ -825,11 +825,11 @@
   ],
   [
     "node/test_attention_4d_with_qk_matmul/model.onnx",
-    "Missing dtype for value '' in op Attention. Hint: run ONNX shape inference or export with static shapes."
+    ""
   ],
   [
     "node/test_attention_4d_with_qk_matmul_bias/model.onnx",
-    "Missing dtype for value '' in op Attention. Hint: run ONNX shape inference or export with static shapes."
+    ""
   ],
   [
     "node/test_attention_4d_with_qk_matmul_bias_expanded/model.onnx",
@@ -841,7 +841,7 @@
   ],
   [
     "node/test_attention_4d_with_qk_matmul_softcap/model.onnx",
-    "Missing dtype for value '' in op Attention. Hint: run ONNX shape inference or export with static shapes."
+    ""
   ],
   [
     "node/test_attention_4d_with_qk_matmul_softcap_expanded/model.onnx",
@@ -849,7 +849,7 @@
   ],
   [
     "node/test_attention_4d_with_qk_matmul_softmax/model.onnx",
-    "Missing dtype for value '' in op Attention. Hint: run ONNX shape inference or export with static shapes."
+    ""
   ],
   [
     "node/test_attention_4d_with_qk_matmul_softmax_expanded/model.onnx",

--- a/tests/test_endtoend_ops.py
+++ b/tests/test_endtoend_ops.py
@@ -856,6 +856,15 @@ OPERATOR_CASES = [
         "opset": 23,
     },
     {
+        "name": "Attention3DGQAWithMask",
+        "op_type": "Attention",
+        "input_shapes": [[1, 4, 16], [1, 6, 8], [1, 6, 10], [4, 6]],
+        "output_shape": [1, 4, 20],
+        "dtype": TensorProto.FLOAT,
+        "attrs": {"q_num_heads": 4, "kv_num_heads": 2},
+        "opset": 23,
+    },
+    {
         "name": "SoftmaxAxis0",
         "op_type": "Softmax",
         "input_shapes": [[2, 3, 4]],


### PR DESCRIPTION
### Motivation
- Add full runtime and codegen support for the ONNX `Attention` operator variants (3D/4D inputs, GQA/MQA/MHA) to replace the previous stub/limited support. 
- Support optional features required by ONNX spec such as `attn_mask`, `past`/`present` KV cache, `nonpad_kv_seqlen`, `softcap`, and `qk_matmul_output_mode` for verification and emitted C testbenches. 
- Produce deterministic, multi-output C emission for Attention kernels and integrate with the existing pass-based lowering and emitter pipeline. 
- Update official ONNX support listings and expected-error fixtures to reflect newly supported Attention cases. 

### Description
- Implemented a comprehensive `_resolve_attention_spec` with robust shape/dtype/attribute checks and support for 3D/4D inputs, `q_num_heads`/`kv_num_heads`, mask shapes, KV cache, `nonpad_kv_seqlen`, `softcap`, and `qk_matmul_output_mode`, returning a rich `_AttentionSpec` structure. 
- Extended runtime `_apply_attention` to handle reshaping 3D→4D, head-group expansion (GQA), mask biasing, causal masking, softcap, KV cache concatenation, nonpad masking, and optional `qk_matmul` outputs. 
- Extended lowering and lowering-to-IR mapping in `Compiler._lower_attention_op` and `run` to propagate optional input/output names and spec fields, and modified `_node_dtype` to ignore empty/optional names. 
- Enhanced `CEmitter` and `templates/attention_op.c.j2` to emit full Attention kernels with optional inputs/outputs and multi-output temp buffer handling via new `_op_outputs` logic, and added a 3D GQA+mask test in `tests/test_endtoend_ops.py`. 
- Updated support documentation and fixtures: `OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`, and `tests/official_onnx_expected_errors.json` to reflect Attention support improvements. 

### Testing
- Ran the full test suite with golden refresh: `UPDATE_REFS=1 pytest -n auto -q`, which completed successfully with `110 passed` and total duration ~22.72s. 
- The C codegen templates were exercised by the end-to-end operator test harness that builds and compiles generated testbench code during `test_operator_c_testbench_matches_onnxruntime` (included above). 
- Updated golden/expected references were refreshed as part of the test run (`UPDATE_REFS=1`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696466f8e9c08325bec620551c303a94)