### PR TITLE
Add Size operator support

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 707 / 1802 official ONNX files.
+Support 709 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -777,11 +777,11 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_l2normalization_axis_0/model.onnx | ❌ | Unsupported op LpNormalization |
 | node/test_l2normalization_axis_1/model.onnx | ❌ | Unsupported op LpNormalization |
 | node/test_layer_normalization_2d_axis0/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_2d_axis0_expanded/model.onnx | ❌ | Unsupported op Size |
-| node/test_layer_normalization_2d_axis0_expanded_ver18/model.onnx | ❌ | Unsupported op Size |
+| node/test_layer_normalization_2d_axis0_expanded/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_layer_normalization_2d_axis0_expanded_ver18/model.onnx | ❌ | Dynamic or zero dims are not supported |
 | node/test_layer_normalization_2d_axis1/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_2d_axis1_expanded/model.onnx | ❌ | Unsupported op Size |
-| node/test_layer_normalization_2d_axis1_expanded_ver18/model.onnx | ❌ | Unsupported op Size |
+| node/test_layer_normalization_2d_axis1_expanded/model.onnx | ❌ | Unsupported op Flatten |
+| node/test_layer_normalization_2d_axis1_expanded_ver18/model.onnx | ❌ | Unsupported op Flatten |
 | node/test_layer_normalization_2d_axis_negative_1/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_2d_axis_negative_1_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis_negative_1_expanded_function_SuffixShape' |
 | node/test_layer_normalization_2d_axis_negative_1_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis_negative_1_expanded_function_SuffixShape' |
@@ -789,14 +789,14 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_layer_normalization_2d_axis_negative_2_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis_negative_2_expanded_function_SuffixShape' |
 | node/test_layer_normalization_2d_axis_negative_2_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis_negative_2_expanded_function_SuffixShape' |
 | node/test_layer_normalization_3d_axis0_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_3d_axis0_epsilon_expanded/model.onnx | ❌ | Unsupported op Size |
-| node/test_layer_normalization_3d_axis0_epsilon_expanded_ver18/model.onnx | ❌ | Unsupported op Size |
+| node/test_layer_normalization_3d_axis0_epsilon_expanded/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_layer_normalization_3d_axis0_epsilon_expanded_ver18/model.onnx | ❌ | Dynamic or zero dims are not supported |
 | node/test_layer_normalization_3d_axis1_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_3d_axis1_epsilon_expanded/model.onnx | ❌ | Unsupported op Size |
-| node/test_layer_normalization_3d_axis1_epsilon_expanded_ver18/model.onnx | ❌ | Unsupported op Size |
+| node/test_layer_normalization_3d_axis1_epsilon_expanded/model.onnx | ❌ | Unsupported op Flatten |
+| node/test_layer_normalization_3d_axis1_epsilon_expanded_ver18/model.onnx | ❌ | Unsupported op Flatten |
 | node/test_layer_normalization_3d_axis2_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_3d_axis2_epsilon_expanded/model.onnx | ❌ | Unsupported op Size |
-| node/test_layer_normalization_3d_axis2_epsilon_expanded_ver18/model.onnx | ❌ | Unsupported op Size |
+| node/test_layer_normalization_3d_axis2_epsilon_expanded/model.onnx | ❌ | Unsupported op Flatten |
+| node/test_layer_normalization_3d_axis2_epsilon_expanded_ver18/model.onnx | ❌ | Unsupported op Flatten |
 | node/test_layer_normalization_3d_axis_negative_1_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_3d_axis_negative_1_epsilon_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis_negative_1_epsilon_expanded_function_SuffixShape' |
 | node/test_layer_normalization_3d_axis_negative_1_epsilon_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis_negative_1_epsilon_expanded_function_SuffixShape' |
@@ -807,17 +807,17 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_layer_normalization_3d_axis_negative_3_epsilon_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis_negative_3_epsilon_expanded_function_SuffixShape' |
 | node/test_layer_normalization_3d_axis_negative_3_epsilon_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis_negative_3_epsilon_expanded_function_SuffixShape' |
 | node/test_layer_normalization_4d_axis0/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_4d_axis0_expanded/model.onnx | ❌ | Unsupported op Size |
-| node/test_layer_normalization_4d_axis0_expanded_ver18/model.onnx | ❌ | Unsupported op Size |
+| node/test_layer_normalization_4d_axis0_expanded/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_layer_normalization_4d_axis0_expanded_ver18/model.onnx | ❌ | Dynamic or zero dims are not supported |
 | node/test_layer_normalization_4d_axis1/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_4d_axis1_expanded/model.onnx | ❌ | Unsupported op Size |
-| node/test_layer_normalization_4d_axis1_expanded_ver18/model.onnx | ❌ | Unsupported op Size |
+| node/test_layer_normalization_4d_axis1_expanded/model.onnx | ❌ | Unsupported op Flatten |
+| node/test_layer_normalization_4d_axis1_expanded_ver18/model.onnx | ❌ | Unsupported op Flatten |
 | node/test_layer_normalization_4d_axis2/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_4d_axis2_expanded/model.onnx | ❌ | Unsupported op Size |
-| node/test_layer_normalization_4d_axis2_expanded_ver18/model.onnx | ❌ | Unsupported op Size |
+| node/test_layer_normalization_4d_axis2_expanded/model.onnx | ❌ | Unsupported op Flatten |
+| node/test_layer_normalization_4d_axis2_expanded_ver18/model.onnx | ❌ | Unsupported op Flatten |
 | node/test_layer_normalization_4d_axis3/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_4d_axis3_expanded/model.onnx | ❌ | Unsupported op Size |
-| node/test_layer_normalization_4d_axis3_expanded_ver18/model.onnx | ❌ | Unsupported op Size |
+| node/test_layer_normalization_4d_axis3_expanded/model.onnx | ❌ | Unsupported op Flatten |
+| node/test_layer_normalization_4d_axis3_expanded_ver18/model.onnx | ❌ | Unsupported op Flatten |
 | node/test_layer_normalization_4d_axis_negative_1/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_4d_axis_negative_1_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis_negative_1_expanded_function_SuffixShape' |
 | node/test_layer_normalization_4d_axis_negative_1_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis_negative_1_expanded_function_SuffixShape' |
@@ -1488,8 +1488,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_sin_example/model.onnx | ✅ |  |
 | node/test_sinh/model.onnx | ❌ | Unsupported op Sinh |
 | node/test_sinh_example/model.onnx | ❌ | Unsupported op Sinh |
-| node/test_size/model.onnx | ❌ | Unsupported op Size |
-| node/test_size_example/model.onnx | ❌ | Unsupported op Size |
+| node/test_size/model.onnx | ✅ |  |
+| node/test_size_example/model.onnx | ✅ |  |
 | node/test_slice/model.onnx | ❌ | Slice starts input must be a constant initializer |
 | node/test_slice_default_axes/model.onnx | ❌ | Slice starts input must be a constant initializer |
 | node/test_slice_default_steps/model.onnx | ❌ | Slice starts input must be a constant initializer |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -6,10 +6,10 @@
 | Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 34 | ████████ |
 | NegativeLogLikelihoodLoss input must be at least 2D | 34 | ████████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████ |
+| Dynamic or zero dims are not supported | 26 | ██████ |
+| Unsupported op Flatten | 23 | █████ |
 | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 22 | █████ |
 | Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 20 | █████ |
-| Dynamic or zero dims are not supported | 20 | █████ |
-| Unsupported op Size | 20 | █████ |
 | Unsupported op LayerNormalization | 19 | ████ |
 | Unsupported op RMSNormalization | 19 | ████ |
 | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 18 | ████ |
@@ -30,7 +30,6 @@
 | Unsupported op Squeeze | 14 | ███ |
 | ReduceSum output shape rank must match input rank | 12 | ███ |
 | Unsupported op Pad | 11 | ███ |
-| Unsupported op Flatten | 11 | ███ |
 | Unsupported op Mod | 10 | ██ |
 | Unsupported op CumSum | 9 | ██ |
 | Unsupported op ImageDecoder | 9 | ██ |

--- a/src/onnx2c/compiler.py
+++ b/src/onnx2c/compiler.py
@@ -82,6 +82,7 @@ from .lowering.reshape import lower_reshape
 from .lowering.resize import lower_resize
 from .lowering.slice import lower_slice
 from .lowering.shape import lower_shape
+from .lowering.size import lower_size
 from .lowering.softmax import lower_softmax
 from .lowering.transpose import lower_transpose
 from .lowering.unsqueeze import lower_unsqueeze

--- a/src/onnx2c/lowering/size.py
+++ b/src/onnx2c/lowering/size.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from ..codegen.c_emitter import SizeOp
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Node
+from .common import shape_product, value_dtype, value_shape
+from .registry import register_lowering
+
+
+@register_lowering("Size")
+def lower_size(graph: Graph, node: Node) -> SizeOp:
+    if len(node.inputs) != 1 or len(node.outputs) != 1:
+        raise UnsupportedOpError("Size must have 1 input and 1 output")
+    input_shape = value_shape(graph, node.inputs[0], node)
+    output_shape = value_shape(graph, node.outputs[0], node)
+    if len(output_shape) != 0:
+        raise ShapeInferenceError("Size output must be a scalar")
+    output_dtype = value_dtype(graph, node.outputs[0], node)
+    if output_dtype != "int64":
+        raise UnsupportedOpError("Size output dtype must be int64")
+    input_dtype = value_dtype(graph, node.inputs[0], node)
+    element_count = shape_product(input_shape)
+    return SizeOp(
+        input0=node.inputs[0],
+        output=node.outputs[0],
+        input_shape=input_shape,
+        output_shape=output_shape,
+        value=element_count,
+        dtype=output_dtype,
+        input_dtype=input_dtype,
+    )

--- a/src/onnx2c/runtime/evaluator.py
+++ b/src/onnx2c/runtime/evaluator.py
@@ -36,6 +36,7 @@ from ..lowering.reduce import (
 from ..lowering.reshape import lower_reshape
 from ..lowering.slice import resolve_slice_spec
 from ..lowering.shape import lower_shape
+from ..lowering.size import lower_size
 from ..lowering.softmax import lower_softmax
 from ..lowering.transpose import lower_transpose
 from ..lowering.unsqueeze import lower_unsqueeze
@@ -507,6 +508,12 @@ def _eval_constant_of_shape(evaluator: Evaluator, node: Node) -> None:
 def _eval_shape(evaluator: Evaluator, node: Node) -> None:
     op = lower_shape(evaluator.graph, node)
     evaluator.values[op.output] = np.array(op.values, dtype=np.int64)
+
+
+@register_evaluator("Size")
+def _eval_size(evaluator: Evaluator, node: Node) -> None:
+    op = lower_size(evaluator.graph, node)
+    evaluator.values[op.output] = np.array(op.value, dtype=np.int64)
 
 
 @register_evaluator("ReduceMean")

--- a/templates/size_op.c.j2
+++ b/templates/size_op.c.j2
@@ -1,0 +1,4 @@
+static inline void {{ op_name }}(const {{ input_c_type }} {{ input0 }}{{ input_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+    (void){{ input0 }};
+    {{ output }}[0] = {{ value }};
+}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -3077,11 +3077,11 @@
   ],
   [
     "node/test_layer_normalization_2d_axis0_expanded/model.onnx",
-    "Unsupported op Size"
+    "Dynamic or zero dims are not supported"
   ],
   [
     "node/test_layer_normalization_2d_axis0_expanded_ver18/model.onnx",
-    "Unsupported op Size"
+    "Dynamic or zero dims are not supported"
   ],
   [
     "node/test_layer_normalization_2d_axis1/model.onnx",
@@ -3089,11 +3089,11 @@
   ],
   [
     "node/test_layer_normalization_2d_axis1_expanded/model.onnx",
-    "Unsupported op Size"
+    "Unsupported op Flatten"
   ],
   [
     "node/test_layer_normalization_2d_axis1_expanded_ver18/model.onnx",
-    "Unsupported op Size"
+    "Unsupported op Flatten"
   ],
   [
     "node/test_layer_normalization_2d_axis_negative_1/model.onnx",
@@ -3125,11 +3125,11 @@
   ],
   [
     "node/test_layer_normalization_3d_axis0_epsilon_expanded/model.onnx",
-    "Unsupported op Size"
+    "Dynamic or zero dims are not supported"
   ],
   [
     "node/test_layer_normalization_3d_axis0_epsilon_expanded_ver18/model.onnx",
-    "Unsupported op Size"
+    "Dynamic or zero dims are not supported"
   ],
   [
     "node/test_layer_normalization_3d_axis1_epsilon/model.onnx",
@@ -3137,11 +3137,11 @@
   ],
   [
     "node/test_layer_normalization_3d_axis1_epsilon_expanded/model.onnx",
-    "Unsupported op Size"
+    "Unsupported op Flatten"
   ],
   [
     "node/test_layer_normalization_3d_axis1_epsilon_expanded_ver18/model.onnx",
-    "Unsupported op Size"
+    "Unsupported op Flatten"
   ],
   [
     "node/test_layer_normalization_3d_axis2_epsilon/model.onnx",
@@ -3149,11 +3149,11 @@
   ],
   [
     "node/test_layer_normalization_3d_axis2_epsilon_expanded/model.onnx",
-    "Unsupported op Size"
+    "Unsupported op Flatten"
   ],
   [
     "node/test_layer_normalization_3d_axis2_epsilon_expanded_ver18/model.onnx",
-    "Unsupported op Size"
+    "Unsupported op Flatten"
   ],
   [
     "node/test_layer_normalization_3d_axis_negative_1_epsilon/model.onnx",
@@ -3197,11 +3197,11 @@
   ],
   [
     "node/test_layer_normalization_4d_axis0_expanded/model.onnx",
-    "Unsupported op Size"
+    "Dynamic or zero dims are not supported"
   ],
   [
     "node/test_layer_normalization_4d_axis0_expanded_ver18/model.onnx",
-    "Unsupported op Size"
+    "Dynamic or zero dims are not supported"
   ],
   [
     "node/test_layer_normalization_4d_axis1/model.onnx",
@@ -3209,11 +3209,11 @@
   ],
   [
     "node/test_layer_normalization_4d_axis1_expanded/model.onnx",
-    "Unsupported op Size"
+    "Unsupported op Flatten"
   ],
   [
     "node/test_layer_normalization_4d_axis1_expanded_ver18/model.onnx",
-    "Unsupported op Size"
+    "Unsupported op Flatten"
   ],
   [
     "node/test_layer_normalization_4d_axis2/model.onnx",
@@ -3221,11 +3221,11 @@
   ],
   [
     "node/test_layer_normalization_4d_axis2_expanded/model.onnx",
-    "Unsupported op Size"
+    "Unsupported op Flatten"
   ],
   [
     "node/test_layer_normalization_4d_axis2_expanded_ver18/model.onnx",
-    "Unsupported op Size"
+    "Unsupported op Flatten"
   ],
   [
     "node/test_layer_normalization_4d_axis3/model.onnx",
@@ -3233,11 +3233,11 @@
   ],
   [
     "node/test_layer_normalization_4d_axis3_expanded/model.onnx",
-    "Unsupported op Size"
+    "Unsupported op Flatten"
   ],
   [
     "node/test_layer_normalization_4d_axis3_expanded_ver18/model.onnx",
-    "Unsupported op Size"
+    "Unsupported op Flatten"
   ],
   [
     "node/test_layer_normalization_4d_axis_negative_1/model.onnx",
@@ -5921,11 +5921,11 @@
   ],
   [
     "node/test_size/model.onnx",
-    "Unsupported op Size"
+    ""
   ],
   [
     "node/test_size_example/model.onnx",
-    "Unsupported op Size"
+    ""
   ],
   [
     "node/test_slice/model.onnx",

--- a/tests/test_size.py
+++ b/tests/test_size.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import numpy as np
+import onnx
+
+from onnx import TensorProto, helper
+
+from onnx2c.compiler import Compiler
+
+
+def _make_size_model() -> onnx.ModelProto:
+    input_shape = [2, 3, 4]
+    input_info = helper.make_tensor_value_info(
+        "in0", TensorProto.FLOAT, input_shape
+    )
+    output = helper.make_tensor_value_info("out", TensorProto.INT64, [])
+    node = helper.make_node("Size", inputs=["in0"], outputs=[output.name])
+    graph = helper.make_graph([node], "size_graph", [input_info], [output])
+    model = helper.make_model(
+        graph,
+        producer_name="onnx2c",
+        opset_imports=[helper.make_operatorsetid("", 13)],
+    )
+    model.ir_version = 7
+    onnx.checker.check_model(model)
+    return model
+
+
+def test_size_run() -> None:
+    model = _make_size_model()
+    compiler = Compiler()
+    data = np.arange(24, dtype=np.float32).reshape(2, 3, 4)
+    outputs = compiler.run(model, {"in0": data})
+    expected = np.array(data.size, dtype=np.int64)
+    np.testing.assert_array_equal(outputs["out"], expected)


### PR DESCRIPTION
### Motivation

- Add support for the ONNX `Size` operator so models that query the number of elements can be lowered, evaluated, and emitted in C. 
- Provide end-to-end behavior (lowering → runtime evaluation → codegen) so `Size` can be verified against ONNX Runtime and included in golden snapshots.

### Description

- Added a lowering implementation `src/onnx2c/lowering/size.py` that validates input/output shapes and dtypes and returns a `SizeOp` with the computed element count. 
- Introduced `SizeOp` to the codegen (`src/onnx2c/codegen/c_emitter.py`) and added a Jinja2 template `templates/size_op.c.j2` to emit the corresponding C helper. 
- Wired runtime evaluation via `lower_size` and `_eval_size` in `src/onnx2c/runtime/evaluator.py` and imported the lowering into `src/onnx2c/compiler.py`. 
- Added tests: unit test `tests/test_size.py` and integrated an ONNX Runtime comparison case into `tests/test_endtoend_ops.py`, and refreshed official ONNX support snapshots and expected-error data.

### Testing

- Ran the full test suite with refreshed references using `UPDATE_REFS=1 pytest -n auto -q`, and all tests passed (145 passed in 42.50s). 
- Golden/reference files were updated to reflect newly supported `Size` examples and snapshot changes and the test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6965f73e081483259a627797ab20f106)