### PR TITLE
lowering: resolve Reshape target shapes from Shape nodes and update validation

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1376,73 +1376,73 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_scatternd_min/model.onnx | ❌ | Unsupported op ScatterND |
 | node/test_scatternd_multiply/model.onnx | ❌ | Unsupported op ScatterND |
 | node/test_sce_NCd1_mean_weight_negative_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx | ❌ | Unsupported op NegativeLogLikelihoodLoss |
 | node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
 | node/test_sce_NCd1d2d3_none_no_weight_negative_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx | ❌ | Unsupported op NegativeLogLikelihoodLoss |
 | node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
 | node/test_sce_NCd1d2d3_sum_weight_high_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx | ❌ | Unsupported op NegativeLogLikelihoodLoss |
 | node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
 | node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx | ❌ | Unsupported op NegativeLogLikelihoodLoss |
 | node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
 | node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx | ❌ | Unsupported op NegativeLogLikelihoodLoss |
 | node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
 | node/test_sce_mean/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
 | node/test_sce_mean_3d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_3d_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_mean_3d_expanded/model.onnx | ❌ | Unsupported op NegativeLogLikelihoodLoss |
 | node/test_sce_mean_3d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_3d_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
-| node/test_sce_mean_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_mean_3d_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
+| node/test_sce_mean_expanded/model.onnx | ❌ | Unsupported op NegativeLogLikelihoodLoss |
 | node/test_sce_mean_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_mean_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
 | node/test_sce_mean_no_weight_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
 | node/test_sce_mean_no_weight_ii_3d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_no_weight_ii_3d_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_mean_no_weight_ii_3d_expanded/model.onnx | ❌ | Unsupported op NegativeLogLikelihoodLoss |
 | node/test_sce_mean_no_weight_ii_3d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
 | node/test_sce_mean_no_weight_ii_4d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_no_weight_ii_4d_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_mean_no_weight_ii_4d_expanded/model.onnx | ❌ | Unsupported op NegativeLogLikelihoodLoss |
 | node/test_sce_mean_no_weight_ii_4d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
-| node/test_sce_mean_no_weight_ii_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
+| node/test_sce_mean_no_weight_ii_expanded/model.onnx | ❌ | Unsupported op NegativeLogLikelihoodLoss |
 | node/test_sce_mean_no_weight_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
 | node/test_sce_mean_weight/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_mean_weight_expanded/model.onnx | ❌ | Unsupported op NegativeLogLikelihoodLoss |
 | node/test_sce_mean_weight_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
 | node/test_sce_mean_weight_ii_3d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_ii_3d_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_mean_weight_ii_3d_expanded/model.onnx | ❌ | Unsupported op NegativeLogLikelihoodLoss |
 | node/test_sce_mean_weight_ii_3d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
 | node/test_sce_mean_weight_ii_4d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_ii_4d_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_mean_weight_ii_4d_expanded/model.onnx | ❌ | Unsupported op NegativeLogLikelihoodLoss |
 | node/test_sce_mean_weight_ii_4d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
-| node/test_sce_mean_weight_ii_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
+| node/test_sce_mean_weight_ii_expanded/model.onnx | ❌ | Unsupported op NegativeLogLikelihoodLoss |
 | node/test_sce_mean_weight_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
 | node/test_sce_mean_weight_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_mean_weight_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
 | node/test_sce_none/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_none_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_none_expanded/model.onnx | ❌ | Unsupported op NegativeLogLikelihoodLoss |
 | node/test_sce_none_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_none_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_none_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
 | node/test_sce_none_weights/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_none_weights_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_none_weights_expanded/model.onnx | ❌ | Unsupported op NegativeLogLikelihoodLoss |
 | node/test_sce_none_weights_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_none_weights_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_none_weights_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
 | node/test_sce_sum/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_sum_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_sum_expanded/model.onnx | ❌ | Unsupported op NegativeLogLikelihoodLoss |
 | node/test_sce_sum_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_sum_log_prob_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
+| node/test_sce_sum_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
 | node/test_selu/model.onnx | ❌ | Unsupported op Selu |
 | node/test_selu_default/model.onnx | ❌ | Unsupported op Selu |
 | node/test_selu_default_expanded_ver18/model.onnx | ❌ | Unsupported op CastLike |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -4,17 +4,17 @@
 | --- | --- | --- |
 | Dynamic dim for tensor '*' | 146 | ██████████████████████████████ |
 | Unsupported elem_type 10 (FLOAT16) for tensor '*'. | 65 | █████████████ |
+| Unsupported op NegativeLogLikelihoodLoss | 35 | ███████ |
 | Missing elem_type for tensor '*' | 34 | ███████ |
 | Unsupported op SoftmaxCrossEntropyLoss | 34 | ███████ |
-| Reshape input and output element counts must match | 34 | ███████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████ |
 | ReduceSum axes input must be constant | 32 | ███████ |
 | Unsupported op CastLike | 31 | ██████ |
 | Unsupported op Cast | 22 | █████ |
+| Unsupported op Identity | 20 | ████ |
 | Unsupported op LayerNormalization | 19 | ████ |
 | Unsupported op RMSNormalization | 19 | ████ |
 | Unsupported op GridSample | 18 | ████ |
-| Unsupported op NegativeLogLikelihoodLoss | 18 | ████ |
 | Unsupported op Split | 17 | ███ |
 | Unsupported op ArgMax | 16 | ███ |
 | Unsupported op ArgMin | 16 | ███ |
@@ -100,7 +100,6 @@
 | Unsupported op RandomUniformLike | 3 | █ |
 | Unsupported op BitwiseNot | 3 | █ |
 | Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 3 | █ |
-| Unsupported op Identity | 3 | █ |
 | Unsupported op DynamicQuantizeLinear | 3 | █ |
 | Unsupported op EyeLike | 3 | █ |
 | Unsupported op GatherND | 3 | █ |

--- a/src/onnx2c/lowering/reshape.py
+++ b/src/onnx2c/lowering/reshape.py
@@ -29,8 +29,8 @@ def _value_dtype(graph: Graph, name: str, node: Node) -> str:
 def _shape_product(shape: tuple[int, ...]) -> int:
     product = 1
     for dim in shape:
-        if dim <= 0:
-            raise ShapeInferenceError("Dynamic or zero dims are not supported")
+        if dim < 0:
+            raise ShapeInferenceError("Dynamic dims are not supported")
         product *= dim
     return product
 
@@ -40,6 +40,25 @@ def _find_initializer(graph: Graph, name: str) -> Initializer | None:
         if initializer.name == name:
             return initializer
     return None
+
+
+def _find_node_by_output(graph: Graph, name: str) -> Node | None:
+    for node in graph.nodes:
+        if name in node.outputs:
+            return node
+    return None
+
+
+def _shape_values_from_shape_node(
+    graph: Graph, name: str, node: Node
+) -> list[int] | None:
+    shape_node = _find_node_by_output(graph, name)
+    if shape_node is None or shape_node.op_type != "Shape":
+        return None
+    if len(shape_node.inputs) != 1 or len(shape_node.outputs) != 1:
+        raise UnsupportedOpError("Shape must have 1 input and 1 output")
+    source_shape = _value_shape(graph, shape_node.inputs[0], node)
+    return list(source_shape)
 
 
 def _resolve_target_shape(
@@ -62,17 +81,14 @@ def _resolve_target_shape(
             output_dims.append(-1)
             continue
         if dim == 0:
-            if allowzero == 1:
-                raise ShapeInferenceError("Reshape does not support zero dims")
-            if index >= len(input_shape):
-                raise ShapeInferenceError(
-                    "Reshape zero dim must index into input shape"
-                )
-            dim = input_shape[index]
+            if allowzero == 0:
+                if index >= len(input_shape):
+                    raise ShapeInferenceError(
+                        "Reshape zero dim must index into input shape"
+                    )
+                dim = input_shape[index]
         if dim < 0:
-            raise ShapeInferenceError(
-                "Reshape dims must be >= -1 when allowzero=0"
-            )
+            raise ShapeInferenceError("Reshape dims must be >= -1")
         output_dims.append(dim)
         known_product *= dim
     input_product = _shape_product(input_shape)
@@ -95,10 +111,6 @@ def lower_reshape(graph: Graph, node: Node) -> ReshapeOp:
     if len(node.inputs) != 2 or len(node.outputs) != 1:
         raise UnsupportedOpError("Reshape must have 2 inputs and 1 output")
     input_shape = _value_shape(graph, node.inputs[0], node)
-    output_shape = _value_shape(graph, node.outputs[0], node)
-    for dim in output_shape:
-        if dim <= 0:
-            raise ShapeInferenceError("Dynamic or zero dims are not supported")
     input_dtype = _value_dtype(graph, node.inputs[0], node)
     output_dtype = _value_dtype(graph, node.outputs[0], node)
     if input_dtype != output_dtype:
@@ -106,12 +118,26 @@ def lower_reshape(graph: Graph, node: Node) -> ReshapeOp:
             "Reshape expects matching input/output dtypes, "
             f"got {input_dtype} and {output_dtype}"
         )
+    output_shape = _value_shape(graph, node.outputs[0], node)
+    allowzero = int(node.attrs.get("allowzero", 0))
     shape_initializer = _find_initializer(graph, node.inputs[1])
+    resolved_shape: tuple[int, ...] | None = None
     if shape_initializer is None:
-        if _shape_product(output_shape) != _shape_product(input_shape):
-            raise ShapeInferenceError(
-                "Reshape input and output element counts must match"
+        shape_values = _shape_values_from_shape_node(
+            graph, node.inputs[1], node
+        )
+        if shape_values is not None:
+            resolved_shape = _resolve_target_shape(
+                input_shape,
+                shape_values,
+                allowzero=allowzero,
+                node=node,
             )
+        else:
+            if _shape_product(output_shape) != _shape_product(input_shape):
+                raise ShapeInferenceError(
+                    "Reshape input and output element counts must match"
+                )
     else:
         if shape_initializer.type.dtype not in {"int64", "int32"}:
             raise UnsupportedOpError(
@@ -124,14 +150,19 @@ def lower_reshape(graph: Graph, node: Node) -> ReshapeOp:
         resolved_shape = _resolve_target_shape(
             input_shape,
             shape_values,
-            allowzero=int(node.attrs.get("allowzero", 0)),
+            allowzero=allowzero,
             node=node,
         )
-        if resolved_shape != output_shape:
+        if output_shape and resolved_shape != output_shape:
             raise ShapeInferenceError(
                 "Reshape output shape must be "
                 f"{resolved_shape}, got {output_shape}"
             )
+    if resolved_shape is not None:
+        output_shape = resolved_shape
+    for dim in output_shape:
+        if dim < 0:
+            raise ShapeInferenceError("Dynamic dims are not supported")
     return ReshapeOp(
         input0=node.inputs[0],
         output=node.outputs[0],

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -5473,7 +5473,7 @@
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op NegativeLogLikelihoodLoss"
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx",
@@ -5481,7 +5481,7 @@
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op Identity"
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii/model.onnx",
@@ -5489,7 +5489,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op NegativeLogLikelihoodLoss"
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob/model.onnx",
@@ -5497,7 +5497,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op Identity"
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii/model.onnx",
@@ -5505,7 +5505,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op NegativeLogLikelihoodLoss"
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob/model.onnx",
@@ -5513,7 +5513,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op Identity"
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx",
@@ -5521,7 +5521,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op NegativeLogLikelihoodLoss"
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx",
@@ -5529,7 +5529,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op Identity"
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx",
@@ -5537,7 +5537,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op NegativeLogLikelihoodLoss"
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx",
@@ -5545,7 +5545,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op Identity"
   ],
   [
     "node/test_sce_mean/model.onnx",
@@ -5557,7 +5557,7 @@
   ],
   [
     "node/test_sce_mean_3d_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op NegativeLogLikelihoodLoss"
   ],
   [
     "node/test_sce_mean_3d_log_prob/model.onnx",
@@ -5565,11 +5565,11 @@
   ],
   [
     "node/test_sce_mean_3d_log_prob_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op Identity"
   ],
   [
     "node/test_sce_mean_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op NegativeLogLikelihoodLoss"
   ],
   [
     "node/test_sce_mean_log_prob/model.onnx",
@@ -5577,7 +5577,7 @@
   ],
   [
     "node/test_sce_mean_log_prob_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op Identity"
   ],
   [
     "node/test_sce_mean_no_weight_ii/model.onnx",
@@ -5589,7 +5589,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op NegativeLogLikelihoodLoss"
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_log_prob/model.onnx",
@@ -5597,7 +5597,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op Identity"
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d/model.onnx",
@@ -5605,7 +5605,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op NegativeLogLikelihoodLoss"
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_log_prob/model.onnx",
@@ -5613,11 +5613,11 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op Identity"
   ],
   [
     "node/test_sce_mean_no_weight_ii_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op NegativeLogLikelihoodLoss"
   ],
   [
     "node/test_sce_mean_no_weight_ii_log_prob/model.onnx",
@@ -5625,7 +5625,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op Identity"
   ],
   [
     "node/test_sce_mean_weight/model.onnx",
@@ -5633,7 +5633,7 @@
   ],
   [
     "node/test_sce_mean_weight_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op NegativeLogLikelihoodLoss"
   ],
   [
     "node/test_sce_mean_weight_ii/model.onnx",
@@ -5645,7 +5645,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_3d_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op NegativeLogLikelihoodLoss"
   ],
   [
     "node/test_sce_mean_weight_ii_3d_log_prob/model.onnx",
@@ -5653,7 +5653,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op Identity"
   ],
   [
     "node/test_sce_mean_weight_ii_4d/model.onnx",
@@ -5661,7 +5661,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_4d_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op NegativeLogLikelihoodLoss"
   ],
   [
     "node/test_sce_mean_weight_ii_4d_log_prob/model.onnx",
@@ -5669,11 +5669,11 @@
   ],
   [
     "node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op Identity"
   ],
   [
     "node/test_sce_mean_weight_ii_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op NegativeLogLikelihoodLoss"
   ],
   [
     "node/test_sce_mean_weight_ii_log_prob/model.onnx",
@@ -5681,7 +5681,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op Identity"
   ],
   [
     "node/test_sce_mean_weight_log_prob/model.onnx",
@@ -5689,7 +5689,7 @@
   ],
   [
     "node/test_sce_mean_weight_log_prob_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op Identity"
   ],
   [
     "node/test_sce_none/model.onnx",
@@ -5697,7 +5697,7 @@
   ],
   [
     "node/test_sce_none_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op NegativeLogLikelihoodLoss"
   ],
   [
     "node/test_sce_none_log_prob/model.onnx",
@@ -5705,7 +5705,7 @@
   ],
   [
     "node/test_sce_none_log_prob_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op Identity"
   ],
   [
     "node/test_sce_none_weights/model.onnx",
@@ -5713,7 +5713,7 @@
   ],
   [
     "node/test_sce_none_weights_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op NegativeLogLikelihoodLoss"
   ],
   [
     "node/test_sce_none_weights_log_prob/model.onnx",
@@ -5721,7 +5721,7 @@
   ],
   [
     "node/test_sce_none_weights_log_prob_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op Identity"
   ],
   [
     "node/test_sce_sum/model.onnx",
@@ -5729,7 +5729,7 @@
   ],
   [
     "node/test_sce_sum_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op NegativeLogLikelihoodLoss"
   ],
   [
     "node/test_sce_sum_log_prob/model.onnx",
@@ -5737,7 +5737,7 @@
   ],
   [
     "node/test_sce_sum_log_prob_expanded/model.onnx",
-    "Reshape input and output element counts must match"
+    "Unsupported op Identity"
   ],
   [
     "node/test_selu/model.onnx",


### PR DESCRIPTION
### Motivation
- Allow `Reshape` lowering to handle cases where the shape input is produced by a `Shape` node instead of a constant initializer. 
- Support `allowzero` semantics and proper `-1` inference for resolved target shapes. 
- Eliminate numerous Reshape-related failures in the official ONNX test expectations by making shape resolution and validation consistent. 

### Description
- Add `_find_node_by_output` and `_shape_values_from_shape_node` to detect `Shape` producers and extract their source tensor shapes. 
- Resolve Reshape target shapes via `_resolve_target_shape` when shape is provided by either an initializer or a `Shape` node, and use the resolved shape for lowering decisions. 
- Relax `_shape_product` to allow zero-valued dims while still rejecting negative (dynamic) dims and update `_resolve_target_shape` to correctly implement `allowzero` and `-1` semantics. 
- Update `lower_reshape` to validate only when output shape is known and to reject dynamic dims (`< 0`) after resolution. 

### Testing
- Ran `UPDATE_REFS=1 pytest -n auto -q` and all tests passed (`121 passed` in `25.58s`).
- References were refreshed as part of the test run, updating `tests/official_onnx_expected_errors.json` and the official ONNX support documents.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6964d767c0cc8325bd8d5aa5287dc564)