### PR TITLE
ops: implement compare operators

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 432 / 1802 official ONNX files.
+Support 488 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -477,24 +477,24 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_clip_default_int8_inbounds/model.onnx | ❌ | Unsupported op Clip |
 | node/test_clip_default_int8_inbounds_expanded/model.onnx | ❌ | Unsupported op Identity |
 | node/test_clip_default_int8_max/model.onnx | ❌ | Unsupported op Clip |
-| node/test_clip_default_int8_max_expanded/model.onnx | ❌ | Unsupported op Less |
+| node/test_clip_default_int8_max_expanded/model.onnx | ❌ | Unsupported op Where |
 | node/test_clip_default_int8_min/model.onnx | ❌ | Unsupported op Clip |
-| node/test_clip_default_int8_min_expanded/model.onnx | ❌ | Unsupported op Less |
+| node/test_clip_default_int8_min_expanded/model.onnx | ❌ | Unsupported op Where |
 | node/test_clip_default_max/model.onnx | ❌ | Unsupported op Clip |
-| node/test_clip_default_max_expanded/model.onnx | ❌ | Unsupported op Less |
+| node/test_clip_default_max_expanded/model.onnx | ❌ | Unsupported op Where |
 | node/test_clip_default_min/model.onnx | ❌ | Unsupported op Clip |
-| node/test_clip_default_min_expanded/model.onnx | ❌ | Unsupported op Less |
+| node/test_clip_default_min_expanded/model.onnx | ❌ | Unsupported op Where |
 | node/test_clip_example/model.onnx | ❌ | Unsupported op Clip |
-| node/test_clip_example_expanded/model.onnx | ❌ | Unsupported op Less |
-| node/test_clip_expanded/model.onnx | ❌ | Unsupported op Less |
+| node/test_clip_example_expanded/model.onnx | ❌ | Unsupported op Where |
+| node/test_clip_expanded/model.onnx | ❌ | Unsupported op Where |
 | node/test_clip_inbounds/model.onnx | ❌ | Unsupported op Clip |
-| node/test_clip_inbounds_expanded/model.onnx | ❌ | Unsupported op Less |
+| node/test_clip_inbounds_expanded/model.onnx | ❌ | Unsupported op Where |
 | node/test_clip_min_greater_than_max/model.onnx | ❌ | Unsupported op Clip |
-| node/test_clip_min_greater_than_max_expanded/model.onnx | ❌ | Unsupported op Less |
+| node/test_clip_min_greater_than_max_expanded/model.onnx | ❌ | Unsupported op Where |
 | node/test_clip_outbounds/model.onnx | ❌ | Unsupported op Clip |
-| node/test_clip_outbounds_expanded/model.onnx | ❌ | Unsupported op Less |
+| node/test_clip_outbounds_expanded/model.onnx | ❌ | Unsupported op Where |
 | node/test_clip_splitbounds/model.onnx | ❌ | Unsupported op Clip |
-| node/test_clip_splitbounds_expanded/model.onnx | ❌ | Unsupported op Less |
+| node/test_clip_splitbounds_expanded/model.onnx | ❌ | Unsupported op Where |
 | node/test_col2im/model.onnx | ❌ | Unsupported op Col2Im |
 | node/test_col2im_5d/model.onnx | ❌ | Unsupported op Col2Im |
 | node/test_col2im_dilations/model.onnx | ❌ | Unsupported op Col2Im |
@@ -613,16 +613,16 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_elu_example/model.onnx | ❌ | Unsupported op Elu |
 | node/test_elu_example_expanded_ver18/model.onnx | ❌ | Unsupported op CastLike |
 | node/test_elu_expanded_ver18/model.onnx | ❌ | Unsupported op CastLike |
-| node/test_equal/model.onnx | ❌ | Unsupported op Equal |
-| node/test_equal_bcast/model.onnx | ❌ | Unsupported op Equal |
-| node/test_equal_int16/model.onnx | ❌ | Unsupported op Equal |
-| node/test_equal_int8/model.onnx | ❌ | Unsupported op Equal |
+| node/test_equal/model.onnx | ✅ |  |
+| node/test_equal_bcast/model.onnx | ✅ |  |
+| node/test_equal_int16/model.onnx | ✅ |  |
+| node/test_equal_int8/model.onnx | ✅ |  |
 | node/test_equal_string/model.onnx | ❌ | Unsupported elem_type 8 (STRING) for tensor 'x'. |
 | node/test_equal_string_broadcast/model.onnx | ❌ | Unsupported elem_type 8 (STRING) for tensor 'x'. |
-| node/test_equal_uint16/model.onnx | ❌ | Unsupported op Equal |
-| node/test_equal_uint32/model.onnx | ❌ | Unsupported op Equal |
-| node/test_equal_uint64/model.onnx | ❌ | Unsupported op Equal |
-| node/test_equal_uint8/model.onnx | ❌ | Unsupported op Equal |
+| node/test_equal_uint16/model.onnx | ✅ |  |
+| node/test_equal_uint32/model.onnx | ✅ |  |
+| node/test_equal_uint64/model.onnx | ✅ |  |
+| node/test_equal_uint8/model.onnx | ✅ |  |
 | node/test_erf/model.onnx | ❌ | Unsupported op Erf |
 | node/test_exp/model.onnx | ✅ |  |
 | node/test_exp_example/model.onnx | ✅ |  |
@@ -675,30 +675,30 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_globalaveragepool_precomputed/model.onnx | ✅ |  |
 | node/test_globalmaxpool/model.onnx | ❌ | Unsupported op GlobalMaxPool |
 | node/test_globalmaxpool_precomputed/model.onnx | ❌ | Unsupported op GlobalMaxPool |
-| node/test_greater/model.onnx | ❌ | Unsupported op Greater |
-| node/test_greater_bcast/model.onnx | ❌ | Unsupported op Greater |
-| node/test_greater_equal/model.onnx | ❌ | Unsupported op GreaterOrEqual |
-| node/test_greater_equal_bcast/model.onnx | ❌ | Unsupported op GreaterOrEqual |
-| node/test_greater_equal_bcast_expanded/model.onnx | ❌ | Unsupported op Greater |
-| node/test_greater_equal_expanded/model.onnx | ❌ | Unsupported op Greater |
-| node/test_greater_equal_int16/model.onnx | ❌ | Unsupported op GreaterOrEqual |
-| node/test_greater_equal_int16_expanded/model.onnx | ❌ | Unsupported op Greater |
-| node/test_greater_equal_int8/model.onnx | ❌ | Unsupported op GreaterOrEqual |
-| node/test_greater_equal_int8_expanded/model.onnx | ❌ | Unsupported op Greater |
-| node/test_greater_equal_uint16/model.onnx | ❌ | Unsupported op GreaterOrEqual |
-| node/test_greater_equal_uint16_expanded/model.onnx | ❌ | Unsupported op Greater |
-| node/test_greater_equal_uint32/model.onnx | ❌ | Unsupported op GreaterOrEqual |
-| node/test_greater_equal_uint32_expanded/model.onnx | ❌ | Unsupported op Greater |
-| node/test_greater_equal_uint64/model.onnx | ❌ | Unsupported op GreaterOrEqual |
-| node/test_greater_equal_uint64_expanded/model.onnx | ❌ | Unsupported op Greater |
-| node/test_greater_equal_uint8/model.onnx | ❌ | Unsupported op GreaterOrEqual |
-| node/test_greater_equal_uint8_expanded/model.onnx | ❌ | Unsupported op Greater |
-| node/test_greater_int16/model.onnx | ❌ | Unsupported op Greater |
-| node/test_greater_int8/model.onnx | ❌ | Unsupported op Greater |
-| node/test_greater_uint16/model.onnx | ❌ | Unsupported op Greater |
-| node/test_greater_uint32/model.onnx | ❌ | Unsupported op Greater |
-| node/test_greater_uint64/model.onnx | ❌ | Unsupported op Greater |
-| node/test_greater_uint8/model.onnx | ❌ | Unsupported op Greater |
+| node/test_greater/model.onnx | ✅ |  |
+| node/test_greater_bcast/model.onnx | ✅ |  |
+| node/test_greater_equal/model.onnx | ✅ |  |
+| node/test_greater_equal_bcast/model.onnx | ✅ |  |
+| node/test_greater_equal_bcast_expanded/model.onnx | ✅ |  |
+| node/test_greater_equal_expanded/model.onnx | ✅ |  |
+| node/test_greater_equal_int16/model.onnx | ✅ |  |
+| node/test_greater_equal_int16_expanded/model.onnx | ✅ |  |
+| node/test_greater_equal_int8/model.onnx | ✅ |  |
+| node/test_greater_equal_int8_expanded/model.onnx | ✅ |  |
+| node/test_greater_equal_uint16/model.onnx | ✅ |  |
+| node/test_greater_equal_uint16_expanded/model.onnx | ✅ |  |
+| node/test_greater_equal_uint32/model.onnx | ✅ |  |
+| node/test_greater_equal_uint32_expanded/model.onnx | ✅ |  |
+| node/test_greater_equal_uint64/model.onnx | ✅ |  |
+| node/test_greater_equal_uint64_expanded/model.onnx | ✅ |  |
+| node/test_greater_equal_uint8/model.onnx | ✅ |  |
+| node/test_greater_equal_uint8_expanded/model.onnx | ✅ |  |
+| node/test_greater_int16/model.onnx | ✅ |  |
+| node/test_greater_int8/model.onnx | ✅ |  |
+| node/test_greater_uint16/model.onnx | ✅ |  |
+| node/test_greater_uint32/model.onnx | ✅ |  |
+| node/test_greater_uint64/model.onnx | ✅ |  |
+| node/test_greater_uint8/model.onnx | ✅ |  |
 | node/test_gridsample/model.onnx | ❌ | Unsupported op GridSample |
 | node/test_gridsample_aligncorners_true/model.onnx | ❌ | Unsupported op GridSample |
 | node/test_gridsample_bicubic/model.onnx | ❌ | Unsupported op GridSample |
@@ -839,30 +839,30 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_leakyrelu_example/model.onnx | ❌ | Unsupported op LeakyRelu |
 | node/test_leakyrelu_example_expanded/model.onnx | ❌ | Unsupported op CastLike |
 | node/test_leakyrelu_expanded/model.onnx | ❌ | Unsupported op CastLike |
-| node/test_less/model.onnx | ❌ | Unsupported op Less |
-| node/test_less_bcast/model.onnx | ❌ | Unsupported op Less |
-| node/test_less_equal/model.onnx | ❌ | Unsupported op LessOrEqual |
-| node/test_less_equal_bcast/model.onnx | ❌ | Unsupported op LessOrEqual |
-| node/test_less_equal_bcast_expanded/model.onnx | ❌ | Unsupported op Less |
-| node/test_less_equal_expanded/model.onnx | ❌ | Unsupported op Less |
-| node/test_less_equal_int16/model.onnx | ❌ | Unsupported op LessOrEqual |
-| node/test_less_equal_int16_expanded/model.onnx | ❌ | Unsupported op Less |
-| node/test_less_equal_int8/model.onnx | ❌ | Unsupported op LessOrEqual |
-| node/test_less_equal_int8_expanded/model.onnx | ❌ | Unsupported op Less |
-| node/test_less_equal_uint16/model.onnx | ❌ | Unsupported op LessOrEqual |
-| node/test_less_equal_uint16_expanded/model.onnx | ❌ | Unsupported op Less |
-| node/test_less_equal_uint32/model.onnx | ❌ | Unsupported op LessOrEqual |
-| node/test_less_equal_uint32_expanded/model.onnx | ❌ | Unsupported op Less |
-| node/test_less_equal_uint64/model.onnx | ❌ | Unsupported op LessOrEqual |
-| node/test_less_equal_uint64_expanded/model.onnx | ❌ | Unsupported op Less |
-| node/test_less_equal_uint8/model.onnx | ❌ | Unsupported op LessOrEqual |
-| node/test_less_equal_uint8_expanded/model.onnx | ❌ | Unsupported op Less |
-| node/test_less_int16/model.onnx | ❌ | Unsupported op Less |
-| node/test_less_int8/model.onnx | ❌ | Unsupported op Less |
-| node/test_less_uint16/model.onnx | ❌ | Unsupported op Less |
-| node/test_less_uint32/model.onnx | ❌ | Unsupported op Less |
-| node/test_less_uint64/model.onnx | ❌ | Unsupported op Less |
-| node/test_less_uint8/model.onnx | ❌ | Unsupported op Less |
+| node/test_less/model.onnx | ✅ |  |
+| node/test_less_bcast/model.onnx | ✅ |  |
+| node/test_less_equal/model.onnx | ✅ |  |
+| node/test_less_equal_bcast/model.onnx | ✅ |  |
+| node/test_less_equal_bcast_expanded/model.onnx | ✅ |  |
+| node/test_less_equal_expanded/model.onnx | ✅ |  |
+| node/test_less_equal_int16/model.onnx | ✅ |  |
+| node/test_less_equal_int16_expanded/model.onnx | ✅ |  |
+| node/test_less_equal_int8/model.onnx | ✅ |  |
+| node/test_less_equal_int8_expanded/model.onnx | ✅ |  |
+| node/test_less_equal_uint16/model.onnx | ✅ |  |
+| node/test_less_equal_uint16_expanded/model.onnx | ✅ |  |
+| node/test_less_equal_uint32/model.onnx | ✅ |  |
+| node/test_less_equal_uint32_expanded/model.onnx | ✅ |  |
+| node/test_less_equal_uint64/model.onnx | ✅ |  |
+| node/test_less_equal_uint64_expanded/model.onnx | ✅ |  |
+| node/test_less_equal_uint8/model.onnx | ✅ |  |
+| node/test_less_equal_uint8_expanded/model.onnx | ✅ |  |
+| node/test_less_int16/model.onnx | ✅ |  |
+| node/test_less_int8/model.onnx | ✅ |  |
+| node/test_less_uint16/model.onnx | ✅ |  |
+| node/test_less_uint32/model.onnx | ✅ |  |
+| node/test_less_uint64/model.onnx | ✅ |  |
+| node/test_less_uint8/model.onnx | ✅ |  |
 | node/test_log/model.onnx | ✅ |  |
 | node/test_log_example/model.onnx | ✅ |  |
 | node/test_logsoftmax_axis_0/model.onnx | ✅ |  |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -10,7 +10,6 @@
 | Reshape input and output element counts must match | 34 | ███████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████ |
 | Unsupported op CastLike | 31 | ██████ |
-| Unsupported op Less | 26 | █████ |
 | Unsupported op Cast | 22 | █████ |
 | Unsupported op LayerNormalization | 19 | ████ |
 | Unsupported op RMSNormalization | 19 | ████ |
@@ -21,7 +20,6 @@
 | Unsupported op ArgMin | 16 | ███ |
 | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 16 | ███ |
 | Unsupported op Clip | 16 | ███ |
-| Unsupported op Greater | 16 | ███ |
 | Unsupported op Trilu | 16 | ███ |
 | Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 14 | ███ |
 | Unsupported elem_type 26 (INT2) for tensor '*'. | 14 | ███ |
@@ -32,6 +30,7 @@
 | Unsupported op GatherElements | 14 | ███ |
 | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 12 | ██ |
 | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 12 | ██ |
+| Unsupported op Where | 12 | ██ |
 | Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 11 | ██ |
 | Unsupported op Pad | 11 | ██ |
 | Unsupported op Flatten | 11 | ██ |
@@ -46,9 +45,6 @@
 | ReduceSumSquare axes input must be constant | 9 | ██ |
 | Unsupported op BitShift | 8 | ██ |
 | Dropout supports only the data input and 1 or 2 outputs | 8 | ██ |
-| Unsupported op Equal | 8 | ██ |
-| Unsupported op GreaterOrEqual | 8 | ██ |
-| Unsupported op LessOrEqual | 8 | ██ |
 | Unsupported op LpPool | 8 | ██ |
 | Unsupported op Max | 8 | ██ |
 | Unsupported op Min | 8 | ██ |
@@ -154,7 +150,6 @@
 | Unsupported op Softsign | 2 | █ |
 | Unsupported op SpaceToDepth | 2 | █ |
 | Unsupported op STFT | 2 | █ |
-| Unsupported op Where | 2 | █ |
 | Unsupported op Gradient | 2 | █ |
 | Unsupported op ArrayFeatureExtractor | 1 | █ |
 | Unsupported op Binarizer | 1 | █ |

--- a/src/onnx2c/codegen/c_emitter.py
+++ b/src/onnx2c/codegen/c_emitter.py
@@ -18,6 +18,7 @@ class BinaryOp:
     operator_kind: str
     shape: tuple[int, ...]
     dtype: str
+    input_dtype: str
 
 
 @dataclass(frozen=True)
@@ -782,6 +783,7 @@ class CEmitter:
                 operator_kind=op.operator_kind,
                 shape=op.shape,
                 dtype=op.dtype,
+                input_dtype=op.input_dtype,
             )
         if isinstance(op, MatMulOp):
             return MatMulOp(
@@ -1151,6 +1153,8 @@ class CEmitter:
             loop_indents = CEmitter._loop_indents(shape)
             inner_indent = CEmitter._inner_indent(shape)
             array_suffix = CEmitter._array_suffix(shape)
+            input_c_type = dtype_info(op.input_dtype).c_type
+            output_c_type = dtype_info(op.dtype).c_type
             common = {
                 "model_name": model.name,
                 "op_name": f"{model.name}_op{index}",
@@ -1160,7 +1164,8 @@ class CEmitter:
                 "loop_vars": loop_vars,
                 "loop_indents": loop_indents,
                 "inner_indent": inner_indent,
-                "c_type": c_type,
+                "input_c_type": input_c_type,
+                "output_c_type": output_c_type,
                 "zero_literal": zero_literal,
             }
             left_expr = f"{op.input0}" + "".join(

--- a/src/onnx2c/ops.py
+++ b/src/onnx2c/ops.py
@@ -19,6 +19,11 @@ BINARY_OP_TYPES = {
     "Add",
     "And",
     "Div",
+    "Equal",
+    "Greater",
+    "GreaterOrEqual",
+    "Less",
+    "LessOrEqual",
     "Max",
     "Mean",
     "Min",
@@ -30,6 +35,14 @@ BINARY_OP_TYPES = {
     "Sub",
     "Sum",
     "Xor",
+}
+
+COMPARE_OP_TYPES = {
+    "Equal",
+    "Greater",
+    "GreaterOrEqual",
+    "Less",
+    "LessOrEqual",
 }
 
 UNARY_OP_TYPES = {
@@ -119,6 +132,14 @@ BINARY_SPECS_BOOL = {
     "And": BinaryOpSpec("&&", "infix", lambda left, right: np.logical_and(left, right)),
     "Or": BinaryOpSpec("||", "infix", lambda left, right: np.logical_or(left, right)),
     "Xor": BinaryOpSpec("!=", "infix", lambda left, right: np.logical_xor(left, right)),
+}
+
+COMPARE_SPECS = {
+    "Equal": BinaryOpSpec("==", "infix", np.equal),
+    "Greater": BinaryOpSpec(">", "infix", np.greater),
+    "GreaterOrEqual": BinaryOpSpec(">=", "infix", np.greater_equal),
+    "Less": BinaryOpSpec("<", "infix", np.less),
+    "LessOrEqual": BinaryOpSpec("<=", "infix", np.less_equal),
 }
 
 BINARY_SPECS_INT = {
@@ -217,6 +238,9 @@ UNARY_APPLY_FUNCS = {
 def binary_op_symbol(
     op_type: str, attrs: Mapping[str, object] | None = None, *, dtype: str
 ) -> BinaryOpSpec | None:
+    compare_spec = COMPARE_SPECS.get(op_type)
+    if compare_spec is not None:
+        return compare_spec
     specs = BINARY_SPECS_BY_DTYPE.get(dtype)
     if specs is not None:
         op_spec = specs.get(op_type)

--- a/templates/binary_op.c.j2
+++ b/templates/binary_op.c.j2
@@ -1,4 +1,4 @@
-void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ array_suffix }}, const {{ c_type }} {{ input1 }}{{ array_suffix }}, {{ c_type }} {{ output }}{{ array_suffix }}) {
+void {{ op_name }}(const {{ input_c_type }} {{ input0 }}{{ array_suffix }}, const {{ input_c_type }} {{ input1 }}{{ array_suffix }}, {{ output_c_type }} {{ output }}{{ array_suffix }}) {
 {% for dim in shape %}
 {{ loop_indents[loop.index0] }}for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -1877,7 +1877,7 @@
   ],
   [
     "node/test_clip_default_int8_max_expanded/model.onnx",
-    "Unsupported op Less"
+    "Unsupported op Where"
   ],
   [
     "node/test_clip_default_int8_min/model.onnx",
@@ -1885,7 +1885,7 @@
   ],
   [
     "node/test_clip_default_int8_min_expanded/model.onnx",
-    "Unsupported op Less"
+    "Unsupported op Where"
   ],
   [
     "node/test_clip_default_max/model.onnx",
@@ -1893,7 +1893,7 @@
   ],
   [
     "node/test_clip_default_max_expanded/model.onnx",
-    "Unsupported op Less"
+    "Unsupported op Where"
   ],
   [
     "node/test_clip_default_min/model.onnx",
@@ -1901,7 +1901,7 @@
   ],
   [
     "node/test_clip_default_min_expanded/model.onnx",
-    "Unsupported op Less"
+    "Unsupported op Where"
   ],
   [
     "node/test_clip_example/model.onnx",
@@ -1909,11 +1909,11 @@
   ],
   [
     "node/test_clip_example_expanded/model.onnx",
-    "Unsupported op Less"
+    "Unsupported op Where"
   ],
   [
     "node/test_clip_expanded/model.onnx",
-    "Unsupported op Less"
+    "Unsupported op Where"
   ],
   [
     "node/test_clip_inbounds/model.onnx",
@@ -1921,7 +1921,7 @@
   ],
   [
     "node/test_clip_inbounds_expanded/model.onnx",
-    "Unsupported op Less"
+    "Unsupported op Where"
   ],
   [
     "node/test_clip_min_greater_than_max/model.onnx",
@@ -1929,7 +1929,7 @@
   ],
   [
     "node/test_clip_min_greater_than_max_expanded/model.onnx",
-    "Unsupported op Less"
+    "Unsupported op Where"
   ],
   [
     "node/test_clip_outbounds/model.onnx",
@@ -1937,7 +1937,7 @@
   ],
   [
     "node/test_clip_outbounds_expanded/model.onnx",
-    "Unsupported op Less"
+    "Unsupported op Where"
   ],
   [
     "node/test_clip_splitbounds/model.onnx",
@@ -1945,7 +1945,7 @@
   ],
   [
     "node/test_clip_splitbounds_expanded/model.onnx",
-    "Unsupported op Less"
+    "Unsupported op Where"
   ],
   [
     "node/test_col2im/model.onnx",
@@ -2421,19 +2421,19 @@
   ],
   [
     "node/test_equal/model.onnx",
-    "Unsupported op Equal"
+    ""
   ],
   [
     "node/test_equal_bcast/model.onnx",
-    "Unsupported op Equal"
+    ""
   ],
   [
     "node/test_equal_int16/model.onnx",
-    "Unsupported op Equal"
+    ""
   ],
   [
     "node/test_equal_int8/model.onnx",
-    "Unsupported op Equal"
+    ""
   ],
   [
     "node/test_equal_string/model.onnx",
@@ -2445,19 +2445,19 @@
   ],
   [
     "node/test_equal_uint16/model.onnx",
-    "Unsupported op Equal"
+    ""
   ],
   [
     "node/test_equal_uint32/model.onnx",
-    "Unsupported op Equal"
+    ""
   ],
   [
     "node/test_equal_uint64/model.onnx",
-    "Unsupported op Equal"
+    ""
   ],
   [
     "node/test_equal_uint8/model.onnx",
-    "Unsupported op Equal"
+    ""
   ],
   [
     "node/test_erf/model.onnx",
@@ -2669,99 +2669,99 @@
   ],
   [
     "node/test_greater/model.onnx",
-    "Unsupported op Greater"
+    ""
   ],
   [
     "node/test_greater_bcast/model.onnx",
-    "Unsupported op Greater"
+    ""
   ],
   [
     "node/test_greater_equal/model.onnx",
-    "Unsupported op GreaterOrEqual"
+    ""
   ],
   [
     "node/test_greater_equal_bcast/model.onnx",
-    "Unsupported op GreaterOrEqual"
+    ""
   ],
   [
     "node/test_greater_equal_bcast_expanded/model.onnx",
-    "Unsupported op Greater"
+    ""
   ],
   [
     "node/test_greater_equal_expanded/model.onnx",
-    "Unsupported op Greater"
+    ""
   ],
   [
     "node/test_greater_equal_int16/model.onnx",
-    "Unsupported op GreaterOrEqual"
+    ""
   ],
   [
     "node/test_greater_equal_int16_expanded/model.onnx",
-    "Unsupported op Greater"
+    ""
   ],
   [
     "node/test_greater_equal_int8/model.onnx",
-    "Unsupported op GreaterOrEqual"
+    ""
   ],
   [
     "node/test_greater_equal_int8_expanded/model.onnx",
-    "Unsupported op Greater"
+    ""
   ],
   [
     "node/test_greater_equal_uint16/model.onnx",
-    "Unsupported op GreaterOrEqual"
+    ""
   ],
   [
     "node/test_greater_equal_uint16_expanded/model.onnx",
-    "Unsupported op Greater"
+    ""
   ],
   [
     "node/test_greater_equal_uint32/model.onnx",
-    "Unsupported op GreaterOrEqual"
+    ""
   ],
   [
     "node/test_greater_equal_uint32_expanded/model.onnx",
-    "Unsupported op Greater"
+    ""
   ],
   [
     "node/test_greater_equal_uint64/model.onnx",
-    "Unsupported op GreaterOrEqual"
+    ""
   ],
   [
     "node/test_greater_equal_uint64_expanded/model.onnx",
-    "Unsupported op Greater"
+    ""
   ],
   [
     "node/test_greater_equal_uint8/model.onnx",
-    "Unsupported op GreaterOrEqual"
+    ""
   ],
   [
     "node/test_greater_equal_uint8_expanded/model.onnx",
-    "Unsupported op Greater"
+    ""
   ],
   [
     "node/test_greater_int16/model.onnx",
-    "Unsupported op Greater"
+    ""
   ],
   [
     "node/test_greater_int8/model.onnx",
-    "Unsupported op Greater"
+    ""
   ],
   [
     "node/test_greater_uint16/model.onnx",
-    "Unsupported op Greater"
+    ""
   ],
   [
     "node/test_greater_uint32/model.onnx",
-    "Unsupported op Greater"
+    ""
   ],
   [
     "node/test_greater_uint64/model.onnx",
-    "Unsupported op Greater"
+    ""
   ],
   [
     "node/test_greater_uint8/model.onnx",
-    "Unsupported op Greater"
+    ""
   ],
   [
     "node/test_gridsample/model.onnx",
@@ -3325,99 +3325,99 @@
   ],
   [
     "node/test_less/model.onnx",
-    "Unsupported op Less"
+    ""
   ],
   [
     "node/test_less_bcast/model.onnx",
-    "Unsupported op Less"
+    ""
   ],
   [
     "node/test_less_equal/model.onnx",
-    "Unsupported op LessOrEqual"
+    ""
   ],
   [
     "node/test_less_equal_bcast/model.onnx",
-    "Unsupported op LessOrEqual"
+    ""
   ],
   [
     "node/test_less_equal_bcast_expanded/model.onnx",
-    "Unsupported op Less"
+    ""
   ],
   [
     "node/test_less_equal_expanded/model.onnx",
-    "Unsupported op Less"
+    ""
   ],
   [
     "node/test_less_equal_int16/model.onnx",
-    "Unsupported op LessOrEqual"
+    ""
   ],
   [
     "node/test_less_equal_int16_expanded/model.onnx",
-    "Unsupported op Less"
+    ""
   ],
   [
     "node/test_less_equal_int8/model.onnx",
-    "Unsupported op LessOrEqual"
+    ""
   ],
   [
     "node/test_less_equal_int8_expanded/model.onnx",
-    "Unsupported op Less"
+    ""
   ],
   [
     "node/test_less_equal_uint16/model.onnx",
-    "Unsupported op LessOrEqual"
+    ""
   ],
   [
     "node/test_less_equal_uint16_expanded/model.onnx",
-    "Unsupported op Less"
+    ""
   ],
   [
     "node/test_less_equal_uint32/model.onnx",
-    "Unsupported op LessOrEqual"
+    ""
   ],
   [
     "node/test_less_equal_uint32_expanded/model.onnx",
-    "Unsupported op Less"
+    ""
   ],
   [
     "node/test_less_equal_uint64/model.onnx",
-    "Unsupported op LessOrEqual"
+    ""
   ],
   [
     "node/test_less_equal_uint64_expanded/model.onnx",
-    "Unsupported op Less"
+    ""
   ],
   [
     "node/test_less_equal_uint8/model.onnx",
-    "Unsupported op LessOrEqual"
+    ""
   ],
   [
     "node/test_less_equal_uint8_expanded/model.onnx",
-    "Unsupported op Less"
+    ""
   ],
   [
     "node/test_less_int16/model.onnx",
-    "Unsupported op Less"
+    ""
   ],
   [
     "node/test_less_int8/model.onnx",
-    "Unsupported op Less"
+    ""
   ],
   [
     "node/test_less_uint16/model.onnx",
-    "Unsupported op Less"
+    ""
   ],
   [
     "node/test_less_uint32/model.onnx",
-    "Unsupported op Less"
+    ""
   ],
   [
     "node/test_less_uint64/model.onnx",
-    "Unsupported op Less"
+    ""
   ],
   [
     "node/test_less_uint8/model.onnx",
-    "Unsupported op Less"
+    ""
   ],
   [
     "node/test_log/model.onnx",


### PR DESCRIPTION
### Motivation

- Add full support for ONNX compare operators (`Equal`, `Greater`, `GreaterOrEqual`, `Less`, `LessOrEqual`) so they can be lowered, evaluated, and emitted in generated C code. 
- Ensure compare ops produce `bool` outputs while accepting non-bool typed inputs and remain deterministic in codegen.

### Description

- Introduce `COMPARE_OP_TYPES` and `COMPARE_SPECS` and return compare specs in `binary_op_symbol` to map compare ops to operator symbols and NumPy apply functions. 
- Extend lowering to recognize compare ops, validate input/output dtypes/shapes, and surface a `BinaryOp` with a distinct `input_dtype` and `dtype` (bool) for codegen. 
- Update runtime evaluator to evaluate compare ops using the input dtype via `apply_binary_op`, and update codegen (`BinaryOp` dataclass, emitter logic, and `templates/binary_op.c.j2`) to generate correct C signatures when input and output types differ. 
- Add end-to-end tests (`_make_compare_model`, `COMPARE_CASES`, and `test_compare_ops_match_onnxruntime`) and refresh official ONNX support golden references (`tests/official_onnx_expected_errors.json`, `OFFICIAL_ONNX_FILE_SUPPORT.md`, and histogram) to reflect newly supported compare ops.

### Testing

- Ran targeted compare tests with `pytest tests/test_endtoend_ops.py -k compare -q`, which passed (5 passed, 76 deselected) in `6.72s`.
- Ran the full suite with refreshed references using `UPDATE_REFS=1 pytest -n auto -q`, which completed successfully (`121 passed`) in `19.91s` and updated the official ONNX support artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6964cd438a6083259fa23ded59187a2a)