### PR TITLE
lowering: allow Reshape with inferred shape

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 423 / 1802 official ONNX files.
+Support 432 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -1251,15 +1251,15 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_relu/model.onnx | ✅ |  |
 | node/test_relu_expanded_ver18/model.onnx | ❌ | Unsupported op CastLike |
 | node/test_reshape_allowzero_reordered/model.onnx | ❌ | Dynamic or zero dims are not supported |
-| node/test_reshape_extended_dims/model.onnx | ❌ | Reshape requires a constant shape input |
-| node/test_reshape_negative_dim/model.onnx | ❌ | Reshape requires a constant shape input |
-| node/test_reshape_negative_extended_dims/model.onnx | ❌ | Reshape requires a constant shape input |
-| node/test_reshape_one_dim/model.onnx | ❌ | Reshape requires a constant shape input |
-| node/test_reshape_reduced_dims/model.onnx | ❌ | Reshape requires a constant shape input |
-| node/test_reshape_reordered_all_dims/model.onnx | ❌ | Reshape requires a constant shape input |
-| node/test_reshape_reordered_last_dims/model.onnx | ❌ | Reshape requires a constant shape input |
-| node/test_reshape_zero_and_negative_dim/model.onnx | ❌ | Reshape requires a constant shape input |
-| node/test_reshape_zero_dim/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_reshape_extended_dims/model.onnx | ✅ |  |
+| node/test_reshape_negative_dim/model.onnx | ✅ |  |
+| node/test_reshape_negative_extended_dims/model.onnx | ✅ |  |
+| node/test_reshape_one_dim/model.onnx | ✅ |  |
+| node/test_reshape_reduced_dims/model.onnx | ✅ |  |
+| node/test_reshape_reordered_all_dims/model.onnx | ✅ |  |
+| node/test_reshape_reordered_last_dims/model.onnx | ✅ |  |
+| node/test_reshape_zero_and_negative_dim/model.onnx | ✅ |  |
+| node/test_reshape_zero_dim/model.onnx | ✅ |  |
 | node/test_resize_downsample_scales_cubic/model.onnx | ✅ |  |
 | node/test_resize_downsample_scales_cubic_A_n0p5_exclude_outside/model.onnx | ✅ |  |
 | node/test_resize_downsample_scales_cubic_align_corners/model.onnx | ✅ |  |
@@ -1376,73 +1376,73 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_scatternd_min/model.onnx | ❌ | Unsupported op ScatterND |
 | node/test_scatternd_multiply/model.onnx | ❌ | Unsupported op ScatterND |
 | node/test_sce_NCd1_mean_weight_negative_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_NCd1d2d3_none_no_weight_negative_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_NCd1d2d3_sum_weight_high_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_mean/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
 | node/test_sce_mean_3d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_3d_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_mean_3d_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_mean_3d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_3d_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
-| node/test_sce_mean_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_mean_3d_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_mean_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_mean_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_mean_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_mean_no_weight_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
 | node/test_sce_mean_no_weight_ii_3d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_no_weight_ii_3d_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_mean_no_weight_ii_3d_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_mean_no_weight_ii_3d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_mean_no_weight_ii_4d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_no_weight_ii_4d_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_mean_no_weight_ii_4d_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_mean_no_weight_ii_4d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
-| node/test_sce_mean_no_weight_ii_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_mean_no_weight_ii_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_mean_no_weight_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_mean_weight/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_mean_weight_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_mean_weight_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
 | node/test_sce_mean_weight_ii_3d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_ii_3d_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_mean_weight_ii_3d_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_mean_weight_ii_3d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_mean_weight_ii_4d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_ii_4d_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_mean_weight_ii_4d_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_mean_weight_ii_4d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
-| node/test_sce_mean_weight_ii_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_mean_weight_ii_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_mean_weight_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_mean_weight_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_mean_weight_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_none/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_none_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_none_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_none_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_none_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_none_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_none_weights/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_none_weights_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_none_weights_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_none_weights_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_none_weights_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_none_weights_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_sum/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_sum_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_sum_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_sce_sum_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_sum_log_prob_expanded/model.onnx | ❌ | Reshape requires a constant shape input |
+| node/test_sce_sum_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_selu/model.onnx | ❌ | Unsupported op Selu |
 | node/test_selu_default/model.onnx | ❌ | Unsupported op Selu |
 | node/test_selu_default_expanded_ver18/model.onnx | ❌ | Unsupported op CastLike |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -5,9 +5,9 @@
 | Dynamic dim for tensor '*' | 146 | ██████████████████████████████ |
 | Unsupported elem_type 10 (FLOAT16) for tensor '*'. | 65 | █████████████ |
 | ReduceSum axes input must be constant | 43 | █████████ |
-| Reshape requires a constant shape input | 43 | █████████ |
 | Missing elem_type for tensor '*' | 34 | ███████ |
 | Unsupported op SoftmaxCrossEntropyLoss | 34 | ███████ |
+| Reshape input and output element counts must match | 34 | ███████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████ |
 | Unsupported op CastLike | 31 | ██████ |
 | Unsupported op Less | 26 | █████ |

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -4973,39 +4973,39 @@
   ],
   [
     "node/test_reshape_extended_dims/model.onnx",
-    "Reshape requires a constant shape input"
+    ""
   ],
   [
     "node/test_reshape_negative_dim/model.onnx",
-    "Reshape requires a constant shape input"
+    ""
   ],
   [
     "node/test_reshape_negative_extended_dims/model.onnx",
-    "Reshape requires a constant shape input"
+    ""
   ],
   [
     "node/test_reshape_one_dim/model.onnx",
-    "Reshape requires a constant shape input"
+    ""
   ],
   [
     "node/test_reshape_reduced_dims/model.onnx",
-    "Reshape requires a constant shape input"
+    ""
   ],
   [
     "node/test_reshape_reordered_all_dims/model.onnx",
-    "Reshape requires a constant shape input"
+    ""
   ],
   [
     "node/test_reshape_reordered_last_dims/model.onnx",
-    "Reshape requires a constant shape input"
+    ""
   ],
   [
     "node/test_reshape_zero_and_negative_dim/model.onnx",
-    "Reshape requires a constant shape input"
+    ""
   ],
   [
     "node/test_reshape_zero_dim/model.onnx",
-    "Reshape requires a constant shape input"
+    ""
   ],
   [
     "node/test_resize_downsample_scales_cubic/model.onnx",
@@ -5473,7 +5473,7 @@
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx",
@@ -5481,7 +5481,7 @@
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii/model.onnx",
@@ -5489,7 +5489,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob/model.onnx",
@@ -5497,7 +5497,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii/model.onnx",
@@ -5505,7 +5505,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob/model.onnx",
@@ -5513,7 +5513,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx",
@@ -5521,7 +5521,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx",
@@ -5529,7 +5529,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx",
@@ -5537,7 +5537,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx",
@@ -5545,7 +5545,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_mean/model.onnx",
@@ -5557,7 +5557,7 @@
   ],
   [
     "node/test_sce_mean_3d_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_mean_3d_log_prob/model.onnx",
@@ -5565,11 +5565,11 @@
   ],
   [
     "node/test_sce_mean_3d_log_prob_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_mean_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_mean_log_prob/model.onnx",
@@ -5577,7 +5577,7 @@
   ],
   [
     "node/test_sce_mean_log_prob_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_mean_no_weight_ii/model.onnx",
@@ -5589,7 +5589,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_log_prob/model.onnx",
@@ -5597,7 +5597,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d/model.onnx",
@@ -5605,7 +5605,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_log_prob/model.onnx",
@@ -5613,11 +5613,11 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_mean_no_weight_ii_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_mean_no_weight_ii_log_prob/model.onnx",
@@ -5625,7 +5625,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_mean_weight/model.onnx",
@@ -5633,7 +5633,7 @@
   ],
   [
     "node/test_sce_mean_weight_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_mean_weight_ii/model.onnx",
@@ -5645,7 +5645,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_3d_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_mean_weight_ii_3d_log_prob/model.onnx",
@@ -5653,7 +5653,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_mean_weight_ii_4d/model.onnx",
@@ -5661,7 +5661,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_4d_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_mean_weight_ii_4d_log_prob/model.onnx",
@@ -5669,11 +5669,11 @@
   ],
   [
     "node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_mean_weight_ii_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_mean_weight_ii_log_prob/model.onnx",
@@ -5681,7 +5681,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_mean_weight_log_prob/model.onnx",
@@ -5689,7 +5689,7 @@
   ],
   [
     "node/test_sce_mean_weight_log_prob_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_none/model.onnx",
@@ -5697,7 +5697,7 @@
   ],
   [
     "node/test_sce_none_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_none_log_prob/model.onnx",
@@ -5705,7 +5705,7 @@
   ],
   [
     "node/test_sce_none_log_prob_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_none_weights/model.onnx",
@@ -5713,7 +5713,7 @@
   ],
   [
     "node/test_sce_none_weights_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_none_weights_log_prob/model.onnx",
@@ -5721,7 +5721,7 @@
   ],
   [
     "node/test_sce_none_weights_log_prob_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_sum/model.onnx",
@@ -5729,7 +5729,7 @@
   ],
   [
     "node/test_sce_sum_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_sce_sum_log_prob/model.onnx",
@@ -5737,7 +5737,7 @@
   ],
   [
     "node/test_sce_sum_log_prob_expanded/model.onnx",
-    "Reshape requires a constant shape input"
+    "Reshape input and output element counts must match"
   ],
   [
     "node/test_selu/model.onnx",


### PR DESCRIPTION
### Motivation
- Previously `Reshape` lowering rejected any non-constant shape input with "Reshape requires a constant shape input" even when the output shape was statically known.  
- The change allows lowering to proceed for common cases where the model already has a static output shape and the total element counts match.  
- This reduces false negatives when processing official ONNX tests and models that encode shape information via value metadata.  
- Keep strict validation when the shape input is present (dtype and 1D) and retain element-count checks to ensure correctness.  

### Description
- Update `src/onnx2c/lowering/reshape.py` to accept a non-constant shape input when the resolved output shape is statically known and `_shape_product(input_shape) == _shape_product(output_shape)`; otherwise continue to validate/resolve the constant shape input.  
- Preserve existing validations: matching input/output dtypes, disallow dynamic/zero dims in the statically-known output shape, and require int32/int64 1D shape initializers when present.  
- Adjust error behavior to raise `ShapeInferenceError("Reshape input and output element counts must match")` for mismatched element counts when the shape input is non-constant.  
- Update test expectation artifacts and support docs: `tests/official_onnx_expected_errors.json`, `OFFICIAL_ONNX_FILE_SUPPORT.md`, and `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md` to reflect the new behavior.  

### Testing
- Ran the full test suite with updated references using `UPDATE_REFS=1 pytest -n auto -q`.  
- Test run completed in approximately `17.47s`.  
- Result: `116 passed` (all tests passed after updating references).  
- No additional failing automated tests were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696497d18e1c8325aaebfe1a810c16c0)