### PR TITLE
Add Flatten operator support

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 709 / 1802 official ONNX files.
+Support 720 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -631,15 +631,15 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_eyelike_populate_off_main_diagonal/model.onnx | ❌ | Unsupported op EyeLike |
 | node/test_eyelike_with_dtype/model.onnx | ❌ | Unsupported op EyeLike |
 | node/test_eyelike_without_dtype/model.onnx | ❌ | Unsupported op EyeLike |
-| node/test_flatten_axis0/model.onnx | ❌ | Unsupported op Flatten |
-| node/test_flatten_axis1/model.onnx | ❌ | Unsupported op Flatten |
-| node/test_flatten_axis2/model.onnx | ❌ | Unsupported op Flatten |
-| node/test_flatten_axis3/model.onnx | ❌ | Unsupported op Flatten |
-| node/test_flatten_default_axis/model.onnx | ❌ | Unsupported op Flatten |
-| node/test_flatten_negative_axis1/model.onnx | ❌ | Unsupported op Flatten |
-| node/test_flatten_negative_axis2/model.onnx | ❌ | Unsupported op Flatten |
-| node/test_flatten_negative_axis3/model.onnx | ❌ | Unsupported op Flatten |
-| node/test_flatten_negative_axis4/model.onnx | ❌ | Unsupported op Flatten |
+| node/test_flatten_axis0/model.onnx | ✅ |  |
+| node/test_flatten_axis1/model.onnx | ✅ |  |
+| node/test_flatten_axis2/model.onnx | ✅ |  |
+| node/test_flatten_axis3/model.onnx | ✅ |  |
+| node/test_flatten_default_axis/model.onnx | ✅ |  |
+| node/test_flatten_negative_axis1/model.onnx | ✅ |  |
+| node/test_flatten_negative_axis2/model.onnx | ✅ |  |
+| node/test_flatten_negative_axis3/model.onnx | ✅ |  |
+| node/test_flatten_negative_axis4/model.onnx | ✅ |  |
 | node/test_floor/model.onnx | ✅ |  |
 | node/test_floor_example/model.onnx | ✅ |  |
 | node/test_gather_0/model.onnx | ❌ | Unsupported op Gather |
@@ -780,8 +780,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_layer_normalization_2d_axis0_expanded/model.onnx | ❌ | Dynamic or zero dims are not supported |
 | node/test_layer_normalization_2d_axis0_expanded_ver18/model.onnx | ❌ | Dynamic or zero dims are not supported |
 | node/test_layer_normalization_2d_axis1/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_2d_axis1_expanded/model.onnx | ❌ | Unsupported op Flatten |
-| node/test_layer_normalization_2d_axis1_expanded_ver18/model.onnx | ❌ | Unsupported op Flatten |
+| node/test_layer_normalization_2d_axis1_expanded/model.onnx | ❌ | Unsupported op Reciprocal |
+| node/test_layer_normalization_2d_axis1_expanded_ver18/model.onnx | ❌ | Unsupported op Reciprocal |
 | node/test_layer_normalization_2d_axis_negative_1/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_2d_axis_negative_1_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis_negative_1_expanded_function_SuffixShape' |
 | node/test_layer_normalization_2d_axis_negative_1_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_2d_axis_negative_1_expanded_function_SuffixShape' |
@@ -792,11 +792,11 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_layer_normalization_3d_axis0_epsilon_expanded/model.onnx | ❌ | Dynamic or zero dims are not supported |
 | node/test_layer_normalization_3d_axis0_epsilon_expanded_ver18/model.onnx | ❌ | Dynamic or zero dims are not supported |
 | node/test_layer_normalization_3d_axis1_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_3d_axis1_epsilon_expanded/model.onnx | ❌ | Unsupported op Flatten |
-| node/test_layer_normalization_3d_axis1_epsilon_expanded_ver18/model.onnx | ❌ | Unsupported op Flatten |
+| node/test_layer_normalization_3d_axis1_epsilon_expanded/model.onnx | ❌ | Unsupported op Reciprocal |
+| node/test_layer_normalization_3d_axis1_epsilon_expanded_ver18/model.onnx | ❌ | Unsupported op Reciprocal |
 | node/test_layer_normalization_3d_axis2_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_3d_axis2_epsilon_expanded/model.onnx | ❌ | Unsupported op Flatten |
-| node/test_layer_normalization_3d_axis2_epsilon_expanded_ver18/model.onnx | ❌ | Unsupported op Flatten |
+| node/test_layer_normalization_3d_axis2_epsilon_expanded/model.onnx | ❌ | Unsupported op Reciprocal |
+| node/test_layer_normalization_3d_axis2_epsilon_expanded_ver18/model.onnx | ❌ | Unsupported op Reciprocal |
 | node/test_layer_normalization_3d_axis_negative_1_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_3d_axis_negative_1_epsilon_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis_negative_1_epsilon_expanded_function_SuffixShape' |
 | node/test_layer_normalization_3d_axis_negative_1_epsilon_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_3d_axis_negative_1_epsilon_expanded_function_SuffixShape' |
@@ -810,14 +810,14 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_layer_normalization_4d_axis0_expanded/model.onnx | ❌ | Dynamic or zero dims are not supported |
 | node/test_layer_normalization_4d_axis0_expanded_ver18/model.onnx | ❌ | Dynamic or zero dims are not supported |
 | node/test_layer_normalization_4d_axis1/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_4d_axis1_expanded/model.onnx | ❌ | Unsupported op Flatten |
-| node/test_layer_normalization_4d_axis1_expanded_ver18/model.onnx | ❌ | Unsupported op Flatten |
+| node/test_layer_normalization_4d_axis1_expanded/model.onnx | ❌ | Unsupported op Reciprocal |
+| node/test_layer_normalization_4d_axis1_expanded_ver18/model.onnx | ❌ | Unsupported op Reciprocal |
 | node/test_layer_normalization_4d_axis2/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_4d_axis2_expanded/model.onnx | ❌ | Unsupported op Flatten |
-| node/test_layer_normalization_4d_axis2_expanded_ver18/model.onnx | ❌ | Unsupported op Flatten |
+| node/test_layer_normalization_4d_axis2_expanded/model.onnx | ❌ | Unsupported op Reciprocal |
+| node/test_layer_normalization_4d_axis2_expanded_ver18/model.onnx | ❌ | Unsupported op Reciprocal |
 | node/test_layer_normalization_4d_axis3/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_4d_axis3_expanded/model.onnx | ❌ | Unsupported op Flatten |
-| node/test_layer_normalization_4d_axis3_expanded_ver18/model.onnx | ❌ | Unsupported op Flatten |
+| node/test_layer_normalization_4d_axis3_expanded/model.onnx | ❌ | Unsupported op Reciprocal |
+| node/test_layer_normalization_4d_axis3_expanded_ver18/model.onnx | ❌ | Unsupported op Reciprocal |
 | node/test_layer_normalization_4d_axis_negative_1/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_4d_axis_negative_1_expanded/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis_negative_1_expanded_function_SuffixShape' |
 | node/test_layer_normalization_4d_axis_negative_1_expanded_ver18/model.onnx | ❌ | Dynamic dim for tensor 'LayerNormalization_test_layer_normalization_4d_axis_negative_1_expanded_function_SuffixShape' |
@@ -1765,7 +1765,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | pytorch-operator/test_operator_conv/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_convtranspose/model.onnx | ❌ | Unsupported op ConvTranspose |
 | pytorch-operator/test_operator_exp/model.onnx | ✅ |  |
-| pytorch-operator/test_operator_flatten/model.onnx | ❌ | Unsupported op Flatten |
+| pytorch-operator/test_operator_flatten/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_index/model.onnx | ❌ | Unsupported op Squeeze |
 | pytorch-operator/test_operator_max/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_maxpool/model.onnx | ✅ |  |
@@ -1786,7 +1786,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | pytorch-operator/test_operator_sqrt/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_symbolic_override/model.onnx | ❌ | Unsupported op InstanceNormalization |
 | pytorch-operator/test_operator_symbolic_override_nested/model.onnx | ❌ | Sum must have 2 inputs and 1 output |
-| pytorch-operator/test_operator_view/model.onnx | ❌ | Unsupported op Flatten |
+| pytorch-operator/test_operator_view/model.onnx | ✅ |  |
 | simple/test_expand_shape_model1/model.onnx | ❌ | Unsupported op Expand |
 | simple/test_expand_shape_model2/model.onnx | ❌ | Unsupported op Expand |
 | simple/test_expand_shape_model3/model.onnx | ❌ | Unsupported op Expand |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -7,7 +7,6 @@
 | NegativeLogLikelihoodLoss input must be at least 2D | 34 | ████████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████ |
 | Dynamic or zero dims are not supported | 26 | ██████ |
-| Unsupported op Flatten | 23 | █████ |
 | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 22 | █████ |
 | Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 20 | █████ |
 | Unsupported op LayerNormalization | 19 | ████ |
@@ -27,6 +26,7 @@
 | Unsupported op Gather | 15 | ███ |
 | Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 14 | ███ |
 | Unsupported op ConvTranspose | 14 | ███ |
+| Unsupported op Reciprocal | 14 | ███ |
 | Unsupported op Squeeze | 14 | ███ |
 | ReduceSum output shape rank must match input rank | 12 | ███ |
 | Unsupported op Pad | 11 | ███ |
@@ -127,7 +127,6 @@
 | Pow expects matching dtypes, got float, int64 | 2 | █ |
 | Unsupported op Pow | 2 | █ |
 | Unsupported op Range | 2 | █ |
-| Unsupported op Reciprocal | 2 | █ |
 | Unsupported op ReverseSequence | 2 | █ |
 | Unsupported op Scan | 2 | █ |
 | Unsupported op Scatter | 2 | █ |

--- a/src/onnx2c/compiler.py
+++ b/src/onnx2c/compiler.py
@@ -62,6 +62,7 @@ from .lowering.common import (
 from .lowering.conv import ConvSpec, resolve_conv_spec
 from .lowering.constant_of_shape import lower_constant_of_shape
 from .lowering.dropout import lower_dropout
+from .lowering.flatten import lower_flatten
 from .lowering.gather_elements import lower_gather_elements
 from .lowering.gemm import resolve_gemm_spec, validate_gemm_bias_shape
 from .lowering.lrn import LrnSpec, resolve_lrn_spec

--- a/src/onnx2c/lowering/flatten.py
+++ b/src/onnx2c/lowering/flatten.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from ..codegen.c_emitter import ReshapeOp
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Node
+from .common import shape_product, value_dtype, value_shape
+from .registry import register_lowering
+
+
+def _normalize_axis(axis: int, rank: int) -> int:
+    if axis < 0:
+        axis += rank
+    if axis < 0 or axis > rank:
+        raise UnsupportedOpError("Flatten axis must be within input rank")
+    return axis
+
+
+def _flatten_output_shape(
+    input_shape: tuple[int, ...], axis: int
+) -> tuple[int, int]:
+    rank = len(input_shape)
+    axis = _normalize_axis(axis, rank)
+    if rank == 0:
+        return (1, 1)
+    for dim in input_shape:
+        if dim <= 0:
+            raise ShapeInferenceError("Dynamic or zero dims are not supported")
+    first = shape_product(input_shape[:axis]) if axis else 1
+    second = shape_product(input_shape[axis:]) if axis < rank else 1
+    return (first, second)
+
+
+@register_lowering("Flatten")
+def lower_flatten(graph: Graph, node: Node) -> ReshapeOp:
+    if len(node.inputs) != 1 or len(node.outputs) != 1:
+        raise UnsupportedOpError("Flatten must have 1 input and 1 output")
+    input_shape = value_shape(graph, node.inputs[0], node)
+    input_dtype = value_dtype(graph, node.inputs[0], node)
+    output_dtype = value_dtype(graph, node.outputs[0], node)
+    if input_dtype != output_dtype:
+        raise UnsupportedOpError(
+            "Flatten expects matching input/output dtypes, "
+            f"got {input_dtype} and {output_dtype}"
+        )
+    axis = int(node.attrs.get("axis", 1))
+    output_shape = _flatten_output_shape(input_shape, axis)
+    expected_shape = value_shape(graph, node.outputs[0], node)
+    if expected_shape and output_shape != expected_shape:
+        raise ShapeInferenceError(
+            "Flatten output shape must be "
+            f"{output_shape}, got {expected_shape}"
+        )
+    return ReshapeOp(
+        input0=node.inputs[0],
+        output=node.outputs[0],
+        input_shape=input_shape,
+        output_shape=output_shape,
+        dtype=input_dtype,
+    )

--- a/src/onnx2c/runtime/evaluator.py
+++ b/src/onnx2c/runtime/evaluator.py
@@ -15,6 +15,7 @@ from ..lowering.concat import lower_concat
 from ..lowering.constant_of_shape import lower_constant_of_shape
 from ..lowering.conv import resolve_conv_spec
 from ..lowering.dropout import lower_dropout
+from ..lowering.flatten import lower_flatten
 from ..lowering.gemm import resolve_gemm_spec
 from ..lowering.logsoftmax import lower_logsoftmax
 from ..lowering.negative_log_likelihood_loss import (
@@ -490,6 +491,14 @@ def _eval_unsqueeze(evaluator: Evaluator, node: Node) -> None:
 @register_evaluator("Reshape")
 def _eval_reshape(evaluator: Evaluator, node: Node) -> None:
     op = lower_reshape(evaluator.graph, node)
+    evaluator.values[op.output] = evaluator.values[op.input0].reshape(
+        op.output_shape
+    )
+
+
+@register_evaluator("Flatten")
+def _eval_flatten(evaluator: Evaluator, node: Node) -> None:
+    op = lower_flatten(evaluator.graph, node)
     evaluator.values[op.output] = evaluator.values[op.input0].reshape(
         op.output_shape
     )

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -2493,39 +2493,39 @@
   ],
   [
     "node/test_flatten_axis0/model.onnx",
-    "Unsupported op Flatten"
+    ""
   ],
   [
     "node/test_flatten_axis1/model.onnx",
-    "Unsupported op Flatten"
+    ""
   ],
   [
     "node/test_flatten_axis2/model.onnx",
-    "Unsupported op Flatten"
+    ""
   ],
   [
     "node/test_flatten_axis3/model.onnx",
-    "Unsupported op Flatten"
+    ""
   ],
   [
     "node/test_flatten_default_axis/model.onnx",
-    "Unsupported op Flatten"
+    ""
   ],
   [
     "node/test_flatten_negative_axis1/model.onnx",
-    "Unsupported op Flatten"
+    ""
   ],
   [
     "node/test_flatten_negative_axis2/model.onnx",
-    "Unsupported op Flatten"
+    ""
   ],
   [
     "node/test_flatten_negative_axis3/model.onnx",
-    "Unsupported op Flatten"
+    ""
   ],
   [
     "node/test_flatten_negative_axis4/model.onnx",
-    "Unsupported op Flatten"
+    ""
   ],
   [
     "node/test_floor/model.onnx",
@@ -3089,11 +3089,11 @@
   ],
   [
     "node/test_layer_normalization_2d_axis1_expanded/model.onnx",
-    "Unsupported op Flatten"
+    "Unsupported op Reciprocal"
   ],
   [
     "node/test_layer_normalization_2d_axis1_expanded_ver18/model.onnx",
-    "Unsupported op Flatten"
+    "Unsupported op Reciprocal"
   ],
   [
     "node/test_layer_normalization_2d_axis_negative_1/model.onnx",
@@ -3137,11 +3137,11 @@
   ],
   [
     "node/test_layer_normalization_3d_axis1_epsilon_expanded/model.onnx",
-    "Unsupported op Flatten"
+    "Unsupported op Reciprocal"
   ],
   [
     "node/test_layer_normalization_3d_axis1_epsilon_expanded_ver18/model.onnx",
-    "Unsupported op Flatten"
+    "Unsupported op Reciprocal"
   ],
   [
     "node/test_layer_normalization_3d_axis2_epsilon/model.onnx",
@@ -3149,11 +3149,11 @@
   ],
   [
     "node/test_layer_normalization_3d_axis2_epsilon_expanded/model.onnx",
-    "Unsupported op Flatten"
+    "Unsupported op Reciprocal"
   ],
   [
     "node/test_layer_normalization_3d_axis2_epsilon_expanded_ver18/model.onnx",
-    "Unsupported op Flatten"
+    "Unsupported op Reciprocal"
   ],
   [
     "node/test_layer_normalization_3d_axis_negative_1_epsilon/model.onnx",
@@ -3209,11 +3209,11 @@
   ],
   [
     "node/test_layer_normalization_4d_axis1_expanded/model.onnx",
-    "Unsupported op Flatten"
+    "Unsupported op Reciprocal"
   ],
   [
     "node/test_layer_normalization_4d_axis1_expanded_ver18/model.onnx",
-    "Unsupported op Flatten"
+    "Unsupported op Reciprocal"
   ],
   [
     "node/test_layer_normalization_4d_axis2/model.onnx",
@@ -3221,11 +3221,11 @@
   ],
   [
     "node/test_layer_normalization_4d_axis2_expanded/model.onnx",
-    "Unsupported op Flatten"
+    "Unsupported op Reciprocal"
   ],
   [
     "node/test_layer_normalization_4d_axis2_expanded_ver18/model.onnx",
-    "Unsupported op Flatten"
+    "Unsupported op Reciprocal"
   ],
   [
     "node/test_layer_normalization_4d_axis3/model.onnx",
@@ -3233,11 +3233,11 @@
   ],
   [
     "node/test_layer_normalization_4d_axis3_expanded/model.onnx",
-    "Unsupported op Flatten"
+    "Unsupported op Reciprocal"
   ],
   [
     "node/test_layer_normalization_4d_axis3_expanded_ver18/model.onnx",
-    "Unsupported op Flatten"
+    "Unsupported op Reciprocal"
   ],
   [
     "node/test_layer_normalization_4d_axis_negative_1/model.onnx",
@@ -7029,7 +7029,7 @@
   ],
   [
     "pytorch-operator/test_operator_flatten/model.onnx",
-    "Unsupported op Flatten"
+    ""
   ],
   [
     "pytorch-operator/test_operator_index/model.onnx",
@@ -7113,7 +7113,7 @@
   ],
   [
     "pytorch-operator/test_operator_view/model.onnx",
-    "Unsupported op Flatten"
+    ""
   ],
   [
     "simple/test_expand_shape_model1/model.onnx",

--- a/tests/test_endtoend_ops.py
+++ b/tests/test_endtoend_ops.py
@@ -1071,6 +1071,14 @@ OPERATOR_CASES = [
         "attrs": {},
     },
     {
+        "name": "FlattenAxis1",
+        "op_type": "Flatten",
+        "input_shapes": [[2, 3, 4]],
+        "output_shape": [2, 12],
+        "dtype": TensorProto.FLOAT,
+        "attrs": {"axis": 1},
+    },
+    {
         "name": "AddInt64",
         "op_type": "Add",
         "input_shapes": [[2, 3], [2, 3]],

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import numpy as np
+import onnx
+
+from onnx import TensorProto, helper
+
+from onnx2c.lowering.flatten import lower_flatten
+from onnx2c.onnx_import import import_onnx
+
+
+def _flatten_output_shape(
+    input_shape: list[int], axis: int
+) -> list[int]:
+    rank = len(input_shape)
+    if axis < 0:
+        axis += rank
+    first = int(np.prod(input_shape[:axis])) if axis else 1
+    second = int(np.prod(input_shape[axis:])) if axis < rank else 1
+    return [first, second]
+
+
+def _make_flatten_model(
+    input_shape: list[int], axis: int
+) -> onnx.ModelProto:
+    input_info = helper.make_tensor_value_info(
+        "in0", TensorProto.FLOAT, input_shape
+    )
+    output_shape = _flatten_output_shape(input_shape, axis)
+    output = helper.make_tensor_value_info(
+        "out", TensorProto.FLOAT, output_shape
+    )
+    node = helper.make_node(
+        "Flatten",
+        inputs=["in0"],
+        outputs=[output.name],
+        axis=axis,
+    )
+    graph = helper.make_graph(
+        [node],
+        "flatten_graph",
+        [input_info],
+        [output],
+    )
+    model = helper.make_model(
+        graph,
+        producer_name="onnx2c",
+        opset_imports=[helper.make_operatorsetid("", 13)],
+    )
+    model.ir_version = 7
+    onnx.checker.check_model(model)
+    return model
+
+
+def test_lower_flatten_axis_default() -> None:
+    model = _make_flatten_model([2, 3, 4], axis=1)
+    graph = import_onnx(model)
+    op = lower_flatten(graph, graph.nodes[0])
+    assert op.input_shape == (2, 3, 4)
+    assert op.output_shape == (2, 12)
+    assert op.dtype == "float"
+
+
+def test_lower_flatten_negative_axis() -> None:
+    model = _make_flatten_model([2, 3, 4], axis=-1)
+    graph = import_onnx(model)
+    op = lower_flatten(graph, graph.nodes[0])
+    assert op.output_shape == (6, 4)


### PR DESCRIPTION
### Motivation
- Support the ONNX `Flatten` operator by lowering it to a reshape-based op so models using `Flatten` can be compiled and executed.  
- Respect the `axis` attribute (including negative axes) and validate shapes/dtypes to preserve correctness and deterministic lowering.  
- Provide runtime evaluation for `Flatten` so verification and constant-folding paths behave like the compiler output.  
- Keep changes minimal and consistent with the existing `Reshape` lowering/emission model.

### Description
- Add a new lowering `src/onnx2c/lowering/flatten.py` that validates `axis`, computes the 2-D output shape, and returns a `ReshapeOp` via `@register_lowering("Flatten")`.  
- Register a runtime evaluator in `src/onnx2c/runtime/evaluator.py` that calls `lower_flatten` and applies `numpy.reshape` for execution/verification.  
- Add unit tests in `tests/test_flatten.py` and include an end-to-end operator case in `tests/test_endtoend_ops.py` to exercise lowering and negative-axis handling.  
- Refresh reference expectations and documentation by updating `tests/official_onnx_expected_errors.json`, `OFFICIAL_ONNX_FILE_SUPPORT.md`, and `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md` to mark official Flatten test files as supported.

### Testing
- Ran the full test suite with reference updates using `UPDATE_REFS=1 pytest -n auto -q`.  
- The final run completed successfully: `148 passed` in `22.50s`.  
- Added unit tests `tests/test_flatten.py` which exercise default and negative-axis behavior and passed under the test run.  
- Updated official ONNX expectation refs as part of the automated test run to reflect newly supported files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6965fbd578988325b4a08d08e47cbce0)