### PR TITLE
lowering: add Slice operator support

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -998,41 +998,41 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_neg_example/model.onnx | ✅ |  |
 | node/test_nesterov_momentum/model.onnx | ❌ | Unsupported op Momentum |
 | node/test_nllloss_NC/model.onnx | ✅ |  |
-| node/test_nllloss_NC_expanded/model.onnx | ❌ | Unsupported op Slice |
+| node/test_nllloss_NC_expanded/model.onnx | ❌ | Unsupported op Squeeze |
 | node/test_nllloss_NCd1/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1_expanded/model.onnx | ❌ | Unsupported op Slice |
+| node/test_nllloss_NCd1_expanded/model.onnx | ❌ | Unsupported op Squeeze |
 | node/test_nllloss_NCd1_ii/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1_ii_expanded/model.onnx | ❌ | Unsupported op Slice |
+| node/test_nllloss_NCd1_ii_expanded/model.onnx | ❌ | Unsupported op Squeeze |
 | node/test_nllloss_NCd1_mean_weight_negative_ii/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1_mean_weight_negative_ii_expanded/model.onnx | ❌ | Unsupported op Slice |
+| node/test_nllloss_NCd1_mean_weight_negative_ii_expanded/model.onnx | ❌ | Unsupported op Gather |
 | node/test_nllloss_NCd1_weight/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1_weight_expanded/model.onnx | ❌ | Unsupported op Slice |
+| node/test_nllloss_NCd1_weight_expanded/model.onnx | ❌ | Unsupported op Gather |
 | node/test_nllloss_NCd1_weight_ii/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1_weight_ii_expanded/model.onnx | ❌ | Unsupported op Slice |
+| node/test_nllloss_NCd1_weight_ii_expanded/model.onnx | ❌ | Unsupported op Gather |
 | node/test_nllloss_NCd1d2/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2_expanded/model.onnx | ❌ | Unsupported op Slice |
+| node/test_nllloss_NCd1d2_expanded/model.onnx | ❌ | Unsupported op Squeeze |
 | node/test_nllloss_NCd1d2_no_weight_reduction_mean_ii/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2_no_weight_reduction_mean_ii_expanded/model.onnx | ❌ | Unsupported op Slice |
+| node/test_nllloss_NCd1d2_no_weight_reduction_mean_ii_expanded/model.onnx | ❌ | Unsupported op Squeeze |
 | node/test_nllloss_NCd1d2_reduction_mean/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2_reduction_mean_expanded/model.onnx | ❌ | Unsupported op Slice |
+| node/test_nllloss_NCd1d2_reduction_mean_expanded/model.onnx | ❌ | Unsupported op Squeeze |
 | node/test_nllloss_NCd1d2_reduction_sum/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2_reduction_sum_expanded/model.onnx | ❌ | Unsupported op Slice |
+| node/test_nllloss_NCd1d2_reduction_sum_expanded/model.onnx | ❌ | Unsupported op Squeeze |
 | node/test_nllloss_NCd1d2_with_weight/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2_with_weight_expanded/model.onnx | ❌ | Unsupported op Slice |
+| node/test_nllloss_NCd1d2_with_weight_expanded/model.onnx | ❌ | Unsupported op Gather |
 | node/test_nllloss_NCd1d2_with_weight_reduction_mean/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2_with_weight_reduction_mean_expanded/model.onnx | ❌ | Unsupported op Slice |
+| node/test_nllloss_NCd1d2_with_weight_reduction_mean_expanded/model.onnx | ❌ | Unsupported op Gather |
 | node/test_nllloss_NCd1d2_with_weight_reduction_sum/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2_with_weight_reduction_sum_expanded/model.onnx | ❌ | Unsupported op Slice |
+| node/test_nllloss_NCd1d2_with_weight_reduction_sum_expanded/model.onnx | ❌ | Unsupported op Gather |
 | node/test_nllloss_NCd1d2_with_weight_reduction_sum_ii/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2_with_weight_reduction_sum_ii_expanded/model.onnx | ❌ | Unsupported op Slice |
+| node/test_nllloss_NCd1d2_with_weight_reduction_sum_ii_expanded/model.onnx | ❌ | Unsupported op Gather |
 | node/test_nllloss_NCd1d2d3_none_no_weight_negative_ii/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx | ❌ | Unsupported op Slice |
+| node/test_nllloss_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx | ❌ | Unsupported op Squeeze |
 | node/test_nllloss_NCd1d2d3_sum_weight_high_ii/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx | ❌ | Unsupported op Slice |
+| node/test_nllloss_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx | ❌ | Unsupported op Gather |
 | node/test_nllloss_NCd1d2d3d4d5_mean_weight/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2d3d4d5_mean_weight_expanded/model.onnx | ❌ | Unsupported op Slice |
+| node/test_nllloss_NCd1d2d3d4d5_mean_weight_expanded/model.onnx | ❌ | Unsupported op Gather |
 | node/test_nllloss_NCd1d2d3d4d5_none_no_weight/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx | ❌ | Unsupported op Slice |
+| node/test_nllloss_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx | ❌ | Unsupported op Squeeze |
 | node/test_nonmaxsuppression_center_point_box_format/model.onnx | ❌ | Unsupported op NonMaxSuppression |
 | node/test_nonmaxsuppression_flipped_coordinates/model.onnx | ❌ | Unsupported op NonMaxSuppression |
 | node/test_nonmaxsuppression_identical_boxes/model.onnx | ❌ | Unsupported op NonMaxSuppression |
@@ -1490,13 +1490,13 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_sinh_example/model.onnx | ❌ | Unsupported op Sinh |
 | node/test_size/model.onnx | ❌ | Unsupported op Size |
 | node/test_size_example/model.onnx | ❌ | Unsupported op Size |
-| node/test_slice/model.onnx | ❌ | Unsupported op Slice |
-| node/test_slice_default_axes/model.onnx | ❌ | Unsupported op Slice |
-| node/test_slice_default_steps/model.onnx | ❌ | Unsupported op Slice |
-| node/test_slice_end_out_of_bounds/model.onnx | ❌ | Unsupported op Slice |
-| node/test_slice_neg/model.onnx | ❌ | Unsupported op Slice |
-| node/test_slice_neg_steps/model.onnx | ❌ | Unsupported op Slice |
-| node/test_slice_negative_axes/model.onnx | ❌ | Unsupported op Slice |
+| node/test_slice/model.onnx | ❌ | Slice starts input must be a constant initializer |
+| node/test_slice_default_axes/model.onnx | ❌ | Slice starts input must be a constant initializer |
+| node/test_slice_default_steps/model.onnx | ❌ | Slice starts input must be a constant initializer |
+| node/test_slice_end_out_of_bounds/model.onnx | ❌ | Slice starts input must be a constant initializer |
+| node/test_slice_neg/model.onnx | ❌ | Slice starts input must be a constant initializer |
+| node/test_slice_neg_steps/model.onnx | ❌ | Slice starts input must be a constant initializer |
+| node/test_slice_negative_axes/model.onnx | ❌ | Slice starts input must be a constant initializer |
 | node/test_slice_start_out_of_bounds/model.onnx | ❌ | Dynamic or zero dims are not supported |
 | node/test_softmax_axis_0/model.onnx | ✅ |  |
 | node/test_softmax_axis_0_expanded/model.onnx | ✅ |  |
@@ -1766,7 +1766,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | pytorch-operator/test_operator_convtranspose/model.onnx | ❌ | Unsupported op ConvTranspose |
 | pytorch-operator/test_operator_exp/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_flatten/model.onnx | ❌ | Unsupported op Flatten |
-| pytorch-operator/test_operator_index/model.onnx | ❌ | Unsupported op Slice |
+| pytorch-operator/test_operator_index/model.onnx | ❌ | Unsupported op Squeeze |
 | pytorch-operator/test_operator_max/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_maxpool/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_min/model.onnx | ✅ |  |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -5,7 +5,6 @@
 | Dynamic dim for tensor '*' | 148 | ██████████████████████████████ |
 | Missing elem_type for tensor '*' | 34 | ███████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ██████ |
-| Unsupported op Slice | 26 | █████ |
 | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 22 | ████ |
 | Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 20 | ████ |
 | Unsupported op Identity | 20 | ████ |
@@ -25,8 +24,10 @@
 | Unsupported op ArgMin | 16 | ███ |
 | Unsupported op Clip | 16 | ███ |
 | Unsupported op Trilu | 16 | ███ |
+| Unsupported op Gather | 15 | ███ |
 | Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 14 | ███ |
 | Unsupported op ConvTranspose | 14 | ███ |
+| Unsupported op Squeeze | 14 | ███ |
 | ReduceSum output shape rank must match input rank | 12 | ██ |
 | Unsupported op Pad | 11 | ██ |
 | Unsupported op Flatten | 11 | ██ |
@@ -42,6 +43,7 @@
 | Unsupported op QLinearMatMul | 8 | ██ |
 | Unsupported op RotaryEmbedding | 8 | ██ |
 | Unsupported op Hardmax | 7 | █ |
+| Slice starts input must be a constant initializer | 7 | █ |
 | Unsupported op TfIdfVectorizer | 7 | █ |
 | Unsupported op TopK | 7 | █ |
 | AveragePool has unsupported attributes | 6 | █ |
@@ -51,7 +53,6 @@
 | Unsupported op Div | 6 | █ |
 | Unsupported op Einsum | 6 | █ |
 | Unsupported op Expand | 6 | █ |
-| Unsupported op Gather | 6 | █ |
 | Unsupported op LpNormalization | 6 | █ |
 | Unsupported op QuantizeLinear | 6 | █ |
 | Unsupported op ScatterElements | 6 | █ |
@@ -81,7 +82,6 @@
 | Unsupported op OptionalHasElement | 4 | █ |
 | CastLike input and output shapes must match | 4 | █ |
 | Unsupported op RNN | 4 | █ |
-| Unsupported op Squeeze | 4 | █ |
 | Unsupported op Tile | 4 | █ |
 | AveragePool supports auto_pad=NOTSET only | 3 | █ |
 | Unsupported op Bernoulli | 3 | █ |

--- a/src/onnx2c/compiler.py
+++ b/src/onnx2c/compiler.py
@@ -36,6 +36,7 @@ from .codegen.c_emitter import (
     ResizeOp,
     SoftmaxOp,
     ShapeOp,
+    SliceOp,
     TransposeOp,
     UnaryOp,
     WhereOp,
@@ -79,6 +80,7 @@ from .lowering.reduce import (
 )
 from .lowering.reshape import lower_reshape
 from .lowering.resize import lower_resize
+from .lowering.slice import lower_slice
 from .lowering.shape import lower_shape
 from .lowering.softmax import lower_softmax
 from .lowering.transpose import lower_transpose
@@ -220,6 +222,7 @@ class Compiler:
             | TransposeOp
             | ConstantOfShapeOp
             | ReshapeOp
+            | SliceOp
             | ResizeOp
             | ReduceOp
             | ShapeOp
@@ -248,6 +251,7 @@ class Compiler:
             | TransposeOp
             | ConstantOfShapeOp
             | ReshapeOp
+            | SliceOp
             | ResizeOp
             | ReduceOp
             | ShapeOp

--- a/src/onnx2c/lowering/slice.py
+++ b/src/onnx2c/lowering/slice.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from ..codegen.c_emitter import SliceOp
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Initializer, Node
+from ..lowering.common import value_dtype, value_shape
+from ..validation import normalize_axis
+from .registry import register_lowering
+
+
+@dataclass(frozen=True)
+class SliceSpec:
+    input_shape: tuple[int, ...]
+    output_shape: tuple[int, ...]
+    starts: tuple[int, ...]
+    steps: tuple[int, ...]
+
+
+def _find_initializer(graph: Graph, name: str) -> Initializer | None:
+    for initializer in graph.initializers:
+        if initializer.name == name:
+            return initializer
+    return None
+
+
+def _read_int_list(
+    graph: Graph, name: str, node: Node, *, label: str
+) -> list[int]:
+    initializer = _find_initializer(graph, name)
+    if initializer is None:
+        raise UnsupportedOpError(
+            f"{node.op_type} {label} input must be a constant initializer"
+        )
+    if initializer.type.dtype not in {"int64", "int32"}:
+        raise UnsupportedOpError(
+            f"{node.op_type} {label} input must be int64 or int32"
+        )
+    data = np.array(initializer.data, dtype=np.int64).reshape(-1)
+    return [int(value) for value in data]
+
+
+def _resolve_inputs(
+    graph: Graph, node: Node
+) -> tuple[list[int], list[int], list[int] | None, list[int] | None]:
+    if "starts" in node.attrs or "ends" in node.attrs:
+        if len(node.inputs) != 1:
+            raise UnsupportedOpError(
+                f"{node.op_type} with starts/ends attributes expects 1 input"
+            )
+        if "starts" not in node.attrs or "ends" not in node.attrs:
+            raise UnsupportedOpError(
+                f"{node.op_type} must specify both starts and ends"
+            )
+        starts = [int(value) for value in node.attrs.get("starts", [])]
+        ends = [int(value) for value in node.attrs.get("ends", [])]
+        axes_attr = node.attrs.get("axes")
+        axes = [int(value) for value in axes_attr] if axes_attr else None
+        steps = None
+        return starts, ends, axes, steps
+    if len(node.inputs) < 3:
+        raise UnsupportedOpError(
+            f"{node.op_type} expects at least 3 inputs"
+        )
+    starts = _read_int_list(graph, node.inputs[1], node, label="starts")
+    ends = _read_int_list(graph, node.inputs[2], node, label="ends")
+    axes = None
+    steps = None
+    if len(node.inputs) >= 4 and node.inputs[3]:
+        axes = _read_int_list(graph, node.inputs[3], node, label="axes")
+    if len(node.inputs) >= 5 and node.inputs[4]:
+        steps = _read_int_list(graph, node.inputs[4], node, label="steps")
+    return starts, ends, axes, steps
+
+
+def _normalize_slices(
+    input_shape: tuple[int, ...],
+    starts: list[int],
+    ends: list[int],
+    axes: list[int] | None,
+    steps: list[int] | None,
+    node: Node,
+) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+    rank = len(input_shape)
+    if rank == 0:
+        raise ShapeInferenceError(
+            f"{node.op_type} does not support scalar inputs"
+        )
+    if len(starts) != len(ends):
+        raise ShapeInferenceError(
+            f"{node.op_type} starts and ends must have matching lengths"
+        )
+    if axes is None:
+        axes = list(range(len(starts)))
+    if steps is None:
+        steps = [1] * len(starts)
+    if len(axes) != len(starts) or len(steps) != len(starts):
+        raise ShapeInferenceError(
+            f"{node.op_type} axes and steps must match starts length"
+        )
+    normalized_starts = [0] * rank
+    normalized_steps = [1] * rank
+    output_shape = list(input_shape)
+    seen_axes: set[int] = set()
+    for index, axis in enumerate(axes):
+        normalized_axis = normalize_axis(int(axis), input_shape, node)
+        if normalized_axis in seen_axes:
+            raise ShapeInferenceError(
+                f"{node.op_type} axes must be unique"
+            )
+        seen_axes.add(normalized_axis)
+        dim = input_shape[normalized_axis]
+        if dim < 0:
+            raise ShapeInferenceError("Dynamic dims are not supported")
+        step = int(steps[index])
+        if step == 0:
+            raise UnsupportedOpError(
+                f"{node.op_type} steps must be non-zero"
+            )
+        if step < 0:
+            raise UnsupportedOpError(
+                f"{node.op_type} only supports positive steps"
+            )
+        start = int(starts[index])
+        end = int(ends[index])
+        if start < 0:
+            start += dim
+        if end < 0:
+            end += dim
+        start = max(0, min(start, dim))
+        end = max(0, min(end, dim))
+        if end <= start:
+            raise ShapeInferenceError("Dynamic or zero dims are not supported")
+        length = (end - start + step - 1) // step
+        if length <= 0:
+            raise ShapeInferenceError("Dynamic or zero dims are not supported")
+        normalized_starts[normalized_axis] = start
+        normalized_steps[normalized_axis] = step
+        output_shape[normalized_axis] = length
+    return (
+        tuple(normalized_starts),
+        tuple(normalized_steps),
+        tuple(output_shape),
+    )
+
+
+def resolve_slice_spec(graph: Graph, node: Node) -> SliceSpec:
+    if len(node.inputs) < 1 or len(node.outputs) != 1:
+        raise UnsupportedOpError("Slice must have 1 output")
+    input_shape = value_shape(graph, node.inputs[0], node)
+    output_shape = value_shape(graph, node.outputs[0], node)
+    input_dtype = value_dtype(graph, node.inputs[0], node)
+    output_dtype = value_dtype(graph, node.outputs[0], node)
+    if input_dtype != output_dtype:
+        raise UnsupportedOpError(
+            f"{node.op_type} expects matching input/output dtypes, "
+            f"got {input_dtype} and {output_dtype}"
+        )
+    if any(dim < 0 for dim in input_shape):
+        raise ShapeInferenceError("Dynamic dims are not supported")
+    if any(dim < 0 for dim in output_shape):
+        raise ShapeInferenceError("Dynamic dims are not supported")
+    starts, ends, axes, steps = _resolve_inputs(graph, node)
+    normalized_starts, normalized_steps, computed_output_shape = _normalize_slices(
+        input_shape, starts, ends, axes, steps, node
+    )
+    if output_shape and computed_output_shape != output_shape:
+        raise ShapeInferenceError(
+            f"{node.op_type} output shape must be "
+            f"{computed_output_shape}, got {output_shape}"
+        )
+    return SliceSpec(
+        input_shape=input_shape,
+        output_shape=computed_output_shape,
+        starts=normalized_starts,
+        steps=normalized_steps,
+    )
+
+
+@register_lowering("Slice")
+def lower_slice(graph: Graph, node: Node) -> SliceOp:
+    spec = resolve_slice_spec(graph, node)
+    dtype = value_dtype(graph, node.inputs[0], node)
+    return SliceOp(
+        input0=node.inputs[0],
+        output=node.outputs[0],
+        input_shape=spec.input_shape,
+        output_shape=spec.output_shape,
+        starts=spec.starts,
+        steps=spec.steps,
+        dtype=dtype,
+    )

--- a/src/onnx2c/runtime/evaluator.py
+++ b/src/onnx2c/runtime/evaluator.py
@@ -34,6 +34,7 @@ from ..lowering.reduce import (
     resolve_reduce_axes,
 )
 from ..lowering.reshape import lower_reshape
+from ..lowering.slice import resolve_slice_spec
 from ..lowering.shape import lower_shape
 from ..lowering.softmax import lower_softmax
 from ..lowering.transpose import lower_transpose
@@ -197,6 +198,17 @@ def _eval_gather_elements(evaluator: Evaluator, node: Node) -> None:
     evaluator.values[node.outputs[0]] = np.take_along_axis(
         data, indices, axis=axis
     )
+
+
+@register_evaluator("Slice")
+def _eval_slice(evaluator: Evaluator, node: Node) -> None:
+    spec = resolve_slice_spec(evaluator.graph, node)
+    input_value = evaluator.values[node.inputs[0]]
+    slices = tuple(
+        slice(start, start + step * size, step)
+        for start, step, size in zip(spec.starts, spec.steps, spec.output_shape)
+    )
+    evaluator.values[node.outputs[0]] = input_value[slices]
 
 
 @register_evaluator("Attention")

--- a/templates/slice_op.c.j2
+++ b/templates/slice_op.c.j2
@@ -1,0 +1,9 @@
+static inline void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+{% for dim in output_shape %}
+for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+{% endfor %}
+{{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = {{ input0 }}{% for idx in input_indices %}[{{ idx }}]{% endfor %};
+{% for _ in output_shape %}
+}
+{% endfor %}
+}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -3961,7 +3961,7 @@
   ],
   [
     "node/test_nllloss_NC_expanded/model.onnx",
-    "Unsupported op Slice"
+    "Unsupported op Squeeze"
   ],
   [
     "node/test_nllloss_NCd1/model.onnx",
@@ -3969,7 +3969,7 @@
   ],
   [
     "node/test_nllloss_NCd1_expanded/model.onnx",
-    "Unsupported op Slice"
+    "Unsupported op Squeeze"
   ],
   [
     "node/test_nllloss_NCd1_ii/model.onnx",
@@ -3977,7 +3977,7 @@
   ],
   [
     "node/test_nllloss_NCd1_ii_expanded/model.onnx",
-    "Unsupported op Slice"
+    "Unsupported op Squeeze"
   ],
   [
     "node/test_nllloss_NCd1_mean_weight_negative_ii/model.onnx",
@@ -3985,7 +3985,7 @@
   ],
   [
     "node/test_nllloss_NCd1_mean_weight_negative_ii_expanded/model.onnx",
-    "Unsupported op Slice"
+    "Unsupported op Gather"
   ],
   [
     "node/test_nllloss_NCd1_weight/model.onnx",
@@ -3993,7 +3993,7 @@
   ],
   [
     "node/test_nllloss_NCd1_weight_expanded/model.onnx",
-    "Unsupported op Slice"
+    "Unsupported op Gather"
   ],
   [
     "node/test_nllloss_NCd1_weight_ii/model.onnx",
@@ -4001,7 +4001,7 @@
   ],
   [
     "node/test_nllloss_NCd1_weight_ii_expanded/model.onnx",
-    "Unsupported op Slice"
+    "Unsupported op Gather"
   ],
   [
     "node/test_nllloss_NCd1d2/model.onnx",
@@ -4009,7 +4009,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2_expanded/model.onnx",
-    "Unsupported op Slice"
+    "Unsupported op Squeeze"
   ],
   [
     "node/test_nllloss_NCd1d2_no_weight_reduction_mean_ii/model.onnx",
@@ -4017,7 +4017,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2_no_weight_reduction_mean_ii_expanded/model.onnx",
-    "Unsupported op Slice"
+    "Unsupported op Squeeze"
   ],
   [
     "node/test_nllloss_NCd1d2_reduction_mean/model.onnx",
@@ -4025,7 +4025,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2_reduction_mean_expanded/model.onnx",
-    "Unsupported op Slice"
+    "Unsupported op Squeeze"
   ],
   [
     "node/test_nllloss_NCd1d2_reduction_sum/model.onnx",
@@ -4033,7 +4033,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2_reduction_sum_expanded/model.onnx",
-    "Unsupported op Slice"
+    "Unsupported op Squeeze"
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight/model.onnx",
@@ -4041,7 +4041,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight_expanded/model.onnx",
-    "Unsupported op Slice"
+    "Unsupported op Gather"
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight_reduction_mean/model.onnx",
@@ -4049,7 +4049,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight_reduction_mean_expanded/model.onnx",
-    "Unsupported op Slice"
+    "Unsupported op Gather"
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight_reduction_sum/model.onnx",
@@ -4057,7 +4057,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight_reduction_sum_expanded/model.onnx",
-    "Unsupported op Slice"
+    "Unsupported op Gather"
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight_reduction_sum_ii/model.onnx",
@@ -4065,7 +4065,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight_reduction_sum_ii_expanded/model.onnx",
-    "Unsupported op Slice"
+    "Unsupported op Gather"
   ],
   [
     "node/test_nllloss_NCd1d2d3_none_no_weight_negative_ii/model.onnx",
@@ -4073,7 +4073,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx",
-    "Unsupported op Slice"
+    "Unsupported op Squeeze"
   ],
   [
     "node/test_nllloss_NCd1d2d3_sum_weight_high_ii/model.onnx",
@@ -4081,7 +4081,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx",
-    "Unsupported op Slice"
+    "Unsupported op Gather"
   ],
   [
     "node/test_nllloss_NCd1d2d3d4d5_mean_weight/model.onnx",
@@ -4089,7 +4089,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2d3d4d5_mean_weight_expanded/model.onnx",
-    "Unsupported op Slice"
+    "Unsupported op Gather"
   ],
   [
     "node/test_nllloss_NCd1d2d3d4d5_none_no_weight/model.onnx",
@@ -4097,7 +4097,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx",
-    "Unsupported op Slice"
+    "Unsupported op Squeeze"
   ],
   [
     "node/test_nonmaxsuppression_center_point_box_format/model.onnx",
@@ -5929,31 +5929,31 @@
   ],
   [
     "node/test_slice/model.onnx",
-    "Unsupported op Slice"
+    "Slice starts input must be a constant initializer"
   ],
   [
     "node/test_slice_default_axes/model.onnx",
-    "Unsupported op Slice"
+    "Slice starts input must be a constant initializer"
   ],
   [
     "node/test_slice_default_steps/model.onnx",
-    "Unsupported op Slice"
+    "Slice starts input must be a constant initializer"
   ],
   [
     "node/test_slice_end_out_of_bounds/model.onnx",
-    "Unsupported op Slice"
+    "Slice starts input must be a constant initializer"
   ],
   [
     "node/test_slice_neg/model.onnx",
-    "Unsupported op Slice"
+    "Slice starts input must be a constant initializer"
   ],
   [
     "node/test_slice_neg_steps/model.onnx",
-    "Unsupported op Slice"
+    "Slice starts input must be a constant initializer"
   ],
   [
     "node/test_slice_negative_axes/model.onnx",
-    "Unsupported op Slice"
+    "Slice starts input must be a constant initializer"
   ],
   [
     "node/test_slice_start_out_of_bounds/model.onnx",
@@ -7033,7 +7033,7 @@
   ],
   [
     "pytorch-operator/test_operator_index/model.onnx",
-    "Unsupported op Slice"
+    "Unsupported op Squeeze"
   ],
   [
     "pytorch-operator/test_operator_max/model.onnx",


### PR DESCRIPTION
### Motivation
- Add support for the ONNX `Slice` operator so models using slicing can be lowered, evaluated and emitted to C.
- Provide deterministic shape/step normalization and explicit validation to keep the pipeline correct-by-comparison and avoid hidden state.
- Emit a simple, templated C kernel for `Slice` that fits the existing codegen model and minimal runtime constraints.
- Add an end-to-end test to ensure generated code matches ONNX Runtime semantics for supported Slice cases.

### Description
- Added a lowering module `src/onnx2c/lowering/slice.py` that implements `resolve_slice_spec`, input normalization/validation, and registers `Slice` lowering via `@register_lowering("Slice")`.
- Introduced `SliceOp` dataclass and wired codegen in `src/onnx2c/codegen/c_emitter.py` to render a new `slice_op.c.j2` template, with index-expression generation for starts/steps.
- Implemented runtime evaluation in `src/onnx2c/runtime/evaluator.py` via `@register_evaluator("Slice")` that reuses the lowering spec and applies NumPy slicing for verification/constant folding.
- Added `templates/slice_op.c.j2` and an end-to-end test `tests/test_endtoend_ops.py::_make_slice_model`/`test_slice_op_matches_onnxruntime`, and updated official support/reference files to reflect the new behavior.

### Testing
- Ran the full test suite with reference updates via `UPDATE_REFS=1 pytest -n auto -q` which completed in `28.55s` and reported `142 passed`.
- Golden/reference files were refreshed as part of the run to capture updated support messages for Slice-related official ONNX files.
- The new end-to-end Slice test verifies lowering, runtime evaluation, and C emission correctness against ONNX Runtime.
- No other automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6965e7855974832580c31d16bb1fc707)