### PR TITLE
Add LSTM support (lowering, codegen, runtime, tests)

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 507 / 1802 official ONNX files.
+Support 511 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -900,10 +900,10 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_lppool_3d_default/model.onnx | ❌ | Unsupported op LpPool |
 | node/test_lrn/model.onnx | ✅ |  |
 | node/test_lrn_default/model.onnx | ✅ |  |
-| node/test_lstm_batchwise/model.onnx | ❌ | Unsupported op LSTM |
-| node/test_lstm_defaults/model.onnx | ❌ | Unsupported op LSTM |
-| node/test_lstm_with_initial_bias/model.onnx | ❌ | Unsupported op LSTM |
-| node/test_lstm_with_peepholes/model.onnx | ❌ | Unsupported op LSTM |
+| node/test_lstm_batchwise/model.onnx | ✅ |  |
+| node/test_lstm_defaults/model.onnx | ✅ |  |
+| node/test_lstm_with_initial_bias/model.onnx | ✅ |  |
+| node/test_lstm_with_peepholes/model.onnx | ✅ |  |
 | node/test_matmul_1d_1d/model.onnx | ❌ | MatMul supports 2D inputs only, got (3,) x (3,) |
 | node/test_matmul_1d_3d/model.onnx | ❌ | MatMul supports 2D inputs only, got (4,) x (2, 4, 1) |
 | node/test_matmul_2d/model.onnx | ✅ |  |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -86,7 +86,6 @@
 | Unsupported op Gelu | 4 | █ |
 | Unsupported op GRU | 4 | █ |
 | Unsupported op HardSigmoid | 4 | █ |
-| Unsupported op LSTM | 4 | █ |
 | Unsupported op Softplus | 4 | █ |
 | Unsupported op OneHot | 4 | █ |
 | Unsupported op OptionalHasElement | 4 | █ |

--- a/src/onnx2c/compiler.py
+++ b/src/onnx2c/compiler.py
@@ -19,6 +19,7 @@ from .codegen.c_emitter import (
     ConstantOfShapeOp,
     GemmOp,
     LrnOp,
+    LstmOp,
     LogSoftmaxOp,
     LoweredModel,
     MatMulOp,
@@ -137,6 +138,7 @@ class Compiler:
             | AveragePoolOp
             | BatchNormOp
             | LrnOp
+            | LstmOp
             | SoftmaxOp
             | LogSoftmaxOp
             | MaxPoolOp

--- a/src/onnx2c/lowering/lstm.py
+++ b/src/onnx2c/lowering/lstm.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Node
+from .common import node_dtype, optional_name, value_dtype, value_shape
+from .registry import register_lowering
+
+ACTIVATION_KIND_BY_NAME = {
+    "Relu": 0,
+    "Tanh": 1,
+    "Sigmoid": 2,
+    "Affine": 3,
+    "LeakyRelu": 4,
+    "ThresholdedRelu": 5,
+    "ScaledTanh": 6,
+    "HardSigmoid": 7,
+    "Elu": 8,
+    "Softsign": 9,
+    "Softplus": 10,
+}
+
+DEFAULT_ACTIVATIONS = ("Sigmoid", "Tanh", "Tanh")
+
+DEFAULT_ALPHA_BY_NAME = {
+    "Affine": 1.0,
+    "LeakyRelu": 0.01,
+    "ThresholdedRelu": 1.0,
+    "ScaledTanh": 1.0,
+    "HardSigmoid": 0.2,
+    "Elu": 1.0,
+}
+
+DEFAULT_BETA_BY_NAME = {
+    "Affine": 0.0,
+    "ScaledTanh": 1.0,
+    "HardSigmoid": 0.5,
+}
+
+
+@dataclass(frozen=True)
+class LstmSpec:
+    input_x: str
+    input_w: str
+    input_r: str
+    input_b: str | None
+    input_sequence_lens: str | None
+    input_initial_h: str | None
+    input_initial_c: str | None
+    input_p: str | None
+    output_y: str | None
+    output_y_h: str | None
+    output_y_c: str | None
+    seq_length: int
+    batch_size: int
+    input_size: int
+    hidden_size: int
+    num_directions: int
+    direction: str
+    layout: int
+    input_forget: int
+    clip: float | None
+    activation_kinds: tuple[int, ...]
+    activation_alphas: tuple[float, ...]
+    activation_betas: tuple[float, ...]
+    dtype: str
+    sequence_lens_dtype: str | None
+
+
+def _normalize_activation_names(values: Iterable[object]) -> list[str]:
+    names: list[str] = []
+    for value in values:
+        if isinstance(value, bytes):
+            value = value.decode("utf-8")
+        if not isinstance(value, str):
+            raise UnsupportedOpError("LSTM activations must be strings")
+        names.append(value)
+    return names
+
+
+def _resolve_activation_params(
+    activations: Sequence[str],
+    activation_alpha: Sequence[float] | None,
+    activation_beta: Sequence[float] | None,
+) -> tuple[tuple[int, ...], tuple[float, ...], tuple[float, ...]]:
+    if activation_alpha is None:
+        activation_alpha = []
+    if activation_beta is None:
+        activation_beta = []
+    if activation_alpha and len(activation_alpha) != len(activations):
+        raise UnsupportedOpError("LSTM activation_alpha must match activations")
+    if activation_beta and len(activation_beta) != len(activations):
+        raise UnsupportedOpError("LSTM activation_beta must match activations")
+    activation_kinds: list[int] = []
+    alphas: list[float] = []
+    betas: list[float] = []
+    for idx, name in enumerate(activations):
+        kind = ACTIVATION_KIND_BY_NAME.get(name)
+        if kind is None:
+            raise UnsupportedOpError(f"Unsupported LSTM activation {name}")
+        activation_kinds.append(kind)
+        if activation_alpha:
+            alpha = float(activation_alpha[idx])
+        else:
+            alpha = DEFAULT_ALPHA_BY_NAME.get(name, 1.0)
+        if activation_beta:
+            beta = float(activation_beta[idx])
+        else:
+            beta = DEFAULT_BETA_BY_NAME.get(name, 0.0)
+        alphas.append(alpha)
+        betas.append(beta)
+    return tuple(activation_kinds), tuple(alphas), tuple(betas)
+
+
+def _resolve_activations(
+    direction: str, num_directions: int, attrs: dict[str, object]
+) -> tuple[tuple[int, ...], tuple[float, ...], tuple[float, ...]]:
+    activations_attr = attrs.get("activations")
+    if activations_attr is None:
+        activations = list(DEFAULT_ACTIVATIONS)
+    else:
+        activations = _normalize_activation_names(activations_attr)
+    if num_directions == 1:
+        if len(activations) != 3:
+            raise UnsupportedOpError("LSTM activations must have length 3")
+    else:
+        if len(activations) == 3:
+            activations = activations * 2
+        elif len(activations) != 6:
+            raise UnsupportedOpError("Bidirectional LSTM activations must be length 6")
+    activation_alpha = attrs.get("activation_alpha")
+    activation_beta = attrs.get("activation_beta")
+    return _resolve_activation_params(
+        activations,
+        activation_alpha,
+        activation_beta,
+    )
+
+
+def _expect_shape(
+    name: str, shape: tuple[int, ...], expected: tuple[int, ...]
+) -> None:
+    if shape != expected:
+        raise UnsupportedOpError(
+            f"LSTM input {name} must have shape {expected}, got {shape}"
+        )
+
+
+def _validate_direction(direction: str, num_directions: int) -> None:
+    if direction == "bidirectional" and num_directions != 2:
+        raise UnsupportedOpError(
+            "LSTM expects num_directions=2 for bidirectional models"
+        )
+    if direction in {"forward", "reverse"} and num_directions != 1:
+        raise UnsupportedOpError(
+            "LSTM expects num_directions=1 for forward/reverse models"
+        )
+    if direction not in {"forward", "reverse", "bidirectional"}:
+        raise UnsupportedOpError(f"Unsupported LSTM direction {direction}")
+
+
+def resolve_lstm_spec(graph: Graph, node: Node) -> LstmSpec:
+    if len(node.inputs) < 3 or len(node.inputs) > 8:
+        raise UnsupportedOpError("LSTM expects between 3 and 8 inputs")
+    if len(node.outputs) < 1 or len(node.outputs) > 3:
+        raise UnsupportedOpError("LSTM expects between 1 and 3 outputs")
+    input_x = node.inputs[0]
+    input_w = node.inputs[1]
+    input_r = node.inputs[2]
+    input_b = optional_name(node.inputs, 3)
+    input_sequence_lens = optional_name(node.inputs, 4)
+    input_initial_h = optional_name(node.inputs, 5)
+    input_initial_c = optional_name(node.inputs, 6)
+    input_p = optional_name(node.inputs, 7)
+    output_y = optional_name(node.outputs, 0)
+    output_y_h = optional_name(node.outputs, 1)
+    output_y_c = optional_name(node.outputs, 2)
+    if output_y is None and output_y_h is None and output_y_c is None:
+        raise UnsupportedOpError("LSTM expects at least one output")
+    op_dtype = node_dtype(
+        graph,
+        node,
+        input_x,
+        input_w,
+        input_r,
+        *(name for name in (input_b, input_initial_h, input_initial_c, input_p) if name),
+        *(name for name in (output_y, output_y_h, output_y_c) if name),
+    )
+    if op_dtype not in {"float", "double"}:
+        raise UnsupportedOpError("LSTM supports float and double inputs only")
+    x_shape = value_shape(graph, input_x, node)
+    if len(x_shape) != 3:
+        raise UnsupportedOpError("LSTM input X must be rank 3")
+    layout = int(node.attrs.get("layout", 0))
+    if layout not in {0, 1}:
+        raise UnsupportedOpError("LSTM layout must be 0 or 1")
+    if layout == 0:
+        seq_length, batch_size, input_size = x_shape
+    else:
+        batch_size, seq_length, input_size = x_shape
+    w_shape = value_shape(graph, input_w, node)
+    if len(w_shape) != 3:
+        raise UnsupportedOpError("LSTM input W must be rank 3")
+    num_directions = w_shape[0]
+    hidden_size_attr = node.attrs.get("hidden_size")
+    if hidden_size_attr is None:
+        if w_shape[1] % 4 != 0:
+            raise UnsupportedOpError("LSTM W shape is not divisible by 4")
+        hidden_size = w_shape[1] // 4
+    else:
+        hidden_size = int(hidden_size_attr)
+    _validate_direction(str(node.attrs.get("direction", "forward")), num_directions)
+    direction = str(node.attrs.get("direction", "forward"))
+    expected_w_shape = (num_directions, 4 * hidden_size, input_size)
+    _expect_shape(input_w, w_shape, expected_w_shape)
+    r_shape = value_shape(graph, input_r, node)
+    expected_r_shape = (num_directions, 4 * hidden_size, hidden_size)
+    _expect_shape(input_r, r_shape, expected_r_shape)
+    if input_b is not None:
+        b_shape = value_shape(graph, input_b, node)
+        _expect_shape(input_b, b_shape, (num_directions, 8 * hidden_size))
+    if input_sequence_lens is not None:
+        seq_dtype = value_dtype(graph, input_sequence_lens, node)
+        if seq_dtype not in {"int32", "int64"}:
+            raise UnsupportedOpError("LSTM sequence_lens must be int32 or int64")
+        seq_shape = value_shape(graph, input_sequence_lens, node)
+        if seq_shape != (batch_size,):
+            raise UnsupportedOpError(
+                "LSTM sequence_lens must match batch size"
+            )
+    if input_initial_h is not None:
+        _expect_shape(
+            input_initial_h,
+            value_shape(graph, input_initial_h, node),
+            (num_directions, batch_size, hidden_size),
+        )
+    if input_initial_c is not None:
+        _expect_shape(
+            input_initial_c,
+            value_shape(graph, input_initial_c, node),
+            (num_directions, batch_size, hidden_size),
+        )
+    if input_p is not None:
+        _expect_shape(
+            input_p,
+            value_shape(graph, input_p, node),
+            (num_directions, 3 * hidden_size),
+        )
+    if output_y is not None:
+        expected_y_shape = (
+            (seq_length, num_directions, batch_size, hidden_size)
+            if layout == 0
+            else (batch_size, seq_length, num_directions, hidden_size)
+        )
+        _expect_shape(output_y, value_shape(graph, output_y, node), expected_y_shape)
+    if output_y_h is not None:
+        _expect_shape(
+            output_y_h,
+            value_shape(graph, output_y_h, node),
+            (num_directions, batch_size, hidden_size),
+        )
+    if output_y_c is not None:
+        _expect_shape(
+            output_y_c,
+            value_shape(graph, output_y_c, node),
+            (num_directions, batch_size, hidden_size),
+        )
+    input_forget = int(node.attrs.get("input_forget", 0))
+    if input_forget not in {0, 1}:
+        raise UnsupportedOpError("LSTM input_forget must be 0 or 1")
+    clip = node.attrs.get("clip")
+    if clip is not None:
+        clip = float(clip)
+        if clip < 0:
+            raise UnsupportedOpError("LSTM clip must be non-negative")
+    activation_kinds, activation_alphas, activation_betas = _resolve_activations(
+        direction, num_directions, node.attrs
+    )
+    sequence_lens_dtype = (
+        value_dtype(graph, input_sequence_lens, node)
+        if input_sequence_lens is not None
+        else None
+    )
+    return LstmSpec(
+        input_x=input_x,
+        input_w=input_w,
+        input_r=input_r,
+        input_b=input_b,
+        input_sequence_lens=input_sequence_lens,
+        input_initial_h=input_initial_h,
+        input_initial_c=input_initial_c,
+        input_p=input_p,
+        output_y=output_y,
+        output_y_h=output_y_h,
+        output_y_c=output_y_c,
+        seq_length=seq_length,
+        batch_size=batch_size,
+        input_size=input_size,
+        hidden_size=hidden_size,
+        num_directions=num_directions,
+        direction=direction,
+        layout=layout,
+        input_forget=input_forget,
+        clip=clip,
+        activation_kinds=activation_kinds,
+        activation_alphas=activation_alphas,
+        activation_betas=activation_betas,
+        dtype=op_dtype,
+        sequence_lens_dtype=sequence_lens_dtype,
+    )
+
+
+@register_lowering("LSTM")
+def lower_lstm(graph: Graph, node: Node) -> "LstmOp":
+    from ..codegen.c_emitter import LstmOp
+
+    spec = resolve_lstm_spec(graph, node)
+    return LstmOp(
+        input_x=spec.input_x,
+        input_w=spec.input_w,
+        input_r=spec.input_r,
+        input_b=spec.input_b,
+        input_sequence_lens=spec.input_sequence_lens,
+        input_initial_h=spec.input_initial_h,
+        input_initial_c=spec.input_initial_c,
+        input_p=spec.input_p,
+        output_y=spec.output_y,
+        output_y_h=spec.output_y_h,
+        output_y_c=spec.output_y_c,
+        seq_length=spec.seq_length,
+        batch_size=spec.batch_size,
+        input_size=spec.input_size,
+        hidden_size=spec.hidden_size,
+        num_directions=spec.num_directions,
+        direction=spec.direction,
+        layout=spec.layout,
+        input_forget=spec.input_forget,
+        clip=spec.clip,
+        activation_kinds=spec.activation_kinds,
+        activation_alphas=spec.activation_alphas,
+        activation_betas=spec.activation_betas,
+        dtype=spec.dtype,
+        sequence_lens_dtype=spec.sequence_lens_dtype,
+    )

--- a/templates/lstm_op.c.j2
+++ b/templates/lstm_op.c.j2
@@ -1,0 +1,219 @@
+static inline {{ c_type }} {{ op_name }}_activation(int kind, {{ c_type }} value, {{ c_type }} alpha, {{ c_type }} beta) {
+    switch (kind) {
+        case 0: /* Relu */
+            return value > {{ zero_literal }} ? value : {{ zero_literal }};
+        case 1: /* Tanh */
+            return {{ tanh_fn }}(value);
+        case 2: /* Sigmoid */
+            return ({{ c_type }}){{ one_literal }} / (({{ c_type }}){{ one_literal }} + {{ exp_fn }}(-value));
+        case 3: /* Affine */
+            return alpha * value + beta;
+        case 4: /* LeakyRelu */
+            return value < {{ zero_literal }} ? alpha * value : value;
+        case 5: /* ThresholdedRelu */
+            return value > alpha ? value : {{ zero_literal }};
+        case 6: /* ScaledTanh */
+            return alpha * {{ tanh_fn }}(beta * value);
+        case 7: /* HardSigmoid */
+            value = alpha * value + beta;
+            if (value < {{ zero_literal }}) {
+                return {{ zero_literal }};
+            }
+            if (value > ({{ c_type }}){{ one_literal }}) {
+                return ({{ c_type }}){{ one_literal }};
+            }
+            return value;
+        case 8: /* Elu */
+            return value >= {{ zero_literal }} ? value : alpha * ({{ exp_fn }}(value) - ({{ c_type }}){{ one_literal }});
+        case 9: /* Softsign */
+            return value / (({{ c_type }}){{ one_literal }} + {{ fabs_fn }}(value));
+        case 10: /* Softplus */
+            return {{ log1p_fn }}({{ exp_fn }}(value));
+        default:
+            return value;
+    }
+}
+
+void {{ op_name }}(const {{ c_type }} {{ input_x }}{{ input_suffix }},
+                  const {{ c_type }} {{ input_w }}{{ w_suffix }},
+                  const {{ c_type }} {{ input_r }}{{ r_suffix }}{% if input_b %},
+                  const {{ c_type }} {{ input_b }}{{ b_suffix }}{% endif %}{% if input_sequence_lens %},
+                  const {{ seq_c_type }} {{ input_sequence_lens }}{{ seq_suffix }}{% endif %}{% if input_initial_h %},
+                  const {{ c_type }} {{ input_initial_h }}{{ h_suffix }}{% endif %}{% if input_initial_c %},
+                  const {{ c_type }} {{ input_initial_c }}{{ c_suffix }}{% endif %}{% if input_p %},
+                  const {{ c_type }} {{ input_p }}{{ p_suffix }}{% endif %}{% if output_y %},
+                  {{ c_type }} {{ output_y }}{{ y_suffix }}{% endif %}{% if output_y_h %},
+                  {{ c_type }} {{ output_y_h }}{{ y_h_suffix }}{% endif %}{% if output_y_c %},
+                  {{ c_type }} {{ output_y_c }}{{ y_c_suffix }}{% endif %}) {
+    const int activations[] = { {% for value in activation_kinds %}{{ value }}{% if not loop.last %}, {% endif %}{% endfor %} };
+    const {{ c_type }} activation_alpha[] = { {% for value in activation_alphas %}{{ value }}{% if not loop.last %}, {% endif %}{% endfor %} };
+    const {{ c_type }} activation_beta[] = { {% for value in activation_betas %}{{ value }}{% if not loop.last %}, {% endif %}{% endfor %} };
+    for (int dir = 0; dir < {{ num_directions }}; ++dir) {
+        int reverse = 0;
+        {% if direction == "reverse" %}
+        reverse = 1;
+        {% elif direction == "bidirectional" %}
+        reverse = dir == 1;
+        {% endif %}
+        int act_offset = dir * 3;
+        int act_f = activations[act_offset];
+        int act_g = activations[act_offset + 1];
+        int act_h = activations[act_offset + 2];
+        {{ c_type }} alpha_f = activation_alpha[act_offset];
+        {{ c_type }} alpha_g = activation_alpha[act_offset + 1];
+        {{ c_type }} alpha_h = activation_alpha[act_offset + 2];
+        {{ c_type }} beta_f = activation_beta[act_offset];
+        {{ c_type }} beta_g = activation_beta[act_offset + 1];
+        {{ c_type }} beta_h = activation_beta[act_offset + 2];
+        {{ c_type }} H_prev[{{ batch_size }}][{{ hidden_size }}];
+        {{ c_type }} C_prev[{{ batch_size }}][{{ hidden_size }}];
+        for (int b = 0; b < {{ batch_size }}; ++b) {
+            for (int h = 0; h < {{ hidden_size }}; ++h) {
+                {% if input_initial_h %}
+                H_prev[b][h] = {{ input_initial_h }}[dir][b][h];
+                {% else %}
+                H_prev[b][h] = {{ zero_literal }};
+                {% endif %}
+                {% if input_initial_c %}
+                C_prev[b][h] = {{ input_initial_c }}[dir][b][h];
+                {% else %}
+                C_prev[b][h] = {{ zero_literal }};
+                {% endif %}
+            }
+        }
+        for (int step = 0; step < {{ seq_length }}; ++step) {
+            int t = reverse ? ({{ seq_length }} - 1 - step) : step;
+            for (int b = 0; b < {{ batch_size }}; ++b) {
+                int seq_limit = {{ seq_length }};
+                {% if input_sequence_lens %}
+                seq_limit = (int){{ input_sequence_lens }}[b];
+                if (seq_limit < 0) {
+                    seq_limit = 0;
+                }
+                if (seq_limit > {{ seq_length }}) {
+                    seq_limit = {{ seq_length }};
+                }
+                {% endif %}
+                if (step >= seq_limit) {
+                    {% if output_y %}
+                    for (int h = 0; h < {{ hidden_size }}; ++h) {
+                        {% if layout == 0 %}
+                        {{ output_y }}[step][dir][b][h] = {{ zero_literal }};
+                        {% else %}
+                        {{ output_y }}[b][step][dir][h] = {{ zero_literal }};
+                        {% endif %}
+                    }
+                    {% endif %}
+                    continue;
+                }
+                {{ c_type }} H_next[{{ hidden_size }}];
+                {{ c_type }} C_next[{{ hidden_size }}];
+                for (int h = 0; h < {{ hidden_size }}; ++h) {
+                    {{ c_type }} gate_i = {{ zero_literal }};
+                    {{ c_type }} gate_o = {{ zero_literal }};
+                    {{ c_type }} gate_f = {{ zero_literal }};
+                    {{ c_type }} gate_c = {{ zero_literal }};
+                    for (int i = 0; i < {{ input_size }}; ++i) {
+                        {% if layout == 0 %}
+                        {{ c_type }} x_val = {{ input_x }}[t][b][i];
+                        {% else %}
+                        {{ c_type }} x_val = {{ input_x }}[b][t][i];
+                        {% endif %}
+                        gate_i += x_val * {{ input_w }}[dir][h][i];
+                        gate_o += x_val * {{ input_w }}[dir][{{ hidden_size }} + h][i];
+                        gate_f += x_val * {{ input_w }}[dir][{{ hidden_size }} * 2 + h][i];
+                        gate_c += x_val * {{ input_w }}[dir][{{ hidden_size }} * 3 + h][i];
+                    }
+                    for (int i = 0; i < {{ hidden_size }}; ++i) {
+                        {{ c_type }} h_val = H_prev[b][i];
+                        gate_i += h_val * {{ input_r }}[dir][h][i];
+                        gate_o += h_val * {{ input_r }}[dir][{{ hidden_size }} + h][i];
+                        gate_f += h_val * {{ input_r }}[dir][{{ hidden_size }} * 2 + h][i];
+                        gate_c += h_val * {{ input_r }}[dir][{{ hidden_size }} * 3 + h][i];
+                    }
+                    {% if input_b %}
+                    gate_i += {{ input_b }}[dir][h] + {{ input_b }}[dir][{{ hidden_size }} * 4 + h];
+                    gate_o += {{ input_b }}[dir][{{ hidden_size }} + h] + {{ input_b }}[dir][{{ hidden_size }} * 5 + h];
+                    gate_f += {{ input_b }}[dir][{{ hidden_size }} * 2 + h] + {{ input_b }}[dir][{{ hidden_size }} * 6 + h];
+                    gate_c += {{ input_b }}[dir][{{ hidden_size }} * 3 + h] + {{ input_b }}[dir][{{ hidden_size }} * 7 + h];
+                    {% endif %}
+                    {% if use_clip %}
+                    if (gate_i > {{ clip_literal }}) {
+                        gate_i = {{ clip_literal }};
+                    } else if (gate_i < -{{ clip_literal }}) {
+                        gate_i = -{{ clip_literal }};
+                    }
+                    if (gate_o > {{ clip_literal }}) {
+                        gate_o = {{ clip_literal }};
+                    } else if (gate_o < -{{ clip_literal }}) {
+                        gate_o = -{{ clip_literal }};
+                    }
+                    if (gate_f > {{ clip_literal }}) {
+                        gate_f = {{ clip_literal }};
+                    } else if (gate_f < -{{ clip_literal }}) {
+                        gate_f = -{{ clip_literal }};
+                    }
+                    if (gate_c > {{ clip_literal }}) {
+                        gate_c = {{ clip_literal }};
+                    } else if (gate_c < -{{ clip_literal }}) {
+                        gate_c = -{{ clip_literal }};
+                    }
+                    {% endif %}
+                    {% if input_p %}
+                    {{ c_type }} i_gate = {{ op_name }}_activation(
+                        act_f, gate_i + {{ input_p }}[dir][h] * C_prev[b][h], alpha_f, beta_f);
+                    {% else %}
+                    {{ c_type }} i_gate = {{ op_name }}_activation(act_f, gate_i, alpha_f, beta_f);
+                    {% endif %}
+                    {{ c_type }} f_gate;
+                    {% if input_forget %}
+                    f_gate = ({{ c_type }}){{ one_literal }} - i_gate;
+                    {% else %}
+                    {% if input_p %}
+                    f_gate = {{ op_name }}_activation(
+                        act_f, gate_f + {{ input_p }}[dir][{{ hidden_size }} * 2 + h] * C_prev[b][h], alpha_f, beta_f);
+                    {% else %}
+                    f_gate = {{ op_name }}_activation(act_f, gate_f, alpha_f, beta_f);
+                    {% endif %}
+                    {% endif %}
+                    {{ c_type }} c_gate = {{ op_name }}_activation(act_g, gate_c, alpha_g, beta_g);
+                    {{ c_type }} c_new = f_gate * C_prev[b][h] + i_gate * c_gate;
+                    {% if input_p %}
+                    {{ c_type }} o_gate = {{ op_name }}_activation(
+                        act_f, gate_o + {{ input_p }}[dir][{{ hidden_size }} + h] * c_new, alpha_f, beta_f);
+                    {% else %}
+                    {{ c_type }} o_gate = {{ op_name }}_activation(act_f, gate_o, alpha_f, beta_f);
+                    {% endif %}
+                    {{ c_type }} h_new = o_gate * {{ op_name }}_activation(act_h, c_new, alpha_h, beta_h);
+                    C_next[h] = c_new;
+                    H_next[h] = h_new;
+                    {% if output_y %}
+                    {% if layout == 0 %}
+                    {{ output_y }}[step][dir][b][h] = h_new;
+                    {% else %}
+                    {{ output_y }}[b][step][dir][h] = h_new;
+                    {% endif %}
+                    {% endif %}
+                }
+                for (int h = 0; h < {{ hidden_size }}; ++h) {
+                    C_prev[b][h] = C_next[h];
+                    H_prev[b][h] = H_next[h];
+                }
+            }
+        }
+        {% if output_y_h %}
+        for (int b = 0; b < {{ batch_size }}; ++b) {
+            for (int h = 0; h < {{ hidden_size }}; ++h) {
+                {{ output_y_h }}[dir][b][h] = H_prev[b][h];
+            }
+        }
+        {% endif %}
+        {% if output_y_c %}
+        for (int b = 0; b < {{ batch_size }}; ++b) {
+            for (int h = 0; h < {{ hidden_size }}; ++h) {
+                {{ output_y_c }}[dir][b][h] = C_prev[b][h];
+            }
+        }
+        {% endif %}
+    }
+}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -3569,19 +3569,19 @@
   ],
   [
     "node/test_lstm_batchwise/model.onnx",
-    "Unsupported op LSTM"
+    ""
   ],
   [
     "node/test_lstm_defaults/model.onnx",
-    "Unsupported op LSTM"
+    ""
   ],
   [
     "node/test_lstm_with_initial_bias/model.onnx",
-    "Unsupported op LSTM"
+    ""
   ],
   [
     "node/test_lstm_with_peepholes/model.onnx",
-    "Unsupported op LSTM"
+    ""
   ],
   [
     "node/test_matmul_1d_1d/model.onnx",


### PR DESCRIPTION
### Motivation

- Implement full ONNX `LSTM` operator handling so models containing LSTM nodes can be lowered, emitted to C, and executed in the Python runtime evaluator.
- Provide activation, bias, peephole and sequence-lens handling plus support for optional inputs/outputs and both layouts/directions.
- Keep behavior deterministic and plumb LSTM through the existing pass-based pipeline (import → lower → emit → runtime).
- Update official ONNX file support expectations to reflect added coverage for LSTM test cases.

### Description

- Add lowering and validation for `LSTM` in `src/onnx2c/lowering/lstm.py`, including activation/alpha/beta handling and shape checks via `resolve_lstm_spec` and `lower_lstm` registration.
- Add `LstmOp` dataclass and wire LSTM into the codegen pipeline in `src/onnx2c/codegen/c_emitter.py`, and add a new Jinja2 template `templates/lstm_op.c.j2` implementing the sequence kernel and activations.
- Implement runtime evaluation and numpy-based reference execution in `src/onnx2c/runtime/evaluator.py` with `_apply_lstm`, `_apply_lstm_activation`, and `_eval_lstm` so `Compiler.run` can execute LSTM graphs.
- Add end-to-end tests and expectations: new LSTM test helpers and cases in `tests/test_endtoend_ops.py`, update `tests/official_onnx_expected_errors.json`, and refresh `OFFICIAL_ONNX_FILE_SUPPORT.md`/histogram entries.

### Testing

- Ran `pytest tests/test_endtoend_ops.py -k lstm`, which executed the LSTM-focused tests and they passed (2 passed) in ~2.25s.
- Generated updated official ONNX support docs/expectations using the existing test tooling so LSTM files are marked supported (files updated: `OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`, and `tests/official_onnx_expected_errors.json`).
- Existing test harness (`_run_cli_verify`) was used to verify emitted C testbench output against ONNX Runtime for an LSTM case; that check passed during the end-to-end test run.
- No new external dependencies were added; templates and codegen were extended following existing project conventions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6964fbe01ac8832b8daf65866eb009a3)