### PR TITLE
compiler: reuse lowering dtype/shape helpers

### DIFF
--- a/src/onnx2c/lowering/common.py
+++ b/src/onnx2c/lowering/common.py
@@ -6,7 +6,7 @@ from ..errors import ShapeInferenceError, UnsupportedOpError
 from ..ir.model import Graph, Node
 
 
-def _ensure_supported_dtype(dtype: str) -> str:
+def ensure_supported_dtype(dtype: str) -> str:
     if dtype not in {
         "float",
         "double",
@@ -24,23 +24,25 @@ def _ensure_supported_dtype(dtype: str) -> str:
     return dtype
 
 
-def value_dtype(graph: Graph, name: str, node: Node) -> str:
+def value_dtype(graph: Graph, name: str, node: Node | None = None) -> str:
     try:
         value = graph.find_value(name)
     except KeyError as exc:
+        op_type = node.op_type if node is not None else "unknown"
         raise ShapeInferenceError(
-            f"Missing dtype for value '{name}' in op {node.op_type}. "
+            f"Missing dtype for value '{name}' in op {op_type}. "
             "Hint: run ONNX shape inference or export with static shapes."
         ) from exc
-    return _ensure_supported_dtype(value.type.dtype)
+    return ensure_supported_dtype(value.type.dtype)
 
 
-def value_shape(graph: Graph, name: str, node: Node) -> tuple[int, ...]:
+def value_shape(graph: Graph, name: str, node: Node | None = None) -> tuple[int, ...]:
     try:
         return graph.find_value(name).type.shape
     except KeyError as exc:
+        op_type = node.op_type if node is not None else "unknown"
         raise ShapeInferenceError(
-            f"Missing shape for value '{name}' in op {node.op_type}. "
+            f"Missing shape for value '{name}' in op {op_type}. "
             "Hint: run ONNX shape inference or export with static shapes."
         ) from exc
 


### PR DESCRIPTION
### Motivation

- Remove duplicated dtype/shape helper logic from the compiler and centralize it with the lowering utilities to keep behavior consistent.
- Ensure error messages and the supported-dtype whitelist are identical between compiler and lowering code by sharing helpers.
- Allow better error context by permitting an optional `node` parameter in value lookups.

### Description

- Replaced compiler-local helpers in `src/onnx2c/compiler.py` with shared functions imported from `src/onnx2c/lowering/common.py` (`ensure_supported_dtype`, `value_dtype`, `value_shape`, `node_dtype`, `shape_product`).
- Extended `value_dtype` and `value_shape` signatures to accept an optional `node` parameter so errors include op context when available.
- Removed duplicate implementations (`_ensure_supported_dtype`, `_value_dtype`, `_node_dtype`, `_value_shape`, `_element_count`) from the compiler.
- Kept existing dtype whitelist and error messages intact by reusing the same validation and ShapeInferenceError/UnsupportedOpError flows.

### Testing

- Ran the full pytest suite with reference updates using `UPDATE_REFS=1 pytest -n auto -q` which completed successfully.
- Test run summary: `116 passed` in `23.81s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6964a565120c83258d90388d4467793d)