### PR TITLE
Treat `Identity` as a unary op and reuse unary codegen

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 704 / 1802 official ONNX files.
+Support 707 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -473,9 +473,9 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_center_crop_pad_pad_expanded/model.onnx | ❌ | Dynamic dim for tensor 'CenterCropPad_test_center_crop_pad_pad_expanded_function_padded_input' |
 | node/test_clip/model.onnx | ❌ | Unsupported op Clip |
 | node/test_clip_default_inbounds/model.onnx | ❌ | Unsupported op Clip |
-| node/test_clip_default_inbounds_expanded/model.onnx | ❌ | Unsupported op Identity |
+| node/test_clip_default_inbounds_expanded/model.onnx | ✅ |  |
 | node/test_clip_default_int8_inbounds/model.onnx | ❌ | Unsupported op Clip |
-| node/test_clip_default_int8_inbounds_expanded/model.onnx | ❌ | Unsupported op Identity |
+| node/test_clip_default_int8_inbounds_expanded/model.onnx | ✅ |  |
 | node/test_clip_default_int8_max/model.onnx | ❌ | Unsupported op Clip |
 | node/test_clip_default_int8_max_expanded/model.onnx | ✅ |  |
 | node/test_clip_default_int8_min/model.onnx | ❌ | Unsupported op Clip |
@@ -748,7 +748,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_hardsigmoid_expanded_ver18/model.onnx | ✅ |  |
 | node/test_hardswish/model.onnx | ❌ | Unsupported op HardSwish |
 | node/test_hardswish_expanded/model.onnx | ❌ | Unsupported op HardSigmoid |
-| node/test_identity/model.onnx | ❌ | Unsupported op Identity |
+| node/test_identity/model.onnx | ✅ |  |
 | node/test_identity_opt/model.onnx | ❌ | Unsupported value type 'optional_type' for 'opt_in'. Hint: export the model with tensor inputs/outputs. |
 | node/test_identity_sequence/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'x'. Hint: export the model with tensor inputs/outputs. |
 | node/test_if/model.onnx | ❌ | Unsupported op If |
@@ -1378,71 +1378,71 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_sce_NCd1_mean_weight_negative_ii/model.onnx | ✅ |  |
 | node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx | ✅ |  |
-| node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
+| node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_NCd1d2d3_none_no_weight_negative_ii/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob/model.onnx | ✅ |  |
-| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
+| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_NCd1d2d3_sum_weight_high_ii/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob/model.onnx | ✅ |  |
-| node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
+| node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx | ✅ |  |
-| node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
+| node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx | ✅ |  |
-| node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
+| node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_mean/model.onnx | ✅ |  |
 | node/test_sce_mean_3d/model.onnx | ✅ |  |
 | node/test_sce_mean_3d_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_mean_3d_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_3d_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
+| node/test_sce_mean_3d_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_mean_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_mean_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
+| node/test_sce_mean_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_mean_no_weight_ii/model.onnx | ✅ |  |
 | node/test_sce_mean_no_weight_ii_3d/model.onnx | ✅ |  |
 | node/test_sce_mean_no_weight_ii_3d_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_mean_no_weight_ii_3d_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
+| node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_mean_no_weight_ii_4d/model.onnx | ✅ |  |
 | node/test_sce_mean_no_weight_ii_4d_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_mean_no_weight_ii_4d_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
+| node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_mean_no_weight_ii_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_mean_no_weight_ii_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
+| node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_mean_weight/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_mean_weight_ii/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_ii_3d/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_ii_3d_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_mean_weight_ii_3d_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
+| node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_mean_weight_ii_4d/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_ii_4d_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_mean_weight_ii_4d_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
+| node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_mean_weight_ii_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_mean_weight_ii_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
+| node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_mean_weight_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_weight_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
+| node/test_sce_mean_weight_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_none/model.onnx | ✅ |  |
 | node/test_sce_none_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_none_log_prob/model.onnx | ✅ |  |
-| node/test_sce_none_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
+| node/test_sce_none_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_none_weights/model.onnx | ✅ |  |
 | node/test_sce_none_weights_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_none_weights_log_prob/model.onnx | ✅ |  |
-| node/test_sce_none_weights_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
+| node/test_sce_none_weights_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_sum/model.onnx | ✅ |  |
 | node/test_sce_sum_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_sce_sum_log_prob/model.onnx | ✅ |  |
-| node/test_sce_sum_log_prob_expanded/model.onnx | ❌ | Unsupported op Identity |
+| node/test_sce_sum_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
 | node/test_selu/model.onnx | ❌ | Unsupported op Selu |
 | node/test_selu_default/model.onnx | ❌ | Unsupported op Selu |
 | node/test_selu_default_expanded_ver18/model.onnx | ✅ |  |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -4,10 +4,10 @@
 | --- | --- | --- |
 | Dynamic dim for tensor '*' | 130 | ██████████████████████████████ |
 | Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 34 | ████████ |
+| NegativeLogLikelihoodLoss input must be at least 2D | 34 | ████████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████ |
 | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 22 | █████ |
 | Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 20 | █████ |
-| Unsupported op Identity | 20 | █████ |
 | Dynamic or zero dims are not supported | 20 | █████ |
 | Unsupported op Size | 20 | █████ |
 | Unsupported op LayerNormalization | 19 | ████ |
@@ -19,7 +19,6 @@
 | Unsupported elem_type 22 (INT4) for tensor '*'. | 17 | ████ |
 | Unsupported elem_type 25 (UINT2) for tensor '*'. | 17 | ████ |
 | Unsupported elem_type 21 (UINT4) for tensor '*'. | 17 | ████ |
-| NegativeLogLikelihoodLoss input must be at least 2D | 17 | ████ |
 | Unsupported op Split | 17 | ████ |
 | Unsupported op ArgMax | 16 | ████ |
 | Unsupported op ArgMin | 16 | ████ |

--- a/src/onnx2c/ops.py
+++ b/src/onnx2c/ops.py
@@ -52,6 +52,7 @@ UNARY_OP_TYPES = {
     "Cos",
     "Exp",
     "Floor",
+    "Identity",
     "Log",
     "Neg",
     "Not",
@@ -73,26 +74,31 @@ def _format_float_literal(value: float, dtype: str) -> str:
 
 
 UNARY_SYMBOLS_BOOL = {
+    "Identity": "identity",
     "Not": "!",
 }
 
 UNARY_SYMBOLS_INT64 = {
     "Abs": "llabs",
+    "Identity": "identity",
     "Neg": "neg",
 }
 
 UNARY_SYMBOLS_INT32 = {
     "Abs": "abs",
+    "Identity": "identity",
     "Neg": "neg",
 }
 
 UNARY_SYMBOLS_INT16 = {
     "Abs": "abs",
+    "Identity": "identity",
     "Neg": "neg",
 }
 
 UNARY_SYMBOLS_INT8 = {
     "Abs": "abs",
+    "Identity": "identity",
     "Neg": "neg",
 }
 
@@ -102,6 +108,7 @@ UNARY_SYMBOLS_DOUBLE = {
     "Cos": "cos",
     "Exp": "exp",
     "Floor": "floor",
+    "Identity": "identity",
     "Log": "log",
     "Neg": "neg",
     "Relu": "relu",
@@ -118,6 +125,7 @@ UNARY_SYMBOLS_FLOAT = {
     "Cos": "cosf",
     "Exp": "expf",
     "Floor": "floorf",
+    "Identity": "identity",
     "Log": "logf",
     "Neg": "neg",
     "Relu": "relu",
@@ -213,6 +221,7 @@ UNARY_APPLY_FUNCS = {
     "abs": np.abs,
     "llabs": np.abs,
     "!": np.logical_not,
+    "identity": lambda value: value,
     "ceilf": np.ceil,
     "ceil": np.ceil,
     "cosf": np.cos,

--- a/templates/unary_op.c.j2
+++ b/templates/unary_op.c.j2
@@ -6,6 +6,8 @@ for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ 
 {{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = {{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %} > {{ zero_literal }} ? {{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %} : {{ zero_literal }};
 {% elif operator == "neg" %}
 {{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = -{{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %};
+{% elif operator == "identity" %}
+{{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = {{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %};
 {% else %}
 {{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = {{ operator }}({{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %});
 {% endif %}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -1861,7 +1861,7 @@
   ],
   [
     "node/test_clip_default_inbounds_expanded/model.onnx",
-    "Unsupported op Identity"
+    ""
   ],
   [
     "node/test_clip_default_int8_inbounds/model.onnx",
@@ -1869,7 +1869,7 @@
   ],
   [
     "node/test_clip_default_int8_inbounds_expanded/model.onnx",
-    "Unsupported op Identity"
+    ""
   ],
   [
     "node/test_clip_default_int8_max/model.onnx",
@@ -2961,7 +2961,7 @@
   ],
   [
     "node/test_identity/model.onnx",
-    "Unsupported op Identity"
+    ""
   ],
   [
     "node/test_identity_opt/model.onnx",
@@ -5481,7 +5481,7 @@
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx",
-    "Unsupported op Identity"
+    "NegativeLogLikelihoodLoss input must be at least 2D"
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii/model.onnx",
@@ -5497,7 +5497,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx",
-    "Unsupported op Identity"
+    "NegativeLogLikelihoodLoss input must be at least 2D"
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii/model.onnx",
@@ -5513,7 +5513,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx",
-    "Unsupported op Identity"
+    "NegativeLogLikelihoodLoss input must be at least 2D"
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx",
@@ -5529,7 +5529,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx",
-    "Unsupported op Identity"
+    "NegativeLogLikelihoodLoss input must be at least 2D"
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx",
@@ -5545,7 +5545,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx",
-    "Unsupported op Identity"
+    "NegativeLogLikelihoodLoss input must be at least 2D"
   ],
   [
     "node/test_sce_mean/model.onnx",
@@ -5565,7 +5565,7 @@
   ],
   [
     "node/test_sce_mean_3d_log_prob_expanded/model.onnx",
-    "Unsupported op Identity"
+    "NegativeLogLikelihoodLoss input must be at least 2D"
   ],
   [
     "node/test_sce_mean_expanded/model.onnx",
@@ -5577,7 +5577,7 @@
   ],
   [
     "node/test_sce_mean_log_prob_expanded/model.onnx",
-    "Unsupported op Identity"
+    "NegativeLogLikelihoodLoss input must be at least 2D"
   ],
   [
     "node/test_sce_mean_no_weight_ii/model.onnx",
@@ -5597,7 +5597,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx",
-    "Unsupported op Identity"
+    "NegativeLogLikelihoodLoss input must be at least 2D"
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d/model.onnx",
@@ -5613,7 +5613,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx",
-    "Unsupported op Identity"
+    "NegativeLogLikelihoodLoss input must be at least 2D"
   ],
   [
     "node/test_sce_mean_no_weight_ii_expanded/model.onnx",
@@ -5625,7 +5625,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx",
-    "Unsupported op Identity"
+    "NegativeLogLikelihoodLoss input must be at least 2D"
   ],
   [
     "node/test_sce_mean_weight/model.onnx",
@@ -5653,7 +5653,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx",
-    "Unsupported op Identity"
+    "NegativeLogLikelihoodLoss input must be at least 2D"
   ],
   [
     "node/test_sce_mean_weight_ii_4d/model.onnx",
@@ -5669,7 +5669,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx",
-    "Unsupported op Identity"
+    "NegativeLogLikelihoodLoss input must be at least 2D"
   ],
   [
     "node/test_sce_mean_weight_ii_expanded/model.onnx",
@@ -5681,7 +5681,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx",
-    "Unsupported op Identity"
+    "NegativeLogLikelihoodLoss input must be at least 2D"
   ],
   [
     "node/test_sce_mean_weight_log_prob/model.onnx",
@@ -5689,7 +5689,7 @@
   ],
   [
     "node/test_sce_mean_weight_log_prob_expanded/model.onnx",
-    "Unsupported op Identity"
+    "NegativeLogLikelihoodLoss input must be at least 2D"
   ],
   [
     "node/test_sce_none/model.onnx",
@@ -5705,7 +5705,7 @@
   ],
   [
     "node/test_sce_none_log_prob_expanded/model.onnx",
-    "Unsupported op Identity"
+    "NegativeLogLikelihoodLoss input must be at least 2D"
   ],
   [
     "node/test_sce_none_weights/model.onnx",
@@ -5721,7 +5721,7 @@
   ],
   [
     "node/test_sce_none_weights_log_prob_expanded/model.onnx",
-    "Unsupported op Identity"
+    "NegativeLogLikelihoodLoss input must be at least 2D"
   ],
   [
     "node/test_sce_sum/model.onnx",
@@ -5737,7 +5737,7 @@
   ],
   [
     "node/test_sce_sum_log_prob_expanded/model.onnx",
-    "Unsupported op Identity"
+    "NegativeLogLikelihoodLoss input must be at least 2D"
   ],
   [
     "node/test_selu/model.onnx",

--- a/tests/test_endtoend_ops.py
+++ b/tests/test_endtoend_ops.py
@@ -1046,6 +1046,14 @@ OPERATOR_CASES = [
         "attrs": {},
     },
     {
+        "name": "Identity",
+        "op_type": "Identity",
+        "input_shapes": [[2, 3]],
+        "output_shape": [2, 3],
+        "dtype": TensorProto.FLOAT,
+        "attrs": {},
+    },
+    {
         "name": "AddInt64",
         "op_type": "Add",
         "input_shapes": [[2, 3], [2, 3]],


### PR DESCRIPTION
### Motivation
- Provide support for the ONNX `Identity` operator while avoiding a separate custom lowering/codegen path. 
- Reuse the existing unary operator pipeline to keep codegen and evaluation consistent and minimal. 

### Description
- Treat `Identity` as a unary operator by adding it to `UNARY_OP_TYPES` and mapping it to the symbol `identity` in `UNARY_SYMBOLS_*` tables. 
- Implement runtime/evaluator support by registering an `identity` entry in `UNARY_APPLY_FUNCS` (a no-op lambda) so `apply_unary_op` handles `Identity`. 
- Reuse the existing unary codegen template by adding an `operator == "identity"` branch in `templates/unary_op.c.j2` and remove the separate `IdentityOp` dataclass, lowering module, and `identity_op.c.j2` template. 
- Update tests and reference/support docs by adding an `Identity` case in `tests/test_endtoend_ops.py` and refreshing `tests/official_onnx_expected_errors.json`, `OFFICIAL_ONNX_FILE_SUPPORT.md`, and `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`. 

### Testing
- Ran `pytest tests/test_endtoend_ops.py -k Identity -q`, which passed (`1 passed, 94 deselected`). 
- Ran full suite with references update via `UPDATE_REFS=1 pytest -n auto -q`, which passed (`143 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6965f0d744e08325bcac4e2f96f51a5a)