### PR TITLE
Add FLOAT16 dtype support

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 687 / 1802 official ONNX files.
+Support 704 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -180,8 +180,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_attention_4d_diff_heads_with_past_and_present_mask4d/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_with_past_and_present_mask4d_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_with_past_and_present_mask4d_expanded_function_KExpanded' |
 | node/test_attention_4d_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_expanded_function_AttnBias' |
-| node/test_attention_4d_fp16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'Q'. |
-| node/test_attention_4d_fp16_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'Q'. |
+| node/test_attention_4d_fp16/model.onnx | ✅ |  |
+| node/test_attention_4d_fp16_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_fp16_expanded_function_AttnBias' |
 | node/test_attention_4d_gqa/model.onnx | ✅ |  |
 | node/test_attention_4d_gqa_attn_mask/model.onnx | ✅ |  |
 | node/test_attention_4d_gqa_attn_mask_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_gqa_attn_mask_expanded_function_KExpanded' |
@@ -194,8 +194,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_attention_4d_gqa_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_gqa_softcap_expanded_function_AttnBias' |
 | node/test_attention_4d_gqa_with_past_and_present/model.onnx | ✅ |  |
 | node/test_attention_4d_gqa_with_past_and_present_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_gqa_with_past_and_present_expanded_function_KExpanded' |
-| node/test_attention_4d_gqa_with_past_and_present_fp16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'Q'. |
-| node/test_attention_4d_gqa_with_past_and_present_fp16_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'Q'. |
+| node/test_attention_4d_gqa_with_past_and_present_fp16/model.onnx | ✅ |  |
+| node/test_attention_4d_gqa_with_past_and_present_fp16_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_gqa_with_past_and_present_fp16_expanded_function_KExpanded' |
 | node/test_attention_4d_scaled/model.onnx | ✅ |  |
 | node/test_attention_4d_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_scaled_expanded_function_AttnBias' |
 | node/test_attention_4d_softcap/model.onnx | ✅ |  |
@@ -285,18 +285,18 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_blackmanwindow_symmetric_expanded/model.onnx | ❌ | Dynamic dim for tensor 'BlackmanWindow_test_blackmanwindow_symmetric_expanded_function_Range' |
 | node/test_cast_BFLOAT16_to_FLOAT/model.onnx | ❌ | Unsupported elem_type 16 (BFLOAT16) for tensor 'input'. |
 | node/test_cast_DOUBLE_to_FLOAT/model.onnx | ✅ |  |
-| node/test_cast_DOUBLE_to_FLOAT16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'output'. |
-| node/test_cast_FLOAT16_to_DOUBLE/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_cast_FLOAT16_to_FLOAT/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_cast_FLOAT16_to_FLOAT4E2M1/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_cast_FLOAT16_to_FLOAT8E4M3FN/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_cast_FLOAT16_to_FLOAT8E4M3FNUZ/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_cast_FLOAT16_to_FLOAT8E5M2/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_cast_FLOAT16_to_FLOAT8E5M2FNUZ/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_cast_FLOAT16_to_INT2/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_cast_FLOAT16_to_INT4/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_cast_FLOAT16_to_UINT2/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_cast_FLOAT16_to_UINT4/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
+| node/test_cast_DOUBLE_to_FLOAT16/model.onnx | ✅ |  |
+| node/test_cast_FLOAT16_to_DOUBLE/model.onnx | ✅ |  |
+| node/test_cast_FLOAT16_to_FLOAT/model.onnx | ✅ |  |
+| node/test_cast_FLOAT16_to_FLOAT4E2M1/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'output'. |
+| node/test_cast_FLOAT16_to_FLOAT8E4M3FN/model.onnx | ❌ | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'output'. |
+| node/test_cast_FLOAT16_to_FLOAT8E4M3FNUZ/model.onnx | ❌ | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor 'output'. |
+| node/test_cast_FLOAT16_to_FLOAT8E5M2/model.onnx | ❌ | Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'output'. |
+| node/test_cast_FLOAT16_to_FLOAT8E5M2FNUZ/model.onnx | ❌ | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor 'output'. |
+| node/test_cast_FLOAT16_to_INT2/model.onnx | ❌ | Unsupported elem_type 26 (INT2) for tensor 'output'. |
+| node/test_cast_FLOAT16_to_INT4/model.onnx | ❌ | Unsupported elem_type 22 (INT4) for tensor 'output'. |
+| node/test_cast_FLOAT16_to_UINT2/model.onnx | ❌ | Unsupported elem_type 25 (UINT2) for tensor 'output'. |
+| node/test_cast_FLOAT16_to_UINT4/model.onnx | ❌ | Unsupported elem_type 21 (UINT4) for tensor 'output'. |
 | node/test_cast_FLOAT4E2M1_to_FLOAT/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'input'. |
 | node/test_cast_FLOAT4E2M1_to_FLOAT16/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'input'. |
 | node/test_cast_FLOAT8E4M3FNUZ_to_FLOAT/model.onnx | ❌ | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor 'input'. |
@@ -309,7 +309,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_cast_FLOAT8E5M2_to_FLOAT16/model.onnx | ❌ | Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'input'. |
 | node/test_cast_FLOAT_to_BFLOAT16/model.onnx | ❌ | Unsupported elem_type 16 (BFLOAT16) for tensor 'output'. |
 | node/test_cast_FLOAT_to_DOUBLE/model.onnx | ✅ |  |
-| node/test_cast_FLOAT_to_FLOAT16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'output'. |
+| node/test_cast_FLOAT_to_FLOAT16/model.onnx | ✅ |  |
 | node/test_cast_FLOAT_to_FLOAT4E2M1/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'output'. |
 | node/test_cast_FLOAT_to_FLOAT8E4M3FN/model.onnx | ❌ | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'output'. |
 | node/test_cast_FLOAT_to_FLOAT8E4M3FNUZ/model.onnx | ❌ | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor 'output'. |
@@ -331,14 +331,14 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_cast_UINT4_to_FLOAT/model.onnx | ❌ | Unsupported elem_type 21 (UINT4) for tensor 'input'. |
 | node/test_cast_UINT4_to_FLOAT16/model.onnx | ❌ | Unsupported elem_type 21 (UINT4) for tensor 'input'. |
 | node/test_cast_UINT4_to_UINT8/model.onnx | ❌ | Unsupported elem_type 21 (UINT4) for tensor 'input'. |
-| node/test_cast_e8m0_FLOAT16_to_FLOAT8E8M0/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
+| node/test_cast_e8m0_FLOAT16_to_FLOAT8E8M0/model.onnx | ❌ | Unsupported elem_type 24 (FLOAT8E8M0) for tensor 'output'. |
 | node/test_cast_e8m0_FLOAT8E8M0_to_FLOAT/model.onnx | ❌ | Unsupported elem_type 24 (FLOAT8E8M0) for tensor 'input'. |
 | node/test_cast_e8m0_FLOAT8E8M0_to_FLOAT16/model.onnx | ❌ | Unsupported elem_type 24 (FLOAT8E8M0) for tensor 'input'. |
 | node/test_cast_e8m0_FLOAT_to_FLOAT8E8M0/model.onnx | ❌ | Unsupported elem_type 24 (FLOAT8E8M0) for tensor 'output'. |
-| node/test_cast_no_saturate_FLOAT16_to_FLOAT8E4M3FN/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_cast_no_saturate_FLOAT16_to_FLOAT8E4M3FNUZ/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_cast_no_saturate_FLOAT16_to_FLOAT8E5M2/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_cast_no_saturate_FLOAT16_to_FLOAT8E5M2FNUZ/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
+| node/test_cast_no_saturate_FLOAT16_to_FLOAT8E4M3FN/model.onnx | ❌ | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'output'. |
+| node/test_cast_no_saturate_FLOAT16_to_FLOAT8E4M3FNUZ/model.onnx | ❌ | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor 'output'. |
+| node/test_cast_no_saturate_FLOAT16_to_FLOAT8E5M2/model.onnx | ❌ | Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'output'. |
+| node/test_cast_no_saturate_FLOAT16_to_FLOAT8E5M2FNUZ/model.onnx | ❌ | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor 'output'. |
 | node/test_cast_no_saturate_FLOAT_to_FLOAT8E4M3FN/model.onnx | ❌ | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'output'. |
 | node/test_cast_no_saturate_FLOAT_to_FLOAT8E4M3FNUZ/model.onnx | ❌ | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor 'output'. |
 | node/test_cast_no_saturate_FLOAT_to_FLOAT8E5M2/model.onnx | ❌ | Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'output'. |
@@ -346,31 +346,31 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_castlike_BFLOAT16_to_FLOAT/model.onnx | ❌ | Unsupported elem_type 16 (BFLOAT16) for tensor 'input'. |
 | node/test_castlike_BFLOAT16_to_FLOAT_expanded/model.onnx | ❌ | Unsupported elem_type 16 (BFLOAT16) for tensor 'input'. |
 | node/test_castlike_DOUBLE_to_FLOAT/model.onnx | ✅ |  |
-| node/test_castlike_DOUBLE_to_FLOAT16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'like'. |
-| node/test_castlike_DOUBLE_to_FLOAT16_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'like'. |
+| node/test_castlike_DOUBLE_to_FLOAT16/model.onnx | ✅ |  |
+| node/test_castlike_DOUBLE_to_FLOAT16_expanded/model.onnx | ✅ |  |
 | node/test_castlike_DOUBLE_to_FLOAT_expanded/model.onnx | ✅ |  |
-| node/test_castlike_FLOAT16_to_DOUBLE/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_FLOAT16_to_DOUBLE_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_FLOAT16_to_FLOAT/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_FLOAT16_to_FLOAT4E2M1/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_FLOAT16_to_FLOAT4E2M1_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_FLOAT16_to_FLOAT8E4M3FN/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_FLOAT16_to_FLOAT8E4M3FNUZ/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_FLOAT16_to_FLOAT8E4M3FNUZ_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_FLOAT16_to_FLOAT8E4M3FN_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_FLOAT16_to_FLOAT8E5M2/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_FLOAT16_to_FLOAT8E5M2FNUZ/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_FLOAT16_to_FLOAT8E5M2FNUZ_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_FLOAT16_to_FLOAT8E5M2_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_FLOAT16_to_FLOAT_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_FLOAT16_to_INT2/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_FLOAT16_to_INT2_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_FLOAT16_to_INT4/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_FLOAT16_to_INT4_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_FLOAT16_to_UINT2/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_FLOAT16_to_UINT2_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_FLOAT16_to_UINT4/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_FLOAT16_to_UINT4_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
+| node/test_castlike_FLOAT16_to_DOUBLE/model.onnx | ✅ |  |
+| node/test_castlike_FLOAT16_to_DOUBLE_expanded/model.onnx | ✅ |  |
+| node/test_castlike_FLOAT16_to_FLOAT/model.onnx | ✅ |  |
+| node/test_castlike_FLOAT16_to_FLOAT4E2M1/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'like'. |
+| node/test_castlike_FLOAT16_to_FLOAT4E2M1_expanded/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'like'. |
+| node/test_castlike_FLOAT16_to_FLOAT8E4M3FN/model.onnx | ❌ | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'like'. |
+| node/test_castlike_FLOAT16_to_FLOAT8E4M3FNUZ/model.onnx | ❌ | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor 'like'. |
+| node/test_castlike_FLOAT16_to_FLOAT8E4M3FNUZ_expanded/model.onnx | ❌ | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor 'like'. |
+| node/test_castlike_FLOAT16_to_FLOAT8E4M3FN_expanded/model.onnx | ❌ | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'like'. |
+| node/test_castlike_FLOAT16_to_FLOAT8E5M2/model.onnx | ❌ | Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'like'. |
+| node/test_castlike_FLOAT16_to_FLOAT8E5M2FNUZ/model.onnx | ❌ | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor 'like'. |
+| node/test_castlike_FLOAT16_to_FLOAT8E5M2FNUZ_expanded/model.onnx | ❌ | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor 'like'. |
+| node/test_castlike_FLOAT16_to_FLOAT8E5M2_expanded/model.onnx | ❌ | Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'like'. |
+| node/test_castlike_FLOAT16_to_FLOAT_expanded/model.onnx | ✅ |  |
+| node/test_castlike_FLOAT16_to_INT2/model.onnx | ❌ | Unsupported elem_type 26 (INT2) for tensor 'like'. |
+| node/test_castlike_FLOAT16_to_INT2_expanded/model.onnx | ❌ | Unsupported elem_type 26 (INT2) for tensor 'like'. |
+| node/test_castlike_FLOAT16_to_INT4/model.onnx | ❌ | Unsupported elem_type 22 (INT4) for tensor 'like'. |
+| node/test_castlike_FLOAT16_to_INT4_expanded/model.onnx | ❌ | Unsupported elem_type 22 (INT4) for tensor 'like'. |
+| node/test_castlike_FLOAT16_to_UINT2/model.onnx | ❌ | Unsupported elem_type 25 (UINT2) for tensor 'like'. |
+| node/test_castlike_FLOAT16_to_UINT2_expanded/model.onnx | ❌ | Unsupported elem_type 25 (UINT2) for tensor 'like'. |
+| node/test_castlike_FLOAT16_to_UINT4/model.onnx | ❌ | Unsupported elem_type 21 (UINT4) for tensor 'like'. |
+| node/test_castlike_FLOAT16_to_UINT4_expanded/model.onnx | ❌ | Unsupported elem_type 21 (UINT4) for tensor 'like'. |
 | node/test_castlike_FLOAT4E2M1_to_FLOAT/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'input'. |
 | node/test_castlike_FLOAT4E2M1_to_FLOAT16/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'input'. |
 | node/test_castlike_FLOAT4E2M1_to_FLOAT16_expanded/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'input'. |
@@ -395,8 +395,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_castlike_FLOAT_to_BFLOAT16_expanded/model.onnx | ❌ | Unsupported elem_type 16 (BFLOAT16) for tensor 'like'. |
 | node/test_castlike_FLOAT_to_DOUBLE/model.onnx | ✅ |  |
 | node/test_castlike_FLOAT_to_DOUBLE_expanded/model.onnx | ✅ |  |
-| node/test_castlike_FLOAT_to_FLOAT16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'like'. |
-| node/test_castlike_FLOAT_to_FLOAT16_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'like'. |
+| node/test_castlike_FLOAT_to_FLOAT16/model.onnx | ✅ |  |
+| node/test_castlike_FLOAT_to_FLOAT16_expanded/model.onnx | ✅ |  |
 | node/test_castlike_FLOAT_to_FLOAT4E2M1/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'like'. |
 | node/test_castlike_FLOAT_to_FLOAT4E2M1_expanded/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'like'. |
 | node/test_castlike_FLOAT_to_FLOAT8E4M3FN/model.onnx | ❌ | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'like'. |
@@ -439,14 +439,14 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_castlike_UINT4_to_FLOAT_expanded/model.onnx | ❌ | Unsupported elem_type 21 (UINT4) for tensor 'input'. |
 | node/test_castlike_UINT4_to_UINT8/model.onnx | ❌ | Unsupported elem_type 21 (UINT4) for tensor 'input'. |
 | node/test_castlike_UINT4_to_UINT8_expanded/model.onnx | ❌ | Unsupported elem_type 21 (UINT4) for tensor 'input'. |
-| node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E4M3FN/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E4M3FNUZ/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E4M3FNUZ_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E4M3FN_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E5M2/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E5M2FNUZ/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E5M2FNUZ_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
-| node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E5M2_expanded/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'input'. |
+| node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E4M3FN/model.onnx | ❌ | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'like'. |
+| node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E4M3FNUZ/model.onnx | ❌ | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor 'like'. |
+| node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E4M3FNUZ_expanded/model.onnx | ❌ | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor 'like'. |
+| node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E4M3FN_expanded/model.onnx | ❌ | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'like'. |
+| node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E5M2/model.onnx | ❌ | Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'like'. |
+| node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E5M2FNUZ/model.onnx | ❌ | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor 'like'. |
+| node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E5M2FNUZ_expanded/model.onnx | ❌ | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor 'like'. |
+| node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E5M2_expanded/model.onnx | ❌ | Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'like'. |
 | node/test_castlike_no_saturate_FLOAT_to_FLOAT8E4M3FN/model.onnx | ❌ | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'like'. |
 | node/test_castlike_no_saturate_FLOAT_to_FLOAT8E4M3FNUZ/model.onnx | ❌ | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor 'like'. |
 | node/test_castlike_no_saturate_FLOAT_to_FLOAT8E4M3FNUZ_expanded/model.onnx | ❌ | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor 'like'. |
@@ -766,11 +766,11 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_instancenorm_epsilon/model.onnx | ❌ | Unsupported op InstanceNormalization |
 | node/test_instancenorm_example/model.onnx | ❌ | Unsupported op InstanceNormalization |
 | node/test_isinf/model.onnx | ❌ | Unsupported op IsInf |
-| node/test_isinf_float16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'x'. |
+| node/test_isinf_float16/model.onnx | ❌ | Unsupported op IsInf |
 | node/test_isinf_negative/model.onnx | ❌ | Unsupported op IsInf |
 | node/test_isinf_positive/model.onnx | ❌ | Unsupported op IsInf |
 | node/test_isnan/model.onnx | ❌ | Unsupported op IsNaN |
-| node/test_isnan_float16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'x'. |
+| node/test_isnan_float16/model.onnx | ❌ | Unsupported op IsNaN |
 | node/test_l1normalization_axis_0/model.onnx | ❌ | Unsupported op LpNormalization |
 | node/test_l1normalization_axis_1/model.onnx | ❌ | Unsupported op LpNormalization |
 | node/test_l1normalization_axis_last/model.onnx | ❌ | Unsupported op LpNormalization |
@@ -913,7 +913,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_matmul_bcast/model.onnx | ✅ |  |
 | node/test_matmulinteger/model.onnx | ❌ | Unsupported op MatMulInteger |
 | node/test_max_example/model.onnx | ❌ | Max must have 2 inputs and 1 output |
-| node/test_max_float16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'data_0'. |
+| node/test_max_float16/model.onnx | ✅ |  |
 | node/test_max_float32/model.onnx | ✅ |  |
 | node/test_max_float64/model.onnx | ✅ |  |
 | node/test_max_int16/model.onnx | ❌ | Unsupported op Max |
@@ -952,7 +952,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_mean_two_inputs/model.onnx | ✅ |  |
 | node/test_melweightmatrix/model.onnx | ❌ | Unsupported op MelWeightMatrix |
 | node/test_min_example/model.onnx | ❌ | Min must have 2 inputs and 1 output |
-| node/test_min_float16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'data_0'. |
+| node/test_min_float16/model.onnx | ✅ |  |
 | node/test_min_float32/model.onnx | ✅ |  |
 | node/test_min_float64/model.onnx | ✅ |  |
 | node/test_min_int16/model.onnx | ❌ | Unsupported op Min |
@@ -969,7 +969,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_mish_expanded/model.onnx | ❌ | Unsupported op Softplus |
 | node/test_mod_broadcast/model.onnx | ❌ | Unsupported op Mod |
 | node/test_mod_int64_fmod/model.onnx | ❌ | Unsupported op Mod |
-| node/test_mod_mixed_sign_float16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'x'. |
+| node/test_mod_mixed_sign_float16/model.onnx | ✅ |  |
 | node/test_mod_mixed_sign_float32/model.onnx | ✅ |  |
 | node/test_mod_mixed_sign_float64/model.onnx | ✅ |  |
 | node/test_mod_mixed_sign_int16/model.onnx | ❌ | Unsupported op Mod |
@@ -1086,13 +1086,13 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_prelu_example/model.onnx | ✅ |  |
 | node/test_prelu_example_expanded/model.onnx | ✅ |  |
 | node/test_qlinearconv/model.onnx | ❌ | Unsupported op QLinearConv |
-| node/test_qlinearmatmul_2D_int8_float16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'a_scale'. |
+| node/test_qlinearmatmul_2D_int8_float16/model.onnx | ❌ | Unsupported op QLinearMatMul |
 | node/test_qlinearmatmul_2D_int8_float32/model.onnx | ❌ | Unsupported op QLinearMatMul |
-| node/test_qlinearmatmul_2D_uint8_float16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'a_scale'. |
+| node/test_qlinearmatmul_2D_uint8_float16/model.onnx | ❌ | Unsupported op QLinearMatMul |
 | node/test_qlinearmatmul_2D_uint8_float32/model.onnx | ❌ | Unsupported op QLinearMatMul |
-| node/test_qlinearmatmul_3D_int8_float16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'a_scale'. |
+| node/test_qlinearmatmul_3D_int8_float16/model.onnx | ❌ | Unsupported op QLinearMatMul |
 | node/test_qlinearmatmul_3D_int8_float32/model.onnx | ❌ | Unsupported op QLinearMatMul |
-| node/test_qlinearmatmul_3D_uint8_float16/model.onnx | ❌ | Unsupported elem_type 10 (FLOAT16) for tensor 'a_scale'. |
+| node/test_qlinearmatmul_3D_uint8_float16/model.onnx | ❌ | Unsupported op QLinearMatMul |
 | node/test_qlinearmatmul_3D_uint8_float32/model.onnx | ❌ | Unsupported op QLinearMatMul |
 | node/test_quantizelinear/model.onnx | ❌ | Unsupported op QuantizeLinear |
 | node/test_quantizelinear_axis/model.onnx | ❌ | Unsupported op QuantizeLinear |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -2,33 +2,32 @@
 
 | Error message | Count | Histogram |
 | --- | --- | --- |
-| Dynamic dim for tensor '*' | 146 | ██████████████████████████████ |
-| Unsupported elem_type 10 (FLOAT16) for tensor '*'. | 65 | █████████████ |
+| Dynamic dim for tensor '*' | 148 | ██████████████████████████████ |
 | Missing elem_type for tensor '*' | 34 | ███████ |
-| Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████ |
+| Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ██████ |
 | Unsupported op Slice | 26 | █████ |
+| Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 22 | ████ |
+| Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 20 | ████ |
 | Unsupported op Identity | 20 | ████ |
 | Dynamic or zero dims are not supported | 20 | ████ |
 | Unsupported op LayerNormalization | 19 | ████ |
 | Unsupported op RMSNormalization | 19 | ████ |
+| Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 18 | ████ |
+| Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 18 | ████ |
 | Unsupported op GridSample | 18 | ████ |
+| Unsupported elem_type 26 (INT2) for tensor '*'. | 17 | ███ |
+| Unsupported elem_type 22 (INT4) for tensor '*'. | 17 | ███ |
+| Unsupported elem_type 25 (UINT2) for tensor '*'. | 17 | ███ |
+| Unsupported elem_type 21 (UINT4) for tensor '*'. | 17 | ███ |
 | NegativeLogLikelihoodLoss input must be at least 2D | 17 | ███ |
 | Unsupported op Split | 17 | ███ |
 | Unsupported op ArgMax | 16 | ███ |
 | Unsupported op ArgMin | 16 | ███ |
-| Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 16 | ███ |
 | Unsupported op Clip | 16 | ███ |
 | Unsupported op Trilu | 16 | ███ |
-| Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 14 | ███ |
-| Unsupported elem_type 26 (INT2) for tensor '*'. | 14 | ███ |
-| Unsupported elem_type 22 (INT4) for tensor '*'. | 14 | ███ |
-| Unsupported elem_type 25 (UINT2) for tensor '*'. | 14 | ███ |
-| Unsupported elem_type 21 (UINT4) for tensor '*'. | 14 | ███ |
+| Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 14 | ███ |
 | Unsupported op ConvTranspose | 14 | ███ |
-| Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 12 | ██ |
-| Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 12 | ██ |
 | ReduceSum output shape rank must match input rank | 12 | ██ |
-| Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 11 | ██ |
 | Unsupported op Pad | 11 | ██ |
 | Unsupported op Flatten | 11 | ██ |
 | Unsupported op Mod | 10 | ██ |
@@ -40,6 +39,7 @@
 | Unsupported op LpPool | 8 | ██ |
 | Unsupported op Max | 8 | ██ |
 | Unsupported op Min | 8 | ██ |
+| Unsupported op QLinearMatMul | 8 | ██ |
 | Unsupported op RotaryEmbedding | 8 | ██ |
 | Unsupported op Hardmax | 7 | █ |
 | Unsupported op TfIdfVectorizer | 7 | █ |
@@ -70,14 +70,15 @@
 | Unsupported op BitwiseAnd | 4 | █ |
 | Unsupported op BitwiseOr | 4 | █ |
 | Unsupported op BitwiseXor | 4 | █ |
+| Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 4 | █ |
 | Unsupported op Compress | 4 | █ |
 | Unsupported op Gelu | 4 | █ |
 | Unsupported op GRU | 4 | █ |
 | Unsupported op HardSigmoid | 4 | █ |
+| Unsupported op IsInf | 4 | █ |
 | Unsupported op Softplus | 4 | █ |
 | Unsupported op OneHot | 4 | █ |
 | Unsupported op OptionalHasElement | 4 | █ |
-| Unsupported op QLinearMatMul | 4 | █ |
 | CastLike input and output shapes must match | 4 | █ |
 | Unsupported op RNN | 4 | █ |
 | Unsupported op Squeeze | 4 | █ |
@@ -86,13 +87,11 @@
 | Unsupported op Bernoulli | 3 | █ |
 | Unsupported op RandomUniformLike | 3 | █ |
 | Unsupported op BitwiseNot | 3 | █ |
-| Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 3 | █ |
 | Unsupported op DynamicQuantizeLinear | 3 | █ |
 | Unsupported op Erf | 3 | █ |
 | Unsupported op EyeLike | 3 | █ |
 | Unsupported op GatherND | 3 | █ |
 | Unsupported op InstanceNormalization | 3 | █ |
-| Unsupported op IsInf | 3 | █ |
 | Unsupported op Loop | 3 | █ |
 | Unsupported op Momentum | 3 | █ |
 | Unsupported op RoiAlign | 3 | █ |
@@ -119,6 +118,7 @@
 | Unsupported op GroupNormalization | 2 | █ |
 | Unsupported op HammingWindow | 2 | █ |
 | Unsupported op HannWindow | 2 | █ |
+| Unsupported op IsNaN | 2 | █ |
 | Max must have 2 inputs and 1 output | 2 | █ |
 | MaxPool must have 1 input and 1 output | 2 | █ |
 | Unsupported op MaxUnpool | 2 | █ |
@@ -148,7 +148,6 @@
 | Gemm bias input must be broadcastable to output shape, got (1,) vs (3, 3) | 1 | █ |
 | Unsupported op HardSwish | 1 | █ |
 | Unsupported op If | 1 | █ |
-| Unsupported op IsNaN | 1 | █ |
 | Unsupported op MatMulInteger | 1 | █ |
 | Unsupported op MelWeightMatrix | 1 | █ |
 | Unsupported op Mish | 1 | █ |

--- a/src/onnx2c/dtypes.py
+++ b/src/onnx2c/dtypes.py
@@ -17,6 +17,7 @@ class DTypeInfo:
 
 
 ONNX_TO_DTYPE = {
+    onnx.TensorProto.FLOAT16: "float16",
     onnx.TensorProto.FLOAT: "float",
     onnx.TensorProto.DOUBLE: "double",
     onnx.TensorProto.BOOL: "bool",
@@ -32,6 +33,14 @@ ONNX_TO_DTYPE = {
 
 
 DTYPE_INFO = {
+    "float16": DTypeInfo(
+        name="float16",
+        c_type="_Float16",
+        np_dtype=np.dtype("float16"),
+        zero_literal="0.0f",
+        min_literal="-INFINITY",
+        max_literal="INFINITY",
+    ),
     "float": DTypeInfo(
         name="float",
         c_type="float",

--- a/src/onnx2c/lowering/attention.py
+++ b/src/onnx2c/lowering/attention.py
@@ -53,7 +53,7 @@ class AttentionSpec:
 def resolve_attention_spec(
     graph: Graph, node: Node, dtype: str
 ) -> AttentionSpec:
-    if dtype not in {"float", "double"}:
+    if dtype not in {"float", "double", "float16"}:
         raise UnsupportedOpError("Unsupported op Attention")
     if len(node.inputs) < 3 or len(node.outputs) < 1:
         raise UnsupportedOpError("Unsupported op Attention")

--- a/src/onnx2c/lowering/average_pool.py
+++ b/src/onnx2c/lowering/average_pool.py
@@ -164,9 +164,9 @@ def lower_average_pool(graph: Graph, node: Node) -> AveragePoolOp:
             "AveragePool expects matching input/output dtypes, "
             f"got {op_dtype} and {output_dtype}"
         )
-    if op_dtype not in {"float", "double"}:
+    if op_dtype not in {"float", "double", "float16"}:
         raise UnsupportedOpError(
-            "AveragePool supports float and double inputs only"
+            "AveragePool supports float16, float, and double inputs only"
         )
     spec = _resolve_average_pool_spec(graph, node)
     return AveragePoolOp(
@@ -200,9 +200,9 @@ def lower_global_average_pool(graph: Graph, node: Node) -> AveragePoolOp:
             "GlobalAveragePool expects matching input/output dtypes, "
             f"got {op_dtype} and {output_dtype}"
         )
-    if op_dtype not in {"float", "double"}:
+    if op_dtype not in {"float", "double", "float16"}:
         raise UnsupportedOpError(
-            "GlobalAveragePool supports float and double inputs only"
+            "GlobalAveragePool supports float16, float, and double inputs only"
         )
     spec = _resolve_global_average_pool_spec(graph, node)
     return AveragePoolOp(

--- a/src/onnx2c/lowering/batch_normalization.py
+++ b/src/onnx2c/lowering/batch_normalization.py
@@ -97,9 +97,9 @@ def _resolve_batch_norm_spec(graph: Graph, node: Node) -> _BatchNormSpec:
 @register_lowering("BatchNormalization")
 def lower_batch_normalization(graph: Graph, node: Node) -> BatchNormOp:
     op_dtype = _node_dtype(graph, node, *node.inputs, *node.outputs)
-    if op_dtype not in {"float", "double"}:
+    if op_dtype not in {"float", "double", "float16"}:
         raise UnsupportedOpError(
-            "BatchNormalization supports float and double inputs only"
+            "BatchNormalization supports float16, float, and double inputs only"
         )
     spec = _resolve_batch_norm_spec(graph, node)
     return BatchNormOp(

--- a/src/onnx2c/lowering/common.py
+++ b/src/onnx2c/lowering/common.py
@@ -8,6 +8,7 @@ from ..ir.model import Graph, Node
 
 def ensure_supported_dtype(dtype: str) -> str:
     if dtype not in {
+        "float16",
         "float",
         "double",
         "bool",

--- a/src/onnx2c/lowering/conv.py
+++ b/src/onnx2c/lowering/conv.py
@@ -167,8 +167,10 @@ def lower_conv(graph: Graph, node: Node) -> ConvOp:
     if len(node.inputs) not in {2, 3} or len(node.outputs) != 1:
         raise UnsupportedOpError("Conv must have 2 or 3 inputs and 1 output")
     op_dtype = _node_dtype(graph, node, *node.inputs, *node.outputs)
-    if op_dtype not in {"float", "double"}:
-        raise UnsupportedOpError("Conv supports float and double inputs only")
+    if op_dtype not in {"float", "double", "float16"}:
+        raise UnsupportedOpError(
+            "Conv supports float16, float, and double inputs only"
+        )
     spec = resolve_conv_spec(graph, node)
     return ConvOp(
         input0=node.inputs[0],

--- a/src/onnx2c/lowering/gemm.py
+++ b/src/onnx2c/lowering/gemm.py
@@ -79,7 +79,7 @@ def _resolve_gemm_attrs(
         )
     if dtype == "bool":
         raise UnsupportedOpError("Gemm supports numeric inputs only")
-    if dtype not in {"float", "double"}:
+    if dtype not in {"float", "double", "float16"}:
         alpha_int = int(alpha)
         beta_int = int(beta)
         if alpha != alpha_int or beta != beta_int:

--- a/src/onnx2c/lowering/logsoftmax.py
+++ b/src/onnx2c/lowering/logsoftmax.py
@@ -16,9 +16,9 @@ def lower_logsoftmax(graph: Graph, node: Node) -> LogSoftmaxOp:
     if len(node.inputs) != 1 or len(node.outputs) != 1:
         raise UnsupportedOpError("LogSoftmax must have 1 input and 1 output")
     op_dtype = _node_dtype(graph, node, *node.inputs, *node.outputs)
-    if op_dtype not in {"float", "double"}:
+    if op_dtype not in {"float", "double", "float16"}:
         raise UnsupportedOpError(
-            "LogSoftmax supports float and double inputs only"
+            "LogSoftmax supports float16, float, and double inputs only"
         )
     input_shape = _value_shape(graph, node.inputs[0], node)
     output_shape = _value_shape(graph, node.outputs[0], node)

--- a/src/onnx2c/lowering/lrn.py
+++ b/src/onnx2c/lowering/lrn.py
@@ -85,8 +85,10 @@ def resolve_lrn_spec(graph: Graph, node: Node) -> LrnSpec:
 @register_lowering("LRN")
 def lower_lrn(graph: Graph, node: Node) -> LrnOp:
     op_dtype = _node_dtype(graph, node, *node.inputs, *node.outputs)
-    if op_dtype not in {"float", "double"}:
-        raise UnsupportedOpError("LRN supports float and double inputs only")
+    if op_dtype not in {"float", "double", "float16"}:
+        raise UnsupportedOpError(
+            "LRN supports float16, float, and double inputs only"
+        )
     spec = resolve_lrn_spec(graph, node)
     return LrnOp(
         input0=node.inputs[0],

--- a/src/onnx2c/lowering/lstm.py
+++ b/src/onnx2c/lowering/lstm.py
@@ -188,8 +188,10 @@ def resolve_lstm_spec(graph: Graph, node: Node) -> LstmSpec:
         *(name for name in (input_b, input_initial_h, input_initial_c, input_p) if name),
         *(name for name in (output_y, output_y_h, output_y_c) if name),
     )
-    if op_dtype not in {"float", "double"}:
-        raise UnsupportedOpError("LSTM supports float and double inputs only")
+    if op_dtype not in {"float", "double", "float16"}:
+        raise UnsupportedOpError(
+            "LSTM supports float16, float, and double inputs only"
+        )
     x_shape = value_shape(graph, input_x, node)
     if len(x_shape) != 3:
         raise UnsupportedOpError("LSTM input X must be rank 3")

--- a/src/onnx2c/lowering/negative_log_likelihood_loss.py
+++ b/src/onnx2c/lowering/negative_log_likelihood_loss.py
@@ -21,9 +21,9 @@ def lower_negative_log_likelihood_loss(
     target_name = node.inputs[1]
     weight_name = node.inputs[2] if len(node.inputs) > 2 else None
     input_dtype = _value_dtype(graph, input_name, node)
-    if input_dtype not in {"float", "double"}:
+    if input_dtype not in {"float", "double", "float16"}:
         raise UnsupportedOpError(
-            "NegativeLogLikelihoodLoss supports float and double inputs only"
+            "NegativeLogLikelihoodLoss supports float16, float, and double inputs only"
         )
     output_dtype = _value_dtype(graph, node.outputs[0], node)
     if output_dtype != input_dtype:

--- a/src/onnx2c/lowering/reduce.py
+++ b/src/onnx2c/lowering/reduce.py
@@ -332,6 +332,7 @@ def _resolve_reduce_spec(graph: Graph, node: Node) -> _ReduceSpec | None:
 
 def _reduce_dtype_supported(dtype: str) -> bool:
     return dtype in {
+        "float16",
         "float",
         "double",
         "int64",
@@ -362,9 +363,10 @@ def lower_reduce(graph: Graph, node: Node) -> ReduceOp | ReshapeOp:
     if node.op_type in REDUCE_OUTPUTS_FLOAT_ONLY and op_dtype not in {
         "float",
         "double",
+        "float16",
     }:
         raise UnsupportedOpError(
-            f"{node.op_type} supports float and double inputs only"
+            f"{node.op_type} supports float16, float, and double inputs only"
         )
     spec = _resolve_reduce_spec(graph, node)
     if spec is None:

--- a/src/onnx2c/lowering/resize.py
+++ b/src/onnx2c/lowering/resize.py
@@ -240,7 +240,7 @@ def _resolve_scales(
     rank = len(config.input_shape)
     if inputs.scales:
         scale_len, _ = _validate_tensor_1d(
-            graph, inputs.scales, node, {"float", "double"}
+            graph, inputs.scales, node, {"float", "double", "float16"}
         )
         if scale_len not in {len(axes), rank}:
             raise UnsupportedOpError("Resize scales length mismatch")
@@ -369,7 +369,7 @@ def lower_resize(graph: Graph, node: Node) -> ResizeOp:
     roi_dtype = None
     if inputs.roi:
         roi_len, roi_dtype = _validate_tensor_1d(
-            graph, inputs.roi, node, {"float", "double"}
+            graph, inputs.roi, node, {"float", "double", "float16"}
         )
         if roi_len == 2 * rank:
             roi_shape = (roi_len,)
@@ -390,7 +390,7 @@ def lower_resize(graph: Graph, node: Node) -> ResizeOp:
     sizes_axes = None
     if inputs.scales:
         scale_len, scales_dtype = _validate_tensor_1d(
-            graph, inputs.scales, node, {"float", "double"}
+            graph, inputs.scales, node, {"float", "double", "float16"}
         )
         scales_shape = (scale_len,)
         if scale_len == len(axes) and len(axes) != rank:

--- a/src/onnx2c/lowering/softmax.py
+++ b/src/onnx2c/lowering/softmax.py
@@ -16,8 +16,10 @@ def lower_softmax(graph: Graph, node: Node) -> SoftmaxOp:
     if len(node.inputs) != 1 or len(node.outputs) != 1:
         raise UnsupportedOpError("Softmax must have 1 input and 1 output")
     op_dtype = _node_dtype(graph, node, *node.inputs, *node.outputs)
-    if op_dtype not in {"float", "double"}:
-        raise UnsupportedOpError("Softmax supports float and double inputs only")
+    if op_dtype not in {"float", "double", "float16"}:
+        raise UnsupportedOpError(
+            "Softmax supports float16, float, and double inputs only"
+        )
     input_shape = _value_shape(graph, node.inputs[0], node)
     output_shape = _value_shape(graph, node.outputs[0], node)
     ensure_output_shape_matches_input(node, input_shape, output_shape)

--- a/src/onnx2c/lowering/softmax_cross_entropy_loss.py
+++ b/src/onnx2c/lowering/softmax_cross_entropy_loss.py
@@ -21,9 +21,9 @@ def lower_softmax_cross_entropy_loss(
     target_name = node.inputs[1]
     weight_name = node.inputs[2] if len(node.inputs) > 2 else None
     input_dtype = _value_dtype(graph, input_name, node)
-    if input_dtype not in {"float", "double"}:
+    if input_dtype not in {"float", "double", "float16"}:
         raise UnsupportedOpError(
-            "SoftmaxCrossEntropyLoss supports float and double inputs only"
+            "SoftmaxCrossEntropyLoss supports float16, float, and double inputs only"
         )
     output_name = node.outputs[0]
     output_dtype = _value_dtype(graph, output_name, node)

--- a/src/onnx2c/ops.py
+++ b/src/onnx2c/ops.py
@@ -67,7 +67,7 @@ def _format_float_literal(value: float, dtype: str) -> str:
     formatted = f"{value:.9g}"
     if "e" not in formatted and "E" not in formatted and "." not in formatted:
         formatted = f"{formatted}.0"
-    if dtype == "float":
+    if dtype in {"float", "float16"}:
         return f"{formatted}f"
     return formatted
 
@@ -189,6 +189,7 @@ UNARY_SYMBOLS_BY_DTYPE = {
     "int8": UNARY_SYMBOLS_INT8,
     "double": UNARY_SYMBOLS_DOUBLE,
     "float": UNARY_SYMBOLS_FLOAT,
+    "float16": UNARY_SYMBOLS_FLOAT,
 }
 
 BINARY_SPECS_BY_DTYPE = {
@@ -203,6 +204,7 @@ BINARY_SPECS_BY_DTYPE = {
     "uint8": BINARY_SPECS_INT,
     "double": BINARY_SPECS_DOUBLE,
     "float": BINARY_SPECS_FLOAT,
+    "float16": BINARY_SPECS_FLOAT,
 }
 
 UNARY_APPLY_FUNCS = {
@@ -246,7 +248,7 @@ def binary_op_symbol(
         op_spec = specs.get(op_type)
         if op_spec is not None:
             return op_spec
-    if dtype not in {"float", "double"}:
+    if dtype not in {"float", "double", "float16"}:
         return None
     if op_type == "Mod":
         fmod = 0
@@ -256,7 +258,7 @@ def binary_op_symbol(
             raise UnsupportedOpError(
                 "Mod only supports fmod=1 for floating point types"
             )
-        func = "fmodf" if dtype == "float" else "fmod"
+        func = "fmodf" if dtype in {"float", "float16"} else "fmod"
         return BinaryOpSpec(func, "func", np.fmod)
     if op_type == "PRelu":
         zero_literal = _format_float_literal(0.0, dtype)

--- a/src/onnx2c/runtime/evaluator.py
+++ b/src/onnx2c/runtime/evaluator.py
@@ -128,7 +128,7 @@ def _eval_gemm(evaluator: Evaluator, node: Node) -> None:
     if spec.trans_b:
         right = right.T
     result = _apply_matmul(left, right)
-    if op_dtype in {"float", "double"}:
+    if op_dtype in {"float", "double", "float16"}:
         alpha = float(spec.alpha)
         beta = float(spec.beta)
     else:
@@ -313,8 +313,10 @@ def _eval_conv(evaluator: Evaluator, node: Node) -> None:
             f"{node.op_type} expects matching input/output dtypes, "
             f"got {op_dtype} and {output_dtype}"
         )
-    if op_dtype not in {"float", "double"}:
-        raise UnsupportedOpError("Conv supports float and double inputs only")
+    if op_dtype not in {"float", "double", "float16"}:
+        raise UnsupportedOpError(
+            "Conv supports float16, float, and double inputs only"
+        )
     spec = resolve_conv_spec(evaluator.graph, node)
     data = evaluator.values[node.inputs[0]]
     weights = evaluator.values[node.inputs[1]]
@@ -352,8 +354,10 @@ def _eval_lrn(evaluator: Evaluator, node: Node) -> None:
             f"{node.op_type} expects matching input/output dtypes, "
             f"got {op_dtype} and {output_dtype}"
         )
-    if op_dtype not in {"float", "double"}:
-        raise UnsupportedOpError("LRN supports float and double inputs only")
+    if op_dtype not in {"float", "double", "float16"}:
+        raise UnsupportedOpError(
+            "LRN supports float16, float, and double inputs only"
+        )
     spec = resolve_lrn_spec(evaluator.graph, node)
     data = evaluator.values[node.inputs[0]]
     evaluator.values[node.outputs[0]] = _apply_lrn(spec, data)
@@ -517,10 +521,10 @@ def _eval_reduce(evaluator: Evaluator, node: Node) -> None:
         )
     if (
         node.op_type in REDUCE_OUTPUTS_FLOAT_ONLY
-        and op_dtype not in {"float", "double"}
+        and op_dtype not in {"float", "double", "float16"}
     ):
         raise UnsupportedOpError(
-            f"{node.op_type} supports float and double inputs only"
+            f"{node.op_type} supports float16, float, and double inputs only"
         )
     value = evaluator.values[node.inputs[0]]
     input_shape = value.shape

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -689,11 +689,11 @@
   ],
   [
     "node/test_attention_4d_fp16/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'Q'."
+    ""
   ],
   [
     "node/test_attention_4d_fp16_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'Q'."
+    "Dynamic dim for tensor 'Attention_test_attention_4d_fp16_expanded_function_AttnBias'"
   ],
   [
     "node/test_attention_4d_gqa/model.onnx",
@@ -745,11 +745,11 @@
   ],
   [
     "node/test_attention_4d_gqa_with_past_and_present_fp16/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'Q'."
+    ""
   ],
   [
     "node/test_attention_4d_gqa_with_past_and_present_fp16_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'Q'."
+    "Dynamic dim for tensor 'Attention_test_attention_4d_gqa_with_past_and_present_fp16_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_4d_scaled/model.onnx",
@@ -1109,51 +1109,51 @@
   ],
   [
     "node/test_cast_DOUBLE_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'output'."
+    ""
   ],
   [
     "node/test_cast_FLOAT16_to_DOUBLE/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    ""
   ],
   [
     "node/test_cast_FLOAT16_to_FLOAT/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    ""
   ],
   [
     "node/test_cast_FLOAT16_to_FLOAT4E2M1/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'output'."
   ],
   [
     "node/test_cast_FLOAT16_to_FLOAT8E4M3FN/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'output'."
   ],
   [
     "node/test_cast_FLOAT16_to_FLOAT8E4M3FNUZ/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor 'output'."
   ],
   [
     "node/test_cast_FLOAT16_to_FLOAT8E5M2/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'output'."
   ],
   [
     "node/test_cast_FLOAT16_to_FLOAT8E5M2FNUZ/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor 'output'."
   ],
   [
     "node/test_cast_FLOAT16_to_INT2/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 26 (INT2) for tensor 'output'."
   ],
   [
     "node/test_cast_FLOAT16_to_INT4/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 22 (INT4) for tensor 'output'."
   ],
   [
     "node/test_cast_FLOAT16_to_UINT2/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 25 (UINT2) for tensor 'output'."
   ],
   [
     "node/test_cast_FLOAT16_to_UINT4/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 21 (UINT4) for tensor 'output'."
   ],
   [
     "node/test_cast_FLOAT4E2M1_to_FLOAT/model.onnx",
@@ -1205,7 +1205,7 @@
   ],
   [
     "node/test_cast_FLOAT_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'output'."
+    ""
   ],
   [
     "node/test_cast_FLOAT_to_FLOAT4E2M1/model.onnx",
@@ -1293,7 +1293,7 @@
   ],
   [
     "node/test_cast_e8m0_FLOAT16_to_FLOAT8E8M0/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 24 (FLOAT8E8M0) for tensor 'output'."
   ],
   [
     "node/test_cast_e8m0_FLOAT8E8M0_to_FLOAT/model.onnx",
@@ -1309,19 +1309,19 @@
   ],
   [
     "node/test_cast_no_saturate_FLOAT16_to_FLOAT8E4M3FN/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'output'."
   ],
   [
     "node/test_cast_no_saturate_FLOAT16_to_FLOAT8E4M3FNUZ/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor 'output'."
   ],
   [
     "node/test_cast_no_saturate_FLOAT16_to_FLOAT8E5M2/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'output'."
   ],
   [
     "node/test_cast_no_saturate_FLOAT16_to_FLOAT8E5M2FNUZ/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor 'output'."
   ],
   [
     "node/test_cast_no_saturate_FLOAT_to_FLOAT8E4M3FN/model.onnx",
@@ -1353,11 +1353,11 @@
   ],
   [
     "node/test_castlike_DOUBLE_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'like'."
+    ""
   ],
   [
     "node/test_castlike_DOUBLE_to_FLOAT16_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'like'."
+    ""
   ],
   [
     "node/test_castlike_DOUBLE_to_FLOAT_expanded/model.onnx",
@@ -1365,91 +1365,91 @@
   ],
   [
     "node/test_castlike_FLOAT16_to_DOUBLE/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    ""
   ],
   [
     "node/test_castlike_FLOAT16_to_DOUBLE_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    ""
   ],
   [
     "node/test_castlike_FLOAT16_to_FLOAT/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    ""
   ],
   [
     "node/test_castlike_FLOAT16_to_FLOAT4E2M1/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'like'."
   ],
   [
     "node/test_castlike_FLOAT16_to_FLOAT4E2M1_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'like'."
   ],
   [
     "node/test_castlike_FLOAT16_to_FLOAT8E4M3FN/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'like'."
   ],
   [
     "node/test_castlike_FLOAT16_to_FLOAT8E4M3FNUZ/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor 'like'."
   ],
   [
     "node/test_castlike_FLOAT16_to_FLOAT8E4M3FNUZ_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor 'like'."
   ],
   [
     "node/test_castlike_FLOAT16_to_FLOAT8E4M3FN_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'like'."
   ],
   [
     "node/test_castlike_FLOAT16_to_FLOAT8E5M2/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'like'."
   ],
   [
     "node/test_castlike_FLOAT16_to_FLOAT8E5M2FNUZ/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor 'like'."
   ],
   [
     "node/test_castlike_FLOAT16_to_FLOAT8E5M2FNUZ_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor 'like'."
   ],
   [
     "node/test_castlike_FLOAT16_to_FLOAT8E5M2_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'like'."
   ],
   [
     "node/test_castlike_FLOAT16_to_FLOAT_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    ""
   ],
   [
     "node/test_castlike_FLOAT16_to_INT2/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 26 (INT2) for tensor 'like'."
   ],
   [
     "node/test_castlike_FLOAT16_to_INT2_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 26 (INT2) for tensor 'like'."
   ],
   [
     "node/test_castlike_FLOAT16_to_INT4/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 22 (INT4) for tensor 'like'."
   ],
   [
     "node/test_castlike_FLOAT16_to_INT4_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 22 (INT4) for tensor 'like'."
   ],
   [
     "node/test_castlike_FLOAT16_to_UINT2/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 25 (UINT2) for tensor 'like'."
   ],
   [
     "node/test_castlike_FLOAT16_to_UINT2_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 25 (UINT2) for tensor 'like'."
   ],
   [
     "node/test_castlike_FLOAT16_to_UINT4/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 21 (UINT4) for tensor 'like'."
   ],
   [
     "node/test_castlike_FLOAT16_to_UINT4_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 21 (UINT4) for tensor 'like'."
   ],
   [
     "node/test_castlike_FLOAT4E2M1_to_FLOAT/model.onnx",
@@ -1549,11 +1549,11 @@
   ],
   [
     "node/test_castlike_FLOAT_to_FLOAT16/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'like'."
+    ""
   ],
   [
     "node/test_castlike_FLOAT_to_FLOAT16_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'like'."
+    ""
   ],
   [
     "node/test_castlike_FLOAT_to_FLOAT4E2M1/model.onnx",
@@ -1725,35 +1725,35 @@
   ],
   [
     "node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E4M3FN/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'like'."
   ],
   [
     "node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E4M3FNUZ/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor 'like'."
   ],
   [
     "node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E4M3FNUZ_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor 'like'."
   ],
   [
     "node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E4M3FN_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'like'."
   ],
   [
     "node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E5M2/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'like'."
   ],
   [
     "node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E5M2FNUZ/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor 'like'."
   ],
   [
     "node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E5M2FNUZ_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor 'like'."
   ],
   [
     "node/test_castlike_no_saturate_FLOAT16_to_FLOAT8E5M2_expanded/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'input'."
+    "Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'like'."
   ],
   [
     "node/test_castlike_no_saturate_FLOAT_to_FLOAT8E4M3FN/model.onnx",
@@ -3033,7 +3033,7 @@
   ],
   [
     "node/test_isinf_float16/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'x'."
+    "Unsupported op IsInf"
   ],
   [
     "node/test_isinf_negative/model.onnx",
@@ -3049,7 +3049,7 @@
   ],
   [
     "node/test_isnan_float16/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'x'."
+    "Unsupported op IsNaN"
   ],
   [
     "node/test_l1normalization_axis_0/model.onnx",
@@ -3621,7 +3621,7 @@
   ],
   [
     "node/test_max_float16/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'data_0'."
+    ""
   ],
   [
     "node/test_max_float32/model.onnx",
@@ -3777,7 +3777,7 @@
   ],
   [
     "node/test_min_float16/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'data_0'."
+    ""
   ],
   [
     "node/test_min_float32/model.onnx",
@@ -3845,7 +3845,7 @@
   ],
   [
     "node/test_mod_mixed_sign_float16/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'x'."
+    ""
   ],
   [
     "node/test_mod_mixed_sign_float32/model.onnx",
@@ -4313,7 +4313,7 @@
   ],
   [
     "node/test_qlinearmatmul_2D_int8_float16/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'a_scale'."
+    "Unsupported op QLinearMatMul"
   ],
   [
     "node/test_qlinearmatmul_2D_int8_float32/model.onnx",
@@ -4321,7 +4321,7 @@
   ],
   [
     "node/test_qlinearmatmul_2D_uint8_float16/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'a_scale'."
+    "Unsupported op QLinearMatMul"
   ],
   [
     "node/test_qlinearmatmul_2D_uint8_float32/model.onnx",
@@ -4329,7 +4329,7 @@
   ],
   [
     "node/test_qlinearmatmul_3D_int8_float16/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'a_scale'."
+    "Unsupported op QLinearMatMul"
   ],
   [
     "node/test_qlinearmatmul_3D_int8_float32/model.onnx",
@@ -4337,7 +4337,7 @@
   ],
   [
     "node/test_qlinearmatmul_3D_uint8_float16/model.onnx",
-    "Unsupported elem_type 10 (FLOAT16) for tensor 'a_scale'."
+    "Unsupported op QLinearMatMul"
   ],
   [
     "node/test_qlinearmatmul_3D_uint8_float32/model.onnx",


### PR DESCRIPTION
### Motivation

- Enable support for ONNX `FLOAT16` (TensorProto.FLOAT16) so models using half-precision can be imported and lowered. 
- Allow float16 to flow through lowering, evaluator and codegen paths for ops that accept floating-point types. 
- Keep codegen deterministic by emitting a consistent C representation for float16 values (`_Float16`).

### Description

- Add `float16` to the ONNX → internal dtype mapping and to `DTYPE_INFO` with `c_type` set to `_Float16` in `src/onnx2c/dtypes.py`. 
- Extend the code generator in `src/onnx2c/codegen/c_emitter.py` with `_format_float16` and handle `float16` in `_format_floating`, `_format_literal`, `_format_value`, `_print_format`, and `_print_cast` so literals and prints for `_Float16` are emitted. 
- Permit `float16` in dtype validation and lowering checks across many ops (e.g., `Softmax`, `LogSoftmax`, `Conv`, `Gemm`, `LSTM`, `LRN`, `AveragePool`, `Attention`, `Reduce`, `Resize`, `SoftmaxCrossEntropyLoss`, `NegativeLogLikelihoodLoss`) and add `float16` handling in `src/onnx2c/ops.py` and runtime evaluator (`src/onnx2c/runtime/evaluator.py`). 
- Refresh official ONNX support artifacts and expected-error list (`OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`, `tests/official_onnx_expected_errors.json`) to reflect the new coverage for float16 files.

### Testing

- Ran the full test suite with reference updates via `UPDATE_REFS=1 pytest -n auto -q` which completed successfully (141 passed) in 33.43s. 
- Golden/reference artifacts were refreshed as part of the test run to reflect newly supported `FLOAT16` cases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6965c408f4948325b404bc0667bc2d1e)