### PR TITLE
lowering: fix LSTM state layout validation

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 525 / 1802 official ONNX files.
+Support 529 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 

--- a/src/onnx2c/lowering/lstm.py
+++ b/src/onnx2c/lowering/lstm.py
@@ -230,17 +230,22 @@ def resolve_lstm_spec(graph: Graph, node: Node) -> LstmSpec:
             raise UnsupportedOpError(
                 "LSTM sequence_lens must match batch size"
             )
+    state_shape = (
+        (num_directions, batch_size, hidden_size)
+        if layout == 0
+        else (batch_size, num_directions, hidden_size)
+    )
     if input_initial_h is not None:
         _expect_shape(
             input_initial_h,
             value_shape(graph, input_initial_h, node),
-            (num_directions, batch_size, hidden_size),
+            state_shape,
         )
     if input_initial_c is not None:
         _expect_shape(
             input_initial_c,
             value_shape(graph, input_initial_c, node),
-            (num_directions, batch_size, hidden_size),
+            state_shape,
         )
     if input_p is not None:
         _expect_shape(
@@ -259,13 +264,13 @@ def resolve_lstm_spec(graph: Graph, node: Node) -> LstmSpec:
         _expect_shape(
             output_y_h,
             value_shape(graph, output_y_h, node),
-            (num_directions, batch_size, hidden_size),
+            state_shape,
         )
     if output_y_c is not None:
         _expect_shape(
             output_y_c,
             value_shape(graph, output_y_c, node),
-            (num_directions, batch_size, hidden_size),
+            state_shape,
         )
     input_forget = int(node.attrs.get("input_forget", 0))
     if input_forget not in {0, 1}:


### PR DESCRIPTION
### Motivation
- Fix incorrect LSTM initial/output state shape validation that assumed a `(num_directions, batch_size, hidden_size)` ordering regardless of `layout` and caused test failures for layout=1 models.  
- Keep compiler behavior consistent with ONNX model value ordering and ensure deterministic validation.
- Refresh the official ONNX support report to reflect corrected expectations after the validation fix.

### Description
- Compute a `state_shape` that is layout-aware (`(num_directions, batch_size, hidden_size)` when `layout==0`, else `(batch_size, num_directions, hidden_size)`) and use it to validate `input_initial_h`, `input_initial_c`, `output_y_h`, and `output_y_c` in `resolve_lstm_spec` in `src/onnx2c/lowering/lstm.py`.
- Update `OFFICIAL_ONNX_FILE_SUPPORT.md` to refresh the supported-file counts and align the golden reference with current behavior.

### Testing
- Ran `pytest -q` before the fix: 2 failed, 124 passed in 138.92s (0:02:18).  
- Ran targeted tests `tests/test_official_onnx_files.py::test_official_onnx_expected_errors` and `tests/test_official_onnx_files.py::test_official_onnx_file_support_doc`: 1 failed, 1 passed in 4.12s.  
- Ran `UPDATE_REFS=1 pytest tests/test_official_onnx_files.py::test_official_onnx_file_support_doc`: 1 passed in 0.82s.  
- Ran full suite with updated refs `UPDATE_REFS=1 pytest -n auto -q`: 126 passed in 31.50s.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69650ff6919483258d86f7026e0c1eef)