### PR TITLE
docs: document operator spec locations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,6 +299,12 @@ When acting as an agent in this repo:
 * problem
 * options
 * recommendation
+12. To find operator specifications within this repository, prefer:
+    * `onnx-org/docs/Operators.md` for the current consolidated operator docs.
+    * `onnx-org/docs/Changelog.md` for versioned operator specs (e.g., Slice-13).
+    * `onnx-org/onnx/defs/**/defs.cc` or `onnx-org/onnx/defs/**/old.cc` for the
+      schema source and historical documentation strings.
+    * Use ripgrep (`rg -n "<OpName>" onnx-org`) to locate the relevant sections.
 
 ## Adding an operator (checklist)
 


### PR DESCRIPTION
### Motivation

- Clarify where to find ONNX operator specifications within the repository to speed up operator additions and reviews.
- Provide concrete file locations and a search command to reduce ambiguity when verifying operator semantics.
- Encourage citing canonical sources when describing operator behavior in PRs.

### Description

- Add item 12 to `AGENTS.md` listing preferred locations for operator specs including `onnx-org/docs/Operators.md`.
- Recommend `onnx-org/docs/Changelog.md` for versioned operator specs and `onnx-org/onnx/defs/**/defs.cc` or `onnx-org/onnx/defs/**/old.cc` for schema source and historical docs.
- Document using ripgrep with `rg -n "<OpName>" onnx-org` to locate operator definitions.

### Testing

- Ran `UPDATE_REFS=1 pytest -n auto -q` to regenerate references and validate the change.
- All automated tests passed: `141 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6965e886c99c83258dc614428cb1b321)