### PR TITLE
reduce: support dynamic axes input handling

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 665 / 1802 official ONNX files.
+Support 687 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -1117,10 +1117,10 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_l1_default_axes_keepdims_example_expanded/model.onnx | ✅ |  |
 | node/test_reduce_l1_default_axes_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_l1_default_axes_keepdims_random_expanded/model.onnx | ✅ |  |
-| node/test_reduce_l1_do_not_keepdims_example/model.onnx | ❌ | ReduceL1 axes input must be constant or inferable from shapes |
-| node/test_reduce_l1_do_not_keepdims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
-| node/test_reduce_l1_do_not_keepdims_random/model.onnx | ❌ | ReduceL1 axes input must be constant or inferable from shapes |
-| node/test_reduce_l1_do_not_keepdims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_l1_do_not_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_l1_do_not_keepdims_example_expanded/model.onnx | ✅ |  |
+| node/test_reduce_l1_do_not_keepdims_random/model.onnx | ✅ |  |
+| node/test_reduce_l1_do_not_keepdims_random_expanded/model.onnx | ✅ |  |
 | node/test_reduce_l1_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
 | node/test_reduce_l1_empty_set_expanded/model.onnx | ❌ | Dynamic or zero dims are not supported |
 | node/test_reduce_l1_keep_dims_example/model.onnx | ✅ |  |
@@ -1135,20 +1135,20 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_l2_default_axes_keepdims_example_expanded/model.onnx | ❌ | ReduceSum output shape must be (1, 1, 1), got () |
 | node/test_reduce_l2_default_axes_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_l2_default_axes_keepdims_random_expanded/model.onnx | ❌ | ReduceSum output shape must be (1, 1, 1), got () |
-| node/test_reduce_l2_do_not_keepdims_example/model.onnx | ❌ | ReduceL2 axes input must be constant or inferable from shapes |
+| node/test_reduce_l2_do_not_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_l2_do_not_keepdims_example_expanded/model.onnx | ❌ | CastLike input and output shapes must match |
-| node/test_reduce_l2_do_not_keepdims_random/model.onnx | ❌ | ReduceL2 axes input must be constant or inferable from shapes |
+| node/test_reduce_l2_do_not_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_l2_do_not_keepdims_random_expanded/model.onnx | ❌ | CastLike input and output shapes must match |
 | node/test_reduce_l2_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
-| node/test_reduce_l2_empty_set_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_l2_empty_set_expanded/model.onnx | ❌ | ReduceSum output shape rank must match input rank |
 | node/test_reduce_l2_keep_dims_example/model.onnx | ✅ |  |
-| node/test_reduce_l2_keep_dims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_l2_keep_dims_example_expanded/model.onnx | ❌ | ReduceSum output shape rank must match input rank |
 | node/test_reduce_l2_keep_dims_random/model.onnx | ✅ |  |
-| node/test_reduce_l2_keep_dims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_l2_keep_dims_random_expanded/model.onnx | ❌ | ReduceSum output shape rank must match input rank |
 | node/test_reduce_l2_negative_axes_keep_dims_example/model.onnx | ✅ |  |
-| node/test_reduce_l2_negative_axes_keep_dims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_l2_negative_axes_keep_dims_example_expanded/model.onnx | ❌ | ReduceSum output shape rank must match input rank |
 | node/test_reduce_l2_negative_axes_keep_dims_random/model.onnx | ✅ |  |
-| node/test_reduce_l2_negative_axes_keep_dims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_l2_negative_axes_keep_dims_random_expanded/model.onnx | ❌ | ReduceSum output shape rank must match input rank |
 | node/test_reduce_log_sum_asc_axes/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_asc_axes_expanded/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_default/model.onnx | ✅ |  |
@@ -1156,32 +1156,32 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_log_sum_desc_axes/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_desc_axes_expanded/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
-| node/test_reduce_log_sum_empty_set_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_log_sum_empty_set_expanded/model.onnx | ❌ | ReduceSum output shape rank must match input rank |
 | node/test_reduce_log_sum_exp_default_axes_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_exp_default_axes_keepdims_example_expanded/model.onnx | ❌ | ReduceSum output shape must be (1, 1, 1), got () |
 | node/test_reduce_log_sum_exp_default_axes_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_exp_default_axes_keepdims_random_expanded/model.onnx | ❌ | ReduceSum output shape must be (1, 1, 1), got () |
-| node/test_reduce_log_sum_exp_do_not_keepdims_example/model.onnx | ❌ | ReduceLogSumExp axes input must be constant or inferable from shapes |
+| node/test_reduce_log_sum_exp_do_not_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_exp_do_not_keepdims_example_expanded/model.onnx | ❌ | CastLike input and output shapes must match |
-| node/test_reduce_log_sum_exp_do_not_keepdims_random/model.onnx | ❌ | ReduceLogSumExp axes input must be constant or inferable from shapes |
+| node/test_reduce_log_sum_exp_do_not_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_exp_do_not_keepdims_random_expanded/model.onnx | ❌ | CastLike input and output shapes must match |
 | node/test_reduce_log_sum_exp_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
-| node/test_reduce_log_sum_exp_empty_set_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_log_sum_exp_empty_set_expanded/model.onnx | ❌ | ReduceSum output shape rank must match input rank |
 | node/test_reduce_log_sum_exp_keepdims_example/model.onnx | ✅ |  |
-| node/test_reduce_log_sum_exp_keepdims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_log_sum_exp_keepdims_example_expanded/model.onnx | ❌ | ReduceSum output shape rank must match input rank |
 | node/test_reduce_log_sum_exp_keepdims_random/model.onnx | ✅ |  |
-| node/test_reduce_log_sum_exp_keepdims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_log_sum_exp_keepdims_random_expanded/model.onnx | ❌ | ReduceSum output shape rank must match input rank |
 | node/test_reduce_log_sum_exp_negative_axes_keepdims_example/model.onnx | ✅ |  |
-| node/test_reduce_log_sum_exp_negative_axes_keepdims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_log_sum_exp_negative_axes_keepdims_example_expanded/model.onnx | ❌ | ReduceSum output shape rank must match input rank |
 | node/test_reduce_log_sum_exp_negative_axes_keepdims_random/model.onnx | ✅ |  |
-| node/test_reduce_log_sum_exp_negative_axes_keepdims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_log_sum_exp_negative_axes_keepdims_random_expanded/model.onnx | ❌ | ReduceSum output shape rank must match input rank |
 | node/test_reduce_log_sum_negative_axes/model.onnx | ✅ |  |
-| node/test_reduce_log_sum_negative_axes_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_log_sum_negative_axes_expanded/model.onnx | ❌ | ReduceSum output shape rank must match input rank |
 | node/test_reduce_max_bool_inputs/model.onnx | ❌ | ReduceMax does not support dtype bool |
 | node/test_reduce_max_default_axes_keepdim_example/model.onnx | ✅ |  |
 | node/test_reduce_max_default_axes_keepdims_random/model.onnx | ✅ |  |
-| node/test_reduce_max_do_not_keepdims_example/model.onnx | ❌ | ReduceMax axes input must be constant or inferable from shapes |
-| node/test_reduce_max_do_not_keepdims_random/model.onnx | ❌ | ReduceMax axes input must be constant or inferable from shapes |
+| node/test_reduce_max_do_not_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_max_do_not_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_max_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
 | node/test_reduce_max_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_max_keepdims_random/model.onnx | ✅ |  |
@@ -1189,8 +1189,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_max_negative_axes_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_mean_default_axes_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_mean_default_axes_keepdims_random/model.onnx | ✅ |  |
-| node/test_reduce_mean_do_not_keepdims_example/model.onnx | ❌ | ReduceMean axes input must be constant or inferable from shapes |
-| node/test_reduce_mean_do_not_keepdims_random/model.onnx | ❌ | ReduceMean axes input must be constant or inferable from shapes |
+| node/test_reduce_mean_do_not_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_mean_do_not_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_mean_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_mean_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_mean_negative_axes_keepdims_example/model.onnx | ✅ |  |
@@ -1198,8 +1198,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_min_bool_inputs/model.onnx | ❌ | ReduceMin does not support dtype bool |
 | node/test_reduce_min_default_axes_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_min_default_axes_keepdims_random/model.onnx | ✅ |  |
-| node/test_reduce_min_do_not_keepdims_example/model.onnx | ❌ | ReduceMin axes input must be constant or inferable from shapes |
-| node/test_reduce_min_do_not_keepdims_random/model.onnx | ❌ | ReduceMin axes input must be constant or inferable from shapes |
+| node/test_reduce_min_do_not_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_min_do_not_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_min_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
 | node/test_reduce_min_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_min_keepdims_random/model.onnx | ✅ |  |
@@ -1207,8 +1207,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_min_negative_axes_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_prod_default_axes_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_prod_default_axes_keepdims_random/model.onnx | ✅ |  |
-| node/test_reduce_prod_do_not_keepdims_example/model.onnx | ❌ | ReduceProd axes input must be constant or inferable from shapes |
-| node/test_reduce_prod_do_not_keepdims_random/model.onnx | ❌ | ReduceProd axes input must be constant or inferable from shapes |
+| node/test_reduce_prod_do_not_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_prod_do_not_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_prod_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
 | node/test_reduce_prod_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_prod_keepdims_random/model.onnx | ✅ |  |
@@ -1216,8 +1216,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_prod_negative_axes_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_sum_default_axes_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_sum_default_axes_keepdims_random/model.onnx | ✅ |  |
-| node/test_reduce_sum_do_not_keepdims_example/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
-| node/test_reduce_sum_do_not_keepdims_random/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_sum_do_not_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_sum_do_not_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_sum_empty_axes_input_noop/model.onnx | ✅ |  |
 | node/test_reduce_sum_empty_axes_input_noop_example/model.onnx | ✅ |  |
 | node/test_reduce_sum_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
@@ -1230,10 +1230,10 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_sum_square_default_axes_keepdims_example_expanded/model.onnx | ✅ |  |
 | node/test_reduce_sum_square_default_axes_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_sum_square_default_axes_keepdims_random_expanded/model.onnx | ✅ |  |
-| node/test_reduce_sum_square_do_not_keepdims_example/model.onnx | ❌ | ReduceSumSquare axes input must be constant or inferable from shapes |
-| node/test_reduce_sum_square_do_not_keepdims_example_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
-| node/test_reduce_sum_square_do_not_keepdims_random/model.onnx | ❌ | ReduceSumSquare axes input must be constant or inferable from shapes |
-| node/test_reduce_sum_square_do_not_keepdims_random_expanded/model.onnx | ❌ | ReduceSum axes input must be constant or inferable from shapes |
+| node/test_reduce_sum_square_do_not_keepdims_example/model.onnx | ✅ |  |
+| node/test_reduce_sum_square_do_not_keepdims_example_expanded/model.onnx | ✅ |  |
+| node/test_reduce_sum_square_do_not_keepdims_random/model.onnx | ✅ |  |
+| node/test_reduce_sum_square_do_not_keepdims_random_expanded/model.onnx | ✅ |  |
 | node/test_reduce_sum_square_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
 | node/test_reduce_sum_square_empty_set_expanded/model.onnx | ❌ | Dynamic or zero dims are not supported |
 | node/test_reduce_sum_square_keepdims_example/model.onnx | ✅ |  |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -12,7 +12,6 @@
 | Unsupported op LayerNormalization | 19 | ████ |
 | Unsupported op RMSNormalization | 19 | ████ |
 | Unsupported op GridSample | 18 | ████ |
-| ReduceSum axes input must be constant or inferable from shapes | 18 | ████ |
 | NegativeLogLikelihoodLoss input must be at least 2D | 17 | ███ |
 | Unsupported op Split | 17 | ███ |
 | Unsupported op ArgMax | 16 | ███ |
@@ -28,6 +27,7 @@
 | Unsupported op ConvTranspose | 14 | ███ |
 | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 12 | ██ |
 | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 12 | ██ |
+| ReduceSum output shape rank must match input rank | 12 | ██ |
 | Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 11 | ██ |
 | Unsupported op Pad | 11 | ██ |
 | Unsupported op Flatten | 11 | ██ |
@@ -129,14 +129,6 @@
 | Unsupported op Pow | 2 | █ |
 | Unsupported op Range | 2 | █ |
 | Unsupported op Reciprocal | 2 | █ |
-| ReduceL1 axes input must be constant or inferable from shapes | 2 | █ |
-| ReduceL2 axes input must be constant or inferable from shapes | 2 | █ |
-| ReduceLogSumExp axes input must be constant or inferable from shapes | 2 | █ |
-| ReduceMax axes input must be constant or inferable from shapes | 2 | █ |
-| ReduceMean axes input must be constant or inferable from shapes | 2 | █ |
-| ReduceMin axes input must be constant or inferable from shapes | 2 | █ |
-| ReduceProd axes input must be constant or inferable from shapes | 2 | █ |
-| ReduceSumSquare axes input must be constant or inferable from shapes | 2 | █ |
 | Unsupported op ReverseSequence | 2 | █ |
 | Unsupported op Scan | 2 | █ |
 | Unsupported op Scatter | 2 | █ |

--- a/src/onnx2c/compiler.py
+++ b/src/onnx2c/compiler.py
@@ -76,7 +76,6 @@ from .lowering.maxpool import MaxPoolSpec, resolve_maxpool_spec
 from .lowering.reduce import (
     REDUCE_KIND_BY_OP,
     REDUCE_OUTPUTS_FLOAT_ONLY,
-    resolve_reduce_axes,
 )
 from .lowering.reshape import lower_reshape
 from .lowering.resize import lower_resize

--- a/templates/reduce_op_dynamic.c.j2
+++ b/templates/reduce_op_dynamic.c.j2
@@ -1,0 +1,77 @@
+static inline void {{ op_name }}({{ params | join(", ") }}) {
+    size_t axis_count = {{ axes_count }};
+    bool reduce_mask[{{ input_shape | length }}];
+    for (size_t i = 0; i < {{ input_shape | length }}; ++i) {
+        reduce_mask[i] = false;
+    }
+    if (axis_count == 0) {
+{% if noop_with_empty_axes %}
+{% for dim in input_shape %}
+        for (size_t {{ input_loop_vars[loop.index0] }} = 0; {{ input_loop_vars[loop.index0] }} < {{ dim }}; ++{{ input_loop_vars[loop.index0] }}) {
+{% endfor %}
+        {{ output }}{{ input_index_expr }} = {{ input0 }}{{ input_index_expr }};
+{% for _ in input_shape %}
+        }
+{% endfor %}
+        return;
+{% else %}
+        for (size_t i = 0; i < {{ input_shape | length }}; ++i) {
+            reduce_mask[i] = true;
+        }
+{% endif %}
+    } else {
+        for (size_t i = 0; i < axis_count; ++i) {
+            int axis = (int){{ axes_input }}[i];
+            if (axis < 0) {
+                axis += {{ input_shape | length }};
+            }
+            if (axis >= 0 && axis < {{ input_shape | length }}) {
+                reduce_mask[axis] = true;
+            }
+        }
+    }
+    size_t reduce_count = 1;
+{% for dim in input_shape %}
+    if (reduce_mask[{{ loop.index0 }}]) {
+        reduce_count *= {{ dim }};
+    }
+{% endfor %}
+{% for dim in output_shape %}
+    for (size_t {{ output_loop_vars[loop.index0] }} = 0; {{ output_loop_vars[loop.index0] }} < {{ dim }}; ++{{ output_loop_vars[loop.index0] }}) {
+{% endfor %}
+        {{ output }}{{ output_loop_index_expr }} = {{ init_literal }};
+{% for _ in output_shape %}
+    }
+{% endfor %}
+{% for dim in input_shape %}
+    for (size_t {{ input_loop_vars[loop.index0] }} = 0; {{ input_loop_vars[loop.index0] }} < {{ dim }}; ++{{ input_loop_vars[loop.index0] }}) {
+{% endfor %}
+        size_t out_indices[{{ output_shape | length }}];
+{% if keepdims %}
+{% for axis in range(input_shape | length) %}
+        out_indices[{{ axis }}] = reduce_mask[{{ axis }}] ? 0 : {{ input_loop_vars[axis] }};
+{% endfor %}
+{% else %}
+        size_t out_pos = 0;
+{% for axis in range(input_shape | length) %}
+        if (!reduce_mask[{{ axis }}]) {
+            out_indices[out_pos++] = {{ input_loop_vars[axis] }};
+        }
+{% endfor %}
+{% endif %}
+        {{ c_type }} *out_ptr = &{{ output }}{{ output_index_expr }};
+        {{ update_expr }}
+{% for _ in input_shape %}
+    }
+{% endfor %}
+{% if post_expr %}
+{% for dim in output_shape %}
+    for (size_t {{ output_loop_vars[loop.index0] }} = 0; {{ output_loop_vars[loop.index0] }} < {{ dim }}; ++{{ output_loop_vars[loop.index0] }}) {
+{% endfor %}
+        {{ c_type }} *out_ptr = &{{ output }}{{ output_loop_index_expr }};
+        {{ post_expr }}
+{% for _ in output_shape %}
+    }
+{% endfor %}
+{% endif %}
+}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -4437,19 +4437,19 @@
   ],
   [
     "node/test_reduce_l1_do_not_keepdims_example/model.onnx",
-    "ReduceL1 axes input must be constant or inferable from shapes"
+    ""
   ],
   [
     "node/test_reduce_l1_do_not_keepdims_example_expanded/model.onnx",
-    "ReduceSum axes input must be constant or inferable from shapes"
+    ""
   ],
   [
     "node/test_reduce_l1_do_not_keepdims_random/model.onnx",
-    "ReduceL1 axes input must be constant or inferable from shapes"
+    ""
   ],
   [
     "node/test_reduce_l1_do_not_keepdims_random_expanded/model.onnx",
-    "ReduceSum axes input must be constant or inferable from shapes"
+    ""
   ],
   [
     "node/test_reduce_l1_empty_set/model.onnx",
@@ -4509,7 +4509,7 @@
   ],
   [
     "node/test_reduce_l2_do_not_keepdims_example/model.onnx",
-    "ReduceL2 axes input must be constant or inferable from shapes"
+    ""
   ],
   [
     "node/test_reduce_l2_do_not_keepdims_example_expanded/model.onnx",
@@ -4517,7 +4517,7 @@
   ],
   [
     "node/test_reduce_l2_do_not_keepdims_random/model.onnx",
-    "ReduceL2 axes input must be constant or inferable from shapes"
+    ""
   ],
   [
     "node/test_reduce_l2_do_not_keepdims_random_expanded/model.onnx",
@@ -4529,7 +4529,7 @@
   ],
   [
     "node/test_reduce_l2_empty_set_expanded/model.onnx",
-    "ReduceSum axes input must be constant or inferable from shapes"
+    "ReduceSum output shape rank must match input rank"
   ],
   [
     "node/test_reduce_l2_keep_dims_example/model.onnx",
@@ -4537,7 +4537,7 @@
   ],
   [
     "node/test_reduce_l2_keep_dims_example_expanded/model.onnx",
-    "ReduceSum axes input must be constant or inferable from shapes"
+    "ReduceSum output shape rank must match input rank"
   ],
   [
     "node/test_reduce_l2_keep_dims_random/model.onnx",
@@ -4545,7 +4545,7 @@
   ],
   [
     "node/test_reduce_l2_keep_dims_random_expanded/model.onnx",
-    "ReduceSum axes input must be constant or inferable from shapes"
+    "ReduceSum output shape rank must match input rank"
   ],
   [
     "node/test_reduce_l2_negative_axes_keep_dims_example/model.onnx",
@@ -4553,7 +4553,7 @@
   ],
   [
     "node/test_reduce_l2_negative_axes_keep_dims_example_expanded/model.onnx",
-    "ReduceSum axes input must be constant or inferable from shapes"
+    "ReduceSum output shape rank must match input rank"
   ],
   [
     "node/test_reduce_l2_negative_axes_keep_dims_random/model.onnx",
@@ -4561,7 +4561,7 @@
   ],
   [
     "node/test_reduce_l2_negative_axes_keep_dims_random_expanded/model.onnx",
-    "ReduceSum axes input must be constant or inferable from shapes"
+    "ReduceSum output shape rank must match input rank"
   ],
   [
     "node/test_reduce_log_sum_asc_axes/model.onnx",
@@ -4593,7 +4593,7 @@
   ],
   [
     "node/test_reduce_log_sum_empty_set_expanded/model.onnx",
-    "ReduceSum axes input must be constant or inferable from shapes"
+    "ReduceSum output shape rank must match input rank"
   ],
   [
     "node/test_reduce_log_sum_exp_default_axes_keepdims_example/model.onnx",
@@ -4613,7 +4613,7 @@
   ],
   [
     "node/test_reduce_log_sum_exp_do_not_keepdims_example/model.onnx",
-    "ReduceLogSumExp axes input must be constant or inferable from shapes"
+    ""
   ],
   [
     "node/test_reduce_log_sum_exp_do_not_keepdims_example_expanded/model.onnx",
@@ -4621,7 +4621,7 @@
   ],
   [
     "node/test_reduce_log_sum_exp_do_not_keepdims_random/model.onnx",
-    "ReduceLogSumExp axes input must be constant or inferable from shapes"
+    ""
   ],
   [
     "node/test_reduce_log_sum_exp_do_not_keepdims_random_expanded/model.onnx",
@@ -4633,7 +4633,7 @@
   ],
   [
     "node/test_reduce_log_sum_exp_empty_set_expanded/model.onnx",
-    "ReduceSum axes input must be constant or inferable from shapes"
+    "ReduceSum output shape rank must match input rank"
   ],
   [
     "node/test_reduce_log_sum_exp_keepdims_example/model.onnx",
@@ -4641,7 +4641,7 @@
   ],
   [
     "node/test_reduce_log_sum_exp_keepdims_example_expanded/model.onnx",
-    "ReduceSum axes input must be constant or inferable from shapes"
+    "ReduceSum output shape rank must match input rank"
   ],
   [
     "node/test_reduce_log_sum_exp_keepdims_random/model.onnx",
@@ -4649,7 +4649,7 @@
   ],
   [
     "node/test_reduce_log_sum_exp_keepdims_random_expanded/model.onnx",
-    "ReduceSum axes input must be constant or inferable from shapes"
+    "ReduceSum output shape rank must match input rank"
   ],
   [
     "node/test_reduce_log_sum_exp_negative_axes_keepdims_example/model.onnx",
@@ -4657,7 +4657,7 @@
   ],
   [
     "node/test_reduce_log_sum_exp_negative_axes_keepdims_example_expanded/model.onnx",
-    "ReduceSum axes input must be constant or inferable from shapes"
+    "ReduceSum output shape rank must match input rank"
   ],
   [
     "node/test_reduce_log_sum_exp_negative_axes_keepdims_random/model.onnx",
@@ -4665,7 +4665,7 @@
   ],
   [
     "node/test_reduce_log_sum_exp_negative_axes_keepdims_random_expanded/model.onnx",
-    "ReduceSum axes input must be constant or inferable from shapes"
+    "ReduceSum output shape rank must match input rank"
   ],
   [
     "node/test_reduce_log_sum_negative_axes/model.onnx",
@@ -4673,7 +4673,7 @@
   ],
   [
     "node/test_reduce_log_sum_negative_axes_expanded/model.onnx",
-    "ReduceSum axes input must be constant or inferable from shapes"
+    "ReduceSum output shape rank must match input rank"
   ],
   [
     "node/test_reduce_max_bool_inputs/model.onnx",
@@ -4689,11 +4689,11 @@
   ],
   [
     "node/test_reduce_max_do_not_keepdims_example/model.onnx",
-    "ReduceMax axes input must be constant or inferable from shapes"
+    ""
   ],
   [
     "node/test_reduce_max_do_not_keepdims_random/model.onnx",
-    "ReduceMax axes input must be constant or inferable from shapes"
+    ""
   ],
   [
     "node/test_reduce_max_empty_set/model.onnx",
@@ -4725,11 +4725,11 @@
   ],
   [
     "node/test_reduce_mean_do_not_keepdims_example/model.onnx",
-    "ReduceMean axes input must be constant or inferable from shapes"
+    ""
   ],
   [
     "node/test_reduce_mean_do_not_keepdims_random/model.onnx",
-    "ReduceMean axes input must be constant or inferable from shapes"
+    ""
   ],
   [
     "node/test_reduce_mean_keepdims_example/model.onnx",
@@ -4761,11 +4761,11 @@
   ],
   [
     "node/test_reduce_min_do_not_keepdims_example/model.onnx",
-    "ReduceMin axes input must be constant or inferable from shapes"
+    ""
   ],
   [
     "node/test_reduce_min_do_not_keepdims_random/model.onnx",
-    "ReduceMin axes input must be constant or inferable from shapes"
+    ""
   ],
   [
     "node/test_reduce_min_empty_set/model.onnx",
@@ -4797,11 +4797,11 @@
   ],
   [
     "node/test_reduce_prod_do_not_keepdims_example/model.onnx",
-    "ReduceProd axes input must be constant or inferable from shapes"
+    ""
   ],
   [
     "node/test_reduce_prod_do_not_keepdims_random/model.onnx",
-    "ReduceProd axes input must be constant or inferable from shapes"
+    ""
   ],
   [
     "node/test_reduce_prod_empty_set/model.onnx",
@@ -4833,11 +4833,11 @@
   ],
   [
     "node/test_reduce_sum_do_not_keepdims_example/model.onnx",
-    "ReduceSum axes input must be constant or inferable from shapes"
+    ""
   ],
   [
     "node/test_reduce_sum_do_not_keepdims_random/model.onnx",
-    "ReduceSum axes input must be constant or inferable from shapes"
+    ""
   ],
   [
     "node/test_reduce_sum_empty_axes_input_noop/model.onnx",
@@ -4889,19 +4889,19 @@
   ],
   [
     "node/test_reduce_sum_square_do_not_keepdims_example/model.onnx",
-    "ReduceSumSquare axes input must be constant or inferable from shapes"
+    ""
   ],
   [
     "node/test_reduce_sum_square_do_not_keepdims_example_expanded/model.onnx",
-    "ReduceSum axes input must be constant or inferable from shapes"
+    ""
   ],
   [
     "node/test_reduce_sum_square_do_not_keepdims_random/model.onnx",
-    "ReduceSumSquare axes input must be constant or inferable from shapes"
+    ""
   ],
   [
     "node/test_reduce_sum_square_do_not_keepdims_random_expanded/model.onnx",
-    "ReduceSum axes input must be constant or inferable from shapes"
+    ""
   ],
   [
     "node/test_reduce_sum_square_empty_set/model.onnx",


### PR DESCRIPTION
### Motivation
- Make Reduce ops handle `axes` provided as a runtime input instead of requiring them to be a constant or inferred from shapes.
- Preserve deterministic lowering and codegen while enabling dynamic axes at runtime where shapes/dtypes are static enough to emit code.
- Provide evaluator support so CPU-side verification/constant-folding can run with runtime `axes` values.
- Update test coverage and reference snapshots to reflect the expanded support.

### Description
- Extend reduce lowering in `src/onnx2c/lowering/reduce.py` to detect constant vs runtime `axes`, return an enhanced `_ReduceSpec` with `axes_input` metadata, and validate static properties when required.
- Add runtime handling in `src/onnx2c/runtime/evaluator.py` to read and normalize `axes` from `node.inputs[1]` and fall back to the existing inference path when absent.
- Extend the IR and codegen (`src/onnx2c/codegen/c_emitter.py`) to carry `axes_input` information and emit either the existing static `reduce_op.c.j2` or a new `reduce_op_dynamic.c.j2` template for runtime axes, plus the dynamic template in `templates/reduce_op_dynamic.c.j2`.
- Add an end-to-end test `test_reduce_op_axes_input_matches_numpy` in `tests/test_endtoend_ops.py` and refresh official ONNX support/error golden files (`OFFICIAL_ONNX_FILE_SUPPORT*` and `tests/official_onnx_expected_errors.json`).

### Testing
- Ran the full PyTest suite with reference updates enabled using `UPDATE_REFS=1 pytest -n auto -q` and all tests passed; result: `141 passed` in `32.89s`.
- Added a targeted unit/integration test exercising a `ReduceSum` with `axes` provided as a runtime input, which passed under the evaluator and compile+verify flow.
- Golden/reference files were updated to reflect the new support and were regenerated with the test run above.
- No other automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6965bbc6b6b08325ac061694b32d00f5)