### PR TITLE
lowering: add SoftmaxCrossEntropyLoss support

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 529 / 1802 official ONNX files.
+Support 563 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -1375,73 +1375,73 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_scatternd_max/model.onnx | ❌ | Unsupported op ScatterND |
 | node/test_scatternd_min/model.onnx | ❌ | Unsupported op ScatterND |
 | node/test_scatternd_multiply/model.onnx | ❌ | Unsupported op ScatterND |
-| node/test_sce_NCd1_mean_weight_negative_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_NCd1_mean_weight_negative_ii/model.onnx | ✅ |  |
 | node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
-| node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx | ✅ |  |
 | node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
-| node/test_sce_NCd1d2d3_none_no_weight_negative_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_NCd1d2d3_none_no_weight_negative_ii/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
-| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
-| node/test_sce_NCd1d2d3_sum_weight_high_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_NCd1d2d3_sum_weight_high_ii/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
-| node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
-| node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
-| node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
-| node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
-| node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
-| node/test_sce_mean/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_3d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_mean/model.onnx | ✅ |  |
+| node/test_sce_mean_3d/model.onnx | ✅ |  |
 | node/test_sce_mean_3d_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
-| node/test_sce_mean_3d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_mean_3d_log_prob/model.onnx | ✅ |  |
 | node/test_sce_mean_3d_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
 | node/test_sce_mean_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
-| node/test_sce_mean_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_mean_log_prob/model.onnx | ✅ |  |
 | node/test_sce_mean_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
-| node/test_sce_mean_no_weight_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_no_weight_ii_3d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_mean_no_weight_ii/model.onnx | ✅ |  |
+| node/test_sce_mean_no_weight_ii_3d/model.onnx | ✅ |  |
 | node/test_sce_mean_no_weight_ii_3d_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
-| node/test_sce_mean_no_weight_ii_3d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_mean_no_weight_ii_3d_log_prob/model.onnx | ✅ |  |
 | node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
-| node/test_sce_mean_no_weight_ii_4d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_mean_no_weight_ii_4d/model.onnx | ✅ |  |
 | node/test_sce_mean_no_weight_ii_4d_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
-| node/test_sce_mean_no_weight_ii_4d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_mean_no_weight_ii_4d_log_prob/model.onnx | ✅ |  |
 | node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
 | node/test_sce_mean_no_weight_ii_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
-| node/test_sce_mean_no_weight_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_mean_no_weight_ii_log_prob/model.onnx | ✅ |  |
 | node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
-| node/test_sce_mean_weight/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_mean_weight/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
-| node/test_sce_mean_weight_ii/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
-| node/test_sce_mean_weight_ii_3d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_mean_weight_ii/model.onnx | ✅ |  |
+| node/test_sce_mean_weight_ii_3d/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_ii_3d_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
-| node/test_sce_mean_weight_ii_3d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_mean_weight_ii_3d_log_prob/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
-| node/test_sce_mean_weight_ii_4d/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_mean_weight_ii_4d/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_ii_4d_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
-| node/test_sce_mean_weight_ii_4d_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_mean_weight_ii_4d_log_prob/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
 | node/test_sce_mean_weight_ii_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
-| node/test_sce_mean_weight_ii_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_mean_weight_ii_log_prob/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
-| node/test_sce_mean_weight_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_mean_weight_log_prob/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
-| node/test_sce_none/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_none/model.onnx | ✅ |  |
 | node/test_sce_none_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
-| node/test_sce_none_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_none_log_prob/model.onnx | ✅ |  |
 | node/test_sce_none_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
-| node/test_sce_none_weights/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_none_weights/model.onnx | ✅ |  |
 | node/test_sce_none_weights_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
-| node/test_sce_none_weights_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_none_weights_log_prob/model.onnx | ✅ |  |
 | node/test_sce_none_weights_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
-| node/test_sce_sum/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_sum/model.onnx | ✅ |  |
 | node/test_sce_sum_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
-| node/test_sce_sum_log_prob/model.onnx | ❌ | Unsupported op SoftmaxCrossEntropyLoss |
+| node/test_sce_sum_log_prob/model.onnx | ✅ |  |
 | node/test_sce_sum_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
 | node/test_selu/model.onnx | ❌ | Unsupported op Selu |
 | node/test_selu_default/model.onnx | ❌ | Unsupported op Selu |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -5,7 +5,6 @@
 | Dynamic dim for tensor '*' | 146 | ██████████████████████████████ |
 | Unsupported elem_type 10 (FLOAT16) for tensor '*'. | 65 | █████████████ |
 | Missing elem_type for tensor '*' | 34 | ███████ |
-| Unsupported op SoftmaxCrossEntropyLoss | 34 | ███████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████ |
 | ReduceSum axes input must be constant | 32 | ███████ |
 | Unsupported op CastLike | 31 | ██████ |

--- a/src/onnx2c/compiler.py
+++ b/src/onnx2c/compiler.py
@@ -22,6 +22,7 @@ from .codegen.c_emitter import (
     LstmOp,
     LogSoftmaxOp,
     NegativeLogLikelihoodLossOp,
+    SoftmaxCrossEntropyLossOp,
     LoweredModel,
     MatMulOp,
     MaxPoolOp,
@@ -58,6 +59,9 @@ from .lowering.lrn import LrnSpec, resolve_lrn_spec
 from .lowering.logsoftmax import lower_logsoftmax
 from .lowering.negative_log_likelihood_loss import (
     lower_negative_log_likelihood_loss,
+)
+from .lowering.softmax_cross_entropy_loss import (
+    lower_softmax_cross_entropy_loss,
 )
 from .lowering.matmul import lower_matmul
 from .lowering.maxpool import MaxPoolSpec, resolve_maxpool_spec
@@ -146,6 +150,7 @@ class Compiler:
             | SoftmaxOp
             | LogSoftmaxOp
             | NegativeLogLikelihoodLossOp
+            | SoftmaxCrossEntropyLossOp
             | MaxPoolOp
             | ConcatOp
             | TransposeOp

--- a/src/onnx2c/lowering/softmax_cross_entropy_loss.py
+++ b/src/onnx2c/lowering/softmax_cross_entropy_loss.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from ..codegen.c_emitter import SoftmaxCrossEntropyLossOp
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Node
+from .common import shape_product as _shape_product
+from .common import value_dtype as _value_dtype
+from .common import value_shape as _value_shape
+from .registry import register_lowering
+
+
+@register_lowering("SoftmaxCrossEntropyLoss")
+def lower_softmax_cross_entropy_loss(
+    graph: Graph, node: Node
+) -> SoftmaxCrossEntropyLossOp:
+    if len(node.inputs) not in {2, 3} or len(node.outputs) not in {1, 2}:
+        raise UnsupportedOpError(
+            "SoftmaxCrossEntropyLoss must have 2 or 3 inputs and 1 or 2 outputs"
+        )
+    input_name = node.inputs[0]
+    target_name = node.inputs[1]
+    weight_name = node.inputs[2] if len(node.inputs) > 2 else None
+    input_dtype = _value_dtype(graph, input_name, node)
+    if input_dtype not in {"float", "double"}:
+        raise UnsupportedOpError(
+            "SoftmaxCrossEntropyLoss supports float and double inputs only"
+        )
+    output_name = node.outputs[0]
+    output_dtype = _value_dtype(graph, output_name, node)
+    if output_dtype != input_dtype:
+        raise UnsupportedOpError(
+            "SoftmaxCrossEntropyLoss output dtype must match input dtype"
+        )
+    log_prob_name = node.outputs[1] if len(node.outputs) > 1 else None
+    if log_prob_name is not None:
+        log_prob_dtype = _value_dtype(graph, log_prob_name, node)
+        if log_prob_dtype != input_dtype:
+            raise UnsupportedOpError(
+                "SoftmaxCrossEntropyLoss log_prob dtype must match input dtype"
+            )
+    target_dtype = _value_dtype(graph, target_name, node)
+    if target_dtype not in {"int32", "int64"}:
+        raise UnsupportedOpError(
+            "SoftmaxCrossEntropyLoss target must be int32 or int64"
+        )
+    if weight_name is not None:
+        weight_dtype = _value_dtype(graph, weight_name, node)
+        if weight_dtype != input_dtype:
+            raise UnsupportedOpError(
+                "SoftmaxCrossEntropyLoss weight dtype must match input dtype"
+            )
+    input_shape = _value_shape(graph, input_name, node)
+    target_shape = _value_shape(graph, target_name, node)
+    output_shape = _value_shape(graph, output_name, node)
+    if len(input_shape) < 2:
+        raise ShapeInferenceError("SoftmaxCrossEntropyLoss input must be at least 2D")
+    if len(target_shape) != len(input_shape) - 1:
+        raise ShapeInferenceError(
+            "SoftmaxCrossEntropyLoss target rank must be input rank - 1"
+        )
+    if input_shape[0] != target_shape[0]:
+        raise ShapeInferenceError(
+            "SoftmaxCrossEntropyLoss target batch dimension must match input"
+        )
+    if input_shape[2:] != target_shape[1:]:
+        raise ShapeInferenceError(
+            "SoftmaxCrossEntropyLoss target spatial dimensions must match input"
+        )
+    if weight_name is not None:
+        weight_shape = _value_shape(graph, weight_name, node)
+        if len(weight_shape) != 1 or weight_shape[0] != input_shape[1]:
+            raise ShapeInferenceError(
+                "SoftmaxCrossEntropyLoss weight must have shape (C,)"
+            )
+    if log_prob_name is not None:
+        log_prob_shape = _value_shape(graph, log_prob_name, node)
+        if log_prob_shape != input_shape:
+            raise ShapeInferenceError(
+                "SoftmaxCrossEntropyLoss log_prob output must match input shape"
+            )
+    reduction = node.attrs.get("reduction", "mean")
+    if isinstance(reduction, bytes):
+        reduction = reduction.decode("utf-8")
+    if reduction not in {"none", "mean", "sum"}:
+        raise UnsupportedOpError(
+            "SoftmaxCrossEntropyLoss reduction must be none, mean, or sum"
+        )
+    if reduction == "none":
+        if output_shape != target_shape:
+            raise ShapeInferenceError(
+                "SoftmaxCrossEntropyLoss output must match target shape "
+                "when reduction is none"
+            )
+    else:
+        if output_shape not in {(), (1,)}:
+            raise ShapeInferenceError(
+                "SoftmaxCrossEntropyLoss output must be scalar when reduced"
+            )
+    n = input_shape[0]
+    c = input_shape[1]
+    d = _shape_product(input_shape[2:]) if len(input_shape) > 2 else 1
+    ignore_index = node.attrs.get("ignore_index")
+    if ignore_index is not None:
+        ignore_index = int(ignore_index)
+    return SoftmaxCrossEntropyLossOp(
+        input0=input_name,
+        target=target_name,
+        weight=weight_name,
+        output=output_name,
+        log_prob=log_prob_name,
+        input_shape=input_shape,
+        target_shape=target_shape,
+        output_shape=output_shape,
+        log_prob_shape=input_shape if log_prob_name is not None else None,
+        n=n,
+        c=c,
+        d=d,
+        reduction=reduction,
+        ignore_index=ignore_index,
+        dtype=input_dtype,
+        target_dtype=target_dtype,
+    )

--- a/templates/softmax_cross_entropy_loss_op.c.j2
+++ b/templates/softmax_cross_entropy_loss_op.c.j2
@@ -1,0 +1,84 @@
+void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix }},
+                   const {{ target_c_type }} {{ target }}{{ target_suffix }}{% if weight %},
+                   const {{ c_type }} {{ weight }}[{{ c }}]{% endif %},
+                   {{ c_type }} {{ output }}{{ output_suffix }}{% if log_prob %},
+                   {{ c_type }} {{ log_prob }}{{ log_prob_suffix }}{% endif %}) {
+    const {{ c_type }} *input_flat = (const {{ c_type }} *){{ input0 }};
+    const {{ target_c_type }} *target_flat = (const {{ target_c_type }} *){{ target }};
+    {{ c_type }} *output_flat = ({{ c_type }} *){{ output }};
+{% if log_prob %}
+    {{ c_type }} *log_prob_flat = ({{ c_type }} *){{ log_prob }};
+{% endif %}
+    const size_t n = {{ n }};
+    const size_t c = {{ c }};
+    const size_t d = {{ d }};
+    {{ c_type }} loss_sum = {{ zero_literal }};
+    {{ c_type }} weight_sum = {{ zero_literal }};
+    for (size_t n_idx = 0; n_idx < n; ++n_idx) {
+        for (size_t d_idx = 0; d_idx < d; ++d_idx) {
+            size_t target_index = n_idx * d + d_idx;
+            {{ target_c_type }} target_value = target_flat[target_index];
+{% if use_ignore_index %}
+            if ((int64_t)target_value == {{ ignore_index }}) {
+{% if reduction == "none" %}
+                output_flat[target_index] = {{ zero_literal }};
+{% endif %}
+                continue;
+            }
+{% endif %}
+            size_t class_index = (size_t)target_value;
+            size_t base = (n_idx * c * d) + d_idx;
+            {{ c_type }} max_value = input_flat[base];
+            for (size_t c_idx = 1; c_idx < c; ++c_idx) {
+                {{ c_type }} value = input_flat[base + c_idx * d];
+                if (value > max_value) {
+                    max_value = value;
+                }
+            }
+            {{ c_type }} sum = {{ zero_literal }};
+            for (size_t c_idx = 0; c_idx < c; ++c_idx) {
+                {{ c_type }} value = input_flat[base + c_idx * d] - max_value;
+                sum += {{ exp_fn }}(value);
+            }
+            {{ c_type }} logsum = {{ log_fn }}(sum);
+{% if log_prob %}
+            {{ c_type }} loss_value = {{ zero_literal }};
+            for (size_t c_idx = 0; c_idx < c; ++c_idx) {
+                {{ c_type }} log_prob_value = input_flat[base + c_idx * d] - max_value - logsum;
+                log_prob_flat[base + c_idx * d] = log_prob_value;
+                if (c_idx == class_index) {
+                    loss_value = -log_prob_value;
+                }
+            }
+{% else %}
+            {{ c_type }} log_prob_value = input_flat[base + class_index * d] - max_value - logsum;
+            {{ c_type }} loss_value = -log_prob_value;
+{% endif %}
+{% if weight %}
+            {{ c_type }} sample_weight = {{ weight }}[class_index];
+            loss_value *= sample_weight;
+{% else %}
+            {{ c_type }} sample_weight = {{ one_literal }};
+{% endif %}
+{% if reduction == "none" %}
+            output_flat[target_index] = loss_value;
+{% else %}
+            loss_sum += loss_value;
+{% if reduction == "mean" %}
+{% if weight or use_ignore_index %}
+            weight_sum += sample_weight;
+{% endif %}
+{% endif %}
+{% endif %}
+        }
+    }
+{% if reduction == "mean" %}
+{% if weight or use_ignore_index %}
+    output_flat[0] = loss_sum / weight_sum;
+{% else %}
+    output_flat[0] = loss_sum / ({{ n }} * {{ d }});
+{% endif %}
+{% elif reduction == "sum" %}
+    output_flat[0] = loss_sum;
+{% endif %}
+}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -5469,7 +5469,7 @@
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx",
@@ -5477,7 +5477,7 @@
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx",
@@ -5485,7 +5485,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx",
@@ -5493,7 +5493,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx",
@@ -5501,7 +5501,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx",
@@ -5509,7 +5509,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx",
@@ -5517,7 +5517,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx",
@@ -5525,7 +5525,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx",
@@ -5533,7 +5533,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx",
@@ -5541,7 +5541,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx",
@@ -5549,11 +5549,11 @@
   ],
   [
     "node/test_sce_mean/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_mean_3d/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_mean_3d_expanded/model.onnx",
@@ -5561,7 +5561,7 @@
   ],
   [
     "node/test_sce_mean_3d_log_prob/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_mean_3d_log_prob_expanded/model.onnx",
@@ -5573,7 +5573,7 @@
   ],
   [
     "node/test_sce_mean_log_prob/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_mean_log_prob_expanded/model.onnx",
@@ -5581,11 +5581,11 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_expanded/model.onnx",
@@ -5593,7 +5593,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_log_prob/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx",
@@ -5601,7 +5601,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_expanded/model.onnx",
@@ -5609,7 +5609,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_log_prob/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx",
@@ -5621,7 +5621,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_log_prob/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx",
@@ -5629,7 +5629,7 @@
   ],
   [
     "node/test_sce_mean_weight/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_mean_weight_expanded/model.onnx",
@@ -5637,11 +5637,11 @@
   ],
   [
     "node/test_sce_mean_weight_ii/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii_3d/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii_3d_expanded/model.onnx",
@@ -5649,7 +5649,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_3d_log_prob/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx",
@@ -5657,7 +5657,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_4d/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii_4d_expanded/model.onnx",
@@ -5665,7 +5665,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_4d_log_prob/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx",
@@ -5677,7 +5677,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_log_prob/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx",
@@ -5685,7 +5685,7 @@
   ],
   [
     "node/test_sce_mean_weight_log_prob/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_mean_weight_log_prob_expanded/model.onnx",
@@ -5693,7 +5693,7 @@
   ],
   [
     "node/test_sce_none/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_none_expanded/model.onnx",
@@ -5701,7 +5701,7 @@
   ],
   [
     "node/test_sce_none_log_prob/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_none_log_prob_expanded/model.onnx",
@@ -5709,7 +5709,7 @@
   ],
   [
     "node/test_sce_none_weights/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_none_weights_expanded/model.onnx",
@@ -5717,7 +5717,7 @@
   ],
   [
     "node/test_sce_none_weights_log_prob/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_none_weights_log_prob_expanded/model.onnx",
@@ -5725,7 +5725,7 @@
   ],
   [
     "node/test_sce_sum/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_sum_expanded/model.onnx",
@@ -5733,7 +5733,7 @@
   ],
   [
     "node/test_sce_sum_log_prob/model.onnx",
-    "Unsupported op SoftmaxCrossEntropyLoss"
+    ""
   ],
   [
     "node/test_sce_sum_log_prob_expanded/model.onnx",

--- a/tests/test_softmax_cross_entropy_loss.py
+++ b/tests/test_softmax_cross_entropy_loss.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+
+from onnx import TensorProto, helper
+
+from onnx2c.compiler import Compiler
+
+
+def _make_sce_model(
+    *, reduction: str, with_weight: bool, ignore_index: int | None, with_log_prob: bool
+) -> onnx.ModelProto:
+    input_shape = [2, 3, 2]
+    target_shape = [2, 2]
+    output_shape = target_shape if reduction == "none" else []
+    input_info = helper.make_tensor_value_info(
+        "input", TensorProto.FLOAT, input_shape
+    )
+    target_info = helper.make_tensor_value_info(
+        "target", TensorProto.INT64, target_shape
+    )
+    inputs = [input_info, target_info]
+    input_names = ["input", "target"]
+    if with_weight:
+        weight_info = helper.make_tensor_value_info(
+            "weight", TensorProto.FLOAT, [input_shape[1]]
+        )
+        inputs.append(weight_info)
+        input_names.append("weight")
+    outputs = [
+        helper.make_tensor_value_info("out", TensorProto.FLOAT, output_shape)
+    ]
+    if with_log_prob:
+        outputs.append(
+            helper.make_tensor_value_info(
+                "log_prob", TensorProto.FLOAT, input_shape
+            )
+        )
+    node = helper.make_node(
+        "SoftmaxCrossEntropyLoss",
+        inputs=input_names,
+        outputs=[output.name for output in outputs],
+        reduction=reduction,
+        ignore_index=ignore_index,
+    )
+    graph = helper.make_graph(
+        [node],
+        "sce_graph",
+        inputs,
+        outputs,
+    )
+    model = helper.make_model(
+        graph,
+        producer_name="onnx2c",
+        opset_imports=[helper.make_operatorsetid("", 13)],
+    )
+    model.ir_version = 7
+    onnx.checker.check_model(model)
+    return model
+
+
+def _expected_sce(
+    values: np.ndarray,
+    target: np.ndarray,
+    weight: np.ndarray | None,
+    *,
+    reduction: str,
+    ignore_index: int | None,
+    return_log_prob: bool,
+) -> tuple[np.ndarray, np.ndarray | None]:
+    input_shape = values.shape
+    target_shape = target.shape
+    n = input_shape[0]
+    c = input_shape[1]
+    max_values = np.max(values, axis=1, keepdims=True)
+    exp_values = np.exp(values - max_values)
+    log_prob = np.log(exp_values / np.sum(exp_values, axis=1, keepdims=True))
+    log_prob_output = log_prob if return_log_prob else None
+    gather_weight = None
+    if weight is not None:
+        gather_weight = np.take(weight, target.astype(np.int32), mode="clip")
+        if ignore_index is not None:
+            gather_weight = np.where(target == ignore_index, 0, gather_weight).astype(
+                dtype=values.dtype
+            )
+    elif ignore_index is not None:
+        gather_weight = np.where(target == ignore_index, 0, 1).astype(
+            dtype=values.dtype
+        )
+    if len(input_shape) != 3:
+        log_prob = log_prob.reshape((n, c, -1))
+        target = target.reshape((n, -1))
+    d = log_prob.shape[2]
+    loss = np.zeros((n, d), dtype=values.dtype)
+    for i in range(n):
+        for d_index in range(d):
+            if ignore_index is None or target[i][d_index] != ignore_index:
+                loss[i][d_index] = -log_prob[i][target[i][d_index]][d_index]
+    if len(input_shape) != 3:
+        loss = loss.reshape(target_shape)
+    if gather_weight is not None:
+        loss = gather_weight * loss
+        if reduction == "mean":
+            loss = loss.sum() / gather_weight.sum()
+            loss = loss.astype(values.dtype)
+            if return_log_prob and log_prob_output is not None:
+                return loss, log_prob_output.astype(values.dtype)
+            return loss, None
+    if reduction == "mean":
+        loss = np.mean(loss)
+    elif reduction == "sum":
+        loss = np.sum(loss)
+    loss = loss.astype(values.dtype)
+    if return_log_prob and log_prob_output is not None:
+        return loss, log_prob_output.astype(values.dtype)
+    return loss, None
+
+
+def test_softmax_cross_entropy_loss_reduction_none_matches_expected() -> None:
+    model = _make_sce_model(
+        reduction="none", with_weight=True, ignore_index=2, with_log_prob=False
+    )
+    values = np.array(
+        [
+            [[1.0, 2.0], [2.5, 3.5], [4.0, 5.0]],
+            [[-1.0, 0.5], [1.5, -2.5], [3.0, -4.0]],
+        ],
+        dtype=np.float32,
+    )
+    target = np.array([[2, 1], [0, 2]], dtype=np.int64)
+    weight = np.array([0.5, 1.0, 1.5], dtype=np.float32)
+    compiler = Compiler()
+    outputs = compiler.run(
+        model, {"input": values, "target": target, "weight": weight}
+    )
+    expected, _ = _expected_sce(
+        values,
+        target,
+        weight,
+        reduction="none",
+        ignore_index=2,
+        return_log_prob=False,
+    )
+    np.testing.assert_allclose(outputs["out"], expected, rtol=1e-4, atol=1e-5)
+
+
+def test_softmax_cross_entropy_loss_log_prob_matches_onnxruntime() -> None:
+    model = _make_sce_model(
+        reduction="mean", with_weight=False, ignore_index=None, with_log_prob=True
+    )
+    values = np.array(
+        [
+            [[1.5, 0.5], [2.0, -1.0], [0.0, 3.0]],
+            [[-2.0, 1.0], [1.0, 2.0], [0.5, -0.5]],
+        ],
+        dtype=np.float32,
+    )
+    target = np.array([[0, 2], [1, 2]], dtype=np.int64)
+    compiler = Compiler()
+    outputs = compiler.run(model, {"input": values, "target": target})
+    sess = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    ort_out, ort_log_prob = sess.run(None, {"input": values, "target": target})
+    np.testing.assert_allclose(outputs["out"], ort_out, rtol=1e-4, atol=1e-5)
+    np.testing.assert_allclose(
+        outputs["log_prob"], ort_log_prob, rtol=1e-4, atol=1e-5
+    )


### PR DESCRIPTION
### Motivation
- Enable support for the ONNX `SoftmaxCrossEntropyLoss` operator in the compiler pipeline so models using this loss can be lowered and executed.
- Provide both runtime evaluation and C code emission for `SoftmaxCrossEntropyLoss` including optional `log_prob` output.
- Keep operator behavior consistent with ONNX reference semantics (reduction modes, `ignore_index`, optional `weight`).
- Update official ONNX support snapshots to reflect the newly supported operator files.

### Description
- Added lowering for `SoftmaxCrossEntropyLoss` in `src/onnx2c/lowering/softmax_cross_entropy_loss.py` which validates types/shapes and emits a `SoftmaxCrossEntropyLossOp` lowering object.
- Implemented runtime evaluation `_apply_softmax_cross_entropy_loss` and registered evaluator in `src/onnx2c/runtime/evaluator.py` to compute loss and optional `log_prob` following ONNX semantics.
- Extended C emission in `src/onnx2c/codegen/c_emitter.py` to recognize `SoftmaxCrossEntropyLossOp`, load a new template, include necessary headers, wire wrapper calls and output shapes/dtypes, and render the op; added the template `templates/softmax_cross_entropy_loss_op.c.j2`.
- Added unit tests `tests/test_softmax_cross_entropy_loss.py` and updated official ONNX support artifacts (`OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`, `tests/official_onnx_expected_errors.json`) to reflect new operator support.

### Testing
- Ran the new targeted tests with `pytest tests/test_softmax_cross_entropy_loss.py -q` which passed (`2 passed in 1.39s`).
- Ran the full test suite with reference updates `UPDATE_REFS=1 pytest -n auto -q` which completed successfully (`128 passed in 19.33s`).
- The added tests verify both `reduction='none'` behavior and `log_prob` output matches ONNX Runtime for representative inputs.
- No additional failing automated tests were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696515dcf9988325a5dd0646412d2a43)