### PR TITLE
codegen: drop operator-specific indent helpers

### DIFF
--- a/src/onnx2c/codegen/c_emitter.py
+++ b/src/onnx2c/codegen/c_emitter.py
@@ -1997,8 +1997,6 @@ class CEmitter:
         if isinstance(op, WhereOp):
             output_shape = CEmitter._codegen_shape(op.output_shape)
             loop_vars = CEmitter._loop_vars(output_shape)
-            loop_indents = CEmitter._loop_indents(output_shape)
-            inner_indent = CEmitter._inner_indent(output_shape)
             output_array_suffix = self._param_array_suffix(output_shape)
             condition_array_suffix = self._param_array_suffix(op.condition_shape)
             x_array_suffix = self._param_array_suffix(op.x_shape)
@@ -2020,8 +2018,6 @@ class CEmitter:
                 op_name=f"{model.name}_op{index}",
                 output_shape=output_shape,
                 loop_vars=loop_vars,
-                loop_indents=loop_indents,
-                inner_indent=inner_indent,
                 condition=op.condition,
                 input_x=op.input_x,
                 input_y=op.input_y,
@@ -2625,8 +2621,6 @@ class CEmitter:
         if isinstance(op, GatherElementsOp):
             output_shape = CEmitter._codegen_shape(op.output_shape)
             loop_vars = CEmitter._loop_vars(output_shape)
-            loop_indents = CEmitter._loop_indents(output_shape)
-            inner_indent = CEmitter._inner_indent(output_shape)
             data_indices = list(loop_vars)
             data_indices[op.axis] = "gather_index"
             rendered = gather_elements_template.render(
@@ -2642,8 +2636,6 @@ class CEmitter:
                 output_suffix=self._param_array_suffix(op.output_shape),
                 output_shape=output_shape,
                 loop_vars=loop_vars,
-                loop_indents=loop_indents,
-                inner_indent=inner_indent,
                 data_indices=data_indices,
                 axis_dim=op.data_shape[op.axis],
             ).rstrip()
@@ -3207,16 +3199,6 @@ class CEmitter:
     def _loop_vars(shape: tuple[int, ...]) -> tuple[str, ...]:
         shape = CEmitter._codegen_shape(shape)
         return tuple(f"i{index}" for index in range(len(shape)))
-
-    @staticmethod
-    def _loop_indents(shape: tuple[int, ...]) -> tuple[str, ...]:
-        shape = CEmitter._codegen_shape(shape)
-        return tuple("" for _ in shape)
-
-    @staticmethod
-    def _inner_indent(shape: tuple[int, ...]) -> str:
-        CEmitter._codegen_shape(shape)
-        return ""
 
     @staticmethod
     def _broadcast_index_expr(

--- a/templates/gather_elements_op.c.j2
+++ b/templates/gather_elements_op.c.j2
@@ -1,13 +1,13 @@
 static inline void {{ op_name }}(const {{ c_type }} {{ data }}{{ data_suffix }}, const {{ indices_c_type }} {{ indices }}{{ indices_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
 {% for dim in output_shape %}
-{{ loop_indents[loop.index0] }}for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
-{{ inner_indent }}int64_t gather_index = (int64_t){{ indices }}{% for var in loop_vars %}[{{ var }}]{% endfor %};
-{{ inner_indent }}if (gather_index < 0) {
-{{ inner_indent }}    gather_index += {{ axis_dim }};
-{{ inner_indent }}}
-{{ inner_indent }}{{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = {{ data }}{% for idx in data_indices %}[{{ idx }}]{% endfor %};
+int64_t gather_index = (int64_t){{ indices }}{% for var in loop_vars %}[{{ var }}]{% endfor %};
+if (gather_index < 0) {
+    gather_index += {{ axis_dim }};
+}
+{{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = {{ data }}{% for idx in data_indices %}[{{ idx }}]{% endfor %};
 {% for _ in output_shape %}
-{{ loop_indents[loop.revindex0] }}}
+}
 {% endfor %}
 }

--- a/templates/where_op.c.j2
+++ b/templates/where_op.c.j2
@@ -1,9 +1,9 @@
 static inline void {{ op_name }}(const {{ condition_c_type }} {{ condition }}{{ condition_array_suffix }}, const {{ input_c_type }} {{ input_x }}{{ x_array_suffix }}, const {{ input_c_type }} {{ input_y }}{{ y_array_suffix }}, {{ output_c_type }} {{ output }}{{ output_array_suffix }}) {
 {% for dim in output_shape %}
-{{ loop_indents[loop.index0] }}for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
-{{ inner_indent }}{{ output_expr }} = {{ condition_expr }} ? {{ x_expr }} : {{ y_expr }};
+{{ output_expr }} = {{ condition_expr }} ? {{ x_expr }} : {{ y_expr }};
 {% for _ in output_shape %}
-{{ loop_indents[loop.revindex0] }}}
+}
 {% endfor %}
 }


### PR DESCRIPTION
### Motivation
- Remove fragile, operator-specific indentation helpers that duplicated formatting logic and complicated template rendering.
- Simplify template code generation by relying on the shared `_format_c_indentation` path to produce deterministic C indentation.

### Description
- Remove `_loop_indents` and `_inner_indent` usage and wiring from `CEmitter` rendering for `WhereOp` and `GatherElementsOp` by stopping the computation and passing of those values to templates.
- Update `templates/where_op.c.j2` and `templates/gather_elements_op.c.j2` to emit explicit loop headers and body lines without relying on `loop_indents`/`inner_indent` template variables.
- Minor refactor to keep `CEmitter._loop_vars` and broadcasting/index helper logic unchanged while centralizing indentation formatting.

### Testing
- Ran the full test suite with `pytest -q` and all tests passed successfully.
- Test run result: `140 passed in 128.11s (0:02:08)`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6965b578f5308325a26501cc7538bf8f)