### PR TITLE
lowering: implement Shape operator

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 413 / 1802 official ONNX files.
+Support 423 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -1376,73 +1376,73 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_scatternd_min/model.onnx | ❌ | Unsupported op ScatterND |
 | node/test_scatternd_multiply/model.onnx | ❌ | Unsupported op ScatterND |
 | node/test_sce_NCd1_mean_weight_negative_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_NCd1d2d3_none_no_weight_negative_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_NCd1d2d3_sum_weight_high_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_mean/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
 | node/test_sce_mean_3d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_3d_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_mean_3d_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_mean_3d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_3d_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
-| node/test_sce_mean_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_mean_3d_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_mean_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_mean_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_mean_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_mean_no_weight_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
 | node/test_sce_mean_no_weight_ii_3d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_no_weight_ii_3d_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_mean_no_weight_ii_3d_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_mean_no_weight_ii_3d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_mean_no_weight_ii_4d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_no_weight_ii_4d_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_mean_no_weight_ii_4d_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_mean_no_weight_ii_4d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
-| node/test_sce_mean_no_weight_ii_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_mean_no_weight_ii_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_mean_no_weight_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_mean_weight/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_mean_weight_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_mean_weight_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
 | node/test_sce_mean_weight_ii_3d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_ii_3d_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_mean_weight_ii_3d_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_mean_weight_ii_3d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_mean_weight_ii_4d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_ii_4d_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_mean_weight_ii_4d_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_mean_weight_ii_4d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
-| node/test_sce_mean_weight_ii_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_mean_weight_ii_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_mean_weight_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_mean_weight_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_mean_weight_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_none/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_none_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_none_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_none_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_none_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_none_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_none_weights/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_none_weights_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_none_weights_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_none_weights_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_none_weights_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_none_weights_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_sum/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_sum_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_sum_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_sce_sum_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_sum_log_prob_expanded/model.onnx | ❌ | Unsupported op Shape |
+| node/test_sce_sum_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
 | node/test_selu/model.onnx | ❌ | Unsupported op Selu |
 | node/test_selu_default/model.onnx | ❌ | Unsupported op Selu |
 | node/test_selu_default_expanded_ver18/model.onnx | ❌ | Unsupported op CastLike |
@@ -1463,17 +1463,17 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_sequence_map_identity_1_sequence_expanded/model.onnx | ❌ | Missing elem_type for tensor 'x' |
 | node/test_sequence_map_identity_2_sequences/model.onnx | ❌ | Missing elem_type for tensor 'x0' |
 | node/test_sequence_map_identity_2_sequences_expanded/model.onnx | ❌ | Missing elem_type for tensor 'x0' |
-| node/test_shape/model.onnx | ❌ | Unsupported op Shape |
-| node/test_shape_clip_end/model.onnx | ❌ | Unsupported op Shape |
-| node/test_shape_clip_start/model.onnx | ❌ | Unsupported op Shape |
-| node/test_shape_end_1/model.onnx | ❌ | Unsupported op Shape |
-| node/test_shape_end_negative_1/model.onnx | ❌ | Unsupported op Shape |
-| node/test_shape_example/model.onnx | ❌ | Unsupported op Shape |
-| node/test_shape_start_1/model.onnx | ❌ | Unsupported op Shape |
-| node/test_shape_start_1_end_2/model.onnx | ❌ | Unsupported op Shape |
-| node/test_shape_start_1_end_negative_1/model.onnx | ❌ | Unsupported op Shape |
+| node/test_shape/model.onnx | ✅ |  |
+| node/test_shape_clip_end/model.onnx | ✅ |  |
+| node/test_shape_clip_start/model.onnx | ✅ |  |
+| node/test_shape_end_1/model.onnx | ✅ |  |
+| node/test_shape_end_negative_1/model.onnx | ✅ |  |
+| node/test_shape_example/model.onnx | ✅ |  |
+| node/test_shape_start_1/model.onnx | ✅ |  |
+| node/test_shape_start_1_end_2/model.onnx | ✅ |  |
+| node/test_shape_start_1_end_negative_1/model.onnx | ✅ |  |
 | node/test_shape_start_greater_than_end/model.onnx | ❌ | Dynamic or zero dims are not supported |
-| node/test_shape_start_negative_1/model.onnx | ❌ | Unsupported op Shape |
+| node/test_shape_start_negative_1/model.onnx | ✅ |  |
 | node/test_shrink_hard/model.onnx | ❌ | Unsupported op Shrink |
 | node/test_shrink_hard_expanded_ver18/model.onnx | ❌ | Unsupported op CastLike |
 | node/test_shrink_soft/model.onnx | ❌ | Unsupported op Shrink |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -4,8 +4,8 @@
 | --- | --- | --- |
 | Dynamic dim for tensor '*' | 146 | ██████████████████████████████ |
 | Unsupported elem_type 10 (FLOAT16) for tensor '*'. | 65 | █████████████ |
-| Unsupported op Shape | 44 | █████████ |
 | ReduceSum axes input must be constant | 43 | █████████ |
+| Reshape requires a constant shape input | 43 | █████████ |
 | Missing elem_type for tensor '*' | 34 | ███████ |
 | Unsupported op SoftmaxCrossEntropyLoss | 34 | ███████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████ |
@@ -44,7 +44,6 @@
 | ReduceL2 axes input must be constant | 9 | ██ |
 | ReduceLogSumExp axes input must be constant | 9 | ██ |
 | ReduceSumSquare axes input must be constant | 9 | ██ |
-| Reshape requires a constant shape input | 9 | ██ |
 | Unsupported op BitShift | 8 | ██ |
 | Dropout supports only the data input and 1 or 2 outputs | 8 | ██ |
 | Unsupported op Equal | 8 | ██ |

--- a/src/onnx2c/codegen/__init__.py
+++ b/src/onnx2c/codegen/__init__.py
@@ -6,6 +6,7 @@ from .c_emitter import (
     GemmOp,
     LoweredModel,
     MatMulOp,
+    ShapeOp,
     UnaryOp,
 )
 
@@ -17,5 +18,6 @@ __all__ = [
     "GemmOp",
     "LoweredModel",
     "MatMulOp",
+    "ShapeOp",
     "UnaryOp",
 ]

--- a/src/onnx2c/lowering/shape.py
+++ b/src/onnx2c/lowering/shape.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from ..codegen.c_emitter import ShapeOp
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Node
+from .registry import register_lowering
+
+
+def _value_shape(graph: Graph, name: str, node: Node) -> tuple[int, ...]:
+    try:
+        return graph.find_value(name).type.shape
+    except KeyError as exc:
+        raise ShapeInferenceError(
+            f"Missing shape for value '{name}' in op {node.op_type}. "
+            "Hint: run ONNX shape inference or export with static shapes."
+        ) from exc
+
+
+def _value_dtype(graph: Graph, name: str, node: Node) -> str:
+    try:
+        return graph.find_value(name).type.dtype
+    except KeyError as exc:
+        raise ShapeInferenceError(
+            f"Missing dtype for value '{name}' in op {node.op_type}. "
+            "Hint: run ONNX shape inference or export with static shapes."
+        ) from exc
+
+
+def _normalize_slice_bounds(
+    rank: int, *, start: int | None, end: int | None
+) -> tuple[int, int]:
+    normalized_start = 0 if start is None else int(start)
+    normalized_end = rank if end is None else int(end)
+    if normalized_start < 0:
+        normalized_start += rank
+    if normalized_end < 0:
+        normalized_end += rank
+    normalized_start = max(0, min(normalized_start, rank))
+    normalized_end = max(0, min(normalized_end, rank))
+    return normalized_start, normalized_end
+
+
+@register_lowering("Shape")
+def lower_shape(graph: Graph, node: Node) -> ShapeOp:
+    if len(node.inputs) != 1 or len(node.outputs) != 1:
+        raise UnsupportedOpError("Shape must have 1 input and 1 output")
+    input_shape = _value_shape(graph, node.inputs[0], node)
+    output_shape = _value_shape(graph, node.outputs[0], node)
+    if len(output_shape) != 1:
+        raise ShapeInferenceError("Shape output must be 1D")
+    if output_shape[0] <= 0:
+        raise ShapeInferenceError("Shape output length must be positive")
+    input_dtype = _value_dtype(graph, node.inputs[0], node)
+    output_dtype = _value_dtype(graph, node.outputs[0], node)
+    if output_dtype != "int64":
+        raise UnsupportedOpError("Shape output dtype must be int64")
+    start = node.attrs.get("start")
+    end = node.attrs.get("end")
+    start_index, end_index = _normalize_slice_bounds(
+        len(input_shape), start=start, end=end
+    )
+    if end_index <= start_index:
+        raise ShapeInferenceError("Shape start must be less than end")
+    expected_shape = (end_index - start_index,)
+    if expected_shape != output_shape:
+        raise ShapeInferenceError(
+            "Shape output shape must be "
+            f"{expected_shape}, got {output_shape}"
+        )
+    return ShapeOp(
+        input0=node.inputs[0],
+        output=node.outputs[0],
+        input_shape=input_shape,
+        output_shape=output_shape,
+        values=input_shape[start_index:end_index],
+        dtype=output_dtype,
+        input_dtype=input_dtype,
+    )

--- a/templates/shape_op.c.j2
+++ b/templates/shape_op.c.j2
@@ -1,0 +1,6 @@
+void {{ op_name }}(const {{ input_c_type }} {{ input0 }}{{ input_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+    (void){{ input0 }};
+{% for value in values %}
+    {{ output }}[{{ loop.index0 }}] = {{ value }};
+{% endfor %}
+}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -5473,7 +5473,7 @@
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx",
@@ -5481,7 +5481,7 @@
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii/model.onnx",
@@ -5489,7 +5489,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob/model.onnx",
@@ -5497,7 +5497,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii/model.onnx",
@@ -5505,7 +5505,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob/model.onnx",
@@ -5513,7 +5513,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx",
@@ -5521,7 +5521,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx",
@@ -5529,7 +5529,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx",
@@ -5537,7 +5537,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx",
@@ -5545,7 +5545,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_mean/model.onnx",
@@ -5557,7 +5557,7 @@
   ],
   [
     "node/test_sce_mean_3d_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_mean_3d_log_prob/model.onnx",
@@ -5565,11 +5565,11 @@
   ],
   [
     "node/test_sce_mean_3d_log_prob_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_mean_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_mean_log_prob/model.onnx",
@@ -5577,7 +5577,7 @@
   ],
   [
     "node/test_sce_mean_log_prob_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_mean_no_weight_ii/model.onnx",
@@ -5589,7 +5589,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_log_prob/model.onnx",
@@ -5597,7 +5597,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d/model.onnx",
@@ -5605,7 +5605,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_log_prob/model.onnx",
@@ -5613,11 +5613,11 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_mean_no_weight_ii_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_mean_no_weight_ii_log_prob/model.onnx",
@@ -5625,7 +5625,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_mean_weight/model.onnx",
@@ -5633,7 +5633,7 @@
   ],
   [
     "node/test_sce_mean_weight_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_mean_weight_ii/model.onnx",
@@ -5645,7 +5645,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_3d_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_mean_weight_ii_3d_log_prob/model.onnx",
@@ -5653,7 +5653,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_mean_weight_ii_4d/model.onnx",
@@ -5661,7 +5661,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_4d_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_mean_weight_ii_4d_log_prob/model.onnx",
@@ -5669,11 +5669,11 @@
   ],
   [
     "node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_mean_weight_ii_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_mean_weight_ii_log_prob/model.onnx",
@@ -5681,7 +5681,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_mean_weight_log_prob/model.onnx",
@@ -5689,7 +5689,7 @@
   ],
   [
     "node/test_sce_mean_weight_log_prob_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_none/model.onnx",
@@ -5697,7 +5697,7 @@
   ],
   [
     "node/test_sce_none_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_none_log_prob/model.onnx",
@@ -5705,7 +5705,7 @@
   ],
   [
     "node/test_sce_none_log_prob_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_none_weights/model.onnx",
@@ -5713,7 +5713,7 @@
   ],
   [
     "node/test_sce_none_weights_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_none_weights_log_prob/model.onnx",
@@ -5721,7 +5721,7 @@
   ],
   [
     "node/test_sce_none_weights_log_prob_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_sum/model.onnx",
@@ -5729,7 +5729,7 @@
   ],
   [
     "node/test_sce_sum_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_sce_sum_log_prob/model.onnx",
@@ -5737,7 +5737,7 @@
   ],
   [
     "node/test_sce_sum_log_prob_expanded/model.onnx",
-    "Unsupported op Shape"
+    "Reshape requires a constant shape input"
   ],
   [
     "node/test_selu/model.onnx",
@@ -5821,39 +5821,39 @@
   ],
   [
     "node/test_shape/model.onnx",
-    "Unsupported op Shape"
+    ""
   ],
   [
     "node/test_shape_clip_end/model.onnx",
-    "Unsupported op Shape"
+    ""
   ],
   [
     "node/test_shape_clip_start/model.onnx",
-    "Unsupported op Shape"
+    ""
   ],
   [
     "node/test_shape_end_1/model.onnx",
-    "Unsupported op Shape"
+    ""
   ],
   [
     "node/test_shape_end_negative_1/model.onnx",
-    "Unsupported op Shape"
+    ""
   ],
   [
     "node/test_shape_example/model.onnx",
-    "Unsupported op Shape"
+    ""
   ],
   [
     "node/test_shape_start_1/model.onnx",
-    "Unsupported op Shape"
+    ""
   ],
   [
     "node/test_shape_start_1_end_2/model.onnx",
-    "Unsupported op Shape"
+    ""
   ],
   [
     "node/test_shape_start_1_end_negative_1/model.onnx",
-    "Unsupported op Shape"
+    ""
   ],
   [
     "node/test_shape_start_greater_than_end/model.onnx",
@@ -5861,7 +5861,7 @@
   ],
   [
     "node/test_shape_start_negative_1/model.onnx",
-    "Unsupported op Shape"
+    ""
   ],
   [
     "node/test_shrink_hard/model.onnx",


### PR DESCRIPTION
### Motivation
- Add full support for the ONNX `Shape` operator (including optional `start`/`end` slice semantics) so models that use `Shape` can be lowered and emitted to C.
- Provide deterministic, compile-time known shape values for emission to keep codegen simple and runtime-free where possible.

### Description
- Implement `lower_shape` in `src/onnx2c/lowering/shape.py` to validate shapes, dtypes and `start`/`end` slicing and to produce a `ShapeOp` lowering.
- Add `ShapeOp` to the codegen data model and integrate it into `src/onnx2c/codegen/c_emitter.py` so lowered `Shape` ops are rendered using a new template `templates/shape_op.c.j2`.
- Handle `Shape` at runtime in `src/onnx2c/compiler.py` (execution path) and wire the lowering into the lowering discovery (`from .lowering.shape import lower_shape`).
- Add end-to-end tests in `tests/test_endtoend_ops.py` and refresh official ONNX support artifacts (`OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`, `tests/official_onnx_expected_errors.json`) to reflect newly supported `Shape` cases.

### Testing
- Ran the full test suite with reference updates enabled: `UPDATE_REFS=1 pytest -n auto -q` and all tests passed.
- Test summary: `116 passed` in `18.03s`.
- New/updated golden references were refreshed as part of the `UPDATE_REFS=1` run.
- The added end-to-end `Shape` tests exercise both lowering and emitted C code via the existing CLI verification path (`onnx2c verify`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69649151b79c83259f7967f21506db5e)