### PR TITLE
validation: centralize axis and shape checks

### DIFF
--- a/src/onnx2c/lowering/common.py
+++ b/src/onnx2c/lowering/common.py
@@ -70,19 +70,6 @@ def shape_product(shape: tuple[int, ...]) -> int:
     return product
 
 
-def normalize_axis(axis: int, shape: tuple[int, ...], node: Node) -> int:
-    if not shape:
-        raise ShapeInferenceError(f"{node.op_type} does not support scalar inputs")
-    rank = len(shape)
-    if axis < 0:
-        axis += rank
-    if axis < 0 or axis >= rank:
-        raise ShapeInferenceError(
-            f"{node.op_type} axis {axis} is out of range for rank {rank}"
-        )
-    return axis
-
-
 def optional_name(names: Sequence[str], index: int) -> str | None:
     if index >= len(names):
         return None

--- a/src/onnx2c/lowering/concat.py
+++ b/src/onnx2c/lowering/concat.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from ..codegen.c_emitter import ConcatOp
-from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..errors import UnsupportedOpError
 from ..ir.model import Graph, Node
 from .common import node_dtype as _node_dtype
 from .common import value_shape as _value_shape
 from .registry import register_lowering
+from ..validation import validate_concat_shapes
 
 
 @register_lowering("Concat")
@@ -15,42 +16,11 @@ def lower_concat(graph: Graph, node: Node) -> ConcatOp:
     op_dtype = _node_dtype(graph, node, *node.inputs, *node.outputs)
     output_shape = _value_shape(graph, node.outputs[0], node)
     input_shapes = tuple(_value_shape(graph, name, node) for name in node.inputs)
-    ranks = {len(shape) for shape in input_shapes}
-    if len(ranks) != 1:
-        raise ShapeInferenceError(
-            f"Concat inputs must have matching ranks, got {input_shapes}"
-        )
-    rank = ranks.pop()
-    axis = int(node.attrs.get("axis", 0))
-    if axis < 0:
-        axis += rank
-    if axis < 0 or axis >= rank:
-        raise ShapeInferenceError(
-            f"Concat axis out of range for rank {rank}: {axis}"
-        )
-    base_shape = list(input_shapes[0])
-    axis_dim = 0
-    for shape in input_shapes:
-        if len(shape) != rank:
-            raise ShapeInferenceError(
-                f"Concat inputs must have matching ranks, got {input_shapes}"
-            )
-        for dim_index, dim in enumerate(shape):
-            if dim_index == axis:
-                continue
-            if dim != base_shape[dim_index]:
-                raise ShapeInferenceError(
-                    "Concat inputs must match on non-axis dimensions, "
-                    f"got {input_shapes}"
-                )
-        axis_dim += shape[axis]
-    base_shape[axis] = axis_dim
-    expected_output_shape = tuple(base_shape)
-    if output_shape != expected_output_shape:
-        raise ShapeInferenceError(
-            "Concat output shape must be "
-            f"{expected_output_shape}, got {output_shape}"
-        )
+    axis = validate_concat_shapes(
+        input_shapes,
+        output_shape,
+        int(node.attrs.get("axis", 0)),
+    )
     return ConcatOp(
         inputs=node.inputs,
         output=node.outputs[0],

--- a/src/onnx2c/lowering/logsoftmax.py
+++ b/src/onnx2c/lowering/logsoftmax.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 from ..codegen.c_emitter import LogSoftmaxOp
-from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..errors import UnsupportedOpError
 from ..ir.model import Graph, Node
 from .common import node_dtype as _node_dtype
-from .common import normalize_axis as _normalize_axis
 from .common import shape_product as _shape_product
 from .common import value_shape as _value_shape
 from .registry import register_lowering
+from ..validation import ensure_output_shape_matches_input
+from ..validation import normalize_axis as _normalize_axis
 
 
 @register_lowering("LogSoftmax")
@@ -21,10 +22,7 @@ def lower_logsoftmax(graph: Graph, node: Node) -> LogSoftmaxOp:
         )
     input_shape = _value_shape(graph, node.inputs[0], node)
     output_shape = _value_shape(graph, node.outputs[0], node)
-    if input_shape != output_shape:
-        raise ShapeInferenceError(
-            f"LogSoftmax output shape must be {input_shape}, got {output_shape}"
-        )
+    ensure_output_shape_matches_input(node, input_shape, output_shape)
     axis = _normalize_axis(
         int(node.attrs.get("axis", -1)),
         input_shape,

--- a/src/onnx2c/lowering/softmax.py
+++ b/src/onnx2c/lowering/softmax.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 from ..codegen.c_emitter import SoftmaxOp
-from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..errors import UnsupportedOpError
 from ..ir.model import Graph, Node
 from .common import node_dtype as _node_dtype
-from .common import normalize_axis as _normalize_axis
 from .common import shape_product as _shape_product
 from .common import value_shape as _value_shape
 from .registry import register_lowering
+from ..validation import ensure_output_shape_matches_input
+from ..validation import normalize_axis as _normalize_axis
 
 
 @register_lowering("Softmax")
@@ -19,10 +20,7 @@ def lower_softmax(graph: Graph, node: Node) -> SoftmaxOp:
         raise UnsupportedOpError("Softmax supports float and double inputs only")
     input_shape = _value_shape(graph, node.inputs[0], node)
     output_shape = _value_shape(graph, node.outputs[0], node)
-    if input_shape != output_shape:
-        raise ShapeInferenceError(
-            f"Softmax output shape must be {input_shape}, got {output_shape}"
-        )
+    ensure_output_shape_matches_input(node, input_shape, output_shape)
     axis = _normalize_axis(
         int(node.attrs.get("axis", -1)),
         input_shape,

--- a/src/onnx2c/validation.py
+++ b/src/onnx2c/validation.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from .errors import ShapeInferenceError
+from .ir.model import Node
+
+
+def normalize_axis(axis: int, shape: tuple[int, ...], node: Node) -> int:
+    if not shape:
+        raise ShapeInferenceError(f"{node.op_type} does not support scalar inputs")
+    rank = len(shape)
+    if axis < 0:
+        axis += rank
+    if axis < 0 or axis >= rank:
+        raise ShapeInferenceError(
+            f"{node.op_type} axis {axis} is out of range for rank {rank}"
+        )
+    return axis
+
+
+def normalize_concat_axis(axis: int, rank: int) -> int:
+    if axis < 0:
+        axis += rank
+    if axis < 0 or axis >= rank:
+        raise ShapeInferenceError(
+            f"Concat axis out of range for rank {rank}: {axis}"
+        )
+    return axis
+
+
+def ensure_output_shape_matches_input(
+    node: Node,
+    input_shape: tuple[int, ...],
+    output_shape: tuple[int, ...],
+) -> None:
+    if input_shape != output_shape:
+        raise ShapeInferenceError(
+            f"{node.op_type} output shape must be {input_shape}, got {output_shape}"
+        )
+
+
+def validate_concat_shapes(
+    input_shapes: tuple[tuple[int, ...], ...],
+    output_shape: tuple[int, ...],
+    axis: int,
+) -> int:
+    ranks = {len(shape) for shape in input_shapes}
+    if len(ranks) != 1:
+        raise ShapeInferenceError(
+            f"Concat inputs must have matching ranks, got {input_shapes}"
+        )
+    rank = ranks.pop()
+    axis = normalize_concat_axis(axis, rank)
+    base_shape = list(input_shapes[0])
+    axis_dim = 0
+    for shape in input_shapes:
+        if len(shape) != rank:
+            raise ShapeInferenceError(
+                f"Concat inputs must have matching ranks, got {input_shapes}"
+            )
+        for dim_index, dim in enumerate(shape):
+            if dim_index == axis:
+                continue
+            if dim != base_shape[dim_index]:
+                raise ShapeInferenceError(
+                    "Concat inputs must match on non-axis dimensions, "
+                    f"got {input_shapes}"
+                )
+        axis_dim += shape[axis]
+    base_shape[axis] = axis_dim
+    expected_output_shape = tuple(base_shape)
+    if output_shape != expected_output_shape:
+        raise ShapeInferenceError(
+            "Concat output shape must be "
+            f"{expected_output_shape}, got {output_shape}"
+        )
+    return axis


### PR DESCRIPTION
### Motivation
- Reduce duplicated axis and shape validation logic scattered across lowering modules by centralizing common checks. 
- Provide reusable helpers for axis normalization, output==input shape validation, and concat shape verification to improve maintainability. 
- Keep existing exception types and messages to avoid breaking tests and golden references. 
- Make lowering code (Softmax/LogSoftmax/Concat) clearer by delegating checks to a single module.

### Description
- Added a new helper module `src/onnx2c/validation.py` with `normalize_axis`, `normalize_concat_axis`, `ensure_output_shape_matches_input`, and `validate_concat_shapes` helpers. 
- Removed `normalize_axis` from `src/onnx2c/lowering/common.py` and updated lowering modules to import validation helpers instead. 
- Refactored `src/onnx2c/lowering/softmax.py` and `src/onnx2c/lowering/logsoftmax.py` to call `ensure_output_shape_matches_input` and `normalize_axis` from the new module. 
- Refactored `src/onnx2c/lowering/concat.py` to call `validate_concat_shapes` and use the returned normalized `axis`.

### Testing
- Ran the full test suite with references update using `UPDATE_REFS=1 pytest -n auto -q` which completed in approximately `41.63s`. 
- All automated tests passed: `116 passed` (no failures).
- No additional unit tests were added since changes only consolidate existing checks and preserve previous behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6964a1e0ceb8832580fa2e2231223094)