### PR TITLE
lowering: implement Where operator

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 573 / 1802 official ONNX files.
+Support 585 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -477,24 +477,24 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_clip_default_int8_inbounds/model.onnx | ❌ | Unsupported op Clip |
 | node/test_clip_default_int8_inbounds_expanded/model.onnx | ❌ | Unsupported op Identity |
 | node/test_clip_default_int8_max/model.onnx | ❌ | Unsupported op Clip |
-| node/test_clip_default_int8_max_expanded/model.onnx | ❌ | Unsupported op Where |
+| node/test_clip_default_int8_max_expanded/model.onnx | ✅ |  |
 | node/test_clip_default_int8_min/model.onnx | ❌ | Unsupported op Clip |
-| node/test_clip_default_int8_min_expanded/model.onnx | ❌ | Unsupported op Where |
+| node/test_clip_default_int8_min_expanded/model.onnx | ✅ |  |
 | node/test_clip_default_max/model.onnx | ❌ | Unsupported op Clip |
-| node/test_clip_default_max_expanded/model.onnx | ❌ | Unsupported op Where |
+| node/test_clip_default_max_expanded/model.onnx | ✅ |  |
 | node/test_clip_default_min/model.onnx | ❌ | Unsupported op Clip |
-| node/test_clip_default_min_expanded/model.onnx | ❌ | Unsupported op Where |
+| node/test_clip_default_min_expanded/model.onnx | ✅ |  |
 | node/test_clip_example/model.onnx | ❌ | Unsupported op Clip |
-| node/test_clip_example_expanded/model.onnx | ❌ | Unsupported op Where |
-| node/test_clip_expanded/model.onnx | ❌ | Unsupported op Where |
+| node/test_clip_example_expanded/model.onnx | ✅ |  |
+| node/test_clip_expanded/model.onnx | ✅ |  |
 | node/test_clip_inbounds/model.onnx | ❌ | Unsupported op Clip |
-| node/test_clip_inbounds_expanded/model.onnx | ❌ | Unsupported op Where |
+| node/test_clip_inbounds_expanded/model.onnx | ✅ |  |
 | node/test_clip_min_greater_than_max/model.onnx | ❌ | Unsupported op Clip |
-| node/test_clip_min_greater_than_max_expanded/model.onnx | ❌ | Unsupported op Where |
+| node/test_clip_min_greater_than_max_expanded/model.onnx | ✅ |  |
 | node/test_clip_outbounds/model.onnx | ❌ | Unsupported op Clip |
-| node/test_clip_outbounds_expanded/model.onnx | ❌ | Unsupported op Where |
+| node/test_clip_outbounds_expanded/model.onnx | ✅ |  |
 | node/test_clip_splitbounds/model.onnx | ❌ | Unsupported op Clip |
-| node/test_clip_splitbounds_expanded/model.onnx | ❌ | Unsupported op Where |
+| node/test_clip_splitbounds_expanded/model.onnx | ✅ |  |
 | node/test_col2im/model.onnx | ❌ | Unsupported op Col2Im |
 | node/test_col2im_5d/model.onnx | ❌ | Unsupported op Col2Im |
 | node/test_col2im_dilations/model.onnx | ❌ | Unsupported op Col2Im |
@@ -1002,17 +1002,17 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_nllloss_NCd1/model.onnx | ✅ |  |
 | node/test_nllloss_NCd1_expanded/model.onnx | ❌ | Unsupported op GatherElements |
 | node/test_nllloss_NCd1_ii/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1_ii_expanded/model.onnx | ❌ | Unsupported op Where |
+| node/test_nllloss_NCd1_ii_expanded/model.onnx | ❌ | Unsupported op GatherElements |
 | node/test_nllloss_NCd1_mean_weight_negative_ii/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1_mean_weight_negative_ii_expanded/model.onnx | ❌ | Unsupported op Where |
+| node/test_nllloss_NCd1_mean_weight_negative_ii_expanded/model.onnx | ❌ | Unsupported op GatherElements |
 | node/test_nllloss_NCd1_weight/model.onnx | ✅ |  |
 | node/test_nllloss_NCd1_weight_expanded/model.onnx | ❌ | Unsupported op GatherElements |
 | node/test_nllloss_NCd1_weight_ii/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1_weight_ii_expanded/model.onnx | ❌ | Unsupported op Where |
+| node/test_nllloss_NCd1_weight_ii_expanded/model.onnx | ❌ | Unsupported op GatherElements |
 | node/test_nllloss_NCd1d2/model.onnx | ✅ |  |
 | node/test_nllloss_NCd1d2_expanded/model.onnx | ❌ | Unsupported op GatherElements |
 | node/test_nllloss_NCd1d2_no_weight_reduction_mean_ii/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2_no_weight_reduction_mean_ii_expanded/model.onnx | ❌ | Unsupported op Where |
+| node/test_nllloss_NCd1d2_no_weight_reduction_mean_ii_expanded/model.onnx | ❌ | Unsupported op GatherElements |
 | node/test_nllloss_NCd1d2_reduction_mean/model.onnx | ✅ |  |
 | node/test_nllloss_NCd1d2_reduction_mean_expanded/model.onnx | ❌ | Unsupported op GatherElements |
 | node/test_nllloss_NCd1d2_reduction_sum/model.onnx | ✅ |  |
@@ -1024,11 +1024,11 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_nllloss_NCd1d2_with_weight_reduction_sum/model.onnx | ✅ |  |
 | node/test_nllloss_NCd1d2_with_weight_reduction_sum_expanded/model.onnx | ❌ | Unsupported op GatherElements |
 | node/test_nllloss_NCd1d2_with_weight_reduction_sum_ii/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2_with_weight_reduction_sum_ii_expanded/model.onnx | ❌ | Unsupported op Where |
+| node/test_nllloss_NCd1d2_with_weight_reduction_sum_ii_expanded/model.onnx | ❌ | Unsupported op GatherElements |
 | node/test_nllloss_NCd1d2d3_none_no_weight_negative_ii/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx | ❌ | Unsupported op Where |
+| node/test_nllloss_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx | ❌ | Unsupported op GatherElements |
 | node/test_nllloss_NCd1d2d3_sum_weight_high_ii/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx | ❌ | Unsupported op Where |
+| node/test_nllloss_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx | ❌ | Unsupported op GatherElements |
 | node/test_nllloss_NCd1d2d3d4d5_mean_weight/model.onnx | ✅ |  |
 | node/test_nllloss_NCd1d2d3d4d5_mean_weight_expanded/model.onnx | ❌ | Unsupported op GatherElements |
 | node/test_nllloss_NCd1d2d3d4d5_none_no_weight/model.onnx | ✅ |  |
@@ -1659,8 +1659,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_unsqueeze_two_axes/model.onnx | ✅ |  |
 | node/test_unsqueeze_unsorted_axes/model.onnx | ✅ |  |
 | node/test_upsample_nearest/model.onnx | ❌ | Unsupported op Upsample |
-| node/test_where_example/model.onnx | ❌ | Unsupported op Where |
-| node/test_where_long_example/model.onnx | ❌ | Unsupported op Where |
+| node/test_where_example/model.onnx | ✅ |  |
+| node/test_where_long_example/model.onnx | ✅ |  |
 | node/test_wrap_pad/model.onnx | ❌ | Unsupported op Pad |
 | node/test_xor2d/model.onnx | ✅ |  |
 | node/test_xor3d/model.onnx | ✅ |  |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -8,8 +8,8 @@
 | Missing elem_type for tensor '*' | 34 | ███████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████ |
 | Unsupported op CastLike | 31 | ██████ |
+| Unsupported op GatherElements | 21 | ████ |
 | Unsupported op Identity | 20 | ████ |
-| Unsupported op Where | 19 | ████ |
 | Unsupported op LayerNormalization | 19 | ████ |
 | Unsupported op RMSNormalization | 19 | ████ |
 | Unsupported op GridSample | 18 | ████ |
@@ -26,7 +26,6 @@
 | Unsupported elem_type 25 (UINT2) for tensor '*'. | 14 | ███ |
 | Unsupported elem_type 21 (UINT4) for tensor '*'. | 14 | ███ |
 | Unsupported op ConvTranspose | 14 | ███ |
-| Unsupported op GatherElements | 14 | ███ |
 | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 12 | ██ |
 | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 12 | ██ |
 | Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 11 | ██ |

--- a/src/onnx2c/compiler.py
+++ b/src/onnx2c/compiler.py
@@ -37,6 +37,7 @@ from .codegen.c_emitter import (
     ShapeOp,
     TransposeOp,
     UnaryOp,
+    WhereOp,
 )
 from .dtypes import dtype_info
 from .errors import ShapeInferenceError, UnsupportedOpError
@@ -81,6 +82,7 @@ from .lowering.shape import lower_shape
 from .lowering.softmax import lower_softmax
 from .lowering.transpose import lower_transpose
 from .lowering.unsqueeze import lower_unsqueeze
+from .lowering.where import lower_where
 from .lowering.registry import get_lowering_registry, resolve_dispatch
 from .onnx_import import import_onnx
 from .ops import (
@@ -246,6 +248,7 @@ class Compiler:
             | ResizeOp
             | ReduceOp
             | ShapeOp
+            | WhereOp
         ] = []
         node_infos: list[NodeInfo] = []
         for node in graph.nodes:

--- a/src/onnx2c/lowering/where.py
+++ b/src/onnx2c/lowering/where.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from ..codegen.c_emitter import WhereOp
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Node
+from .common import value_dtype as _value_dtype
+from .common import value_shape as _value_shape
+from .registry import register_lowering
+
+
+def _broadcast_shape(shapes: tuple[tuple[int, ...], ...], node: Node) -> tuple[int, ...]:
+    if not shapes:
+        return ()
+    max_rank = max(len(shape) for shape in shapes)
+    padded = [
+        (1,) * (max_rank - len(shape)) + shape
+        for shape in shapes
+    ]
+    broadcast: list[int] = []
+    for dims in zip(*padded):
+        dim = max(dims)
+        if any(item not in (1, dim) for item in dims):
+            raise ShapeInferenceError(
+                f"{node.op_type} inputs must be broadcastable, got {shapes}"
+            )
+        broadcast.append(dim)
+    return tuple(broadcast)
+
+
+@register_lowering("Where")
+def lower_where(graph: Graph, node: Node) -> WhereOp:
+    if len(node.inputs) != 3 or len(node.outputs) != 1:
+        raise UnsupportedOpError("Where must have 3 inputs and 1 output")
+    condition_name, x_name, y_name = node.inputs
+    output_name = node.outputs[0]
+    condition_dtype = _value_dtype(graph, condition_name, node)
+    if condition_dtype != "bool":
+        raise UnsupportedOpError(
+            f"Where expects bool condition, got {condition_dtype}"
+        )
+    x_dtype = _value_dtype(graph, x_name, node)
+    y_dtype = _value_dtype(graph, y_name, node)
+    output_dtype = _value_dtype(graph, output_name, node)
+    if x_dtype != y_dtype or output_dtype != x_dtype:
+        raise UnsupportedOpError(
+            "Where expects matching input/output dtypes, "
+            f"got {x_dtype}, {y_dtype}, {output_dtype}"
+        )
+    condition_shape = _value_shape(graph, condition_name, node)
+    x_shape = _value_shape(graph, x_name, node)
+    y_shape = _value_shape(graph, y_name, node)
+    output_shape = _value_shape(graph, output_name, node)
+    broadcast_shape = _broadcast_shape(
+        (condition_shape, x_shape, y_shape),
+        node,
+    )
+    if output_shape != broadcast_shape:
+        raise ShapeInferenceError(
+            f"Where output shape must be {broadcast_shape}, got {output_shape}"
+        )
+    return WhereOp(
+        condition=condition_name,
+        input_x=x_name,
+        input_y=y_name,
+        output=output_name,
+        condition_shape=condition_shape,
+        x_shape=x_shape,
+        y_shape=y_shape,
+        output_shape=output_shape,
+        dtype=output_dtype,
+    )

--- a/src/onnx2c/runtime/evaluator.py
+++ b/src/onnx2c/runtime/evaluator.py
@@ -37,6 +37,7 @@ from ..lowering.shape import lower_shape
 from ..lowering.softmax import lower_softmax
 from ..lowering.transpose import lower_transpose
 from ..lowering.unsqueeze import lower_unsqueeze
+from ..lowering.where import lower_where
 from ..lowering.registry import resolve_dispatch
 from ..lowering.common import node_dtype, optional_name, value_dtype
 from ..ops import (
@@ -145,6 +146,15 @@ def _eval_cast(evaluator: Evaluator, node: Node) -> None:
     evaluator.values[node.outputs[0]] = input_value.astype(
         target_info.np_dtype, copy=False
     )
+
+
+@register_evaluator("Where")
+def _eval_where(evaluator: Evaluator, node: Node) -> None:
+    lower_where(evaluator.graph, node)
+    condition = evaluator.values[node.inputs[0]]
+    x_value = evaluator.values[node.inputs[1]]
+    y_value = evaluator.values[node.inputs[2]]
+    evaluator.values[node.outputs[0]] = np.where(condition, x_value, y_value)
 
 
 @register_evaluator("Attention")

--- a/templates/where_op.c.j2
+++ b/templates/where_op.c.j2
@@ -1,0 +1,9 @@
+static inline void {{ op_name }}(const {{ condition_c_type }} {{ condition }}{{ condition_array_suffix }}, const {{ input_c_type }} {{ input_x }}{{ x_array_suffix }}, const {{ input_c_type }} {{ input_y }}{{ y_array_suffix }}, {{ output_c_type }} {{ output }}{{ output_array_suffix }}) {
+{% for dim in output_shape %}
+{{ loop_indents[loop.index0] }}for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+{% endfor %}
+{{ inner_indent }}{{ output_expr }} = {{ condition_expr }} ? {{ x_expr }} : {{ y_expr }};
+{% for _ in output_shape %}
+{{ loop_indents[loop.revindex0] }}}
+{% endfor %}
+}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -1877,7 +1877,7 @@
   ],
   [
     "node/test_clip_default_int8_max_expanded/model.onnx",
-    "Unsupported op Where"
+    ""
   ],
   [
     "node/test_clip_default_int8_min/model.onnx",
@@ -1885,7 +1885,7 @@
   ],
   [
     "node/test_clip_default_int8_min_expanded/model.onnx",
-    "Unsupported op Where"
+    ""
   ],
   [
     "node/test_clip_default_max/model.onnx",
@@ -1893,7 +1893,7 @@
   ],
   [
     "node/test_clip_default_max_expanded/model.onnx",
-    "Unsupported op Where"
+    ""
   ],
   [
     "node/test_clip_default_min/model.onnx",
@@ -1901,7 +1901,7 @@
   ],
   [
     "node/test_clip_default_min_expanded/model.onnx",
-    "Unsupported op Where"
+    ""
   ],
   [
     "node/test_clip_example/model.onnx",
@@ -1909,11 +1909,11 @@
   ],
   [
     "node/test_clip_example_expanded/model.onnx",
-    "Unsupported op Where"
+    ""
   ],
   [
     "node/test_clip_expanded/model.onnx",
-    "Unsupported op Where"
+    ""
   ],
   [
     "node/test_clip_inbounds/model.onnx",
@@ -1921,7 +1921,7 @@
   ],
   [
     "node/test_clip_inbounds_expanded/model.onnx",
-    "Unsupported op Where"
+    ""
   ],
   [
     "node/test_clip_min_greater_than_max/model.onnx",
@@ -1929,7 +1929,7 @@
   ],
   [
     "node/test_clip_min_greater_than_max_expanded/model.onnx",
-    "Unsupported op Where"
+    ""
   ],
   [
     "node/test_clip_outbounds/model.onnx",
@@ -1937,7 +1937,7 @@
   ],
   [
     "node/test_clip_outbounds_expanded/model.onnx",
-    "Unsupported op Where"
+    ""
   ],
   [
     "node/test_clip_splitbounds/model.onnx",
@@ -1945,7 +1945,7 @@
   ],
   [
     "node/test_clip_splitbounds_expanded/model.onnx",
-    "Unsupported op Where"
+    ""
   ],
   [
     "node/test_col2im/model.onnx",
@@ -3977,7 +3977,7 @@
   ],
   [
     "node/test_nllloss_NCd1_ii_expanded/model.onnx",
-    "Unsupported op Where"
+    "Unsupported op GatherElements"
   ],
   [
     "node/test_nllloss_NCd1_mean_weight_negative_ii/model.onnx",
@@ -3985,7 +3985,7 @@
   ],
   [
     "node/test_nllloss_NCd1_mean_weight_negative_ii_expanded/model.onnx",
-    "Unsupported op Where"
+    "Unsupported op GatherElements"
   ],
   [
     "node/test_nllloss_NCd1_weight/model.onnx",
@@ -4001,7 +4001,7 @@
   ],
   [
     "node/test_nllloss_NCd1_weight_ii_expanded/model.onnx",
-    "Unsupported op Where"
+    "Unsupported op GatherElements"
   ],
   [
     "node/test_nllloss_NCd1d2/model.onnx",
@@ -4017,7 +4017,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2_no_weight_reduction_mean_ii_expanded/model.onnx",
-    "Unsupported op Where"
+    "Unsupported op GatherElements"
   ],
   [
     "node/test_nllloss_NCd1d2_reduction_mean/model.onnx",
@@ -4065,7 +4065,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight_reduction_sum_ii_expanded/model.onnx",
-    "Unsupported op Where"
+    "Unsupported op GatherElements"
   ],
   [
     "node/test_nllloss_NCd1d2d3_none_no_weight_negative_ii/model.onnx",
@@ -4073,7 +4073,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx",
-    "Unsupported op Where"
+    "Unsupported op GatherElements"
   ],
   [
     "node/test_nllloss_NCd1d2d3_sum_weight_high_ii/model.onnx",
@@ -4081,7 +4081,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx",
-    "Unsupported op Where"
+    "Unsupported op GatherElements"
   ],
   [
     "node/test_nllloss_NCd1d2d3d4d5_mean_weight/model.onnx",
@@ -6605,11 +6605,11 @@
   ],
   [
     "node/test_where_example/model.onnx",
-    "Unsupported op Where"
+    ""
   ],
   [
     "node/test_where_long_example/model.onnx",
-    "Unsupported op Where"
+    ""
   ],
   [
     "node/test_wrap_pad/model.onnx",


### PR DESCRIPTION
### Motivation
- Add support for the ONNX `Where` operator so models using conditional selection can be lowered, emitted to C, and executed by the runtime.
- Ensure `Where` lowering validates dtypes and broadcast-compatible shapes to avoid incorrect code generation or runtime errors.
- Update official ONNX support expectations and snapshots to reflect the newly-supported `Where` cases.

### Description
- Implement `Where` lowering and validation in `src/onnx2c/lowering/where.py` with broadcast shape checking and dtype consistency checks, returning a new `WhereOp` lowering descriptor.
- Add `WhereOp` model type and codegen support to `src/onnx2c/codegen/c_emitter.py`, including a `_broadcast_index_expr` helper and integration of a new template `templates/where_op.c.j2` to emit selection loops that honor broadcasting.
- Wire up runtime evaluation by adding a `Where` evaluator that calls `lower_where` and uses `np.where` in `src/onnx2c/runtime/evaluator.py`, and import the lowering into the compiler in `src/onnx2c/compiler.py`.
- Refresh official ONNX support references and expected-error snapshots in `OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`, and `tests/official_onnx_expected_errors.json` to reflect enabled `Where` coverage.

### Testing
- Ran the test suite with `UPDATE_REFS=1 pytest -n auto -q` and all tests passed (`136 passed`), completing in about `27.39s`.
- The official ONNX expected-errors snapshot was updated to mark previously failing `Where` cases as supported and adjust related histogram entries.
- No new failing unit tests were introduced and C template loading remains covered by existing template tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6965aaae760083259dbd273d5a73528d)