### PR TITLE
codegen: add LogSoftmax support

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 364 / 1802 official ONNX files.
+Support 374 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -865,25 +865,25 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_less_uint8/model.onnx | ❌ | Unsupported op Less |
 | node/test_log/model.onnx | ✅ |  |
 | node/test_log_example/model.onnx | ✅ |  |
-| node/test_logsoftmax_axis_0/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_logsoftmax_axis_0/model.onnx | ✅ |  |
 | node/test_logsoftmax_axis_0_expanded/model.onnx | ✅ |  |
 | node/test_logsoftmax_axis_0_expanded_ver18/model.onnx | ✅ |  |
-| node/test_logsoftmax_axis_1/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_logsoftmax_axis_1/model.onnx | ✅ |  |
 | node/test_logsoftmax_axis_1_expanded/model.onnx | ✅ |  |
 | node/test_logsoftmax_axis_1_expanded_ver18/model.onnx | ✅ |  |
-| node/test_logsoftmax_axis_2/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_logsoftmax_axis_2/model.onnx | ✅ |  |
 | node/test_logsoftmax_axis_2_expanded/model.onnx | ✅ |  |
 | node/test_logsoftmax_axis_2_expanded_ver18/model.onnx | ✅ |  |
-| node/test_logsoftmax_default_axis/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_logsoftmax_default_axis/model.onnx | ✅ |  |
 | node/test_logsoftmax_default_axis_expanded/model.onnx | ✅ |  |
 | node/test_logsoftmax_default_axis_expanded_ver18/model.onnx | ✅ |  |
-| node/test_logsoftmax_example_1/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_logsoftmax_example_1/model.onnx | ✅ |  |
 | node/test_logsoftmax_example_1_expanded/model.onnx | ✅ |  |
 | node/test_logsoftmax_example_1_expanded_ver18/model.onnx | ✅ |  |
-| node/test_logsoftmax_large_number/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_logsoftmax_large_number/model.onnx | ✅ |  |
 | node/test_logsoftmax_large_number_expanded/model.onnx | ✅ |  |
 | node/test_logsoftmax_large_number_expanded_ver18/model.onnx | ✅ |  |
-| node/test_logsoftmax_negative_axis/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_logsoftmax_negative_axis/model.onnx | ✅ |  |
 | node/test_logsoftmax_negative_axis_expanded/model.onnx | ✅ |  |
 | node/test_logsoftmax_negative_axis_expanded_ver18/model.onnx | ✅ |  |
 | node/test_loop11/model.onnx | ❌ | Unsupported op Loop |
@@ -1376,73 +1376,73 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_scatternd_min/model.onnx | ❌ | Unsupported op ScatterND |
 | node/test_scatternd_multiply/model.onnx | ❌ | Unsupported op ScatterND |
 | node/test_sce_NCd1_mean_weight_negative_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_NCd1d2d3_none_no_weight_negative_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_NCd1d2d3_sum_weight_high_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_mean/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
 | node/test_sce_mean_3d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_3d_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_mean_3d_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_mean_3d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_3d_log_prob_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
-| node/test_sce_mean_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_mean_3d_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_mean_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_mean_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_log_prob_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_mean_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_mean_no_weight_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
 | node/test_sce_mean_no_weight_ii_3d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_no_weight_ii_3d_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_mean_no_weight_ii_3d_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_mean_no_weight_ii_3d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_mean_no_weight_ii_4d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_no_weight_ii_4d_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_mean_no_weight_ii_4d_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_mean_no_weight_ii_4d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
-| node/test_sce_mean_no_weight_ii_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_mean_no_weight_ii_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_mean_no_weight_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_mean_weight/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_mean_weight_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_mean_weight_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
 | node/test_sce_mean_weight_ii_3d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_ii_3d_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_mean_weight_ii_3d_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_mean_weight_ii_3d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_mean_weight_ii_4d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_ii_4d_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_mean_weight_ii_4d_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_mean_weight_ii_4d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
-| node/test_sce_mean_weight_ii_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_mean_weight_ii_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_mean_weight_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_mean_weight_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_log_prob_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_mean_weight_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_none/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_none_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_none_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_none_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_none_log_prob_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_none_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_none_weights/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_none_weights_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_none_weights_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_none_weights_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_none_weights_log_prob_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_none_weights_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_sum/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_sum_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_sum_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_sce_sum_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_sum_log_prob_expanded/model.onnx | ❌ | Unsupported op LogSoftmax |
+| node/test_sce_sum_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
 | node/test_selu/model.onnx | ❌ | Unsupported op Selu |
 | node/test_selu_default/model.onnx | ❌ | Unsupported op Selu |
 | node/test_selu_default_expanded_ver18/model.onnx | ❌ | Unsupported op CastLike |
@@ -1720,7 +1720,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | pytorch-converted/test_LeakyReLU_with_negval/model.onnx | ❌ | Unsupported op LeakyRelu |
 | pytorch-converted/test_Linear/model.onnx | ✅ |  |
 | pytorch-converted/test_Linear_no_bias/model.onnx | ✅ |  |
-| pytorch-converted/test_LogSoftmax/model.onnx | ❌ | Unsupported op LogSoftmax |
+| pytorch-converted/test_LogSoftmax/model.onnx | ✅ |  |
 | pytorch-converted/test_MaxPool1d/model.onnx | ✅ |  |
 | pytorch-converted/test_MaxPool1d_stride/model.onnx | ✅ |  |
 | pytorch-converted/test_MaxPool1d_stride_padding_dilation/model.onnx | ✅ |  |
@@ -1748,8 +1748,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | pytorch-converted/test_Softsign/model.onnx | ✅ |  |
 | pytorch-converted/test_Tanh/model.onnx | ✅ |  |
 | pytorch-converted/test_ZeroPad2d/model.onnx | ❌ | Unsupported op Pad |
-| pytorch-converted/test_log_softmax_dim3/model.onnx | ❌ | Unsupported op LogSoftmax |
-| pytorch-converted/test_log_softmax_lastdim/model.onnx | ❌ | Unsupported op LogSoftmax |
+| pytorch-converted/test_log_softmax_dim3/model.onnx | ✅ |  |
+| pytorch-converted/test_log_softmax_lastdim/model.onnx | ✅ |  |
 | pytorch-converted/test_softmax_functional_dim3/model.onnx | ✅ |  |
 | pytorch-converted/test_softmax_lastdim/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_add_broadcast/model.onnx | ✅ |  |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -4,7 +4,7 @@
 | --- | --- | --- |
 | Dynamic dim for tensor '*' | 146 | ██████████████████████████████ |
 | Unsupported elem_type 10 (FLOAT16) for tensor '*'. | 65 | █████████████ |
-| Unsupported op LogSoftmax | 44 | █████████ |
+| Unsupported op Shape | 44 | █████████ |
 | ReduceSum axes input must be constant | 43 | █████████ |
 | Unsupported op Resize | 39 | ████████ |
 | Missing elem_type for tensor '*' | 34 | ███████ |
@@ -37,7 +37,6 @@
 | Unsupported op Pad | 11 | ██ |
 | Unsupported op Flatten | 11 | ██ |
 | Unsupported op Mod | 10 | ██ |
-| Unsupported op Shape | 10 | ██ |
 | Dynamic or zero dims are not supported | 9 | ██ |
 | Unsupported op CumSum | 9 | ██ |
 | Unsupported op ImageDecoder | 9 | ██ |

--- a/templates/logsoftmax_op.c.j2
+++ b/templates/logsoftmax_op.c.j2
@@ -1,0 +1,29 @@
+void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ array_suffix }}, {{ c_type }} {{ output }}{{ array_suffix }}) {
+    const {{ c_type }} *input_flat = (const {{ c_type }} *){{ input0 }};
+    {{ c_type }} *output_flat = ({{ c_type }} *){{ output }};
+    const size_t outer = {{ outer }};
+    const size_t axis_size = {{ axis_size }};
+    const size_t inner = {{ inner }};
+    for (size_t outer_idx = 0; outer_idx < outer; ++outer_idx) {
+        for (size_t inner_idx = 0; inner_idx < inner; ++inner_idx) {
+            size_t base = (outer_idx * axis_size * inner) + inner_idx;
+            {{ c_type }} max_value = input_flat[base];
+            for (size_t axis_idx = 1; axis_idx < axis_size; ++axis_idx) {
+                {{ c_type }} value = input_flat[base + axis_idx * inner];
+                if (value > max_value) {
+                    max_value = value;
+                }
+            }
+            {{ c_type }} sum = 0;
+            for (size_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
+                {{ c_type }} value = {{ exp_fn }}(input_flat[base + axis_idx * inner] - max_value);
+                sum += value;
+            }
+            {{ c_type }} logsum = {{ log_fn }}(sum);
+            for (size_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
+                {{ c_type }} value = input_flat[base + axis_idx * inner] - max_value;
+                output_flat[base + axis_idx * inner] = value - logsum;
+            }
+        }
+    }
+}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -3429,7 +3429,7 @@
   ],
   [
     "node/test_logsoftmax_axis_0/model.onnx",
-    "Unsupported op LogSoftmax"
+    ""
   ],
   [
     "node/test_logsoftmax_axis_0_expanded/model.onnx",
@@ -3441,7 +3441,7 @@
   ],
   [
     "node/test_logsoftmax_axis_1/model.onnx",
-    "Unsupported op LogSoftmax"
+    ""
   ],
   [
     "node/test_logsoftmax_axis_1_expanded/model.onnx",
@@ -3453,7 +3453,7 @@
   ],
   [
     "node/test_logsoftmax_axis_2/model.onnx",
-    "Unsupported op LogSoftmax"
+    ""
   ],
   [
     "node/test_logsoftmax_axis_2_expanded/model.onnx",
@@ -3465,7 +3465,7 @@
   ],
   [
     "node/test_logsoftmax_default_axis/model.onnx",
-    "Unsupported op LogSoftmax"
+    ""
   ],
   [
     "node/test_logsoftmax_default_axis_expanded/model.onnx",
@@ -3477,7 +3477,7 @@
   ],
   [
     "node/test_logsoftmax_example_1/model.onnx",
-    "Unsupported op LogSoftmax"
+    ""
   ],
   [
     "node/test_logsoftmax_example_1_expanded/model.onnx",
@@ -3489,7 +3489,7 @@
   ],
   [
     "node/test_logsoftmax_large_number/model.onnx",
-    "Unsupported op LogSoftmax"
+    ""
   ],
   [
     "node/test_logsoftmax_large_number_expanded/model.onnx",
@@ -3501,7 +3501,7 @@
   ],
   [
     "node/test_logsoftmax_negative_axis/model.onnx",
-    "Unsupported op LogSoftmax"
+    ""
   ],
   [
     "node/test_logsoftmax_negative_axis_expanded/model.onnx",
@@ -5473,7 +5473,7 @@
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx",
@@ -5481,7 +5481,7 @@
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii/model.onnx",
@@ -5489,7 +5489,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob/model.onnx",
@@ -5497,7 +5497,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii/model.onnx",
@@ -5505,7 +5505,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob/model.onnx",
@@ -5513,7 +5513,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx",
@@ -5521,7 +5521,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx",
@@ -5529,7 +5529,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx",
@@ -5537,7 +5537,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx",
@@ -5545,7 +5545,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_mean/model.onnx",
@@ -5557,7 +5557,7 @@
   ],
   [
     "node/test_sce_mean_3d_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_mean_3d_log_prob/model.onnx",
@@ -5565,11 +5565,11 @@
   ],
   [
     "node/test_sce_mean_3d_log_prob_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_mean_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_mean_log_prob/model.onnx",
@@ -5577,7 +5577,7 @@
   ],
   [
     "node/test_sce_mean_log_prob_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_mean_no_weight_ii/model.onnx",
@@ -5589,7 +5589,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_log_prob/model.onnx",
@@ -5597,7 +5597,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d/model.onnx",
@@ -5605,7 +5605,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_log_prob/model.onnx",
@@ -5613,11 +5613,11 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_mean_no_weight_ii_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_mean_no_weight_ii_log_prob/model.onnx",
@@ -5625,7 +5625,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_mean_weight/model.onnx",
@@ -5633,7 +5633,7 @@
   ],
   [
     "node/test_sce_mean_weight_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_mean_weight_ii/model.onnx",
@@ -5645,7 +5645,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_3d_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_mean_weight_ii_3d_log_prob/model.onnx",
@@ -5653,7 +5653,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_mean_weight_ii_4d/model.onnx",
@@ -5661,7 +5661,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_4d_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_mean_weight_ii_4d_log_prob/model.onnx",
@@ -5669,11 +5669,11 @@
   ],
   [
     "node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_mean_weight_ii_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_mean_weight_ii_log_prob/model.onnx",
@@ -5681,7 +5681,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_mean_weight_log_prob/model.onnx",
@@ -5689,7 +5689,7 @@
   ],
   [
     "node/test_sce_mean_weight_log_prob_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_none/model.onnx",
@@ -5697,7 +5697,7 @@
   ],
   [
     "node/test_sce_none_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_none_log_prob/model.onnx",
@@ -5705,7 +5705,7 @@
   ],
   [
     "node/test_sce_none_log_prob_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_none_weights/model.onnx",
@@ -5713,7 +5713,7 @@
   ],
   [
     "node/test_sce_none_weights_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_none_weights_log_prob/model.onnx",
@@ -5721,7 +5721,7 @@
   ],
   [
     "node/test_sce_none_weights_log_prob_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_sum/model.onnx",
@@ -5729,7 +5729,7 @@
   ],
   [
     "node/test_sce_sum_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_sce_sum_log_prob/model.onnx",
@@ -5737,7 +5737,7 @@
   ],
   [
     "node/test_sce_sum_log_prob_expanded/model.onnx",
-    "Unsupported op LogSoftmax"
+    "Unsupported op Shape"
   ],
   [
     "node/test_selu/model.onnx",
@@ -6849,7 +6849,7 @@
   ],
   [
     "pytorch-converted/test_LogSoftmax/model.onnx",
-    "Unsupported op LogSoftmax"
+    ""
   ],
   [
     "pytorch-converted/test_MaxPool1d/model.onnx",
@@ -6961,11 +6961,11 @@
   ],
   [
     "pytorch-converted/test_log_softmax_dim3/model.onnx",
-    "Unsupported op LogSoftmax"
+    ""
   ],
   [
     "pytorch-converted/test_log_softmax_lastdim/model.onnx",
-    "Unsupported op LogSoftmax"
+    ""
   ],
   [
     "pytorch-converted/test_softmax_functional_dim3/model.onnx",

--- a/tests/test_softmax_runtime.py
+++ b/tests/test_softmax_runtime.py
@@ -25,10 +25,57 @@ def _make_softmax_model(axis: int, shape: list[int]) -> onnx.ModelProto:
     return model
 
 
+def _make_logsoftmax_model(axis: int, shape: list[int]) -> onnx.ModelProto:
+    input_info = helper.make_tensor_value_info("in0", TensorProto.FLOAT, shape)
+    output_info = helper.make_tensor_value_info("out", TensorProto.FLOAT, shape)
+    node = helper.make_node(
+        "LogSoftmax", inputs=["in0"], outputs=["out"], axis=axis
+    )
+    graph = helper.make_graph(
+        [node], "logsoftmax_graph", [input_info], [output_info]
+    )
+    model = helper.make_model(
+        graph,
+        producer_name="onnx2c",
+        opset_imports=[helper.make_operatorsetid("", 13)],
+    )
+    model.ir_version = 7
+    onnx.checker.check_model(model)
+    return model
+
+
 @pytest.mark.parametrize("axis", [0, 1, -1])
 def test_softmax_runtime_matches_onnxruntime(axis: int) -> None:
     shape = [2, 3, 4]
     model = _make_softmax_model(axis, shape)
+    inputs = np.array(
+        [
+            [
+                [1000.0, 1001.0, 1002.0, 1003.0],
+                [1.0, 2.0, 3.0, 4.0],
+                [5.0, 6.0, 7.0, 8.0],
+            ],
+            [
+                [-2.0, -1.0, 0.0, 1.0],
+                [10.0, 11.0, 12.0, 13.0],
+                [20.0, 21.0, 22.0, 23.0],
+            ],
+        ],
+        dtype=np.float32,
+    )
+    compiler = Compiler()
+    outputs = compiler.run(model, {"in0": inputs})
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    (ort_out,) = sess.run(None, {"in0": inputs})
+    np.testing.assert_allclose(outputs["out"], ort_out, rtol=1e-4, atol=1e-5)
+
+
+@pytest.mark.parametrize("axis", [0, 1, -1])
+def test_logsoftmax_runtime_matches_onnxruntime(axis: int) -> None:
+    shape = [2, 3, 4]
+    model = _make_logsoftmax_model(axis, shape)
     inputs = np.array(
         [
             [


### PR DESCRIPTION
### Motivation
- Implement LogSoftmax so the compiler can lower, emit C, and execute models that use the `LogSoftmax` ONNX op.
- Provide a numerically stable runtime implementation matching ONNX Runtime semantics (reuse the same shifted-max trick as `Softmax`).
- Update the repository support listings and golden expectations to reflect enabled `LogSoftmax` coverage.

### Description
- Add `LogSoftmaxOp` support in the lowering/codegen path by introducing `_lower_logsoftmax_op` in `src/onnx2c/compiler.py` and a `LogSoftmaxOp` dataclass in `src/onnx2c/codegen/c_emitter.py`.
- Implement runtime evaluation with a new `_apply_logsoftmax` helper in `src/onnx2c/compiler.py` and wire `LogSoftmax` handling into the interpreter loop.
- Add a C emission template `templates/logsoftmax_op.c.j2` and wire it into `CEmitter` so generated C includes a `logsoftmax` operator implementation.
- Add runtime tests in `tests/test_softmax_runtime.py` for `LogSoftmax` (multi-axis), and refresh `OFFICIAL_ONNX_FILE_SUPPORT.md` / `tests/official_onnx_expected_errors.json` to reflect newly supported cases.

### Testing
- Ran the full test suite with reference update using `UPDATE_REFS=1 pytest -n auto -q`.
- Test run result: `113 passed` in `20.96s`.
- Golden/reference files and official support listings were updated as part of the test run to reflect the new support.
- The new `LogSoftmax` runtime tests assert numerical agreement with ONNX Runtime (via `onnxruntime`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69646dc9eba08325ab36af8da03e48c4)