### PR TITLE
docs: require clarifying operator semantics first

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,7 +296,11 @@ When acting as an agent in this repo:
 
    * avoid hardcoding operator names and special cases
    * prefer registries / dispatch tables for op lowering and kernels
-10. If the architecture starts drifting, propose a short design note in `docs/` with:
+10. When adding a new operator, clarify the operator semantics first.
+11. When clarifying operator semantics, consult the ONNX operator specs at
+    https://onnx.ai/onnx/operators/index.html and cite the specific operator page
+    in PR descriptions when applicable.
+12. If the architecture starts drifting, propose a short design note in `docs/` with:
 
 * problem
 * options


### PR DESCRIPTION
### Motivation

- Reduce incorrect implementations by requiring agents to verify operator semantics before adding new operators.
- Point agents to the authoritative ONNX operator specification to ensure consistent semantics resolution.
- Improve PR traceability by asking for specific operator pages to be cited when applicable.

### Description

- Updated `AGENTS.md` to add a new rule: "When adding a new operator, clarify the operator semantics first.".
- Kept and relocated the guidance to consult `https://onnx.ai/onnx/operators/index.html` and to cite the specific operator page in PR descriptions.
- Adjusted the surrounding numbering and ordering in `AGENTS.md` to integrate the new guidance.

### Testing

- Ran `pytest -n auto -q` as part of validation.
- Test run completed successfully with `141 passed in 22.89s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6965e0d1ab1c83258409c145867db1e3)