### PR TITLE
Add Resize operator support (nearest/asymmetric/floor)

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1260,45 +1260,45 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reshape_reordered_last_dims/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_reshape_zero_and_negative_dim/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_reshape_zero_dim/model.onnx | ❌ | Reshape requires a constant shape input |
-| node/test_resize_downsample_scales_cubic/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_downsample_scales_cubic_A_n0p5_exclude_outside/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_downsample_scales_cubic_align_corners/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_downsample_scales_cubic_antialias/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_downsample_scales_linear/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_downsample_scales_linear_align_corners/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_downsample_scales_linear_antialias/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_downsample_scales_linear_half_pixel_symmetric/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_downsample_scales_nearest/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_downsample_sizes_cubic/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_downsample_sizes_cubic_antialias/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_downsample_sizes_linear_antialias/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_downsample_sizes_linear_pytorch_half_pixel/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_downsample_sizes_nearest/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_downsample_sizes_nearest_not_larger/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_downsample_sizes_nearest_not_smaller/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_tf_crop_and_resize/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_tf_crop_and_resize_axes_2_3/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_tf_crop_and_resize_axes_3_2/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_tf_crop_and_resize_extrapolation_value/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_upsample_scales_cubic/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_upsample_scales_cubic_A_n0p5_exclude_outside/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_upsample_scales_cubic_align_corners/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_upsample_scales_cubic_asymmetric/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_upsample_scales_linear/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_upsample_scales_linear_align_corners/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_upsample_scales_linear_half_pixel_symmetric/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_upsample_scales_nearest/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_upsample_scales_nearest_axes_2_3/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_upsample_scales_nearest_axes_3_2/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_upsample_sizes_cubic/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_upsample_sizes_nearest/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_upsample_sizes_nearest_axes_2_3/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_upsample_sizes_nearest_axes_3_2/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_upsample_sizes_nearest_ceil_half_pixel/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_upsample_sizes_nearest_floor_align_corners/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_upsample_sizes_nearest_not_larger/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_upsample_sizes_nearest_not_smaller/model.onnx | ❌ | Unsupported op Resize |
-| node/test_resize_upsample_sizes_nearest_round_prefer_ceil_asymmetric/model.onnx | ❌ | Unsupported op Resize |
+| node/test_resize_downsample_scales_cubic/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_downsample_scales_cubic_A_n0p5_exclude_outside/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_downsample_scales_cubic_align_corners/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_downsample_scales_cubic_antialias/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_downsample_scales_linear/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_downsample_scales_linear_align_corners/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_downsample_scales_linear_antialias/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_downsample_scales_linear_half_pixel_symmetric/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_downsample_scales_nearest/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_downsample_sizes_cubic/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_downsample_sizes_cubic_antialias/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_downsample_sizes_linear_antialias/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_downsample_sizes_linear_pytorch_half_pixel/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_downsample_sizes_nearest/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_downsample_sizes_nearest_not_larger/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_downsample_sizes_nearest_not_smaller/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_tf_crop_and_resize/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_tf_crop_and_resize_axes_2_3/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_tf_crop_and_resize_axes_3_2/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_tf_crop_and_resize_extrapolation_value/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_upsample_scales_cubic/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_upsample_scales_cubic_A_n0p5_exclude_outside/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_upsample_scales_cubic_align_corners/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_upsample_scales_cubic_asymmetric/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_upsample_scales_linear/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_upsample_scales_linear_align_corners/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_upsample_scales_linear_half_pixel_symmetric/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_upsample_scales_nearest/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_upsample_scales_nearest_axes_2_3/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_upsample_scales_nearest_axes_3_2/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_upsample_sizes_cubic/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_upsample_sizes_nearest/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_upsample_sizes_nearest_axes_2_3/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_upsample_sizes_nearest_axes_3_2/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_upsample_sizes_nearest_ceil_half_pixel/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_upsample_sizes_nearest_floor_align_corners/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_upsample_sizes_nearest_not_larger/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_upsample_sizes_nearest_not_smaller/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_upsample_sizes_nearest_round_prefer_ceil_asymmetric/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
 | node/test_reversesequence_batch/model.onnx | ❌ | Unsupported op ReverseSequence |
 | node/test_reversesequence_time/model.onnx | ❌ | Unsupported op ReverseSequence |
 | node/test_rms_normalization_2d_axis0/model.onnx | ❌ | Unsupported op RMSNormalization |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -6,7 +6,7 @@
 | Unsupported elem_type 10 (FLOAT16) for tensor '*'. | 65 | █████████████ |
 | Unsupported op Shape | 44 | █████████ |
 | ReduceSum axes input must be constant | 43 | █████████ |
-| Unsupported op Resize | 39 | ████████ |
+| Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs | 39 | ████████ |
 | Missing elem_type for tensor '*' | 34 | ███████ |
 | Unsupported op SoftmaxCrossEntropyLoss | 34 | ███████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████ |

--- a/src/onnx2c/compiler.py
+++ b/src/onnx2c/compiler.py
@@ -27,6 +27,7 @@ from .codegen.c_emitter import (
     MaxPoolOp,
     ReduceOp,
     ReshapeOp,
+    ResizeOp,
     SoftmaxOp,
     TransposeOp,
     UnaryOp,
@@ -48,6 +49,7 @@ from .lowering.reduce import (
     resolve_reduce_axes,
 )
 from .lowering.reshape import lower_reshape
+from .lowering.resize import lower_resize
 from .lowering.unsqueeze import lower_unsqueeze
 from .onnx_import import import_onnx
 
@@ -110,6 +112,7 @@ class Compiler:
             | TransposeOp
             | ConstantOfShapeOp
             | ReshapeOp
+            | ResizeOp
             | ReduceOp
         ] = []
         for node in graph.nodes:

--- a/src/onnx2c/lowering/resize.py
+++ b/src/onnx2c/lowering/resize.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from ..codegen.c_emitter import ResizeOp
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Initializer, Node
+from .registry import register_lowering
+
+_SUPPORTED_RESIZE_MESSAGE = (
+    "Resize supports nearest mode with asymmetric coordinates and floor "
+    "rounding using constant scales or sizes for 4D NCHW inputs"
+)
+
+
+def _value_shape(graph: Graph, name: str, node: Node) -> tuple[int, ...]:
+    try:
+        return graph.find_value(name).type.shape
+    except KeyError as exc:
+        raise ShapeInferenceError(
+            f"Missing shape for value '{name}' in op {node.op_type}. "
+            "Hint: run ONNX shape inference or export with static shapes."
+        ) from exc
+
+
+def _value_dtype(graph: Graph, name: str, node: Node) -> str:
+    try:
+        return graph.find_value(name).type.dtype
+    except KeyError as exc:
+        raise ShapeInferenceError(
+            f"Missing dtype for value '{name}' in op {node.op_type}. "
+            "Hint: run ONNX shape inference or export with static shapes."
+        ) from exc
+
+
+def _find_initializer(graph: Graph, name: str) -> Initializer | None:
+    for initializer in graph.initializers:
+        if initializer.name == name:
+            return initializer
+    return None
+
+
+def _decode_attr(value: object, default: str) -> str:
+    if value is None:
+        return default
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="ignore")
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def _resolve_scales(graph: Graph, name: str, rank: int) -> tuple[float, ...]:
+    initializer = _find_initializer(graph, name)
+    if initializer is None:
+        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
+    if initializer.type.dtype not in {"float", "double"}:
+        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
+    if len(initializer.type.shape) != 1:
+        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
+    if initializer.type.shape[0] != rank:
+        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
+    return tuple(float(value) for value in initializer.data.reshape(-1))
+
+
+def _resolve_sizes(graph: Graph, name: str, rank: int) -> tuple[int, ...]:
+    initializer = _find_initializer(graph, name)
+    if initializer is None:
+        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
+    if initializer.type.dtype not in {"int64", "int32"}:
+        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
+    if len(initializer.type.shape) != 1:
+        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
+    if initializer.type.shape[0] != rank:
+        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
+    return tuple(int(value) for value in initializer.data.reshape(-1))
+
+
+def _validate_resize_config(node: Node) -> None:
+    supported_attrs = {
+        "coordinate_transformation_mode",
+        "mode",
+        "nearest_mode",
+    }
+    if set(node.attrs) - supported_attrs:
+        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
+    mode = _decode_attr(node.attrs.get("mode"), "nearest")
+    coordinate_mode = _decode_attr(
+        node.attrs.get("coordinate_transformation_mode"), "half_pixel"
+    )
+    nearest_mode = _decode_attr(node.attrs.get("nearest_mode"), "round_prefer_floor")
+    if mode != "nearest":
+        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
+    if coordinate_mode != "asymmetric":
+        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
+    if nearest_mode != "floor":
+        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
+
+
+@register_lowering("Resize")
+def lower_resize(graph: Graph, node: Node) -> ResizeOp:
+    if len(node.inputs) != 4 or len(node.outputs) != 1:
+        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
+    _validate_resize_config(node)
+    if node.inputs[1]:
+        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
+    input_shape = _value_shape(graph, node.inputs[0], node)
+    output_shape = _value_shape(graph, node.outputs[0], node)
+    if len(input_shape) != 4 or len(output_shape) != 4:
+        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
+    input_dtype = _value_dtype(graph, node.inputs[0], node)
+    output_dtype = _value_dtype(graph, node.outputs[0], node)
+    if input_dtype != output_dtype:
+        raise UnsupportedOpError(
+            "Resize expects matching input/output dtypes, "
+            f"got {input_dtype} and {output_dtype}"
+        )
+    scales_name = node.inputs[2]
+    sizes_name = node.inputs[3]
+    if scales_name and sizes_name:
+        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
+    if not scales_name and not sizes_name:
+        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
+    batch, channels, in_h, in_w = input_shape
+    if sizes_name:
+        sizes = _resolve_sizes(graph, sizes_name, len(input_shape))
+        if sizes[0] != batch or sizes[1] != channels:
+            raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
+        out_h, out_w = sizes[2], sizes[3]
+        if output_shape != sizes:
+            raise ShapeInferenceError(
+                "Resize output shape must be "
+                f"{sizes}, got {output_shape}"
+            )
+        scale_h = out_h / in_h
+        scale_w = out_w / in_w
+    else:
+        scales = _resolve_scales(graph, scales_name, len(input_shape))
+        if scales[0] != 1.0 or scales[1] != 1.0:
+            raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
+        scale_h, scale_w = scales[2], scales[3]
+        out_h = int(round(in_h * scale_h))
+        out_w = int(round(in_w * scale_w))
+        expected_output = (batch, channels, out_h, out_w)
+        if output_shape != expected_output:
+            raise ShapeInferenceError(
+                "Resize output shape must be "
+                f"{expected_output}, got {output_shape}"
+            )
+    if out_h <= 0 or out_w <= 0:
+        raise ShapeInferenceError("Resize output shape must be positive")
+    return ResizeOp(
+        input0=node.inputs[0],
+        output=node.outputs[0],
+        batch=batch,
+        channels=channels,
+        in_h=in_h,
+        in_w=in_w,
+        out_h=out_h,
+        out_w=out_w,
+        scale_h=scale_h,
+        scale_w=scale_w,
+        dtype=input_dtype,
+    )

--- a/templates/resize_op.c.j2
+++ b/templates/resize_op.c.j2
@@ -1,0 +1,25 @@
+void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+    const double scale_h = {{ scale_h_literal }};
+    const double scale_w = {{ scale_w_literal }};
+    for (size_t n = 0; n < {{ batch }}; ++n) {
+        for (size_t c = 0; c < {{ channels }}; ++c) {
+            for (size_t oh = 0; oh < {{ out_h }}; ++oh) {
+                int ih = (int)((double)oh / scale_h);
+                if (ih < 0) {
+                    ih = 0;
+                } else if (ih >= {{ in_h }}) {
+                    ih = {{ in_h }} - 1;
+                }
+                for (size_t ow = 0; ow < {{ out_w }}; ++ow) {
+                    int iw = (int)((double)ow / scale_w);
+                    if (iw < 0) {
+                        iw = 0;
+                    } else if (iw >= {{ in_w }}) {
+                        iw = {{ in_w }} - 1;
+                    }
+                    {{ output }}[n][c][oh][ow] = {{ input0 }}[n][c][ih][iw];
+                }
+            }
+        }
+    }
+}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -5009,159 +5009,159 @@
   ],
   [
     "node/test_resize_downsample_scales_cubic/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_downsample_scales_cubic_A_n0p5_exclude_outside/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_downsample_scales_cubic_align_corners/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_downsample_scales_cubic_antialias/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_downsample_scales_linear/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_downsample_scales_linear_align_corners/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_downsample_scales_linear_antialias/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_downsample_scales_linear_half_pixel_symmetric/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_downsample_scales_nearest/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_downsample_sizes_cubic/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_downsample_sizes_cubic_antialias/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_downsample_sizes_linear_antialias/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_downsample_sizes_linear_pytorch_half_pixel/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_downsample_sizes_nearest/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_downsample_sizes_nearest_not_larger/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_downsample_sizes_nearest_not_smaller/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_tf_crop_and_resize/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_tf_crop_and_resize_axes_2_3/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_tf_crop_and_resize_axes_3_2/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_tf_crop_and_resize_extrapolation_value/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_upsample_scales_cubic/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_upsample_scales_cubic_A_n0p5_exclude_outside/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_upsample_scales_cubic_align_corners/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_upsample_scales_cubic_asymmetric/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_upsample_scales_linear/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_upsample_scales_linear_align_corners/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_upsample_scales_linear_half_pixel_symmetric/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_upsample_scales_nearest/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_upsample_scales_nearest_axes_2_3/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_upsample_scales_nearest_axes_3_2/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_upsample_sizes_cubic/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_upsample_sizes_nearest/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_upsample_sizes_nearest_axes_2_3/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_upsample_sizes_nearest_axes_3_2/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_upsample_sizes_nearest_ceil_half_pixel/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_upsample_sizes_nearest_floor_align_corners/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_upsample_sizes_nearest_not_larger/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_upsample_sizes_nearest_not_smaller/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_resize_upsample_sizes_nearest_round_prefer_ceil_asymmetric/model.onnx",
-    "Unsupported op Resize"
+    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
   ],
   [
     "node/test_reversesequence_batch/model.onnx",


### PR DESCRIPTION
### Motivation

- Implement ONNX `Resize` support to reduce the number of unsupported official ONNX files and enable simple nearest-neighbor resizing in generated C code.
- Target a minimal, well-defined subset: 4D NCHW inputs with `mode='nearest'`, `coordinate_transformation_mode='asymmetric'`, and `nearest_mode='floor'` using constant `sizes` or `scales`.
- Keep lowering and codegen deterministic and conservative: reject unsupported variants with an explicit, actionable error message.

### Description

- Add a lowering pass `src/onnx2c/lowering/resize.py` that validates shape/dtype, requires constant `sizes` or `scales`, enforces supported attrs, and constructs a `ResizeOp` lowering for 4D NCHW nearest/asymmetric/floor cases.
- Introduce `ResizeOp` to the codegen dataclasses and wire it into `src/onnx2c/codegen/c_emitter.py` so the emitter can render a resize operator call.
- Add a C template `templates/resize_op.c.j2` implementing nearest-neighbor sampling (asymmetric/floor) and integrate it into the emitter rendering pipeline.
- Add an end-to-end test (`tests/test_endtoend_ops.py`) and refresh official expectation artefacts and docs (`tests/official_onnx_expected_errors.json`, `OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`) to reflect the new message for unsupported Resize variants.

### Testing

- Ran the full pytest suite with updated references using `UPDATE_REFS=1 pytest -n auto -q` and the run completed successfully.
- Test result: `114 passed` in `21.61s` (all tests green after reference update).
- Golden/reference files were updated as part of the change to keep official expectation artifacts consistent with the new error message.
- Unit and end-to-end coverage includes the new `test_resize_op_matches_onnxruntime` case exercising lowering → codegen → verify path.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696482f1e4348325b6048fd4b54948ae)