### PR TITLE
onnx_import: enable data propagation in shape inference and improve non-tensor diagnostics

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -100,50 +100,50 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_atanh_example/model.onnx | ✅ |  |
 | node/test_attention_3d/model.onnx | ✅ |  |
 | node/test_attention_3d_attn_mask/model.onnx | ✅ |  |
-| node/test_attention_3d_attn_mask_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_attn_mask_expanded_function_QIntermediate' |
+| node/test_attention_3d_attn_mask_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_attn_mask_expanded_function_KExpanded' |
 | node/test_attention_3d_causal/model.onnx | ✅ |  |
-| node/test_attention_3d_causal_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_causal_expanded_function_QIntermediate' |
+| node/test_attention_3d_causal_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_causal_expanded_function_RangeRow' |
 | node/test_attention_3d_diff_heads_sizes/model.onnx | ✅ |  |
 | node/test_attention_3d_diff_heads_sizes_attn_mask/model.onnx | ✅ |  |
-| node/test_attention_3d_diff_heads_sizes_attn_mask_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_attn_mask_expanded_function_QIntermediate' |
+| node/test_attention_3d_diff_heads_sizes_attn_mask_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_attn_mask_expanded_function_KExpanded' |
 | node/test_attention_3d_diff_heads_sizes_causal/model.onnx | ✅ |  |
-| node/test_attention_3d_diff_heads_sizes_causal_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_causal_expanded_function_QIntermediate' |
-| node/test_attention_3d_diff_heads_sizes_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_expanded_function_QIntermediate' |
+| node/test_attention_3d_diff_heads_sizes_causal_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_causal_expanded_function_RangeRow' |
+| node/test_attention_3d_diff_heads_sizes_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_expanded_function_KExpanded' |
 | node/test_attention_3d_diff_heads_sizes_scaled/model.onnx | ✅ |  |
-| node/test_attention_3d_diff_heads_sizes_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_scaled_expanded_function_QIntermediate' |
+| node/test_attention_3d_diff_heads_sizes_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_scaled_expanded_function_KExpanded' |
 | node/test_attention_3d_diff_heads_sizes_softcap/model.onnx | ✅ |  |
-| node/test_attention_3d_diff_heads_sizes_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_softcap_expanded_function_QIntermediate' |
+| node/test_attention_3d_diff_heads_sizes_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_softcap_expanded_function_KExpanded' |
 | node/test_attention_3d_diff_heads_with_past_and_present/model.onnx | ✅ |  |
-| node/test_attention_3d_diff_heads_with_past_and_present_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_with_past_and_present_expanded_function_QIntermediate' |
-| node/test_attention_3d_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_expanded_function_QIntermediate' |
+| node/test_attention_3d_diff_heads_with_past_and_present_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_with_past_and_present_expanded_function_KExpanded' |
+| node/test_attention_3d_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_expanded_function_KExpanded' |
 | node/test_attention_3d_gqa/model.onnx | ✅ |  |
 | node/test_attention_3d_gqa_attn_mask/model.onnx | ✅ |  |
-| node/test_attention_3d_gqa_attn_mask_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_gqa_attn_mask_expanded_function_QIntermediate' |
+| node/test_attention_3d_gqa_attn_mask_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_gqa_attn_mask_expanded_function_KExpanded' |
 | node/test_attention_3d_gqa_causal/model.onnx | ✅ |  |
-| node/test_attention_3d_gqa_causal_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_gqa_causal_expanded_function_QIntermediate' |
-| node/test_attention_3d_gqa_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_gqa_expanded_function_QIntermediate' |
+| node/test_attention_3d_gqa_causal_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_gqa_causal_expanded_function_RangeRow' |
+| node/test_attention_3d_gqa_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_gqa_expanded_function_KExpanded' |
 | node/test_attention_3d_gqa_scaled/model.onnx | ✅ |  |
-| node/test_attention_3d_gqa_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_gqa_scaled_expanded_function_QIntermediate' |
+| node/test_attention_3d_gqa_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_gqa_scaled_expanded_function_KExpanded' |
 | node/test_attention_3d_gqa_softcap/model.onnx | ✅ |  |
-| node/test_attention_3d_gqa_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_gqa_softcap_expanded_function_QIntermediate' |
+| node/test_attention_3d_gqa_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_gqa_softcap_expanded_function_KExpanded' |
 | node/test_attention_3d_gqa_with_past_and_present/model.onnx | ✅ |  |
-| node/test_attention_3d_gqa_with_past_and_present_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_gqa_with_past_and_present_expanded_function_QIntermediate' |
+| node/test_attention_3d_gqa_with_past_and_present_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_gqa_with_past_and_present_expanded_function_KExpanded' |
 | node/test_attention_3d_scaled/model.onnx | ✅ |  |
-| node/test_attention_3d_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_scaled_expanded_function_QIntermediate' |
+| node/test_attention_3d_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_scaled_expanded_function_KExpanded' |
 | node/test_attention_3d_softcap/model.onnx | ✅ |  |
-| node/test_attention_3d_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_softcap_expanded_function_QIntermediate' |
+| node/test_attention_3d_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_softcap_expanded_function_KExpanded' |
 | node/test_attention_3d_transpose_verification/model.onnx | ✅ |  |
-| node/test_attention_3d_transpose_verification_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_transpose_verification_expanded_function_QIntermediate' |
+| node/test_attention_3d_transpose_verification_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_transpose_verification_expanded_function_KExpanded' |
 | node/test_attention_3d_with_past_and_present/model.onnx | ✅ |  |
-| node/test_attention_3d_with_past_and_present_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_expanded_function_QIntermediate' |
+| node/test_attention_3d_with_past_and_present_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_expanded_function_KExpanded' |
 | node/test_attention_3d_with_past_and_present_qk_matmul/model.onnx | ✅ |  |
 | node/test_attention_3d_with_past_and_present_qk_matmul_bias/model.onnx | ✅ |  |
-| node/test_attention_3d_with_past_and_present_qk_matmul_bias_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_qk_matmul_bias_expanded_function_QIntermediate' |
-| node/test_attention_3d_with_past_and_present_qk_matmul_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_qk_matmul_expanded_function_QIntermediate' |
+| node/test_attention_3d_with_past_and_present_qk_matmul_bias_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_qk_matmul_bias_expanded_function_KExpanded' |
+| node/test_attention_3d_with_past_and_present_qk_matmul_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_qk_matmul_expanded_function_KExpanded' |
 | node/test_attention_3d_with_past_and_present_qk_matmul_softcap/model.onnx | ✅ |  |
-| node/test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded_function_QIntermediate' |
+| node/test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded_function_KExpanded' |
 | node/test_attention_3d_with_past_and_present_qk_matmul_softmax/model.onnx | ✅ |  |
-| node/test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded_function_QIntermediate' |
+| node/test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded_function_KExpanded' |
 | node/test_attention_4d/model.onnx | ✅ |  |
 | node/test_attention_4d_attn_mask/model.onnx | ✅ |  |
 | node/test_attention_4d_attn_mask_3d/model.onnx | ✅ |  |
@@ -160,46 +160,46 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_attention_4d_attn_mask_bool_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_attn_mask_bool_expanded_function_KExpanded' |
 | node/test_attention_4d_attn_mask_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_attn_mask_expanded_function_KExpanded' |
 | node/test_attention_4d_causal/model.onnx | ✅ |  |
-| node/test_attention_4d_causal_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_causal_expanded_function_AttnBias' |
+| node/test_attention_4d_causal_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_causal_expanded_function_RangeRow' |
 | node/test_attention_4d_diff_heads_mask4d_padded_kv/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_mask4d_padded_kv_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_mask4d_padded_kv_expanded_function_AttnBias' |
 | node/test_attention_4d_diff_heads_sizes/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_sizes_attn_mask/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_sizes_attn_mask_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_sizes_attn_mask_expanded_function_KExpanded' |
 | node/test_attention_4d_diff_heads_sizes_causal/model.onnx | ✅ |  |
-| node/test_attention_4d_diff_heads_sizes_causal_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_sizes_causal_expanded_function_AttnBias' |
-| node/test_attention_4d_diff_heads_sizes_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_sizes_expanded_function_AttnBias' |
+| node/test_attention_4d_diff_heads_sizes_causal_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_sizes_causal_expanded_function_RangeRow' |
+| node/test_attention_4d_diff_heads_sizes_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_sizes_expanded_function_KExpanded' |
 | node/test_attention_4d_diff_heads_sizes_scaled/model.onnx | ✅ |  |
-| node/test_attention_4d_diff_heads_sizes_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_sizes_scaled_expanded_function_AttnBias' |
+| node/test_attention_4d_diff_heads_sizes_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_sizes_scaled_expanded_function_KExpanded' |
 | node/test_attention_4d_diff_heads_sizes_softcap/model.onnx | ✅ |  |
-| node/test_attention_4d_diff_heads_sizes_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_sizes_softcap_expanded_function_AttnBias' |
+| node/test_attention_4d_diff_heads_sizes_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_sizes_softcap_expanded_function_KExpanded' |
 | node/test_attention_4d_diff_heads_with_past_and_present/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_with_past_and_present_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_with_past_and_present_expanded_function_KExpanded' |
 | node/test_attention_4d_diff_heads_with_past_and_present_mask3d/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_with_past_and_present_mask3d_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_with_past_and_present_mask3d_expanded_function_KExpanded' |
 | node/test_attention_4d_diff_heads_with_past_and_present_mask4d/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_with_past_and_present_mask4d_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_with_past_and_present_mask4d_expanded_function_KExpanded' |
-| node/test_attention_4d_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_expanded_function_AttnBias' |
+| node/test_attention_4d_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_expanded_function_KExpanded' |
 | node/test_attention_4d_fp16/model.onnx | ✅ |  |
-| node/test_attention_4d_fp16_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_fp16_expanded_function_AttnBias' |
+| node/test_attention_4d_fp16_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_fp16_expanded_function_KExpanded' |
 | node/test_attention_4d_gqa/model.onnx | ✅ |  |
 | node/test_attention_4d_gqa_attn_mask/model.onnx | ✅ |  |
 | node/test_attention_4d_gqa_attn_mask_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_gqa_attn_mask_expanded_function_KExpanded' |
 | node/test_attention_4d_gqa_causal/model.onnx | ✅ |  |
-| node/test_attention_4d_gqa_causal_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_gqa_causal_expanded_function_AttnBias' |
-| node/test_attention_4d_gqa_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_gqa_expanded_function_AttnBias' |
+| node/test_attention_4d_gqa_causal_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_gqa_causal_expanded_function_RangeRow' |
+| node/test_attention_4d_gqa_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_gqa_expanded_function_KExpanded' |
 | node/test_attention_4d_gqa_scaled/model.onnx | ✅ |  |
-| node/test_attention_4d_gqa_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_gqa_scaled_expanded_function_AttnBias' |
+| node/test_attention_4d_gqa_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_gqa_scaled_expanded_function_KExpanded' |
 | node/test_attention_4d_gqa_softcap/model.onnx | ✅ |  |
-| node/test_attention_4d_gqa_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_gqa_softcap_expanded_function_AttnBias' |
+| node/test_attention_4d_gqa_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_gqa_softcap_expanded_function_KExpanded' |
 | node/test_attention_4d_gqa_with_past_and_present/model.onnx | ✅ |  |
 | node/test_attention_4d_gqa_with_past_and_present_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_gqa_with_past_and_present_expanded_function_KExpanded' |
 | node/test_attention_4d_gqa_with_past_and_present_fp16/model.onnx | ✅ |  |
 | node/test_attention_4d_gqa_with_past_and_present_fp16_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_gqa_with_past_and_present_fp16_expanded_function_KExpanded' |
 | node/test_attention_4d_scaled/model.onnx | ✅ |  |
-| node/test_attention_4d_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_scaled_expanded_function_AttnBias' |
+| node/test_attention_4d_scaled_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_scaled_expanded_function_KExpanded' |
 | node/test_attention_4d_softcap/model.onnx | ✅ |  |
-| node/test_attention_4d_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_softcap_expanded_function_AttnBias' |
+| node/test_attention_4d_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_softcap_expanded_function_KExpanded' |
 | node/test_attention_4d_with_past_and_present/model.onnx | ✅ |  |
 | node/test_attention_4d_with_past_and_present_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_past_and_present_expanded_function_KExpanded' |
 | node/test_attention_4d_with_past_and_present_qk_matmul/model.onnx | ✅ |  |
@@ -217,7 +217,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_attention_4d_with_qk_matmul/model.onnx | ✅ |  |
 | node/test_attention_4d_with_qk_matmul_bias/model.onnx | ✅ |  |
 | node/test_attention_4d_with_qk_matmul_bias_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_qk_matmul_bias_expanded_function_KExpanded' |
-| node/test_attention_4d_with_qk_matmul_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_qk_matmul_expanded_function_AttnBias' |
+| node/test_attention_4d_with_qk_matmul_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_qk_matmul_expanded_function_KExpanded' |
 | node/test_attention_4d_with_qk_matmul_softcap/model.onnx | ✅ |  |
 | node/test_attention_4d_with_qk_matmul_softcap_expanded/model.onnx | ❌ | Dynamic dim for tensor 'Attention_test_attention_4d_with_qk_matmul_softcap_expanded_function_KExpanded' |
 | node/test_attention_4d_with_qk_matmul_softmax/model.onnx | ✅ |  |
@@ -749,11 +749,11 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_hardswish/model.onnx | ❌ | Unsupported op HardSwish |
 | node/test_hardswish_expanded/model.onnx | ❌ | Unsupported op HardSigmoid |
 | node/test_identity/model.onnx | ❌ | Unsupported op Identity |
-| node/test_identity_opt/model.onnx | ❌ | Missing elem_type for tensor 'opt_in' |
-| node/test_identity_sequence/model.onnx | ❌ | Missing elem_type for tensor 'x' |
+| node/test_identity_opt/model.onnx | ❌ | Unsupported value type 'optional_type' for 'opt_in'. Hint: export the model with tensor inputs/outputs. |
+| node/test_identity_sequence/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'x'. Hint: export the model with tensor inputs/outputs. |
 | node/test_if/model.onnx | ❌ | Unsupported op If |
-| node/test_if_opt/model.onnx | ❌ | Missing elem_type for tensor 'sequence' |
-| node/test_if_seq/model.onnx | ❌ | Missing elem_type for tensor 'res' |
+| node/test_if_opt/model.onnx | ❌ | Unsupported value type 'optional_type' for 'sequence'. Hint: export the model with tensor inputs/outputs. |
+| node/test_if_seq/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'res'. Hint: export the model with tensor inputs/outputs. |
 | node/test_image_decoder_decode_bmp_rgb/model.onnx | ❌ | Unsupported op ImageDecoder |
 | node/test_image_decoder_decode_jpeg2k_rgb/model.onnx | ❌ | Unsupported op ImageDecoder |
 | node/test_image_decoder_decode_jpeg_bgr/model.onnx | ❌ | Unsupported op ImageDecoder |
@@ -777,11 +777,11 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_l2normalization_axis_0/model.onnx | ❌ | Unsupported op LpNormalization |
 | node/test_l2normalization_axis_1/model.onnx | ❌ | Unsupported op LpNormalization |
 | node/test_layer_normalization_2d_axis0/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_2d_axis0_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis0_expanded_function_SuffixShape' |
-| node/test_layer_normalization_2d_axis0_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis0_expanded_function_SuffixShape' |
+| node/test_layer_normalization_2d_axis0_expanded/model.onnx | ❌ | Unsupported op Size |
+| node/test_layer_normalization_2d_axis0_expanded_ver18/model.onnx | ❌ | Unsupported op Size |
 | node/test_layer_normalization_2d_axis1/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_2d_axis1_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis1_expanded_function_SuffixShape' |
-| node/test_layer_normalization_2d_axis1_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis1_expanded_function_SuffixShape' |
+| node/test_layer_normalization_2d_axis1_expanded/model.onnx | ❌ | Unsupported op Size |
+| node/test_layer_normalization_2d_axis1_expanded_ver18/model.onnx | ❌ | Unsupported op Size |
 | node/test_layer_normalization_2d_axis_negative_1/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_2d_axis_negative_1_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis_negative_1_expanded_function_SuffixShape' |
 | node/test_layer_normalization_2d_axis_negative_1_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis_negative_1_expanded_function_SuffixShape' |
@@ -789,14 +789,14 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_layer_normalization_2d_axis_negative_2_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis_negative_2_expanded_function_SuffixShape' |
 | node/test_layer_normalization_2d_axis_negative_2_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis_negative_2_expanded_function_SuffixShape' |
 | node/test_layer_normalization_3d_axis0_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_3d_axis0_epsilon_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis0_epsilon_expanded_function_SuffixShape' |
-| node/test_layer_normalization_3d_axis0_epsilon_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis0_epsilon_expanded_function_SuffixShape' |
+| node/test_layer_normalization_3d_axis0_epsilon_expanded/model.onnx | ❌ | Unsupported op Size |
+| node/test_layer_normalization_3d_axis0_epsilon_expanded_ver18/model.onnx | ❌ | Unsupported op Size |
 | node/test_layer_normalization_3d_axis1_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_3d_axis1_epsilon_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis1_epsilon_expanded_function_SuffixShape' |
-| node/test_layer_normalization_3d_axis1_epsilon_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis1_epsilon_expanded_function_SuffixShape' |
+| node/test_layer_normalization_3d_axis1_epsilon_expanded/model.onnx | ❌ | Unsupported op Size |
+| node/test_layer_normalization_3d_axis1_epsilon_expanded_ver18/model.onnx | ❌ | Unsupported op Size |
 | node/test_layer_normalization_3d_axis2_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_3d_axis2_epsilon_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis2_epsilon_expanded_function_SuffixShape' |
-| node/test_layer_normalization_3d_axis2_epsilon_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis2_epsilon_expanded_function_SuffixShape' |
+| node/test_layer_normalization_3d_axis2_epsilon_expanded/model.onnx | ❌ | Unsupported op Size |
+| node/test_layer_normalization_3d_axis2_epsilon_expanded_ver18/model.onnx | ❌ | Unsupported op Size |
 | node/test_layer_normalization_3d_axis_negative_1_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_3d_axis_negative_1_epsilon_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis_negative_1_epsilon_expanded_function_SuffixShape' |
 | node/test_layer_normalization_3d_axis_negative_1_epsilon_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis_negative_1_epsilon_expanded_function_SuffixShape' |
@@ -807,17 +807,17 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_layer_normalization_3d_axis_negative_3_epsilon_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis_negative_3_epsilon_expanded_function_SuffixShape' |
 | node/test_layer_normalization_3d_axis_negative_3_epsilon_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis_negative_3_epsilon_expanded_function_SuffixShape' |
 | node/test_layer_normalization_4d_axis0/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_4d_axis0_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis0_expanded_function_SuffixShape' |
-| node/test_layer_normalization_4d_axis0_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis0_expanded_function_SuffixShape' |
+| node/test_layer_normalization_4d_axis0_expanded/model.onnx | ❌ | Unsupported op Size |
+| node/test_layer_normalization_4d_axis0_expanded_ver18/model.onnx | ❌ | Unsupported op Size |
 | node/test_layer_normalization_4d_axis1/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_4d_axis1_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis1_expanded_function_SuffixShape' |
-| node/test_layer_normalization_4d_axis1_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis1_expanded_function_SuffixShape' |
+| node/test_layer_normalization_4d_axis1_expanded/model.onnx | ❌ | Unsupported op Size |
+| node/test_layer_normalization_4d_axis1_expanded_ver18/model.onnx | ❌ | Unsupported op Size |
 | node/test_layer_normalization_4d_axis2/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_4d_axis2_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis2_expanded_function_SuffixShape' |
-| node/test_layer_normalization_4d_axis2_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis2_expanded_function_SuffixShape' |
+| node/test_layer_normalization_4d_axis2_expanded/model.onnx | ❌ | Unsupported op Size |
+| node/test_layer_normalization_4d_axis2_expanded_ver18/model.onnx | ❌ | Unsupported op Size |
 | node/test_layer_normalization_4d_axis3/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_4d_axis3_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis3_expanded_function_SuffixShape' |
-| node/test_layer_normalization_4d_axis3_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis3_expanded_function_SuffixShape' |
+| node/test_layer_normalization_4d_axis3_expanded/model.onnx | ❌ | Unsupported op Size |
+| node/test_layer_normalization_4d_axis3_expanded_ver18/model.onnx | ❌ | Unsupported op Size |
 | node/test_layer_normalization_4d_axis_negative_1/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_4d_axis_negative_1_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis_negative_1_expanded_function_SuffixShape' |
 | node/test_layer_normalization_4d_axis_negative_1_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis_negative_1_expanded_function_SuffixShape' |
@@ -887,8 +887,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_logsoftmax_negative_axis_expanded/model.onnx | ✅ |  |
 | node/test_logsoftmax_negative_axis_expanded_ver18/model.onnx | ✅ |  |
 | node/test_loop11/model.onnx | ❌ | Unsupported op Loop |
-| node/test_loop13_seq/model.onnx | ❌ | Missing elem_type for tensor 'seq_empty' |
-| node/test_loop16_seq_none/model.onnx | ❌ | Missing elem_type for tensor 'opt_seq' |
+| node/test_loop13_seq/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'seq_empty'. Hint: export the model with tensor inputs/outputs. |
+| node/test_loop16_seq_none/model.onnx | ❌ | Unsupported value type 'optional_type' for 'opt_seq'. Hint: export the model with tensor inputs/outputs. |
 | node/test_lpnormalization_default/model.onnx | ❌ | Unsupported op LpNormalization |
 | node/test_lppool_1d_default/model.onnx | ❌ | Unsupported op LpPool |
 | node/test_lppool_2d_default/model.onnx | ❌ | Unsupported op LpPool |
@@ -1050,17 +1050,17 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_onehot_with_axis/model.onnx | ❌ | Unsupported op OneHot |
 | node/test_onehot_with_negative_axis/model.onnx | ❌ | Unsupported op OneHot |
 | node/test_onehot_without_axis/model.onnx | ❌ | Unsupported op OneHot |
-| node/test_optional_get_element_optional_sequence/model.onnx | ❌ | Missing elem_type for tensor 'optional_input' |
-| node/test_optional_get_element_optional_tensor/model.onnx | ❌ | Missing elem_type for tensor 'optional_input' |
-| node/test_optional_get_element_sequence/model.onnx | ❌ | Missing elem_type for tensor 'optional_input' |
+| node/test_optional_get_element_optional_sequence/model.onnx | ❌ | Unsupported value type 'optional_type' for 'optional_input'. Hint: export the model with tensor inputs/outputs. |
+| node/test_optional_get_element_optional_tensor/model.onnx | ❌ | Unsupported value type 'optional_type' for 'optional_input'. Hint: export the model with tensor inputs/outputs. |
+| node/test_optional_get_element_sequence/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'optional_input'. Hint: export the model with tensor inputs/outputs. |
 | node/test_optional_get_element_tensor/model.onnx | ❌ | Unsupported op OptionalGetElement |
 | node/test_optional_has_element_empty_no_input_name_optional_input/model.onnx | ❌ | Unsupported op OptionalHasElement |
 | node/test_optional_has_element_empty_no_input_name_tensor_input/model.onnx | ❌ | Unsupported op OptionalHasElement |
 | node/test_optional_has_element_empty_no_input_optional_input/model.onnx | ❌ | Unsupported op OptionalHasElement |
 | node/test_optional_has_element_empty_no_input_tensor_input/model.onnx | ❌ | Unsupported op OptionalHasElement |
-| node/test_optional_has_element_empty_optional_input/model.onnx | ❌ | Missing elem_type for tensor 'optional_input' |
-| node/test_optional_has_element_optional_input/model.onnx | ❌ | Missing elem_type for tensor 'optional_input' |
-| node/test_optional_has_element_tensor_input/model.onnx | ❌ | Missing elem_type for tensor 'optional_input' |
+| node/test_optional_has_element_empty_optional_input/model.onnx | ❌ | Unsupported value type 'optional_type' for 'optional_input'. Hint: export the model with tensor inputs/outputs. |
+| node/test_optional_has_element_optional_input/model.onnx | ❌ | Unsupported value type 'optional_type' for 'optional_input'. Hint: export the model with tensor inputs/outputs. |
+| node/test_optional_has_element_tensor_input/model.onnx | ❌ | Unsupported value type 'optional_type' for 'optional_input'. Hint: export the model with tensor inputs/outputs. |
 | node/test_or2d/model.onnx | ✅ |  |
 | node/test_or3d/model.onnx | ✅ |  |
 | node/test_or4d/model.onnx | ✅ |  |
@@ -1345,7 +1345,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_roialign_mode_max/model.onnx | ❌ | Unsupported op RoiAlign |
 | node/test_rotary_embedding/model.onnx | ❌ | Unsupported op RotaryEmbedding |
 | node/test_rotary_embedding_3d_input/model.onnx | ❌ | Unsupported op RotaryEmbedding |
-| node/test_rotary_embedding_3d_input_expanded/model.onnx | ❌ | Dynamic dim for tensor 'RotaryEmbedding_test_rotary_embedding_3d_input_expanded_function_XIn' |
+| node/test_rotary_embedding_3d_input_expanded/model.onnx | ❌ | Dynamic dim for tensor 'RotaryEmbedding_test_rotary_embedding_3d_input_expanded_function_CosCacheSliced' |
 | node/test_rotary_embedding_expanded/model.onnx | ❌ | Dynamic dim for tensor 'RotaryEmbedding_test_rotary_embedding_expanded_function_CosCacheSliced' |
 | node/test_rotary_embedding_interleaved/model.onnx | ❌ | Unsupported op RotaryEmbedding |
 | node/test_rotary_embedding_interleaved_expanded/model.onnx | ❌ | Dynamic dim for tensor 'RotaryEmbedding_test_rotary_embedding_interleaved_expanded_function_CosCacheSliced' |
@@ -1449,20 +1449,20 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_selu_example/model.onnx | ❌ | Unsupported op Selu |
 | node/test_selu_example_expanded_ver18/model.onnx | ✅ |  |
 | node/test_selu_expanded_ver18/model.onnx | ✅ |  |
-| node/test_sequence_insert_at_back/model.onnx | ❌ | Missing elem_type for tensor 'sequence' |
-| node/test_sequence_insert_at_front/model.onnx | ❌ | Missing elem_type for tensor 'sequence' |
-| node/test_sequence_map_add_1_sequence_1_tensor/model.onnx | ❌ | Missing elem_type for tensor 'x0' |
-| node/test_sequence_map_add_1_sequence_1_tensor_expanded/model.onnx | ❌ | Missing elem_type for tensor 'x0' |
-| node/test_sequence_map_add_2_sequences/model.onnx | ❌ | Missing elem_type for tensor 'x0' |
-| node/test_sequence_map_add_2_sequences_expanded/model.onnx | ❌ | Missing elem_type for tensor 'x0' |
-| node/test_sequence_map_extract_shapes/model.onnx | ❌ | Missing elem_type for tensor 'in_seq' |
-| node/test_sequence_map_extract_shapes_expanded/model.onnx | ❌ | Missing elem_type for tensor 'in_seq' |
-| node/test_sequence_map_identity_1_sequence/model.onnx | ❌ | Missing elem_type for tensor 'x' |
-| node/test_sequence_map_identity_1_sequence_1_tensor/model.onnx | ❌ | Missing elem_type for tensor 'x0' |
-| node/test_sequence_map_identity_1_sequence_1_tensor_expanded/model.onnx | ❌ | Missing elem_type for tensor 'x0' |
-| node/test_sequence_map_identity_1_sequence_expanded/model.onnx | ❌ | Missing elem_type for tensor 'x' |
-| node/test_sequence_map_identity_2_sequences/model.onnx | ❌ | Missing elem_type for tensor 'x0' |
-| node/test_sequence_map_identity_2_sequences_expanded/model.onnx | ❌ | Missing elem_type for tensor 'x0' |
+| node/test_sequence_insert_at_back/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'sequence'. Hint: export the model with tensor inputs/outputs. |
+| node/test_sequence_insert_at_front/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'sequence'. Hint: export the model with tensor inputs/outputs. |
+| node/test_sequence_map_add_1_sequence_1_tensor/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'x0'. Hint: export the model with tensor inputs/outputs. |
+| node/test_sequence_map_add_1_sequence_1_tensor_expanded/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'x0'. Hint: export the model with tensor inputs/outputs. |
+| node/test_sequence_map_add_2_sequences/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'x0'. Hint: export the model with tensor inputs/outputs. |
+| node/test_sequence_map_add_2_sequences_expanded/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'x0'. Hint: export the model with tensor inputs/outputs. |
+| node/test_sequence_map_extract_shapes/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'in_seq'. Hint: export the model with tensor inputs/outputs. |
+| node/test_sequence_map_extract_shapes_expanded/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'in_seq'. Hint: export the model with tensor inputs/outputs. |
+| node/test_sequence_map_identity_1_sequence/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'x'. Hint: export the model with tensor inputs/outputs. |
+| node/test_sequence_map_identity_1_sequence_1_tensor/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'x0'. Hint: export the model with tensor inputs/outputs. |
+| node/test_sequence_map_identity_1_sequence_1_tensor_expanded/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'x0'. Hint: export the model with tensor inputs/outputs. |
+| node/test_sequence_map_identity_1_sequence_expanded/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'x'. Hint: export the model with tensor inputs/outputs. |
+| node/test_sequence_map_identity_2_sequences/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'x0'. Hint: export the model with tensor inputs/outputs. |
+| node/test_sequence_map_identity_2_sequences_expanded/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'x0'. Hint: export the model with tensor inputs/outputs. |
 | node/test_shape/model.onnx | ✅ |  |
 | node/test_shape_clip_end/model.onnx | ✅ |  |
 | node/test_shape_clip_start/model.onnx | ✅ |  |
@@ -1537,9 +1537,9 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_split_equal_parts_2d_opset13/model.onnx | ❌ | Unsupported op Split |
 | node/test_split_equal_parts_default_axis_opset13/model.onnx | ❌ | Unsupported op Split |
 | node/test_split_equal_parts_default_axis_opset18/model.onnx | ❌ | Unsupported op Split |
-| node/test_split_to_sequence_1/model.onnx | ❌ | Missing elem_type for tensor 'seq' |
-| node/test_split_to_sequence_2/model.onnx | ❌ | Missing elem_type for tensor 'seq' |
-| node/test_split_to_sequence_nokeepdims/model.onnx | ❌ | Missing elem_type for tensor 'seq' |
+| node/test_split_to_sequence_1/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'seq'. Hint: export the model with tensor inputs/outputs. |
+| node/test_split_to_sequence_2/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'seq'. Hint: export the model with tensor inputs/outputs. |
+| node/test_split_to_sequence_nokeepdims/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'seq'. Hint: export the model with tensor inputs/outputs. |
 | node/test_split_variable_parts_1d_opset13/model.onnx | ❌ | Unsupported op Split |
 | node/test_split_variable_parts_1d_opset18/model.onnx | ❌ | Unsupported op Split |
 | node/test_split_variable_parts_2d_opset13/model.onnx | ❌ | Unsupported op Split |
@@ -1794,12 +1794,12 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | simple/test_gradient_of_add/model.onnx | ❌ | Unsupported op Gradient |
 | simple/test_gradient_of_add_and_mul/model.onnx | ❌ | Unsupported op Gradient |
 | simple/test_sequence_model1/model.onnx | ❌ | Dynamic dim for tensor 'out' |
-| simple/test_sequence_model2/model.onnx | ❌ | Missing elem_type for tensor 'seq_1' |
-| simple/test_sequence_model3/model.onnx | ❌ | Missing elem_type for tensor 'seq_1' |
+| simple/test_sequence_model2/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'seq_1'. Hint: export the model with tensor inputs/outputs. |
+| simple/test_sequence_model3/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'seq_1'. Hint: export the model with tensor inputs/outputs. |
 | simple/test_sequence_model4/model.onnx | ❌ | Dynamic dim for tensor 'out' |
-| simple/test_sequence_model5/model.onnx | ❌ | Missing elem_type for tensor 'seq_1' |
-| simple/test_sequence_model6/model.onnx | ❌ | Missing elem_type for tensor 'seq_1' |
-| simple/test_sequence_model7/model.onnx | ❌ | Missing elem_type for tensor 'seq_1' |
+| simple/test_sequence_model5/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'seq_1'. Hint: export the model with tensor inputs/outputs. |
+| simple/test_sequence_model6/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'seq_1'. Hint: export the model with tensor inputs/outputs. |
+| simple/test_sequence_model7/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'seq_1'. Hint: export the model with tensor inputs/outputs. |
 | simple/test_sequence_model8/model.onnx | ❌ | Dynamic dim for tensor 'X' |
 | simple/test_shrink/model.onnx | ❌ | Unsupported op Shrink |
 | simple/test_sign_model/model.onnx | ❌ | Unsupported op Sign |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -2,35 +2,36 @@
 
 | Error message | Count | Histogram |
 | --- | --- | --- |
-| Dynamic dim for tensor '*' | 148 | ██████████████████████████████ |
-| Missing elem_type for tensor '*' | 34 | ███████ |
-| Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ██████ |
-| Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 22 | ████ |
-| Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 20 | ████ |
-| Unsupported op Identity | 20 | ████ |
-| Dynamic or zero dims are not supported | 20 | ████ |
+| Dynamic dim for tensor '*' | 130 | ██████████████████████████████ |
+| Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 34 | ████████ |
+| Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████ |
+| Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 22 | █████ |
+| Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 20 | █████ |
+| Unsupported op Identity | 20 | █████ |
+| Dynamic or zero dims are not supported | 20 | █████ |
+| Unsupported op Size | 20 | █████ |
 | Unsupported op LayerNormalization | 19 | ████ |
 | Unsupported op RMSNormalization | 19 | ████ |
 | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 18 | ████ |
 | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 18 | ████ |
 | Unsupported op GridSample | 18 | ████ |
-| Unsupported elem_type 26 (INT2) for tensor '*'. | 17 | ███ |
-| Unsupported elem_type 22 (INT4) for tensor '*'. | 17 | ███ |
-| Unsupported elem_type 25 (UINT2) for tensor '*'. | 17 | ███ |
-| Unsupported elem_type 21 (UINT4) for tensor '*'. | 17 | ███ |
-| NegativeLogLikelihoodLoss input must be at least 2D | 17 | ███ |
-| Unsupported op Split | 17 | ███ |
-| Unsupported op ArgMax | 16 | ███ |
-| Unsupported op ArgMin | 16 | ███ |
-| Unsupported op Clip | 16 | ███ |
-| Unsupported op Trilu | 16 | ███ |
+| Unsupported elem_type 26 (INT2) for tensor '*'. | 17 | ████ |
+| Unsupported elem_type 22 (INT4) for tensor '*'. | 17 | ████ |
+| Unsupported elem_type 25 (UINT2) for tensor '*'. | 17 | ████ |
+| Unsupported elem_type 21 (UINT4) for tensor '*'. | 17 | ████ |
+| NegativeLogLikelihoodLoss input must be at least 2D | 17 | ████ |
+| Unsupported op Split | 17 | ████ |
+| Unsupported op ArgMax | 16 | ████ |
+| Unsupported op ArgMin | 16 | ████ |
+| Unsupported op Clip | 16 | ████ |
+| Unsupported op Trilu | 16 | ████ |
 | Unsupported op Gather | 15 | ███ |
 | Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 14 | ███ |
 | Unsupported op ConvTranspose | 14 | ███ |
 | Unsupported op Squeeze | 14 | ███ |
-| ReduceSum output shape rank must match input rank | 12 | ██ |
-| Unsupported op Pad | 11 | ██ |
-| Unsupported op Flatten | 11 | ██ |
+| ReduceSum output shape rank must match input rank | 12 | ███ |
+| Unsupported op Pad | 11 | ███ |
+| Unsupported op Flatten | 11 | ███ |
 | Unsupported op Mod | 10 | ██ |
 | Unsupported op CumSum | 9 | ██ |
 | Unsupported op ImageDecoder | 9 | ██ |
@@ -42,10 +43,10 @@
 | Unsupported op Min | 8 | ██ |
 | Unsupported op QLinearMatMul | 8 | ██ |
 | Unsupported op RotaryEmbedding | 8 | ██ |
-| Unsupported op Hardmax | 7 | █ |
-| Slice starts input must be a constant initializer | 7 | █ |
-| Unsupported op TfIdfVectorizer | 7 | █ |
-| Unsupported op TopK | 7 | █ |
+| Unsupported op Hardmax | 7 | ██ |
+| Slice starts input must be a constant initializer | 7 | ██ |
+| Unsupported op TfIdfVectorizer | 7 | ██ |
+| Unsupported op TopK | 7 | ██ |
 | AveragePool has unsupported attributes | 6 | █ |
 | Unsupported elem_type 16 (BFLOAT16) for tensor '*'. | 6 | █ |
 | Unsupported op CenterCropPad | 6 | █ |
@@ -134,7 +135,6 @@
 | Unsupported op Scatter | 2 | █ |
 | Unsupported op Sign | 2 | █ |
 | Unsupported op Sinh | 2 | █ |
-| Unsupported op Size | 2 | █ |
 | Unsupported op Softsign | 2 | █ |
 | Unsupported op SpaceToDepth | 2 | █ |
 | Unsupported op STFT | 2 | █ |

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -369,7 +369,7 @@
   ],
   [
     "node/test_attention_3d_attn_mask_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_3d_attn_mask_expanded_function_QIntermediate'"
+    "Dynamic dim for tensor 'Attention_test_attention_3d_attn_mask_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_3d_causal/model.onnx",
@@ -377,7 +377,7 @@
   ],
   [
     "node/test_attention_3d_causal_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_3d_causal_expanded_function_QIntermediate'"
+    "Dynamic dim for tensor 'Attention_test_attention_3d_causal_expanded_function_RangeRow'"
   ],
   [
     "node/test_attention_3d_diff_heads_sizes/model.onnx",
@@ -389,7 +389,7 @@
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_attn_mask_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_attn_mask_expanded_function_QIntermediate'"
+    "Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_attn_mask_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_causal/model.onnx",
@@ -397,11 +397,11 @@
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_causal_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_causal_expanded_function_QIntermediate'"
+    "Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_causal_expanded_function_RangeRow'"
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_expanded_function_QIntermediate'"
+    "Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_scaled/model.onnx",
@@ -409,7 +409,7 @@
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_scaled_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_scaled_expanded_function_QIntermediate'"
+    "Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_scaled_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_softcap/model.onnx",
@@ -417,7 +417,7 @@
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_softcap_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_softcap_expanded_function_QIntermediate'"
+    "Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_sizes_softcap_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_3d_diff_heads_with_past_and_present/model.onnx",
@@ -425,11 +425,11 @@
   ],
   [
     "node/test_attention_3d_diff_heads_with_past_and_present_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_with_past_and_present_expanded_function_QIntermediate'"
+    "Dynamic dim for tensor 'Attention_test_attention_3d_diff_heads_with_past_and_present_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_3d_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_3d_expanded_function_QIntermediate'"
+    "Dynamic dim for tensor 'Attention_test_attention_3d_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_3d_gqa/model.onnx",
@@ -441,7 +441,7 @@
   ],
   [
     "node/test_attention_3d_gqa_attn_mask_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_3d_gqa_attn_mask_expanded_function_QIntermediate'"
+    "Dynamic dim for tensor 'Attention_test_attention_3d_gqa_attn_mask_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_3d_gqa_causal/model.onnx",
@@ -449,11 +449,11 @@
   ],
   [
     "node/test_attention_3d_gqa_causal_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_3d_gqa_causal_expanded_function_QIntermediate'"
+    "Dynamic dim for tensor 'Attention_test_attention_3d_gqa_causal_expanded_function_RangeRow'"
   ],
   [
     "node/test_attention_3d_gqa_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_3d_gqa_expanded_function_QIntermediate'"
+    "Dynamic dim for tensor 'Attention_test_attention_3d_gqa_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_3d_gqa_scaled/model.onnx",
@@ -461,7 +461,7 @@
   ],
   [
     "node/test_attention_3d_gqa_scaled_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_3d_gqa_scaled_expanded_function_QIntermediate'"
+    "Dynamic dim for tensor 'Attention_test_attention_3d_gqa_scaled_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_3d_gqa_softcap/model.onnx",
@@ -469,7 +469,7 @@
   ],
   [
     "node/test_attention_3d_gqa_softcap_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_3d_gqa_softcap_expanded_function_QIntermediate'"
+    "Dynamic dim for tensor 'Attention_test_attention_3d_gqa_softcap_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_3d_gqa_with_past_and_present/model.onnx",
@@ -477,7 +477,7 @@
   ],
   [
     "node/test_attention_3d_gqa_with_past_and_present_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_3d_gqa_with_past_and_present_expanded_function_QIntermediate'"
+    "Dynamic dim for tensor 'Attention_test_attention_3d_gqa_with_past_and_present_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_3d_scaled/model.onnx",
@@ -485,7 +485,7 @@
   ],
   [
     "node/test_attention_3d_scaled_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_3d_scaled_expanded_function_QIntermediate'"
+    "Dynamic dim for tensor 'Attention_test_attention_3d_scaled_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_3d_softcap/model.onnx",
@@ -493,7 +493,7 @@
   ],
   [
     "node/test_attention_3d_softcap_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_3d_softcap_expanded_function_QIntermediate'"
+    "Dynamic dim for tensor 'Attention_test_attention_3d_softcap_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_3d_transpose_verification/model.onnx",
@@ -501,7 +501,7 @@
   ],
   [
     "node/test_attention_3d_transpose_verification_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_3d_transpose_verification_expanded_function_QIntermediate'"
+    "Dynamic dim for tensor 'Attention_test_attention_3d_transpose_verification_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_3d_with_past_and_present/model.onnx",
@@ -509,7 +509,7 @@
   ],
   [
     "node/test_attention_3d_with_past_and_present_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_expanded_function_QIntermediate'"
+    "Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul/model.onnx",
@@ -521,11 +521,11 @@
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_bias_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_qk_matmul_bias_expanded_function_QIntermediate'"
+    "Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_qk_matmul_bias_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_qk_matmul_expanded_function_QIntermediate'"
+    "Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_qk_matmul_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_softcap/model.onnx",
@@ -533,7 +533,7 @@
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded_function_QIntermediate'"
+    "Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_softmax/model.onnx",
@@ -541,7 +541,7 @@
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded_function_QIntermediate'"
+    "Dynamic dim for tensor 'Attention_test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_4d/model.onnx",
@@ -609,7 +609,7 @@
   ],
   [
     "node/test_attention_4d_causal_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_4d_causal_expanded_function_AttnBias'"
+    "Dynamic dim for tensor 'Attention_test_attention_4d_causal_expanded_function_RangeRow'"
   ],
   [
     "node/test_attention_4d_diff_heads_mask4d_padded_kv/model.onnx",
@@ -637,11 +637,11 @@
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_causal_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_sizes_causal_expanded_function_AttnBias'"
+    "Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_sizes_causal_expanded_function_RangeRow'"
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_sizes_expanded_function_AttnBias'"
+    "Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_sizes_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_scaled/model.onnx",
@@ -649,7 +649,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_scaled_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_sizes_scaled_expanded_function_AttnBias'"
+    "Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_sizes_scaled_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_softcap/model.onnx",
@@ -657,7 +657,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_softcap_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_sizes_softcap_expanded_function_AttnBias'"
+    "Dynamic dim for tensor 'Attention_test_attention_4d_diff_heads_sizes_softcap_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present/model.onnx",
@@ -685,7 +685,7 @@
   ],
   [
     "node/test_attention_4d_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_4d_expanded_function_AttnBias'"
+    "Dynamic dim for tensor 'Attention_test_attention_4d_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_4d_fp16/model.onnx",
@@ -693,7 +693,7 @@
   ],
   [
     "node/test_attention_4d_fp16_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_4d_fp16_expanded_function_AttnBias'"
+    "Dynamic dim for tensor 'Attention_test_attention_4d_fp16_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_4d_gqa/model.onnx",
@@ -713,11 +713,11 @@
   ],
   [
     "node/test_attention_4d_gqa_causal_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_4d_gqa_causal_expanded_function_AttnBias'"
+    "Dynamic dim for tensor 'Attention_test_attention_4d_gqa_causal_expanded_function_RangeRow'"
   ],
   [
     "node/test_attention_4d_gqa_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_4d_gqa_expanded_function_AttnBias'"
+    "Dynamic dim for tensor 'Attention_test_attention_4d_gqa_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_4d_gqa_scaled/model.onnx",
@@ -725,7 +725,7 @@
   ],
   [
     "node/test_attention_4d_gqa_scaled_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_4d_gqa_scaled_expanded_function_AttnBias'"
+    "Dynamic dim for tensor 'Attention_test_attention_4d_gqa_scaled_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_4d_gqa_softcap/model.onnx",
@@ -733,7 +733,7 @@
   ],
   [
     "node/test_attention_4d_gqa_softcap_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_4d_gqa_softcap_expanded_function_AttnBias'"
+    "Dynamic dim for tensor 'Attention_test_attention_4d_gqa_softcap_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_4d_gqa_with_past_and_present/model.onnx",
@@ -757,7 +757,7 @@
   ],
   [
     "node/test_attention_4d_scaled_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_4d_scaled_expanded_function_AttnBias'"
+    "Dynamic dim for tensor 'Attention_test_attention_4d_scaled_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_4d_softcap/model.onnx",
@@ -765,7 +765,7 @@
   ],
   [
     "node/test_attention_4d_softcap_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_4d_softcap_expanded_function_AttnBias'"
+    "Dynamic dim for tensor 'Attention_test_attention_4d_softcap_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_4d_with_past_and_present/model.onnx",
@@ -837,7 +837,7 @@
   ],
   [
     "node/test_attention_4d_with_qk_matmul_expanded/model.onnx",
-    "Dynamic dim for tensor 'Attention_test_attention_4d_with_qk_matmul_expanded_function_AttnBias'"
+    "Dynamic dim for tensor 'Attention_test_attention_4d_with_qk_matmul_expanded_function_KExpanded'"
   ],
   [
     "node/test_attention_4d_with_qk_matmul_softcap/model.onnx",
@@ -2965,11 +2965,11 @@
   ],
   [
     "node/test_identity_opt/model.onnx",
-    "Missing elem_type for tensor 'opt_in'"
+    "Unsupported value type 'optional_type' for 'opt_in'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_identity_sequence/model.onnx",
-    "Missing elem_type for tensor 'x'"
+    "Unsupported value type 'sequence_type' for 'x'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_if/model.onnx",
@@ -2977,11 +2977,11 @@
   ],
   [
     "node/test_if_opt/model.onnx",
-    "Missing elem_type for tensor 'sequence'"
+    "Unsupported value type 'optional_type' for 'sequence'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_if_seq/model.onnx",
-    "Missing elem_type for tensor 'res'"
+    "Unsupported value type 'sequence_type' for 'res'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_image_decoder_decode_bmp_rgb/model.onnx",
@@ -3077,11 +3077,11 @@
   ],
   [
     "node/test_layer_normalization_2d_axis0_expanded/model.onnx",
-    "Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis0_expanded_function_SuffixShape'"
+    "Unsupported op Size"
   ],
   [
     "node/test_layer_normalization_2d_axis0_expanded_ver18/model.onnx",
-    "Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis0_expanded_function_SuffixShape'"
+    "Unsupported op Size"
   ],
   [
     "node/test_layer_normalization_2d_axis1/model.onnx",
@@ -3089,11 +3089,11 @@
   ],
   [
     "node/test_layer_normalization_2d_axis1_expanded/model.onnx",
-    "Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis1_expanded_function_SuffixShape'"
+    "Unsupported op Size"
   ],
   [
     "node/test_layer_normalization_2d_axis1_expanded_ver18/model.onnx",
-    "Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis1_expanded_function_SuffixShape'"
+    "Unsupported op Size"
   ],
   [
     "node/test_layer_normalization_2d_axis_negative_1/model.onnx",
@@ -3125,11 +3125,11 @@
   ],
   [
     "node/test_layer_normalization_3d_axis0_epsilon_expanded/model.onnx",
-    "Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis0_epsilon_expanded_function_SuffixShape'"
+    "Unsupported op Size"
   ],
   [
     "node/test_layer_normalization_3d_axis0_epsilon_expanded_ver18/model.onnx",
-    "Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis0_epsilon_expanded_function_SuffixShape'"
+    "Unsupported op Size"
   ],
   [
     "node/test_layer_normalization_3d_axis1_epsilon/model.onnx",
@@ -3137,11 +3137,11 @@
   ],
   [
     "node/test_layer_normalization_3d_axis1_epsilon_expanded/model.onnx",
-    "Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis1_epsilon_expanded_function_SuffixShape'"
+    "Unsupported op Size"
   ],
   [
     "node/test_layer_normalization_3d_axis1_epsilon_expanded_ver18/model.onnx",
-    "Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis1_epsilon_expanded_function_SuffixShape'"
+    "Unsupported op Size"
   ],
   [
     "node/test_layer_normalization_3d_axis2_epsilon/model.onnx",
@@ -3149,11 +3149,11 @@
   ],
   [
     "node/test_layer_normalization_3d_axis2_epsilon_expanded/model.onnx",
-    "Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis2_epsilon_expanded_function_SuffixShape'"
+    "Unsupported op Size"
   ],
   [
     "node/test_layer_normalization_3d_axis2_epsilon_expanded_ver18/model.onnx",
-    "Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis2_epsilon_expanded_function_SuffixShape'"
+    "Unsupported op Size"
   ],
   [
     "node/test_layer_normalization_3d_axis_negative_1_epsilon/model.onnx",
@@ -3197,11 +3197,11 @@
   ],
   [
     "node/test_layer_normalization_4d_axis0_expanded/model.onnx",
-    "Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis0_expanded_function_SuffixShape'"
+    "Unsupported op Size"
   ],
   [
     "node/test_layer_normalization_4d_axis0_expanded_ver18/model.onnx",
-    "Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis0_expanded_function_SuffixShape'"
+    "Unsupported op Size"
   ],
   [
     "node/test_layer_normalization_4d_axis1/model.onnx",
@@ -3209,11 +3209,11 @@
   ],
   [
     "node/test_layer_normalization_4d_axis1_expanded/model.onnx",
-    "Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis1_expanded_function_SuffixShape'"
+    "Unsupported op Size"
   ],
   [
     "node/test_layer_normalization_4d_axis1_expanded_ver18/model.onnx",
-    "Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis1_expanded_function_SuffixShape'"
+    "Unsupported op Size"
   ],
   [
     "node/test_layer_normalization_4d_axis2/model.onnx",
@@ -3221,11 +3221,11 @@
   ],
   [
     "node/test_layer_normalization_4d_axis2_expanded/model.onnx",
-    "Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis2_expanded_function_SuffixShape'"
+    "Unsupported op Size"
   ],
   [
     "node/test_layer_normalization_4d_axis2_expanded_ver18/model.onnx",
-    "Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis2_expanded_function_SuffixShape'"
+    "Unsupported op Size"
   ],
   [
     "node/test_layer_normalization_4d_axis3/model.onnx",
@@ -3233,11 +3233,11 @@
   ],
   [
     "node/test_layer_normalization_4d_axis3_expanded/model.onnx",
-    "Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis3_expanded_function_SuffixShape'"
+    "Unsupported op Size"
   ],
   [
     "node/test_layer_normalization_4d_axis3_expanded_ver18/model.onnx",
-    "Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis3_expanded_function_SuffixShape'"
+    "Unsupported op Size"
   ],
   [
     "node/test_layer_normalization_4d_axis_negative_1/model.onnx",
@@ -3517,11 +3517,11 @@
   ],
   [
     "node/test_loop13_seq/model.onnx",
-    "Missing elem_type for tensor 'seq_empty'"
+    "Unsupported value type 'sequence_type' for 'seq_empty'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_loop16_seq_none/model.onnx",
-    "Missing elem_type for tensor 'opt_seq'"
+    "Unsupported value type 'optional_type' for 'opt_seq'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_lpnormalization_default/model.onnx",
@@ -4169,15 +4169,15 @@
   ],
   [
     "node/test_optional_get_element_optional_sequence/model.onnx",
-    "Missing elem_type for tensor 'optional_input'"
+    "Unsupported value type 'optional_type' for 'optional_input'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_optional_get_element_optional_tensor/model.onnx",
-    "Missing elem_type for tensor 'optional_input'"
+    "Unsupported value type 'optional_type' for 'optional_input'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_optional_get_element_sequence/model.onnx",
-    "Missing elem_type for tensor 'optional_input'"
+    "Unsupported value type 'sequence_type' for 'optional_input'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_optional_get_element_tensor/model.onnx",
@@ -4201,15 +4201,15 @@
   ],
   [
     "node/test_optional_has_element_empty_optional_input/model.onnx",
-    "Missing elem_type for tensor 'optional_input'"
+    "Unsupported value type 'optional_type' for 'optional_input'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_optional_has_element_optional_input/model.onnx",
-    "Missing elem_type for tensor 'optional_input'"
+    "Unsupported value type 'optional_type' for 'optional_input'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_optional_has_element_tensor_input/model.onnx",
-    "Missing elem_type for tensor 'optional_input'"
+    "Unsupported value type 'optional_type' for 'optional_input'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_or2d/model.onnx",
@@ -5349,7 +5349,7 @@
   ],
   [
     "node/test_rotary_embedding_3d_input_expanded/model.onnx",
-    "Dynamic dim for tensor 'RotaryEmbedding_test_rotary_embedding_3d_input_expanded_function_XIn'"
+    "Dynamic dim for tensor 'RotaryEmbedding_test_rotary_embedding_3d_input_expanded_function_CosCacheSliced'"
   ],
   [
     "node/test_rotary_embedding_expanded/model.onnx",
@@ -5765,59 +5765,59 @@
   ],
   [
     "node/test_sequence_insert_at_back/model.onnx",
-    "Missing elem_type for tensor 'sequence'"
+    "Unsupported value type 'sequence_type' for 'sequence'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_sequence_insert_at_front/model.onnx",
-    "Missing elem_type for tensor 'sequence'"
+    "Unsupported value type 'sequence_type' for 'sequence'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_sequence_map_add_1_sequence_1_tensor/model.onnx",
-    "Missing elem_type for tensor 'x0'"
+    "Unsupported value type 'sequence_type' for 'x0'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_sequence_map_add_1_sequence_1_tensor_expanded/model.onnx",
-    "Missing elem_type for tensor 'x0'"
+    "Unsupported value type 'sequence_type' for 'x0'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_sequence_map_add_2_sequences/model.onnx",
-    "Missing elem_type for tensor 'x0'"
+    "Unsupported value type 'sequence_type' for 'x0'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_sequence_map_add_2_sequences_expanded/model.onnx",
-    "Missing elem_type for tensor 'x0'"
+    "Unsupported value type 'sequence_type' for 'x0'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_sequence_map_extract_shapes/model.onnx",
-    "Missing elem_type for tensor 'in_seq'"
+    "Unsupported value type 'sequence_type' for 'in_seq'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_sequence_map_extract_shapes_expanded/model.onnx",
-    "Missing elem_type for tensor 'in_seq'"
+    "Unsupported value type 'sequence_type' for 'in_seq'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_sequence_map_identity_1_sequence/model.onnx",
-    "Missing elem_type for tensor 'x'"
+    "Unsupported value type 'sequence_type' for 'x'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_sequence_map_identity_1_sequence_1_tensor/model.onnx",
-    "Missing elem_type for tensor 'x0'"
+    "Unsupported value type 'sequence_type' for 'x0'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_sequence_map_identity_1_sequence_1_tensor_expanded/model.onnx",
-    "Missing elem_type for tensor 'x0'"
+    "Unsupported value type 'sequence_type' for 'x0'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_sequence_map_identity_1_sequence_expanded/model.onnx",
-    "Missing elem_type for tensor 'x'"
+    "Unsupported value type 'sequence_type' for 'x'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_sequence_map_identity_2_sequences/model.onnx",
-    "Missing elem_type for tensor 'x0'"
+    "Unsupported value type 'sequence_type' for 'x0'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_sequence_map_identity_2_sequences_expanded/model.onnx",
-    "Missing elem_type for tensor 'x0'"
+    "Unsupported value type 'sequence_type' for 'x0'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_shape/model.onnx",
@@ -6117,15 +6117,15 @@
   ],
   [
     "node/test_split_to_sequence_1/model.onnx",
-    "Missing elem_type for tensor 'seq'"
+    "Unsupported value type 'sequence_type' for 'seq'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_split_to_sequence_2/model.onnx",
-    "Missing elem_type for tensor 'seq'"
+    "Unsupported value type 'sequence_type' for 'seq'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_split_to_sequence_nokeepdims/model.onnx",
-    "Missing elem_type for tensor 'seq'"
+    "Unsupported value type 'sequence_type' for 'seq'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "node/test_split_variable_parts_1d_opset13/model.onnx",
@@ -7145,11 +7145,11 @@
   ],
   [
     "simple/test_sequence_model2/model.onnx",
-    "Missing elem_type for tensor 'seq_1'"
+    "Unsupported value type 'sequence_type' for 'seq_1'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "simple/test_sequence_model3/model.onnx",
-    "Missing elem_type for tensor 'seq_1'"
+    "Unsupported value type 'sequence_type' for 'seq_1'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "simple/test_sequence_model4/model.onnx",
@@ -7157,15 +7157,15 @@
   ],
   [
     "simple/test_sequence_model5/model.onnx",
-    "Missing elem_type for tensor 'seq_1'"
+    "Unsupported value type 'sequence_type' for 'seq_1'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "simple/test_sequence_model6/model.onnx",
-    "Missing elem_type for tensor 'seq_1'"
+    "Unsupported value type 'sequence_type' for 'seq_1'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "simple/test_sequence_model7/model.onnx",
-    "Missing elem_type for tensor 'seq_1'"
+    "Unsupported value type 'sequence_type' for 'seq_1'. Hint: export the model with tensor inputs/outputs."
   ],
   [
     "simple/test_sequence_model8/model.onnx",


### PR DESCRIPTION
### Motivation
- Shape inference sometimes lacked propagated value/type information and produced confusing `Missing elem_type` errors for non-tensor value kinds.
- Use ONNX-provided data propagation during inference to recover more type/shape information where possible by default.
- Non-`tensor_type` value kinds (e.g. `optional_type`, `sequence_type`) cannot be reliably mapped to tensor types automatically and should surface a clearer unsupported-message.

### Description
- Call `shape_inference.infer_shapes(model, data_prop=True)` during `import_onnx` to enable ONNX data propagation.
- Add `_unsupported_value_type` that returns an `UnsupportedOpError` with a consistent hint, and make `_tensor_type` check `WhichOneof("value")` and raise for non-`tensor_type` entries.
- Refresh expected-error references and support tables in `tests/official_onnx_expected_errors.json`, `OFFICIAL_ONNX_FILE_SUPPORT.md`, and `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md` to reflect updated inference/messages.
- No changes to lowering or codegen behavior; this is strictly an import-time diagnostic improvement.

### Testing
- Ran `UPDATE_REFS=1 pytest -n auto -q` with reference updates and all tests passed: `142 passed` in ~21s.
- Golden/reference files were refreshed to match the updated inference behavior and error messages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6965ecc03758832586a037376e736d77)