### PR TITLE
build: add pyproject for editable installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "onnx2c"
+version = "0.1.0"
+description = "ONNX to C compiler"
+requires-python = ">=3.10"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]


### PR DESCRIPTION
### Motivation
- Enable `pip install -e .` for the repository's `src/`-based package layout.
- Provide minimal build metadata so modern packaging tools and editable installs work reliably.
- Use `setuptools.build_meta` with a known minimum `setuptools` version for predictable builds.
- Make the package discoverable by tooling by explicitly configuring the package directory.

### Description
- Added a root `pyproject.toml` with a `[build-system]` section requiring `setuptools>=61` and `build-backend = "setuptools.build_meta"`.
- Added a minimal `[project]` block with `name`, `version`, `description`, and `requires-python` set to `">=3.10"`.
- Configured setuptools to use the `src` layout via `[tool.setuptools]` `package-dir = {"" = "src"}` and `[tool.setuptools.packages.find] where = ["src"]`.
- Created the `pyproject.toml` file at the repository root to enable editable installs and packaging tools.

### Testing
- Ran `UPDATE_REFS=1 pytest -n auto -q` as the automated test command.
- Test run output: `116 passed in 18.37s`.
- All automated tests succeeded.
- No failures reported by the test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6964b67f69508325a8c2ec5ebe39fe91)