### PR TITLE
lowering: allow empty reduce axes inputs

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 488 / 1802 official ONNX files.
+Support 507 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -1113,10 +1113,10 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_range_int32_type_negative_delta_expanded/model.onnx | ❌ | Unsupported op Cast |
 | node/test_reciprocal/model.onnx | ❌ | Unsupported op Reciprocal |
 | node/test_reciprocal_example/model.onnx | ❌ | Unsupported op Reciprocal |
-| node/test_reduce_l1_default_axes_keepdims_example/model.onnx | ❌ | ReduceL1 axes input must be constant |
-| node/test_reduce_l1_default_axes_keepdims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_l1_default_axes_keepdims_random/model.onnx | ❌ | ReduceL1 axes input must be constant |
-| node/test_reduce_l1_default_axes_keepdims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
+| node/test_reduce_l1_default_axes_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_l1_default_axes_keepdims_example_expanded/model.onnx | ✅ |  |
+| node/test_reduce_l1_default_axes_keepdims_random/model.onnx | ✅ |  |
+| node/test_reduce_l1_default_axes_keepdims_random_expanded/model.onnx | ✅ |  |
 | node/test_reduce_l1_do_not_keepdims_example/model.onnx | ❌ | ReduceL1 axes input must be constant |
 | node/test_reduce_l1_do_not_keepdims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
 | node/test_reduce_l1_do_not_keepdims_random/model.onnx | ❌ | ReduceL1 axes input must be constant |
@@ -1131,10 +1131,10 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_l1_negative_axes_keep_dims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
 | node/test_reduce_l1_negative_axes_keep_dims_random/model.onnx | ❌ | ReduceL1 axes input must be constant |
 | node/test_reduce_l1_negative_axes_keep_dims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_l2_default_axes_keepdims_example/model.onnx | ❌ | ReduceL2 axes input must be constant |
-| node/test_reduce_l2_default_axes_keepdims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_l2_default_axes_keepdims_random/model.onnx | ❌ | ReduceL2 axes input must be constant |
-| node/test_reduce_l2_default_axes_keepdims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
+| node/test_reduce_l2_default_axes_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_l2_default_axes_keepdims_example_expanded/model.onnx | ❌ | ReduceSum output shape must be (1, 1, 1), got () |
+| node/test_reduce_l2_default_axes_keepdims_random/model.onnx | ✅ |  |
+| node/test_reduce_l2_default_axes_keepdims_random_expanded/model.onnx | ❌ | ReduceSum output shape must be (1, 1, 1), got () |
 | node/test_reduce_l2_do_not_keepdims_example/model.onnx | ❌ | ReduceL2 axes input must be constant |
 | node/test_reduce_l2_do_not_keepdims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
 | node/test_reduce_l2_do_not_keepdims_random/model.onnx | ❌ | ReduceL2 axes input must be constant |
@@ -1151,15 +1151,15 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_l2_negative_axes_keep_dims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
 | node/test_reduce_log_sum_asc_axes/model.onnx | ❌ | ReduceLogSum axes input must be constant |
 | node/test_reduce_log_sum_asc_axes_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_log_sum_default/model.onnx | ❌ | ReduceLogSum axes input must be constant |
-| node/test_reduce_log_sum_default_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
+| node/test_reduce_log_sum_default/model.onnx | ✅ |  |
+| node/test_reduce_log_sum_default_expanded/model.onnx | ❌ | ReduceSum output shape must be (1, 1, 1), got () |
 | node/test_reduce_log_sum_desc_axes/model.onnx | ❌ | ReduceLogSum axes input must be constant |
 | node/test_reduce_log_sum_desc_axes_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
 | node/test_reduce_log_sum_empty_set/model.onnx | ❌ | ReduceLogSum axes input must be constant |
 | node/test_reduce_log_sum_empty_set_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_log_sum_exp_default_axes_keepdims_example/model.onnx | ❌ | ReduceLogSumExp axes input must be constant |
+| node/test_reduce_log_sum_exp_default_axes_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_exp_default_axes_keepdims_example_expanded/model.onnx | ❌ | Unsupported op Cast |
-| node/test_reduce_log_sum_exp_default_axes_keepdims_random/model.onnx | ❌ | ReduceLogSumExp axes input must be constant |
+| node/test_reduce_log_sum_exp_default_axes_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_exp_default_axes_keepdims_random_expanded/model.onnx | ❌ | Unsupported op Cast |
 | node/test_reduce_log_sum_exp_do_not_keepdims_example/model.onnx | ❌ | ReduceLogSumExp axes input must be constant |
 | node/test_reduce_log_sum_exp_do_not_keepdims_example_expanded/model.onnx | ❌ | Unsupported op Cast |
@@ -1187,8 +1187,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_max_keepdims_random/model.onnx | ❌ | ReduceMax axes input must be constant |
 | node/test_reduce_max_negative_axes_keepdims_example/model.onnx | ❌ | ReduceMax axes input must be constant |
 | node/test_reduce_max_negative_axes_keepdims_random/model.onnx | ❌ | ReduceMax axes input must be constant |
-| node/test_reduce_mean_default_axes_keepdims_example/model.onnx | ❌ | ReduceMean axes input must be constant |
-| node/test_reduce_mean_default_axes_keepdims_random/model.onnx | ❌ | ReduceMean axes input must be constant |
+| node/test_reduce_mean_default_axes_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_mean_default_axes_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_mean_do_not_keepdims_example/model.onnx | ❌ | ReduceMean axes input must be constant |
 | node/test_reduce_mean_do_not_keepdims_random/model.onnx | ❌ | ReduceMean axes input must be constant |
 | node/test_reduce_mean_keepdims_example/model.onnx | ❌ | ReduceMean axes input must be constant |
@@ -1214,22 +1214,22 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_prod_keepdims_random/model.onnx | ❌ | ReduceProd axes input must be constant |
 | node/test_reduce_prod_negative_axes_keepdims_example/model.onnx | ❌ | ReduceProd axes input must be constant |
 | node/test_reduce_prod_negative_axes_keepdims_random/model.onnx | ❌ | ReduceProd axes input must be constant |
-| node/test_reduce_sum_default_axes_keepdims_example/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_sum_default_axes_keepdims_random/model.onnx | ❌ | ReduceSum axes input must be constant |
+| node/test_reduce_sum_default_axes_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_sum_default_axes_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_sum_do_not_keepdims_example/model.onnx | ❌ | ReduceSum axes input must be constant |
 | node/test_reduce_sum_do_not_keepdims_random/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_sum_empty_axes_input_noop/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_sum_empty_axes_input_noop_example/model.onnx | ❌ | ReduceSum axes input must be constant |
+| node/test_reduce_sum_empty_axes_input_noop/model.onnx | ✅ |  |
+| node/test_reduce_sum_empty_axes_input_noop_example/model.onnx | ✅ |  |
 | node/test_reduce_sum_empty_set/model.onnx | ❌ | ReduceSum axes input must be constant |
 | node/test_reduce_sum_empty_set_non_reduced_axis_zero/model.onnx | ❌ | Dynamic or zero dims are not supported |
 | node/test_reduce_sum_keepdims_example/model.onnx | ❌ | ReduceSum axes input must be constant |
 | node/test_reduce_sum_keepdims_random/model.onnx | ❌ | ReduceSum axes input must be constant |
 | node/test_reduce_sum_negative_axes_keepdims_example/model.onnx | ❌ | ReduceSum axes input must be constant |
 | node/test_reduce_sum_negative_axes_keepdims_random/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_sum_square_default_axes_keepdims_example/model.onnx | ❌ | ReduceSumSquare axes input must be constant |
-| node/test_reduce_sum_square_default_axes_keepdims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_sum_square_default_axes_keepdims_random/model.onnx | ❌ | ReduceSumSquare axes input must be constant |
-| node/test_reduce_sum_square_default_axes_keepdims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
+| node/test_reduce_sum_square_default_axes_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_sum_square_default_axes_keepdims_example_expanded/model.onnx | ✅ |  |
+| node/test_reduce_sum_square_default_axes_keepdims_random/model.onnx | ✅ |  |
+| node/test_reduce_sum_square_default_axes_keepdims_random_expanded/model.onnx | ✅ |  |
 | node/test_reduce_sum_square_do_not_keepdims_example/model.onnx | ❌ | ReduceSumSquare axes input must be constant |
 | node/test_reduce_sum_square_do_not_keepdims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
 | node/test_reduce_sum_square_do_not_keepdims_random/model.onnx | ❌ | ReduceSumSquare axes input must be constant |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -4,11 +4,11 @@
 | --- | --- | --- |
 | Dynamic dim for tensor '*' | 146 | ██████████████████████████████ |
 | Unsupported elem_type 10 (FLOAT16) for tensor '*'. | 65 | █████████████ |
-| ReduceSum axes input must be constant | 43 | █████████ |
 | Missing elem_type for tensor '*' | 34 | ███████ |
 | Unsupported op SoftmaxCrossEntropyLoss | 34 | ███████ |
 | Reshape input and output element counts must match | 34 | ███████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████ |
+| ReduceSum axes input must be constant | 32 | ███████ |
 | Unsupported op CastLike | 31 | ██████ |
 | Unsupported op Cast | 22 | █████ |
 | Unsupported op LayerNormalization | 19 | ████ |
@@ -39,22 +39,21 @@
 | Unsupported op CumSum | 9 | ██ |
 | Unsupported op ImageDecoder | 9 | ██ |
 | Unsupported op NonMaxSuppression | 9 | ██ |
-| ReduceL1 axes input must be constant | 9 | ██ |
-| ReduceL2 axes input must be constant | 9 | ██ |
-| ReduceLogSumExp axes input must be constant | 9 | ██ |
-| ReduceSumSquare axes input must be constant | 9 | ██ |
 | Unsupported op BitShift | 8 | ██ |
 | Dropout supports only the data input and 1 or 2 outputs | 8 | ██ |
 | Unsupported op LpPool | 8 | ██ |
 | Unsupported op Max | 8 | ██ |
 | Unsupported op Min | 8 | ██ |
-| ReduceMean axes input must be constant | 8 | ██ |
 | Unsupported op RotaryEmbedding | 8 | ██ |
 | Unsupported op Slice | 8 | ██ |
 | Unsupported op Hardmax | 7 | █ |
+| ReduceL1 axes input must be constant | 7 | █ |
+| ReduceL2 axes input must be constant | 7 | █ |
+| ReduceLogSumExp axes input must be constant | 7 | █ |
 | ReduceMax axes input must be constant | 7 | █ |
 | ReduceMin axes input must be constant | 7 | █ |
 | ReduceProd axes input must be constant | 7 | █ |
+| ReduceSumSquare axes input must be constant | 7 | █ |
 | Unsupported op TfIdfVectorizer | 7 | █ |
 | Unsupported op TopK | 7 | █ |
 | AveragePool has unsupported attributes | 6 | █ |
@@ -67,6 +66,7 @@
 | Unsupported op Gather | 6 | █ |
 | Unsupported op LpNormalization | 6 | █ |
 | Unsupported op QuantizeLinear | 6 | █ |
+| ReduceMean axes input must be constant | 6 | █ |
 | Unsupported op ScatterElements | 6 | █ |
 | Unsupported op Unique | 6 | █ |
 | AveragePool expects 2D kernel_shape | 5 | █ |
@@ -74,7 +74,6 @@
 | Unsupported op Col2Im | 5 | █ |
 | Unsupported op DequantizeLinear | 5 | █ |
 | Unsupported op LeakyRelu | 5 | █ |
-| ReduceLogSum axes input must be constant | 5 | █ |
 | Unsupported op ScatterND | 5 | █ |
 | Unsupported op Selu | 5 | █ |
 | Unsupported op Sigmoid | 5 | █ |
@@ -92,6 +91,7 @@
 | Unsupported op OneHot | 4 | █ |
 | Unsupported op OptionalHasElement | 4 | █ |
 | Unsupported op QLinearMatMul | 4 | █ |
+| ReduceLogSum axes input must be constant | 4 | █ |
 | Unsupported op RNN | 4 | █ |
 | Unsupported op Squeeze | 4 | █ |
 | Unsupported op Tile | 4 | █ |
@@ -107,6 +107,7 @@
 | Unsupported op InstanceNormalization | 3 | █ |
 | Unsupported op IsInf | 3 | █ |
 | Unsupported op Momentum | 3 | █ |
+| ReduceSum output shape must be (1, 1, 1), got () | 3 | █ |
 | Unsupported op RoiAlign | 3 | █ |
 | Unsupported op Shrink | 3 | █ |
 | Sum must have 2 inputs and 1 output | 3 | █ |

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -4421,19 +4421,19 @@
   ],
   [
     "node/test_reduce_l1_default_axes_keepdims_example/model.onnx",
-    "ReduceL1 axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_l1_default_axes_keepdims_example_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_l1_default_axes_keepdims_random/model.onnx",
-    "ReduceL1 axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_l1_default_axes_keepdims_random_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_l1_do_not_keepdims_example/model.onnx",
@@ -4493,19 +4493,19 @@
   ],
   [
     "node/test_reduce_l2_default_axes_keepdims_example/model.onnx",
-    "ReduceL2 axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_l2_default_axes_keepdims_example_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "ReduceSum output shape must be (1, 1, 1), got ()"
   ],
   [
     "node/test_reduce_l2_default_axes_keepdims_random/model.onnx",
-    "ReduceL2 axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_l2_default_axes_keepdims_random_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "ReduceSum output shape must be (1, 1, 1), got ()"
   ],
   [
     "node/test_reduce_l2_do_not_keepdims_example/model.onnx",
@@ -4573,11 +4573,11 @@
   ],
   [
     "node/test_reduce_log_sum_default/model.onnx",
-    "ReduceLogSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_log_sum_default_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "ReduceSum output shape must be (1, 1, 1), got ()"
   ],
   [
     "node/test_reduce_log_sum_desc_axes/model.onnx",
@@ -4597,7 +4597,7 @@
   ],
   [
     "node/test_reduce_log_sum_exp_default_axes_keepdims_example/model.onnx",
-    "ReduceLogSumExp axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_log_sum_exp_default_axes_keepdims_example_expanded/model.onnx",
@@ -4605,7 +4605,7 @@
   ],
   [
     "node/test_reduce_log_sum_exp_default_axes_keepdims_random/model.onnx",
-    "ReduceLogSumExp axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_log_sum_exp_default_axes_keepdims_random_expanded/model.onnx",
@@ -4717,11 +4717,11 @@
   ],
   [
     "node/test_reduce_mean_default_axes_keepdims_example/model.onnx",
-    "ReduceMean axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_mean_default_axes_keepdims_random/model.onnx",
-    "ReduceMean axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_mean_do_not_keepdims_example/model.onnx",
@@ -4825,11 +4825,11 @@
   ],
   [
     "node/test_reduce_sum_default_axes_keepdims_example/model.onnx",
-    "ReduceSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_sum_default_axes_keepdims_random/model.onnx",
-    "ReduceSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_sum_do_not_keepdims_example/model.onnx",
@@ -4841,11 +4841,11 @@
   ],
   [
     "node/test_reduce_sum_empty_axes_input_noop/model.onnx",
-    "ReduceSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_sum_empty_axes_input_noop_example/model.onnx",
-    "ReduceSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_sum_empty_set/model.onnx",
@@ -4873,19 +4873,19 @@
   ],
   [
     "node/test_reduce_sum_square_default_axes_keepdims_example/model.onnx",
-    "ReduceSumSquare axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_sum_square_default_axes_keepdims_example_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_sum_square_default_axes_keepdims_random/model.onnx",
-    "ReduceSumSquare axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_sum_square_default_axes_keepdims_random_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_sum_square_do_not_keepdims_example/model.onnx",


### PR DESCRIPTION
### Motivation
- Avoid spurious "axes input must be constant" errors when ONNX represents an absent optional Reduce axes input as an empty string or as a non-initializer input with zero elements.
- Make lowering deterministic and tolerant of ONNX export quirks that surface in official ONNX tests (empty axes inputs represented via shape metadata). 
- Refresh the official ONNX expectations and support documentation to reflect the newly accepted cases.

### Description
- In `_axes_from_initializer` treat `node.inputs[1] == ""` as absent and return `None` instead of erroring. 
- For non-initializer axes inputs call `graph.find_value` and accept `int32`/`int64` typed values, returning `()` when the value has a zero-element shape, otherwise raising `UnsupportedOpError` if the axes are not constant. 
- Preserve existing initializer handling (dtype checks and converting initializer data to a tuple of ints). 
- Updated `tests/official_onnx_expected_errors.json`, `OFFICIAL_ONNX_FILE_SUPPORT.md`, and `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md` to refresh expectations and support counts.

### Testing
- Ran `UPDATE_REFS=1 pytest -n auto -q` to refresh references and execute the test suite. 
- All automated tests passed: `121 passed` (about `25.22s`).
- Official ONNX expectation files were refreshed to reflect the newly supported Reduce cases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6964d2e6476083258334b93937c071a6)