### PR TITLE
lowering: infer reduce axes from shapes

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 616 / 1802 official ONNX files.
+Support 665 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -1117,133 +1117,133 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_l1_default_axes_keepdims_example_expanded/model.onnx | ✅ |  |
 | node/test_reduce_l1_default_axes_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_l1_default_axes_keepdims_random_expanded/model.onnx | ✅ |  |
-| node/test_reduce_l1_do_not_keepdims_example/model.onnx | ❌ | ReduceL1 axes input must be constant |
-| node/test_reduce_l1_do_not_keepdims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_l1_do_not_keepdims_random/model.onnx | ❌ | ReduceL1 axes input must be constant |
-| node/test_reduce_l1_do_not_keepdims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_l1_empty_set/model.onnx | ❌ | ReduceL1 axes input must be constant |
-| node/test_reduce_l1_empty_set_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_l1_keep_dims_example/model.onnx | ❌ | ReduceL1 axes input must be constant |
-| node/test_reduce_l1_keep_dims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_l1_keep_dims_random/model.onnx | ❌ | ReduceL1 axes input must be constant |
-| node/test_reduce_l1_keep_dims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_l1_negative_axes_keep_dims_example/model.onnx | ❌ | ReduceL1 axes input must be constant |
-| node/test_reduce_l1_negative_axes_keep_dims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_l1_negative_axes_keep_dims_random/model.onnx | ❌ | ReduceL1 axes input must be constant |
-| node/test_reduce_l1_negative_axes_keep_dims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
+| node/test_reduce_l1_do_not_keepdims_example/model.onnx | ❌ | ReduceL1 axes input must be constant or inferable from shapes |
+| node/test_reduce_l1_do_not_keepdims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_l1_do_not_keepdims_random/model.onnx | ❌ | ReduceL1 axes input must be constant or inferable from shapes |
+| node/test_reduce_l1_do_not_keepdims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_l1_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_reduce_l1_empty_set_expanded/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_reduce_l1_keep_dims_example/model.onnx | ✅ |  |
+| node/test_reduce_l1_keep_dims_example_expanded/model.onnx | ✅ |  |
+| node/test_reduce_l1_keep_dims_random/model.onnx | ✅ |  |
+| node/test_reduce_l1_keep_dims_random_expanded/model.onnx | ✅ |  |
+| node/test_reduce_l1_negative_axes_keep_dims_example/model.onnx | ✅ |  |
+| node/test_reduce_l1_negative_axes_keep_dims_example_expanded/model.onnx | ✅ |  |
+| node/test_reduce_l1_negative_axes_keep_dims_random/model.onnx | ✅ |  |
+| node/test_reduce_l1_negative_axes_keep_dims_random_expanded/model.onnx | ✅ |  |
 | node/test_reduce_l2_default_axes_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_l2_default_axes_keepdims_example_expanded/model.onnx | ❌ | ReduceSum output shape must be (1, 1, 1), got () |
 | node/test_reduce_l2_default_axes_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_l2_default_axes_keepdims_random_expanded/model.onnx | ❌ | ReduceSum output shape must be (1, 1, 1), got () |
-| node/test_reduce_l2_do_not_keepdims_example/model.onnx | ❌ | ReduceL2 axes input must be constant |
-| node/test_reduce_l2_do_not_keepdims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_l2_do_not_keepdims_random/model.onnx | ❌ | ReduceL2 axes input must be constant |
-| node/test_reduce_l2_do_not_keepdims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_l2_empty_set/model.onnx | ❌ | ReduceL2 axes input must be constant |
-| node/test_reduce_l2_empty_set_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_l2_keep_dims_example/model.onnx | ❌ | ReduceL2 axes input must be constant |
-| node/test_reduce_l2_keep_dims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_l2_keep_dims_random/model.onnx | ❌ | ReduceL2 axes input must be constant |
-| node/test_reduce_l2_keep_dims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_l2_negative_axes_keep_dims_example/model.onnx | ❌ | ReduceL2 axes input must be constant |
-| node/test_reduce_l2_negative_axes_keep_dims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_l2_negative_axes_keep_dims_random/model.onnx | ❌ | ReduceL2 axes input must be constant |
-| node/test_reduce_l2_negative_axes_keep_dims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_log_sum_asc_axes/model.onnx | ❌ | ReduceLogSum axes input must be constant |
-| node/test_reduce_log_sum_asc_axes_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
+| node/test_reduce_l2_do_not_keepdims_example/model.onnx | ❌ | ReduceL2 axes input must be constant or inferable from shapes |
+| node/test_reduce_l2_do_not_keepdims_example_expanded/model.onnx | ❌ | CastLike input and output shapes must match |
+| node/test_reduce_l2_do_not_keepdims_random/model.onnx | ❌ | ReduceL2 axes input must be constant or inferable from shapes |
+| node/test_reduce_l2_do_not_keepdims_random_expanded/model.onnx | ❌ | CastLike input and output shapes must match |
+| node/test_reduce_l2_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_reduce_l2_empty_set_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_l2_keep_dims_example/model.onnx | ✅ |  |
+| node/test_reduce_l2_keep_dims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_l2_keep_dims_random/model.onnx | ✅ |  |
+| node/test_reduce_l2_keep_dims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_l2_negative_axes_keep_dims_example/model.onnx | ✅ |  |
+| node/test_reduce_l2_negative_axes_keep_dims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_l2_negative_axes_keep_dims_random/model.onnx | ✅ |  |
+| node/test_reduce_l2_negative_axes_keep_dims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_log_sum_asc_axes/model.onnx | ✅ |  |
+| node/test_reduce_log_sum_asc_axes_expanded/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_default/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_default_expanded/model.onnx | ❌ | ReduceSum output shape must be (1, 1, 1), got () |
-| node/test_reduce_log_sum_desc_axes/model.onnx | ❌ | ReduceLogSum axes input must be constant |
-| node/test_reduce_log_sum_desc_axes_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_log_sum_empty_set/model.onnx | ❌ | ReduceLogSum axes input must be constant |
-| node/test_reduce_log_sum_empty_set_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
+| node/test_reduce_log_sum_desc_axes/model.onnx | ✅ |  |
+| node/test_reduce_log_sum_desc_axes_expanded/model.onnx | ✅ |  |
+| node/test_reduce_log_sum_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_reduce_log_sum_empty_set_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
 | node/test_reduce_log_sum_exp_default_axes_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_exp_default_axes_keepdims_example_expanded/model.onnx | ❌ | ReduceSum output shape must be (1, 1, 1), got () |
 | node/test_reduce_log_sum_exp_default_axes_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_exp_default_axes_keepdims_random_expanded/model.onnx | ❌ | ReduceSum output shape must be (1, 1, 1), got () |
-| node/test_reduce_log_sum_exp_do_not_keepdims_example/model.onnx | ❌ | ReduceLogSumExp axes input must be constant |
-| node/test_reduce_log_sum_exp_do_not_keepdims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_log_sum_exp_do_not_keepdims_random/model.onnx | ❌ | ReduceLogSumExp axes input must be constant |
-| node/test_reduce_log_sum_exp_do_not_keepdims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_log_sum_exp_empty_set/model.onnx | ❌ | ReduceLogSumExp axes input must be constant |
-| node/test_reduce_log_sum_exp_empty_set_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_log_sum_exp_keepdims_example/model.onnx | ❌ | ReduceLogSumExp axes input must be constant |
-| node/test_reduce_log_sum_exp_keepdims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_log_sum_exp_keepdims_random/model.onnx | ❌ | ReduceLogSumExp axes input must be constant |
-| node/test_reduce_log_sum_exp_keepdims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_log_sum_exp_negative_axes_keepdims_example/model.onnx | ❌ | ReduceLogSumExp axes input must be constant |
-| node/test_reduce_log_sum_exp_negative_axes_keepdims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_log_sum_exp_negative_axes_keepdims_random/model.onnx | ❌ | ReduceLogSumExp axes input must be constant |
-| node/test_reduce_log_sum_exp_negative_axes_keepdims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_log_sum_negative_axes/model.onnx | ❌ | ReduceLogSum axes input must be constant |
-| node/test_reduce_log_sum_negative_axes_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
+| node/test_reduce_log_sum_exp_do_not_keepdims_example/model.onnx | ❌ | ReduceLogSumExp axes input must be constant or inferable from shapes |
+| node/test_reduce_log_sum_exp_do_not_keepdims_example_expanded/model.onnx | ❌ | CastLike input and output shapes must match |
+| node/test_reduce_log_sum_exp_do_not_keepdims_random/model.onnx | ❌ | ReduceLogSumExp axes input must be constant or inferable from shapes |
+| node/test_reduce_log_sum_exp_do_not_keepdims_random_expanded/model.onnx | ❌ | CastLike input and output shapes must match |
+| node/test_reduce_log_sum_exp_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_reduce_log_sum_exp_empty_set_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_log_sum_exp_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_log_sum_exp_keepdims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_log_sum_exp_keepdims_random/model.onnx | ✅ |  |
+| node/test_reduce_log_sum_exp_keepdims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_log_sum_exp_negative_axes_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_log_sum_exp_negative_axes_keepdims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_log_sum_exp_negative_axes_keepdims_random/model.onnx | ✅ |  |
+| node/test_reduce_log_sum_exp_negative_axes_keepdims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_log_sum_negative_axes/model.onnx | ✅ |  |
+| node/test_reduce_log_sum_negative_axes_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
 | node/test_reduce_max_bool_inputs/model.onnx | ❌ | ReduceMax does not support dtype bool |
 | node/test_reduce_max_default_axes_keepdim_example/model.onnx | ✅ |  |
 | node/test_reduce_max_default_axes_keepdims_random/model.onnx | ✅ |  |
-| node/test_reduce_max_do_not_keepdims_example/model.onnx | ❌ | ReduceMax axes input must be constant |
-| node/test_reduce_max_do_not_keepdims_random/model.onnx | ❌ | ReduceMax axes input must be constant |
-| node/test_reduce_max_empty_set/model.onnx | ❌ | ReduceMax axes input must be constant |
-| node/test_reduce_max_keepdims_example/model.onnx | ❌ | ReduceMax axes input must be constant |
-| node/test_reduce_max_keepdims_random/model.onnx | ❌ | ReduceMax axes input must be constant |
-| node/test_reduce_max_negative_axes_keepdims_example/model.onnx | ❌ | ReduceMax axes input must be constant |
-| node/test_reduce_max_negative_axes_keepdims_random/model.onnx | ❌ | ReduceMax axes input must be constant |
+| node/test_reduce_max_do_not_keepdims_example/model.onnx | ❌ | ReduceMax axes input must be constant or inferable from shapes |
+| node/test_reduce_max_do_not_keepdims_random/model.onnx | ❌ | ReduceMax axes input must be constant or inferable from shapes |
+| node/test_reduce_max_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_reduce_max_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_max_keepdims_random/model.onnx | ✅ |  |
+| node/test_reduce_max_negative_axes_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_max_negative_axes_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_mean_default_axes_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_mean_default_axes_keepdims_random/model.onnx | ✅ |  |
-| node/test_reduce_mean_do_not_keepdims_example/model.onnx | ❌ | ReduceMean axes input must be constant |
-| node/test_reduce_mean_do_not_keepdims_random/model.onnx | ❌ | ReduceMean axes input must be constant |
-| node/test_reduce_mean_keepdims_example/model.onnx | ❌ | ReduceMean axes input must be constant |
-| node/test_reduce_mean_keepdims_random/model.onnx | ❌ | ReduceMean axes input must be constant |
-| node/test_reduce_mean_negative_axes_keepdims_example/model.onnx | ❌ | ReduceMean axes input must be constant |
-| node/test_reduce_mean_negative_axes_keepdims_random/model.onnx | ❌ | ReduceMean axes input must be constant |
+| node/test_reduce_mean_do_not_keepdims_example/model.onnx | ❌ | ReduceMean axes input must be constant or inferable from shapes |
+| node/test_reduce_mean_do_not_keepdims_random/model.onnx | ❌ | ReduceMean axes input must be constant or inferable from shapes |
+| node/test_reduce_mean_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_mean_keepdims_random/model.onnx | ✅ |  |
+| node/test_reduce_mean_negative_axes_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_mean_negative_axes_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_min_bool_inputs/model.onnx | ❌ | ReduceMin does not support dtype bool |
 | node/test_reduce_min_default_axes_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_min_default_axes_keepdims_random/model.onnx | ✅ |  |
-| node/test_reduce_min_do_not_keepdims_example/model.onnx | ❌ | ReduceMin axes input must be constant |
-| node/test_reduce_min_do_not_keepdims_random/model.onnx | ❌ | ReduceMin axes input must be constant |
-| node/test_reduce_min_empty_set/model.onnx | ❌ | ReduceMin axes input must be constant |
-| node/test_reduce_min_keepdims_example/model.onnx | ❌ | ReduceMin axes input must be constant |
-| node/test_reduce_min_keepdims_random/model.onnx | ❌ | ReduceMin axes input must be constant |
-| node/test_reduce_min_negative_axes_keepdims_example/model.onnx | ❌ | ReduceMin axes input must be constant |
-| node/test_reduce_min_negative_axes_keepdims_random/model.onnx | ❌ | ReduceMin axes input must be constant |
+| node/test_reduce_min_do_not_keepdims_example/model.onnx | ❌ | ReduceMin axes input must be constant or inferable from shapes |
+| node/test_reduce_min_do_not_keepdims_random/model.onnx | ❌ | ReduceMin axes input must be constant or inferable from shapes |
+| node/test_reduce_min_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_reduce_min_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_min_keepdims_random/model.onnx | ✅ |  |
+| node/test_reduce_min_negative_axes_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_min_negative_axes_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_prod_default_axes_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_prod_default_axes_keepdims_random/model.onnx | ✅ |  |
-| node/test_reduce_prod_do_not_keepdims_example/model.onnx | ❌ | ReduceProd axes input must be constant |
-| node/test_reduce_prod_do_not_keepdims_random/model.onnx | ❌ | ReduceProd axes input must be constant |
-| node/test_reduce_prod_empty_set/model.onnx | ❌ | ReduceProd axes input must be constant |
-| node/test_reduce_prod_keepdims_example/model.onnx | ❌ | ReduceProd axes input must be constant |
-| node/test_reduce_prod_keepdims_random/model.onnx | ❌ | ReduceProd axes input must be constant |
-| node/test_reduce_prod_negative_axes_keepdims_example/model.onnx | ❌ | ReduceProd axes input must be constant |
-| node/test_reduce_prod_negative_axes_keepdims_random/model.onnx | ❌ | ReduceProd axes input must be constant |
+| node/test_reduce_prod_do_not_keepdims_example/model.onnx | ❌ | ReduceProd axes input must be constant or inferable from shapes |
+| node/test_reduce_prod_do_not_keepdims_random/model.onnx | ❌ | ReduceProd axes input must be constant or inferable from shapes |
+| node/test_reduce_prod_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_reduce_prod_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_prod_keepdims_random/model.onnx | ✅ |  |
+| node/test_reduce_prod_negative_axes_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_prod_negative_axes_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_sum_default_axes_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_sum_default_axes_keepdims_random/model.onnx | ✅ |  |
-| node/test_reduce_sum_do_not_keepdims_example/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_sum_do_not_keepdims_random/model.onnx | ❌ | ReduceSum axes input must be constant |
+| node/test_reduce_sum_do_not_keepdims_example/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_sum_do_not_keepdims_random/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
 | node/test_reduce_sum_empty_axes_input_noop/model.onnx | ✅ |  |
 | node/test_reduce_sum_empty_axes_input_noop_example/model.onnx | ✅ |  |
-| node/test_reduce_sum_empty_set/model.onnx | ❌ | ReduceSum axes input must be constant |
+| node/test_reduce_sum_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
 | node/test_reduce_sum_empty_set_non_reduced_axis_zero/model.onnx | ❌ | Dynamic or zero dims are not supported |
-| node/test_reduce_sum_keepdims_example/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_sum_keepdims_random/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_sum_negative_axes_keepdims_example/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_sum_negative_axes_keepdims_random/model.onnx | ❌ | ReduceSum axes input must be constant |
+| node/test_reduce_sum_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_sum_keepdims_random/model.onnx | ✅ |  |
+| node/test_reduce_sum_negative_axes_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_sum_negative_axes_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_sum_square_default_axes_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_sum_square_default_axes_keepdims_example_expanded/model.onnx | ✅ |  |
 | node/test_reduce_sum_square_default_axes_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_sum_square_default_axes_keepdims_random_expanded/model.onnx | ✅ |  |
-| node/test_reduce_sum_square_do_not_keepdims_example/model.onnx | ❌ | ReduceSumSquare axes input must be constant |
-| node/test_reduce_sum_square_do_not_keepdims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_sum_square_do_not_keepdims_random/model.onnx | ❌ | ReduceSumSquare axes input must be constant |
-| node/test_reduce_sum_square_do_not_keepdims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_sum_square_empty_set/model.onnx | ❌ | ReduceSumSquare axes input must be constant |
-| node/test_reduce_sum_square_empty_set_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_sum_square_keepdims_example/model.onnx | ❌ | ReduceSumSquare axes input must be constant |
-| node/test_reduce_sum_square_keepdims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_sum_square_keepdims_random/model.onnx | ❌ | ReduceSumSquare axes input must be constant |
-| node/test_reduce_sum_square_keepdims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_sum_square_negative_axes_keepdims_example/model.onnx | ❌ | ReduceSumSquare axes input must be constant |
-| node/test_reduce_sum_square_negative_axes_keepdims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
-| node/test_reduce_sum_square_negative_axes_keepdims_random/model.onnx | ❌ | ReduceSumSquare axes input must be constant |
-| node/test_reduce_sum_square_negative_axes_keepdims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant |
+| node/test_reduce_sum_square_do_not_keepdims_example/model.onnx | ❌ | ReduceSumSquare axes input must be constant or inferable from shapes |
+| node/test_reduce_sum_square_do_not_keepdims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_sum_square_do_not_keepdims_random/model.onnx | ❌ | ReduceSumSquare axes input must be constant or inferable from shapes |
+| node/test_reduce_sum_square_do_not_keepdims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_sum_square_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_reduce_sum_square_empty_set_expanded/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_reduce_sum_square_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_sum_square_keepdims_example_expanded/model.onnx | ✅ |  |
+| node/test_reduce_sum_square_keepdims_random/model.onnx | ✅ |  |
+| node/test_reduce_sum_square_keepdims_random_expanded/model.onnx | ✅ |  |
+| node/test_reduce_sum_square_negative_axes_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_sum_square_negative_axes_keepdims_example_expanded/model.onnx | ✅ |  |
+| node/test_reduce_sum_square_negative_axes_keepdims_random/model.onnx | ✅ |  |
+| node/test_reduce_sum_square_negative_axes_keepdims_random_expanded/model.onnx | ✅ |  |
 | node/test_reflect_pad/model.onnx | ❌ | Unsupported op Pad |
 | node/test_regex_full_match_basic/model.onnx | ❌ | Unsupported elem_type 8 (STRING) for tensor 'X'. |
 | node/test_regex_full_match_email_domain/model.onnx | ❌ | Unsupported elem_type 8 (STRING) for tensor 'X'. |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -4,14 +4,15 @@
 | --- | --- | --- |
 | Dynamic dim for tensor '*' | 146 | ██████████████████████████████ |
 | Unsupported elem_type 10 (FLOAT16) for tensor '*'. | 65 | █████████████ |
-| ReduceSum axes input must be constant | 39 | ████████ |
 | Missing elem_type for tensor '*' | 34 | ███████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████ |
 | Unsupported op Slice | 26 | █████ |
 | Unsupported op Identity | 20 | ████ |
+| Dynamic or zero dims are not supported | 20 | ████ |
 | Unsupported op LayerNormalization | 19 | ████ |
 | Unsupported op RMSNormalization | 19 | ████ |
 | Unsupported op GridSample | 18 | ████ |
+| ReduceSum axes input must be constant or inferable from shapes | 18 | ████ |
 | NegativeLogLikelihoodLoss input must be at least 2D | 17 | ███ |
 | Unsupported op Split | 17 | ███ |
 | Unsupported op ArgMax | 16 | ███ |
@@ -31,7 +32,6 @@
 | Unsupported op Pad | 11 | ██ |
 | Unsupported op Flatten | 11 | ██ |
 | Unsupported op Mod | 10 | ██ |
-| Dynamic or zero dims are not supported | 9 | ██ |
 | Unsupported op CumSum | 9 | ██ |
 | Unsupported op ImageDecoder | 9 | ██ |
 | Unsupported op NonMaxSuppression | 9 | ██ |
@@ -42,13 +42,6 @@
 | Unsupported op Min | 8 | ██ |
 | Unsupported op RotaryEmbedding | 8 | ██ |
 | Unsupported op Hardmax | 7 | █ |
-| ReduceL1 axes input must be constant | 7 | █ |
-| ReduceL2 axes input must be constant | 7 | █ |
-| ReduceLogSumExp axes input must be constant | 7 | █ |
-| ReduceMax axes input must be constant | 7 | █ |
-| ReduceMin axes input must be constant | 7 | █ |
-| ReduceProd axes input must be constant | 7 | █ |
-| ReduceSumSquare axes input must be constant | 7 | █ |
 | Unsupported op TfIdfVectorizer | 7 | █ |
 | Unsupported op TopK | 7 | █ |
 | AveragePool has unsupported attributes | 6 | █ |
@@ -61,7 +54,6 @@
 | Unsupported op Gather | 6 | █ |
 | Unsupported op LpNormalization | 6 | █ |
 | Unsupported op QuantizeLinear | 6 | █ |
-| ReduceMean axes input must be constant | 6 | █ |
 | Unsupported op ScatterElements | 6 | █ |
 | Unsupported op Sigmoid | 6 | █ |
 | Unsupported op Unique | 6 | █ |
@@ -86,7 +78,7 @@
 | Unsupported op OneHot | 4 | █ |
 | Unsupported op OptionalHasElement | 4 | █ |
 | Unsupported op QLinearMatMul | 4 | █ |
-| ReduceLogSum axes input must be constant | 4 | █ |
+| CastLike input and output shapes must match | 4 | █ |
 | Unsupported op RNN | 4 | █ |
 | Unsupported op Squeeze | 4 | █ |
 | Unsupported op Tile | 4 | █ |
@@ -137,6 +129,14 @@
 | Unsupported op Pow | 2 | █ |
 | Unsupported op Range | 2 | █ |
 | Unsupported op Reciprocal | 2 | █ |
+| ReduceL1 axes input must be constant or inferable from shapes | 2 | █ |
+| ReduceL2 axes input must be constant or inferable from shapes | 2 | █ |
+| ReduceLogSumExp axes input must be constant or inferable from shapes | 2 | █ |
+| ReduceMax axes input must be constant or inferable from shapes | 2 | █ |
+| ReduceMean axes input must be constant or inferable from shapes | 2 | █ |
+| ReduceMin axes input must be constant or inferable from shapes | 2 | █ |
+| ReduceProd axes input must be constant or inferable from shapes | 2 | █ |
+| ReduceSumSquare axes input must be constant or inferable from shapes | 2 | █ |
 | Unsupported op ReverseSequence | 2 | █ |
 | Unsupported op Scan | 2 | █ |
 | Unsupported op Scatter | 2 | █ |

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -4437,59 +4437,59 @@
   ],
   [
     "node/test_reduce_l1_do_not_keepdims_example/model.onnx",
-    "ReduceL1 axes input must be constant"
+    "ReduceL1 axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_l1_do_not_keepdims_example_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "ReduceSum axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_l1_do_not_keepdims_random/model.onnx",
-    "ReduceL1 axes input must be constant"
+    "ReduceL1 axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_l1_do_not_keepdims_random_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "ReduceSum axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_l1_empty_set/model.onnx",
-    "ReduceL1 axes input must be constant"
+    "Dynamic or zero dims are not supported"
   ],
   [
     "node/test_reduce_l1_empty_set_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "Dynamic or zero dims are not supported"
   ],
   [
     "node/test_reduce_l1_keep_dims_example/model.onnx",
-    "ReduceL1 axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_l1_keep_dims_example_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_l1_keep_dims_random/model.onnx",
-    "ReduceL1 axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_l1_keep_dims_random_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_l1_negative_axes_keep_dims_example/model.onnx",
-    "ReduceL1 axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_l1_negative_axes_keep_dims_example_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_l1_negative_axes_keep_dims_random/model.onnx",
-    "ReduceL1 axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_l1_negative_axes_keep_dims_random_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_l2_default_axes_keepdims_example/model.onnx",
@@ -4509,67 +4509,67 @@
   ],
   [
     "node/test_reduce_l2_do_not_keepdims_example/model.onnx",
-    "ReduceL2 axes input must be constant"
+    "ReduceL2 axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_l2_do_not_keepdims_example_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "CastLike input and output shapes must match"
   ],
   [
     "node/test_reduce_l2_do_not_keepdims_random/model.onnx",
-    "ReduceL2 axes input must be constant"
+    "ReduceL2 axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_l2_do_not_keepdims_random_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "CastLike input and output shapes must match"
   ],
   [
     "node/test_reduce_l2_empty_set/model.onnx",
-    "ReduceL2 axes input must be constant"
+    "Dynamic or zero dims are not supported"
   ],
   [
     "node/test_reduce_l2_empty_set_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "ReduceSum axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_l2_keep_dims_example/model.onnx",
-    "ReduceL2 axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_l2_keep_dims_example_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "ReduceSum axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_l2_keep_dims_random/model.onnx",
-    "ReduceL2 axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_l2_keep_dims_random_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "ReduceSum axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_l2_negative_axes_keep_dims_example/model.onnx",
-    "ReduceL2 axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_l2_negative_axes_keep_dims_example_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "ReduceSum axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_l2_negative_axes_keep_dims_random/model.onnx",
-    "ReduceL2 axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_l2_negative_axes_keep_dims_random_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "ReduceSum axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_log_sum_asc_axes/model.onnx",
-    "ReduceLogSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_log_sum_asc_axes_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_log_sum_default/model.onnx",
@@ -4581,19 +4581,19 @@
   ],
   [
     "node/test_reduce_log_sum_desc_axes/model.onnx",
-    "ReduceLogSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_log_sum_desc_axes_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_log_sum_empty_set/model.onnx",
-    "ReduceLogSum axes input must be constant"
+    "Dynamic or zero dims are not supported"
   ],
   [
     "node/test_reduce_log_sum_empty_set_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "ReduceSum axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_log_sum_exp_default_axes_keepdims_example/model.onnx",
@@ -4613,67 +4613,67 @@
   ],
   [
     "node/test_reduce_log_sum_exp_do_not_keepdims_example/model.onnx",
-    "ReduceLogSumExp axes input must be constant"
+    "ReduceLogSumExp axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_log_sum_exp_do_not_keepdims_example_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "CastLike input and output shapes must match"
   ],
   [
     "node/test_reduce_log_sum_exp_do_not_keepdims_random/model.onnx",
-    "ReduceLogSumExp axes input must be constant"
+    "ReduceLogSumExp axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_log_sum_exp_do_not_keepdims_random_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "CastLike input and output shapes must match"
   ],
   [
     "node/test_reduce_log_sum_exp_empty_set/model.onnx",
-    "ReduceLogSumExp axes input must be constant"
+    "Dynamic or zero dims are not supported"
   ],
   [
     "node/test_reduce_log_sum_exp_empty_set_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "ReduceSum axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_log_sum_exp_keepdims_example/model.onnx",
-    "ReduceLogSumExp axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_log_sum_exp_keepdims_example_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "ReduceSum axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_log_sum_exp_keepdims_random/model.onnx",
-    "ReduceLogSumExp axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_log_sum_exp_keepdims_random_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "ReduceSum axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_log_sum_exp_negative_axes_keepdims_example/model.onnx",
-    "ReduceLogSumExp axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_log_sum_exp_negative_axes_keepdims_example_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "ReduceSum axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_log_sum_exp_negative_axes_keepdims_random/model.onnx",
-    "ReduceLogSumExp axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_log_sum_exp_negative_axes_keepdims_random_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "ReduceSum axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_log_sum_negative_axes/model.onnx",
-    "ReduceLogSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_log_sum_negative_axes_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "ReduceSum axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_max_bool_inputs/model.onnx",
@@ -4689,31 +4689,31 @@
   ],
   [
     "node/test_reduce_max_do_not_keepdims_example/model.onnx",
-    "ReduceMax axes input must be constant"
+    "ReduceMax axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_max_do_not_keepdims_random/model.onnx",
-    "ReduceMax axes input must be constant"
+    "ReduceMax axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_max_empty_set/model.onnx",
-    "ReduceMax axes input must be constant"
+    "Dynamic or zero dims are not supported"
   ],
   [
     "node/test_reduce_max_keepdims_example/model.onnx",
-    "ReduceMax axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_max_keepdims_random/model.onnx",
-    "ReduceMax axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_max_negative_axes_keepdims_example/model.onnx",
-    "ReduceMax axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_max_negative_axes_keepdims_random/model.onnx",
-    "ReduceMax axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_mean_default_axes_keepdims_example/model.onnx",
@@ -4725,27 +4725,27 @@
   ],
   [
     "node/test_reduce_mean_do_not_keepdims_example/model.onnx",
-    "ReduceMean axes input must be constant"
+    "ReduceMean axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_mean_do_not_keepdims_random/model.onnx",
-    "ReduceMean axes input must be constant"
+    "ReduceMean axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_mean_keepdims_example/model.onnx",
-    "ReduceMean axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_mean_keepdims_random/model.onnx",
-    "ReduceMean axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_mean_negative_axes_keepdims_example/model.onnx",
-    "ReduceMean axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_mean_negative_axes_keepdims_random/model.onnx",
-    "ReduceMean axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_min_bool_inputs/model.onnx",
@@ -4761,31 +4761,31 @@
   ],
   [
     "node/test_reduce_min_do_not_keepdims_example/model.onnx",
-    "ReduceMin axes input must be constant"
+    "ReduceMin axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_min_do_not_keepdims_random/model.onnx",
-    "ReduceMin axes input must be constant"
+    "ReduceMin axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_min_empty_set/model.onnx",
-    "ReduceMin axes input must be constant"
+    "Dynamic or zero dims are not supported"
   ],
   [
     "node/test_reduce_min_keepdims_example/model.onnx",
-    "ReduceMin axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_min_keepdims_random/model.onnx",
-    "ReduceMin axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_min_negative_axes_keepdims_example/model.onnx",
-    "ReduceMin axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_min_negative_axes_keepdims_random/model.onnx",
-    "ReduceMin axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_prod_default_axes_keepdims_example/model.onnx",
@@ -4797,31 +4797,31 @@
   ],
   [
     "node/test_reduce_prod_do_not_keepdims_example/model.onnx",
-    "ReduceProd axes input must be constant"
+    "ReduceProd axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_prod_do_not_keepdims_random/model.onnx",
-    "ReduceProd axes input must be constant"
+    "ReduceProd axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_prod_empty_set/model.onnx",
-    "ReduceProd axes input must be constant"
+    "Dynamic or zero dims are not supported"
   ],
   [
     "node/test_reduce_prod_keepdims_example/model.onnx",
-    "ReduceProd axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_prod_keepdims_random/model.onnx",
-    "ReduceProd axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_prod_negative_axes_keepdims_example/model.onnx",
-    "ReduceProd axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_prod_negative_axes_keepdims_random/model.onnx",
-    "ReduceProd axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_sum_default_axes_keepdims_example/model.onnx",
@@ -4833,11 +4833,11 @@
   ],
   [
     "node/test_reduce_sum_do_not_keepdims_example/model.onnx",
-    "ReduceSum axes input must be constant"
+    "ReduceSum axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_sum_do_not_keepdims_random/model.onnx",
-    "ReduceSum axes input must be constant"
+    "ReduceSum axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_sum_empty_axes_input_noop/model.onnx",
@@ -4849,7 +4849,7 @@
   ],
   [
     "node/test_reduce_sum_empty_set/model.onnx",
-    "ReduceSum axes input must be constant"
+    "Dynamic or zero dims are not supported"
   ],
   [
     "node/test_reduce_sum_empty_set_non_reduced_axis_zero/model.onnx",
@@ -4857,19 +4857,19 @@
   ],
   [
     "node/test_reduce_sum_keepdims_example/model.onnx",
-    "ReduceSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_sum_keepdims_random/model.onnx",
-    "ReduceSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_sum_negative_axes_keepdims_example/model.onnx",
-    "ReduceSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_sum_negative_axes_keepdims_random/model.onnx",
-    "ReduceSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_sum_square_default_axes_keepdims_example/model.onnx",
@@ -4889,59 +4889,59 @@
   ],
   [
     "node/test_reduce_sum_square_do_not_keepdims_example/model.onnx",
-    "ReduceSumSquare axes input must be constant"
+    "ReduceSumSquare axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_sum_square_do_not_keepdims_example_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "ReduceSum axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_sum_square_do_not_keepdims_random/model.onnx",
-    "ReduceSumSquare axes input must be constant"
+    "ReduceSumSquare axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_sum_square_do_not_keepdims_random_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "ReduceSum axes input must be constant or inferable from shapes"
   ],
   [
     "node/test_reduce_sum_square_empty_set/model.onnx",
-    "ReduceSumSquare axes input must be constant"
+    "Dynamic or zero dims are not supported"
   ],
   [
     "node/test_reduce_sum_square_empty_set_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    "Dynamic or zero dims are not supported"
   ],
   [
     "node/test_reduce_sum_square_keepdims_example/model.onnx",
-    "ReduceSumSquare axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_sum_square_keepdims_example_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_sum_square_keepdims_random/model.onnx",
-    "ReduceSumSquare axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_sum_square_keepdims_random_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_sum_square_negative_axes_keepdims_example/model.onnx",
-    "ReduceSumSquare axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_sum_square_negative_axes_keepdims_example_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_sum_square_negative_axes_keepdims_random/model.onnx",
-    "ReduceSumSquare axes input must be constant"
+    ""
   ],
   [
     "node/test_reduce_sum_square_negative_axes_keepdims_random_expanded/model.onnx",
-    "ReduceSum axes input must be constant"
+    ""
   ],
   [
     "node/test_reflect_pad/model.onnx",


### PR DESCRIPTION
### Motivation
- Reduce ops frequently failed with "axes input must be constant" when axes were provided as a non-constant but shape-deterministic input, preventing many official ONNX tests from being supported. 
- The change aims to infer reduce axes from input/output shapes when the axes input is present but not a constant initializer, improving support and diagnostics. 

### Description
- Replace previous `_axes_from_initializer` logic with `_axes_input_info(graph, node)` that returns both axes (if constant) and a presence flag, and propagate clearer error messages. 
- Add `_infer_axes_from_shapes(input_shape, output_shape, keepdims, node)` to deduce a unique axes set by comparing input and output shapes (including a backtracking search for non-keepdims). 
- Update `resolve_reduce_axes` to use the new helpers and to accept inferred axes when the axes input is non-constant but determinable from shapes, raising an `UnsupportedOpError` when ambiguous. 
- Refresh support snapshots and expected error listings in `OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`, and `tests/official_onnx_expected_errors.json` to reflect the improved behavior. 

### Testing
- Ran the full test suite with reference updates using `UPDATE_REFS=1 pytest -n auto -q`. 
- All tests passed: `140 passed` in `28.28s`. 
- Updated golden/reference files as part of the test run to match the new behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6965b80a807c83259d967a8a587b4d0a)