### PR TITLE
resize: implement full operator support

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 374 / 1802 official ONNX files.
+Support 413 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -1260,45 +1260,45 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reshape_reordered_last_dims/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_reshape_zero_and_negative_dim/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_reshape_zero_dim/model.onnx | ❌ | Reshape requires a constant shape input |
-| node/test_resize_downsample_scales_cubic/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_downsample_scales_cubic_A_n0p5_exclude_outside/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_downsample_scales_cubic_align_corners/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_downsample_scales_cubic_antialias/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_downsample_scales_linear/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_downsample_scales_linear_align_corners/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_downsample_scales_linear_antialias/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_downsample_scales_linear_half_pixel_symmetric/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_downsample_scales_nearest/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_downsample_sizes_cubic/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_downsample_sizes_cubic_antialias/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_downsample_sizes_linear_antialias/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_downsample_sizes_linear_pytorch_half_pixel/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_downsample_sizes_nearest/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_downsample_sizes_nearest_not_larger/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_downsample_sizes_nearest_not_smaller/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_tf_crop_and_resize/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_tf_crop_and_resize_axes_2_3/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_tf_crop_and_resize_axes_3_2/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_tf_crop_and_resize_extrapolation_value/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_upsample_scales_cubic/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_upsample_scales_cubic_A_n0p5_exclude_outside/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_upsample_scales_cubic_align_corners/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_upsample_scales_cubic_asymmetric/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_upsample_scales_linear/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_upsample_scales_linear_align_corners/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_upsample_scales_linear_half_pixel_symmetric/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_upsample_scales_nearest/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_upsample_scales_nearest_axes_2_3/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_upsample_scales_nearest_axes_3_2/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_upsample_sizes_cubic/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_upsample_sizes_nearest/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_upsample_sizes_nearest_axes_2_3/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_upsample_sizes_nearest_axes_3_2/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_upsample_sizes_nearest_ceil_half_pixel/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_upsample_sizes_nearest_floor_align_corners/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_upsample_sizes_nearest_not_larger/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_upsample_sizes_nearest_not_smaller/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
-| node/test_resize_upsample_sizes_nearest_round_prefer_ceil_asymmetric/model.onnx | ❌ | Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs |
+| node/test_resize_downsample_scales_cubic/model.onnx | ✅ |  |
+| node/test_resize_downsample_scales_cubic_A_n0p5_exclude_outside/model.onnx | ✅ |  |
+| node/test_resize_downsample_scales_cubic_align_corners/model.onnx | ✅ |  |
+| node/test_resize_downsample_scales_cubic_antialias/model.onnx | ✅ |  |
+| node/test_resize_downsample_scales_linear/model.onnx | ✅ |  |
+| node/test_resize_downsample_scales_linear_align_corners/model.onnx | ✅ |  |
+| node/test_resize_downsample_scales_linear_antialias/model.onnx | ✅ |  |
+| node/test_resize_downsample_scales_linear_half_pixel_symmetric/model.onnx | ✅ |  |
+| node/test_resize_downsample_scales_nearest/model.onnx | ✅ |  |
+| node/test_resize_downsample_sizes_cubic/model.onnx | ✅ |  |
+| node/test_resize_downsample_sizes_cubic_antialias/model.onnx | ✅ |  |
+| node/test_resize_downsample_sizes_linear_antialias/model.onnx | ✅ |  |
+| node/test_resize_downsample_sizes_linear_pytorch_half_pixel/model.onnx | ✅ |  |
+| node/test_resize_downsample_sizes_nearest/model.onnx | ✅ |  |
+| node/test_resize_downsample_sizes_nearest_not_larger/model.onnx | ✅ |  |
+| node/test_resize_downsample_sizes_nearest_not_smaller/model.onnx | ✅ |  |
+| node/test_resize_tf_crop_and_resize/model.onnx | ✅ |  |
+| node/test_resize_tf_crop_and_resize_axes_2_3/model.onnx | ✅ |  |
+| node/test_resize_tf_crop_and_resize_axes_3_2/model.onnx | ✅ |  |
+| node/test_resize_tf_crop_and_resize_extrapolation_value/model.onnx | ✅ |  |
+| node/test_resize_upsample_scales_cubic/model.onnx | ✅ |  |
+| node/test_resize_upsample_scales_cubic_A_n0p5_exclude_outside/model.onnx | ✅ |  |
+| node/test_resize_upsample_scales_cubic_align_corners/model.onnx | ✅ |  |
+| node/test_resize_upsample_scales_cubic_asymmetric/model.onnx | ✅ |  |
+| node/test_resize_upsample_scales_linear/model.onnx | ✅ |  |
+| node/test_resize_upsample_scales_linear_align_corners/model.onnx | ✅ |  |
+| node/test_resize_upsample_scales_linear_half_pixel_symmetric/model.onnx | ✅ |  |
+| node/test_resize_upsample_scales_nearest/model.onnx | ✅ |  |
+| node/test_resize_upsample_scales_nearest_axes_2_3/model.onnx | ✅ |  |
+| node/test_resize_upsample_scales_nearest_axes_3_2/model.onnx | ✅ |  |
+| node/test_resize_upsample_sizes_cubic/model.onnx | ✅ |  |
+| node/test_resize_upsample_sizes_nearest/model.onnx | ✅ |  |
+| node/test_resize_upsample_sizes_nearest_axes_2_3/model.onnx | ✅ |  |
+| node/test_resize_upsample_sizes_nearest_axes_3_2/model.onnx | ✅ |  |
+| node/test_resize_upsample_sizes_nearest_ceil_half_pixel/model.onnx | ✅ |  |
+| node/test_resize_upsample_sizes_nearest_floor_align_corners/model.onnx | ✅ |  |
+| node/test_resize_upsample_sizes_nearest_not_larger/model.onnx | ✅ |  |
+| node/test_resize_upsample_sizes_nearest_not_smaller/model.onnx | ✅ |  |
+| node/test_resize_upsample_sizes_nearest_round_prefer_ceil_asymmetric/model.onnx | ✅ |  |
 | node/test_reversesequence_batch/model.onnx | ❌ | Unsupported op ReverseSequence |
 | node/test_reversesequence_time/model.onnx | ❌ | Unsupported op ReverseSequence |
 | node/test_rms_normalization_2d_axis0/model.onnx | ❌ | Unsupported op RMSNormalization |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -6,7 +6,6 @@
 | Unsupported elem_type 10 (FLOAT16) for tensor '*'. | 65 | █████████████ |
 | Unsupported op Shape | 44 | █████████ |
 | ReduceSum axes input must be constant | 43 | █████████ |
-| Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs | 39 | ████████ |
 | Missing elem_type for tensor '*' | 34 | ███████ |
 | Unsupported op SoftmaxCrossEntropyLoss | 34 | ███████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████ |

--- a/src/onnx2c/lowering/resize.py
+++ b/src/onnx2c/lowering/resize.py
@@ -1,14 +1,50 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from ..codegen.c_emitter import ResizeOp
 from ..errors import ShapeInferenceError, UnsupportedOpError
 from ..ir.model import Graph, Initializer, Node
 from .registry import register_lowering
 
-_SUPPORTED_RESIZE_MESSAGE = (
-    "Resize supports nearest mode with asymmetric coordinates and floor "
-    "rounding using constant scales or sizes for 4D NCHW inputs"
-)
+_SUPPORTED_COORD_MODES = {
+    "half_pixel",
+    "half_pixel_symmetric",
+    "asymmetric",
+    "align_corners",
+    "pytorch_half_pixel",
+    "tf_crop_and_resize",
+}
+_SUPPORTED_MODES = {"nearest", "linear", "cubic"}
+_SUPPORTED_NEAREST_MODES = {
+    "round_prefer_floor",
+    "round_prefer_ceil",
+    "floor",
+    "ceil",
+}
+_SUPPORTED_KEEP_ASPECT = {"stretch", "not_larger", "not_smaller"}
+
+
+@dataclass(frozen=True)
+class _ResizeInputs:
+    roi: str | None
+    scales: str | None
+    sizes: str | None
+
+
+@dataclass(frozen=True)
+class _ResolvedScales:
+    scales: tuple[float, ...]
+    output_shape: tuple[int, ...]
+    axes: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class _InputConfig:
+    input_shape: tuple[int, ...]
+    output_shape: tuple[int, ...]
+    input_dtype: str
+    output_dtype: str
 
 
 def _value_shape(graph: Graph, name: str, node: Node) -> tuple[int, ...]:
@@ -48,115 +84,350 @@ def _decode_attr(value: object, default: str) -> str:
     return str(value)
 
 
-def _resolve_scales(graph: Graph, name: str, rank: int) -> tuple[float, ...]:
-    initializer = _find_initializer(graph, name)
-    if initializer is None:
-        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
-    if initializer.type.dtype not in {"float", "double"}:
-        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
-    if len(initializer.type.shape) != 1:
-        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
-    if initializer.type.shape[0] != rank:
-        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
-    return tuple(float(value) for value in initializer.data.reshape(-1))
+def _normalize_axes(
+    axes: tuple[int, ...], rank: int, node: Node
+) -> tuple[int, ...]:
+    normalized: list[int] = []
+    for axis in axes:
+        axis = int(axis)
+        if axis < 0:
+            axis += rank
+        if axis < 0 or axis >= rank:
+            raise ShapeInferenceError(
+                f"Resize axis {axis} is out of range for rank {rank}"
+            )
+        normalized.append(axis)
+    if len(set(normalized)) != len(normalized):
+        raise ShapeInferenceError("Resize axes must be unique")
+    return tuple(normalized)
 
 
-def _resolve_sizes(graph: Graph, name: str, rank: int) -> tuple[int, ...]:
-    initializer = _find_initializer(graph, name)
-    if initializer is None:
-        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
-    if initializer.type.dtype not in {"int64", "int32"}:
-        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
-    if len(initializer.type.shape) != 1:
-        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
-    if initializer.type.shape[0] != rank:
-        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
-    return tuple(int(value) for value in initializer.data.reshape(-1))
+def _round_half_up(value: float) -> int:
+    return int(value + 0.5)
 
 
-def _validate_resize_config(node: Node) -> None:
-    supported_attrs = {
-        "coordinate_transformation_mode",
-        "mode",
-        "nearest_mode",
-    }
-    if set(node.attrs) - supported_attrs:
-        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
-    mode = _decode_attr(node.attrs.get("mode"), "nearest")
-    coordinate_mode = _decode_attr(
-        node.attrs.get("coordinate_transformation_mode"), "half_pixel"
+def _parse_input_names(node: Node) -> _ResizeInputs:
+    inputs = list(node.inputs)
+    if len(inputs) > 4:
+        raise UnsupportedOpError("Resize expects at most 4 inputs")
+    while len(inputs) < 4:
+        inputs.append("")
+    _, roi, scales, sizes = inputs[:4]
+    return _ResizeInputs(
+        roi=roi or None,
+        scales=scales or None,
+        sizes=sizes or None,
     )
-    nearest_mode = _decode_attr(node.attrs.get("nearest_mode"), "round_prefer_floor")
-    if mode != "nearest":
-        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
-    if coordinate_mode != "asymmetric":
-        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
-    if nearest_mode != "floor":
-        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
+
+
+def _parse_axes(node: Node, rank: int) -> tuple[int, ...]:
+    axes_attr = node.attrs.get("axes")
+    if axes_attr is None:
+        return tuple(range(rank))
+    axes = tuple(int(value) for value in axes_attr)
+    return _normalize_axes(axes, rank, node)
+
+
+def _resolve_input_shapes(
+    graph: Graph, node: Node, input_name: str
+) -> _InputConfig:
+    input_shape = _value_shape(graph, input_name, node)
+    output_shape = _value_shape(graph, node.outputs[0], node)
+    input_dtype = _value_dtype(graph, input_name, node)
+    output_dtype = _value_dtype(graph, node.outputs[0], node)
+    return _InputConfig(
+        input_shape=input_shape,
+        output_shape=output_shape,
+        input_dtype=input_dtype,
+        output_dtype=output_dtype,
+    )
+
+
+def _resolve_scales_from_sizes(
+    sizes: tuple[int, ...],
+    input_shape: tuple[int, ...],
+    axes: tuple[int, ...],
+    keep_aspect_ratio_policy: str,
+) -> _ResolvedScales:
+    rank = len(input_shape)
+    full_sizes = list(input_shape)
+    for index, axis in enumerate(axes):
+        full_sizes[axis] = sizes[index]
+    if keep_aspect_ratio_policy != "stretch":
+        scales = [full_sizes[axis] / input_shape[axis] for axis in axes]
+        if keep_aspect_ratio_policy == "not_larger":
+            scale = min(scales)
+        else:
+            scale = max(scales)
+        for axis in axes:
+            full_sizes[axis] = _round_half_up(scale * input_shape[axis])
+        return _ResolvedScales(
+            scales=tuple(
+                scale if axis in axes else 1.0
+                for axis in range(rank)
+            ),
+            output_shape=tuple(full_sizes),
+            axes=axes,
+        )
+    scales = tuple(
+        full_sizes[axis] / input_shape[axis] if axis in axes else 1.0
+        for axis in range(rank)
+    )
+    return _ResolvedScales(
+        scales=scales,
+        output_shape=tuple(full_sizes),
+        axes=axes,
+    )
+
+
+def _resolve_scales_from_values(
+    scales: tuple[float, ...],
+    input_shape: tuple[int, ...],
+    axes: tuple[int, ...],
+) -> _ResolvedScales:
+    rank = len(input_shape)
+    full_scales = [1.0] * rank
+    for index, axis in enumerate(axes):
+        full_scales[axis] = scales[index]
+    output_shape = tuple(
+        int(input_shape[axis] * full_scales[axis])
+        if axis in axes
+        else input_shape[axis]
+        for axis in range(rank)
+    )
+    return _ResolvedScales(
+        scales=tuple(full_scales),
+        output_shape=output_shape,
+        axes=axes,
+    )
+
+
+def _load_initializer_values(
+    graph: Graph, name: str, node: Node
+) -> tuple[float | int, ...] | None:
+    initializer = _find_initializer(graph, name)
+    if initializer is None:
+        return None
+    data = initializer.data.reshape(-1)
+    return tuple(data.tolist())
+
+
+def _validate_tensor_1d(
+    graph: Graph,
+    name: str,
+    node: Node,
+    dtype_options: set[str],
+) -> tuple[int, str]:
+    shape = _value_shape(graph, name, node)
+    if len(shape) != 1:
+        raise UnsupportedOpError("Resize expects 1D auxiliary inputs")
+    dtype = _value_dtype(graph, name, node)
+    if dtype not in dtype_options:
+        raise UnsupportedOpError(
+            f"Resize expects {name} to have dtype in {sorted(dtype_options)}"
+        )
+    return shape[0], dtype
+
+
+def _resolve_scales(
+    graph: Graph,
+    node: Node,
+    config: _InputConfig,
+    inputs: _ResizeInputs,
+    axes: tuple[int, ...],
+    keep_aspect_ratio_policy: str,
+) -> tuple[tuple[float, ...], tuple[int, ...]]:
+    rank = len(config.input_shape)
+    if inputs.scales:
+        scale_len, _ = _validate_tensor_1d(
+            graph, inputs.scales, node, {"float", "double"}
+        )
+        if scale_len not in {len(axes), rank}:
+            raise UnsupportedOpError("Resize scales length mismatch")
+        if scale_len == rank and axes != tuple(range(rank)):
+            raise UnsupportedOpError(
+                "Resize scales length conflicts with axes configuration"
+            )
+        scale_axes = axes if scale_len == len(axes) else tuple(range(rank))
+        values = _load_initializer_values(graph, inputs.scales, node)
+        if values is None:
+            scales = tuple(
+                config.output_shape[axis] / config.input_shape[axis]
+                if axis in scale_axes
+                else 1.0
+                for axis in range(rank)
+            )
+            return scales, config.output_shape
+        resolved = _resolve_scales_from_values(
+            tuple(float(value) for value in values),
+            config.input_shape,
+            scale_axes,
+        )
+        return resolved.scales, resolved.output_shape
+    if inputs.sizes:
+        size_len, _ = _validate_tensor_1d(
+            graph, inputs.sizes, node, {"int64", "int32"}
+        )
+        if size_len not in {len(axes), rank}:
+            raise UnsupportedOpError("Resize sizes length mismatch")
+        if size_len == rank and axes != tuple(range(rank)):
+            raise UnsupportedOpError(
+                "Resize sizes length conflicts with axes configuration"
+            )
+        size_axes = axes if size_len == len(axes) else tuple(range(rank))
+        values = _load_initializer_values(graph, inputs.sizes, node)
+        if values is None:
+            scales = tuple(
+                config.output_shape[axis] / config.input_shape[axis]
+                if axis in size_axes
+                else 1.0
+                for axis in range(rank)
+            )
+            return scales, config.output_shape
+        resolved = _resolve_scales_from_sizes(
+            tuple(int(value) for value in values),
+            config.input_shape,
+            size_axes,
+            keep_aspect_ratio_policy,
+        )
+        return resolved.scales, resolved.output_shape
+    raise UnsupportedOpError("Resize expects scales or sizes input")
+
+
+def _validate_output_shape(
+    expected: tuple[int, ...],
+    actual: tuple[int, ...],
+) -> None:
+    if expected != actual:
+        raise ShapeInferenceError(
+            f"Resize output shape must be {expected}, got {actual}"
+        )
+    if any(dim <= 0 for dim in actual):
+        raise ShapeInferenceError("Resize output shape must be positive")
 
 
 @register_lowering("Resize")
 def lower_resize(graph: Graph, node: Node) -> ResizeOp:
-    if len(node.inputs) != 4 or len(node.outputs) != 1:
-        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
-    _validate_resize_config(node)
-    if node.inputs[1]:
-        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
-    input_shape = _value_shape(graph, node.inputs[0], node)
-    output_shape = _value_shape(graph, node.outputs[0], node)
-    if len(input_shape) != 4 or len(output_shape) != 4:
-        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
-    input_dtype = _value_dtype(graph, node.inputs[0], node)
-    output_dtype = _value_dtype(graph, node.outputs[0], node)
-    if input_dtype != output_dtype:
+    if len(node.outputs) != 1:
+        raise UnsupportedOpError("Resize expects one output")
+    inputs = _parse_input_names(node)
+    if inputs.scales and inputs.sizes:
+        raise UnsupportedOpError("Resize cannot set both scales and sizes")
+    if not inputs.scales and not inputs.sizes:
+        raise UnsupportedOpError("Resize expects scales or sizes input")
+    mode = _decode_attr(node.attrs.get("mode"), "nearest")
+    coordinate_mode = _decode_attr(
+        node.attrs.get("coordinate_transformation_mode"), "half_pixel"
+    )
+    nearest_mode = _decode_attr(
+        node.attrs.get("nearest_mode"), "round_prefer_floor"
+    )
+    keep_aspect_ratio_policy = _decode_attr(
+        node.attrs.get("keep_aspect_ratio_policy"), "stretch"
+    )
+    antialias = bool(int(node.attrs.get("antialias", 0)))
+    cubic_coeff_a = float(node.attrs.get("cubic_coeff_a", -0.75))
+    exclude_outside = bool(int(node.attrs.get("exclude_outside", 0)))
+    extrapolation_value = float(node.attrs.get("extrapolation_value", 0.0))
+    if mode not in _SUPPORTED_MODES:
+        raise UnsupportedOpError(f"Resize mode {mode!r} is not supported")
+    if coordinate_mode not in _SUPPORTED_COORD_MODES:
+        raise UnsupportedOpError(
+            "Resize coordinate_transformation_mode "
+            f"{coordinate_mode!r} is not supported"
+        )
+    if nearest_mode not in _SUPPORTED_NEAREST_MODES:
+        raise UnsupportedOpError(
+            f"Resize nearest_mode {nearest_mode!r} is not supported"
+        )
+    if keep_aspect_ratio_policy not in _SUPPORTED_KEEP_ASPECT:
+        raise UnsupportedOpError(
+            "Resize keep_aspect_ratio_policy "
+            f"{keep_aspect_ratio_policy!r} is not supported"
+        )
+    if antialias and mode == "nearest":
+        raise UnsupportedOpError("Resize antialias is not supported for nearest")
+    config = _resolve_input_shapes(graph, node, node.inputs[0])
+    if config.input_dtype != config.output_dtype:
         raise UnsupportedOpError(
             "Resize expects matching input/output dtypes, "
-            f"got {input_dtype} and {output_dtype}"
+            f"got {config.input_dtype} and {config.output_dtype}"
         )
-    scales_name = node.inputs[2]
-    sizes_name = node.inputs[3]
-    if scales_name and sizes_name:
-        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
-    if not scales_name and not sizes_name:
-        raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
-    batch, channels, in_h, in_w = input_shape
-    if sizes_name:
-        sizes = _resolve_sizes(graph, sizes_name, len(input_shape))
-        if sizes[0] != batch or sizes[1] != channels:
-            raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
-        out_h, out_w = sizes[2], sizes[3]
-        if output_shape != sizes:
-            raise ShapeInferenceError(
-                "Resize output shape must be "
-                f"{sizes}, got {output_shape}"
-            )
-        scale_h = out_h / in_h
-        scale_w = out_w / in_w
-    else:
-        scales = _resolve_scales(graph, scales_name, len(input_shape))
-        if scales[0] != 1.0 or scales[1] != 1.0:
-            raise UnsupportedOpError(_SUPPORTED_RESIZE_MESSAGE)
-        scale_h, scale_w = scales[2], scales[3]
-        out_h = int(round(in_h * scale_h))
-        out_w = int(round(in_w * scale_w))
-        expected_output = (batch, channels, out_h, out_w)
-        if output_shape != expected_output:
-            raise ShapeInferenceError(
-                "Resize output shape must be "
-                f"{expected_output}, got {output_shape}"
-            )
-    if out_h <= 0 or out_w <= 0:
-        raise ShapeInferenceError("Resize output shape must be positive")
+    rank = len(config.input_shape)
+    axes = _parse_axes(node, rank)
+    scales, expected_output = _resolve_scales(
+        graph,
+        node,
+        config,
+        inputs,
+        axes,
+        keep_aspect_ratio_policy,
+    )
+    _validate_output_shape(expected_output, config.output_shape)
+    roi_shape = None
+    roi_axes = None
+    roi_dtype = None
+    if inputs.roi:
+        roi_len, roi_dtype = _validate_tensor_1d(
+            graph, inputs.roi, node, {"float", "double"}
+        )
+        if roi_len == 2 * rank:
+            roi_shape = (roi_len,)
+        elif roi_len == 2 * len(axes):
+            roi_shape = (roi_len,)
+            roi_axes = axes
+        else:
+            raise UnsupportedOpError("Resize roi length mismatch")
+        if coordinate_mode != "tf_crop_and_resize" and roi_len != 0:
+            roi_axes = roi_axes if roi_len == 2 * len(axes) else None
+    if coordinate_mode == "tf_crop_and_resize" and not inputs.roi:
+        raise UnsupportedOpError("Resize requires roi for tf_crop_and_resize")
+    scales_shape = None
+    sizes_shape = None
+    scales_dtype = None
+    sizes_dtype = None
+    scales_axes = None
+    sizes_axes = None
+    if inputs.scales:
+        scale_len, scales_dtype = _validate_tensor_1d(
+            graph, inputs.scales, node, {"float", "double"}
+        )
+        scales_shape = (scale_len,)
+        if scale_len == len(axes) and len(axes) != rank:
+            scales_axes = axes
+    if inputs.sizes:
+        size_len, sizes_dtype = _validate_tensor_1d(
+            graph, inputs.sizes, node, {"int64", "int32"}
+        )
+        sizes_shape = (size_len,)
+        if size_len == len(axes) and len(axes) != rank:
+            sizes_axes = axes
     return ResizeOp(
         input0=node.inputs[0],
         output=node.outputs[0],
-        batch=batch,
-        channels=channels,
-        in_h=in_h,
-        in_w=in_w,
-        out_h=out_h,
-        out_w=out_w,
-        scale_h=scale_h,
-        scale_w=scale_w,
-        dtype=input_dtype,
+        input_shape=config.input_shape,
+        output_shape=config.output_shape,
+        scales=scales,
+        scales_input=inputs.scales,
+        sizes_input=inputs.sizes,
+        roi_input=inputs.roi,
+        axes=axes,
+        scales_shape=scales_shape,
+        sizes_shape=sizes_shape,
+        roi_shape=roi_shape,
+        scales_dtype=scales_dtype,
+        sizes_dtype=sizes_dtype,
+        roi_dtype=roi_dtype,
+        scales_axes=scales_axes,
+        sizes_axes=sizes_axes,
+        roi_axes=roi_axes,
+        mode=mode,
+        coordinate_transformation_mode=coordinate_mode,
+        nearest_mode=nearest_mode,
+        cubic_coeff_a=cubic_coeff_a,
+        exclude_outside=exclude_outside,
+        extrapolation_value=extrapolation_value,
+        antialias=antialias,
+        keep_aspect_ratio_policy=keep_aspect_ratio_policy,
+        dtype=config.input_dtype,
     )

--- a/templates/resize_op.c.j2
+++ b/templates/resize_op.c.j2
@@ -1,25 +1,277 @@
-void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
-    const double scale_h = {{ scale_h_literal }};
-    const double scale_w = {{ scale_w_literal }};
-    for (size_t n = 0; n < {{ batch }}; ++n) {
-        for (size_t c = 0; c < {{ channels }}; ++c) {
-            for (size_t oh = 0; oh < {{ out_h }}; ++oh) {
-                int ih = (int)((double)oh / scale_h);
-                if (ih < 0) {
-                    ih = 0;
-                } else if (ih >= {{ in_h }}) {
-                    ih = {{ in_h }} - 1;
-                }
-                for (size_t ow = 0; ow < {{ out_w }}; ++ow) {
-                    int iw = (int)((double)ow / scale_w);
-                    if (iw < 0) {
-                        iw = 0;
-                    } else if (iw >= {{ in_w }}) {
-                        iw = {{ in_w }} - 1;
-                    }
-                    {{ output }}[n][c][oh][ow] = {{ input0 }}[n][c][ih][iw];
-                }
-            }
-        }
+void {{ op_name }}({{ params | join(', ') }}) {
+    const int64_t input_shape[{{ rank }}] = { {% for dim in input_shape %}{{ dim }}{% if not loop.last %}, {% endif %}{% endfor %} };
+    const int64_t output_shape[{{ rank }}] = { {% for dim in output_shape %}{{ dim }}{% if not loop.last %}, {% endif %}{% endfor %} };
+    double scales[{{ rank }}];
+{% if roi_input %}
+    double roi[{{ rank * 2 }}];
+{% if roi_axes %}
+    for (size_t r = 0; r < {{ rank }}; ++r) {
+        roi[r] = 0.0;
+        roi[r + {{ rank }}] = 1.0;
     }
+{% for axis in axes %}
+    roi[{{ axis }}] = (double){{ roi_input }}[{{ roi_axis_map[loop.index0] }}];
+    roi[{{ axis + rank }}] = (double){{ roi_input }}[{{ roi_axis_map[loop.index0] + (axes | length) }}];
+{% endfor %}
+{% else %}
+    for (size_t r = 0; r < {{ rank * 2 }}; ++r) {
+        roi[r] = (double){{ roi_input }}[r];
+    }
+{% endif %}
+{% else %}
+    const double roi[{{ rank * 2 }}] = {
+{% for _ in range(rank) %}        0.0{% if not loop.last %},{% endif %}
+{% endfor %}{% if rank > 0 %},{% endif %}
+{% for _ in range(rank) %}        1.0{% if not loop.last %},{% endif %}
+{% endfor %}
+    };
+{% endif %}
+{% if scales_input %}
+{% if scales_axes %}
+    for (size_t r = 0; r < {{ rank }}; ++r) {
+        scales[r] = 1.0;
+    }
+{% for axis in axes %}
+    scales[{{ axis }}] = (double){{ scales_input }}[{{ scales_axis_map[loop.index0] }}];
+{% endfor %}
+{% else %}
+{% for axis in range(rank) %}
+    scales[{{ axis }}] = (double){{ scales_input }}[{{ axis }}];
+{% endfor %}
+{% endif %}
+{% elif sizes_input %}
+{% if keep_aspect_ratio_policy != "stretch" %}
+{% if keep_aspect_ratio_policy == "not_larger" %}
+    double scale_value = INFINITY;
+{% else %}
+    double scale_value = 0.0;
+{% endif %}
+{% for axis in axes %}
+    {
+        const double size_axis = (double){{ sizes_input }}[{{ sizes_axis_map[loop.index0] }}];
+        const double axis_scale = size_axis / (double)input_shape[{{ axis }}];
+{% if keep_aspect_ratio_policy == "not_larger" %}
+        if (axis_scale < scale_value) {
+            scale_value = axis_scale;
+        }
+{% else %}
+        if (axis_scale > scale_value) {
+            scale_value = axis_scale;
+        }
+{% endif %}
+    }
+{% endfor %}
+    for (size_t r = 0; r < {{ rank }}; ++r) {
+        scales[r] = 1.0;
+    }
+{% for axis in axes %}
+    scales[{{ axis }}] = scale_value;
+{% endfor %}
+{% else %}
+    for (size_t r = 0; r < {{ rank }}; ++r) {
+        scales[r] = 1.0;
+    }
+{% for axis in axes %}
+    scales[{{ axis }}] = (double){{ sizes_input }}[{{ sizes_axis_map[loop.index0] }}] / (double)input_shape[{{ axis }}];
+{% endfor %}
+{% endif %}
+{% else %}
+{% for axis in range(rank) %}
+    scales[{{ axis }}] = {{ scales[axis] }};
+{% endfor %}
+{% endif %}
+{% for dim in output_shape %}
+{{ loop_indents[loop.index0] }}for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+{% endfor %}
+{{ inner_indent }}int use_extrapolation = 0;
+{% for dim in range(rank) %}
+{{ inner_indent }}double x_orig{{ dim }};
+{% if coordinate_transformation_mode == "align_corners" %}
+{{ inner_indent }}if (output_shape[{{ dim }}] == 1) {
+{{ inner_indent }}    x_orig{{ dim }} = 0.0;
+{{ inner_indent }}} else {
+{{ inner_indent }}    x_orig{{ dim }} = (double){{ loop_vars[dim] }} * (input_shape[{{ dim }}] - 1) / (double)(output_shape[{{ dim }}] - 1);
+{{ inner_indent }}}
+{% elif coordinate_transformation_mode == "asymmetric" %}
+{{ inner_indent }}x_orig{{ dim }} = (double){{ loop_vars[dim] }} / scales[{{ dim }}];
+{% elif coordinate_transformation_mode == "tf_crop_and_resize" %}
+{{ inner_indent }}{
+{{ inner_indent }}    const double roi_start = roi[{{ dim }}];
+{{ inner_indent }}    const double roi_end = roi[{{ dim + rank }}];
+{{ inner_indent }}    if (output_shape[{{ dim }}] == 1) {
+{{ inner_indent }}        x_orig{{ dim }} = (roi_end - roi_start) * (input_shape[{{ dim }}] - 1) / 2.0;
+{{ inner_indent }}    } else {
+{{ inner_indent }}        x_orig{{ dim }} = (double){{ loop_vars[dim] }} * (roi_end - roi_start) * (input_shape[{{ dim }}] - 1)
+{{ inner_indent }}            / (double)(output_shape[{{ dim }}] - 1);
+{{ inner_indent }}    }
+{{ inner_indent }}    x_orig{{ dim }} += roi_start * (input_shape[{{ dim }}] - 1);
+{{ inner_indent }}    if (x_orig{{ dim }} < 0.0 || x_orig{{ dim }} > (double)(input_shape[{{ dim }}] - 1)) {
+{{ inner_indent }}        use_extrapolation = 1;
+{{ inner_indent }}    }
+{{ inner_indent }}}
+{% elif coordinate_transformation_mode == "pytorch_half_pixel" %}
+{{ inner_indent }}if (output_shape[{{ dim }}] == 1) {
+{{ inner_indent }}    x_orig{{ dim }} = -0.5;
+{{ inner_indent }}} else {
+{{ inner_indent }}    x_orig{{ dim }} = ((double){{ loop_vars[dim] }} + 0.5) / scales[{{ dim }}] - 0.5;
+{{ inner_indent }}}
+{% elif coordinate_transformation_mode == "half_pixel_symmetric" %}
+{{ inner_indent }}{
+{{ inner_indent }}    const double output_width = scales[{{ dim }}] * (double)input_shape[{{ dim }}];
+{{ inner_indent }}    const double adjustment = (double)output_shape[{{ dim }}] / output_width;
+{{ inner_indent }}    const double center = (double)input_shape[{{ dim }}] / 2.0;
+{{ inner_indent }}    const double offset = center * (1.0 - adjustment);
+{{ inner_indent }}    x_orig{{ dim }} = offset + ((double){{ loop_vars[dim] }} + 0.5) / scales[{{ dim }}] - 0.5;
+{{ inner_indent }}}
+{% else %}
+{{ inner_indent }}x_orig{{ dim }} = ((double){{ loop_vars[dim] }} + 0.5) / scales[{{ dim }}] - 0.5;
+{% endif %}
+{% endfor %}
+{{ inner_indent }}if (use_extrapolation) {
+{{ inner_indent }}    {{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = ({{ c_type }}){{ extrapolation_value }};
+{{ inner_indent }}} else {
+{% if mode == "nearest" %}
+{% for dim in range(rank) %}
+{{ inner_indent }}    const double x_val{{ dim }} = x_orig{{ dim }};
+{{ inner_indent }}    const double x_floor{{ dim }} = floor(x_val{{ dim }});
+{{ inner_indent }}    const double x_ceil{{ dim }} = ceil(x_val{{ dim }});
+{{ inner_indent }}    int idx{{ dim }};
+{% if nearest_mode == "round_prefer_floor" %}
+{{ inner_indent }}    idx{{ dim }} = (x_val{{ dim }} - x_floor{{ dim }} <= 0.5) ? (int)x_floor{{ dim }} : (int)x_ceil{{ dim }};
+{% elif nearest_mode == "round_prefer_ceil" %}
+{{ inner_indent }}    idx{{ dim }} = (x_val{{ dim }} - x_floor{{ dim }} < 0.5) ? (int)x_floor{{ dim }} : (int)x_ceil{{ dim }};
+{% elif nearest_mode == "floor" %}
+{{ inner_indent }}    idx{{ dim }} = (int)x_floor{{ dim }};
+{% else %}
+{{ inner_indent }}    idx{{ dim }} = (int)x_ceil{{ dim }};
+{% endif %}
+{{ inner_indent }}    if (idx{{ dim }} < 0) {
+{{ inner_indent }}        idx{{ dim }} = 0;
+{{ inner_indent }}    } else if (idx{{ dim }} >= input_shape[{{ dim }}]) {
+{{ inner_indent }}        idx{{ dim }} = (int)input_shape[{{ dim }}] - 1;
+{{ inner_indent }}    }
+{% endfor %}
+{{ inner_indent }}    {{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = {{ input0 }}{% for dim in range(rank) %}[idx{{ dim }}]{% endfor %};
+{% else %}
+{{ inner_indent }}    double acc = 0.0;
+{% for dim in range(rank) %}
+{{ inner_indent }}    double x_floor{{ dim }} = floor(x_orig{{ dim }});
+{{ inner_indent }}    double ratio{{ dim }} = x_orig{{ dim }} - x_floor{{ dim }};
+{{ inner_indent }}    const int is_integer{{ dim }} = ratio{{ dim }} == 0.0;
+{{ inner_indent }}    if (is_integer{{ dim }}) {
+{{ inner_indent }}        ratio{{ dim }} = 1.0;
+{{ inner_indent }}    }
+{{ inner_indent }}    int count{{ dim }};
+{% if antialias %}
+{{ inner_indent }}    double scale_clamped{{ dim }} = scales[{{ dim }}] < 1.0 ? scales[{{ dim }}] : 1.0;
+{% if mode == "linear" %}
+{{ inner_indent }}    int coeff_start{{ dim }} = (int)floor(-1.0 / scale_clamped{{ dim }}) + 1;
+{{ inner_indent }}    count{{ dim }} = 2 - 2 * coeff_start{{ dim }};
+{% else %}
+{{ inner_indent }}    int coeff_start{{ dim }} = (int)floor(-2.0 / scale_clamped{{ dim }}) + 1;
+{{ inner_indent }}    int coeff_end{{ dim }} = 2 - coeff_start{{ dim }};
+{{ inner_indent }}    count{{ dim }} = coeff_end{{ dim }} - coeff_start{{ dim }};
+{% endif %}
+{% else %}
+{% if mode == "linear" %}
+{{ inner_indent }}    count{{ dim }} = 2;
+{% else %}
+{{ inner_indent }}    count{{ dim }} = 4;
+{% endif %}
+{% endif %}
+{{ inner_indent }}    int start_index{{ dim }} = (int)x_floor{{ dim }} - (count{{ dim }} / 2);
+{{ inner_indent }}    if (!is_integer{{ dim }}) {
+{{ inner_indent }}        start_index{{ dim }} += 1;
+{{ inner_indent }}    }
+{{ inner_indent }}    int idx{{ dim }}_values[count{{ dim }}];
+{{ inner_indent }}    double coeff{{ dim }}[count{{ dim }}];
+{% if antialias %}
+{{ inner_indent }}    double coeff_sum{{ dim }} = 0.0;
+{{ inner_indent }}    for (int c = 0; c < count{{ dim }}; ++c) {
+{{ inner_indent }}        idx{{ dim }}_values[c] = start_index{{ dim }} + c;
+{% if mode == "linear" %}
+{{ inner_indent }}        double arg = (coeff_start{{ dim }} + c - ratio{{ dim }}) * scale_clamped{{ dim }};
+{{ inner_indent }}        double coeff = 1.0 - fabs(arg);
+{{ inner_indent }}        if (coeff < 0.0) {
+{{ inner_indent }}            coeff = 0.0;
+{{ inner_indent }}        }
+{% else %}
+{{ inner_indent }}        double x = scale_clamped{{ dim }} * (coeff_start{{ dim }} + c - ratio{{ dim }});
+{{ inner_indent }}        double ax = fabs(x);
+{{ inner_indent }}        double coeff;
+{{ inner_indent }}        if (ax <= 1.0) {
+{{ inner_indent }}            coeff = ({{ cubic_coeff_a }} + 2.0) * ax * ax * ax - ({{ cubic_coeff_a }} + 3.0) * ax * ax + 1.0;
+{{ inner_indent }}        } else if (ax < 2.0) {
+{{ inner_indent }}            coeff = {{ cubic_coeff_a }} * ax * ax * ax - 5.0 * {{ cubic_coeff_a }} * ax * ax + 8.0 * {{ cubic_coeff_a }} * ax - 4.0 * {{ cubic_coeff_a }};
+{{ inner_indent }}        } else {
+{{ inner_indent }}            coeff = 0.0;
+{{ inner_indent }}        }
+{% endif %}
+{{ inner_indent }}        coeff{{ dim }}[c] = coeff;
+{{ inner_indent }}        coeff_sum{{ dim }} += coeff;
+{{ inner_indent }}    }
+{{ inner_indent }}    if (coeff_sum{{ dim }} > 0.0) {
+{{ inner_indent }}        for (int c = 0; c < count{{ dim }}; ++c) {
+{{ inner_indent }}            coeff{{ dim }}[c] /= coeff_sum{{ dim }};
+{{ inner_indent }}        }
+{{ inner_indent }}    }
+{% else %}
+{{ inner_indent }}    for (int c = 0; c < count{{ dim }}; ++c) {
+{{ inner_indent }}        idx{{ dim }}_values[c] = start_index{{ dim }} + c;
+{{ inner_indent }}    }
+{% if mode == "linear" %}
+{{ inner_indent }}    coeff{{ dim }}[0] = 1.0 - ratio{{ dim }};
+{{ inner_indent }}    coeff{{ dim }}[1] = ratio{{ dim }};
+{% else %}
+{{ inner_indent }}    {
+{{ inner_indent }}        const double t = 1.0 - ratio{{ dim }};
+{{ inner_indent }}        coeff{{ dim }}[0] = (({{ cubic_coeff_a }} * (ratio{{ dim }} + 1.0) - 5.0 * {{ cubic_coeff_a }}) * (ratio{{ dim }} + 1.0) + 8.0 * {{ cubic_coeff_a }}) * (ratio{{ dim }} + 1.0) - 4.0 * {{ cubic_coeff_a }};
+{{ inner_indent }}        coeff{{ dim }}[1] = (({{ cubic_coeff_a }} + 2.0) * ratio{{ dim }} - ({{ cubic_coeff_a }} + 3.0)) * ratio{{ dim }} * ratio{{ dim }} + 1.0;
+{{ inner_indent }}        coeff{{ dim }}[2] = (({{ cubic_coeff_a }} + 2.0) * t - ({{ cubic_coeff_a }} + 3.0)) * t * t + 1.0;
+{{ inner_indent }}        coeff{{ dim }}[3] = (({{ cubic_coeff_a }} * (t + 1.0) - 5.0 * {{ cubic_coeff_a }}) * (t + 1.0) + 8.0 * {{ cubic_coeff_a }}) * (t + 1.0) - 4.0 * {{ cubic_coeff_a }};
+{{ inner_indent }}    }
+{% endif %}
+{% endif %}
+{% if exclude_outside %}
+{{ inner_indent }}    {
+{{ inner_indent }}        double coeff_sum{{ dim }} = 0.0;
+{{ inner_indent }}        for (int c = 0; c < count{{ dim }}; ++c) {
+{{ inner_indent }}            if (idx{{ dim }}_values[c] < 0 || idx{{ dim }}_values[c] >= input_shape[{{ dim }}]) {
+{{ inner_indent }}                coeff{{ dim }}[c] = 0.0;
+{{ inner_indent }}            }
+{{ inner_indent }}            coeff_sum{{ dim }} += coeff{{ dim }}[c];
+{{ inner_indent }}        }
+{{ inner_indent }}        if (coeff_sum{{ dim }} > 0.0) {
+{{ inner_indent }}            for (int c = 0; c < count{{ dim }}; ++c) {
+{{ inner_indent }}                coeff{{ dim }}[c] /= coeff_sum{{ dim }};
+{{ inner_indent }}            }
+{{ inner_indent }}        }
+{{ inner_indent }}    }
+{% endif %}
+{% endfor %}
+{% for dim in range(rank) %}
+{{ inner_indent }}    for (int n{{ dim }} = 0; n{{ dim }} < count{{ dim }}; ++n{{ dim }}) {
+{% endfor %}
+{{ inner_indent }}        double weight = 1.0;
+{% for dim in range(rank) %}
+{{ inner_indent }}        weight *= coeff{{ dim }}[n{{ dim }}];
+{% endfor %}
+{% for dim in range(rank) %}
+{{ inner_indent }}        int idx{{ dim }} = idx{{ dim }}_values[n{{ dim }}];
+{{ inner_indent }}        if (idx{{ dim }} < 0) {
+{{ inner_indent }}            idx{{ dim }} = 0;
+{{ inner_indent }}        } else if (idx{{ dim }} >= input_shape[{{ dim }}]) {
+{{ inner_indent }}            idx{{ dim }} = (int)input_shape[{{ dim }}] - 1;
+{{ inner_indent }}        }
+{% endfor %}
+{{ inner_indent }}        acc += weight * (double){{ input0 }}{% for dim in range(rank) %}[idx{{ dim }}]{% endfor %};
+{% for dim in range(rank) %}
+{{ inner_indent }}    }
+{% endfor %}
+{{ inner_indent }}    {{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = ({{ c_type }})acc;
+{% endif %}
+{{ inner_indent }}}
+{% for _ in output_shape %}
+{{ loop_indents[loop.revindex0] }}}
+{% endfor %}
 }

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -5009,159 +5009,159 @@
   ],
   [
     "node/test_resize_downsample_scales_cubic/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_downsample_scales_cubic_A_n0p5_exclude_outside/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_downsample_scales_cubic_align_corners/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_downsample_scales_cubic_antialias/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_downsample_scales_linear/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_downsample_scales_linear_align_corners/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_downsample_scales_linear_antialias/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_downsample_scales_linear_half_pixel_symmetric/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_downsample_scales_nearest/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_downsample_sizes_cubic/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_downsample_sizes_cubic_antialias/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_downsample_sizes_linear_antialias/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_downsample_sizes_linear_pytorch_half_pixel/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_downsample_sizes_nearest/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_downsample_sizes_nearest_not_larger/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_downsample_sizes_nearest_not_smaller/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_tf_crop_and_resize/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_tf_crop_and_resize_axes_2_3/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_tf_crop_and_resize_axes_3_2/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_tf_crop_and_resize_extrapolation_value/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_upsample_scales_cubic/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_upsample_scales_cubic_A_n0p5_exclude_outside/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_upsample_scales_cubic_align_corners/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_upsample_scales_cubic_asymmetric/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_upsample_scales_linear/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_upsample_scales_linear_align_corners/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_upsample_scales_linear_half_pixel_symmetric/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_upsample_scales_nearest/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_upsample_scales_nearest_axes_2_3/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_upsample_scales_nearest_axes_3_2/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_upsample_sizes_cubic/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_upsample_sizes_nearest/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_upsample_sizes_nearest_axes_2_3/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_upsample_sizes_nearest_axes_3_2/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_upsample_sizes_nearest_ceil_half_pixel/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_upsample_sizes_nearest_floor_align_corners/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_upsample_sizes_nearest_not_larger/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_upsample_sizes_nearest_not_smaller/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_resize_upsample_sizes_nearest_round_prefer_ceil_asymmetric/model.onnx",
-    "Resize supports nearest mode with asymmetric coordinates and floor rounding using constant scales or sizes for 4D NCHW inputs"
+    ""
   ],
   [
     "node/test_reversesequence_batch/model.onnx",


### PR DESCRIPTION
### Motivation

- Replace the previous limited 4D NCHW `Resize` handling with a full, general lowering and codegen implementation to support ONNX `Resize` semantics (axes, roi, scales/sizes, coordinate modes, interpolation modes, antialias, and keep-aspect policies).
- Ensure the compiler emits deterministic, N‑D C kernels for `Resize` so generated code can be verified against reference implementations and official ONNX tests.

### Description

- Implemented comprehensive `Resize` lowering in `src/onnx2c/lowering/resize.py` with input parsing, axes normalization, initializer loading, `scales`/`sizes` resolution (including `keep_aspect_ratio_policy`), ROI handling and full attribute validation, returning a rich `ResizeOp` spec.
- Extended `ResizeOp` data model in `src/onnx2c/codegen/c_emitter.py` and updated `_resolve_op`, `_op_outputs`, wrapper emission and call-site generation so auxiliary inputs (roi/scales/sizes), axes mappings and dtypes are propagated into codegen.
- Added a new `templates/resize_op.c.j2` that emits N‑D interpolation code supporting `nearest`/`linear`/`cubic`, coordinate transform modes, antialiasing, extrapolation and edge handling, and wired it into the emitter render path.
- Updated includes, helpers, and official ONNX expectations/golden references (`tests/official_onnx_expected_errors.json`, `OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`) to reflect the new `Resize` support.

### Testing

- Ran the full test suite with updated references using `UPDATE_REFS=1 pytest -n auto -q` which completed successfully in `22.94s` and updated golden refs.
- All tests passed: `114 passed in 22.94s` (reference files refreshed where applicable).
- The change includes targeted validation in lowering to raise `UnsupportedOpError` or `ShapeInferenceError` for unsupported or malformed inputs (covered by the official ONNX file comparisons).
- Golden/reference files were refreshed as part of the update pass (`UPDATE_REFS=1`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69648c6fbf6c8325abd1263f63acf5ef)