### PR TITLE
loss: complete NegativeLogLikelihoodLoss handling

### DIFF
--- a/src/onnx2c/codegen/c_emitter.py
+++ b/src/onnx2c/codegen/c_emitter.py
@@ -252,7 +252,7 @@ class NegativeLogLikelihoodLossOp:
     c: int
     d: int
     reduction: str
-    ignore_index: int
+    ignore_index: int | None
     dtype: str
     target_dtype: str
 
@@ -2621,6 +2621,8 @@ class CEmitter:
             ).rstrip()
             return with_node_comment(rendered)
         if isinstance(op, NegativeLogLikelihoodLossOp):
+            use_ignore_index = int(op.ignore_index is not None)
+            ignore_index = op.ignore_index if op.ignore_index is not None else -1
             rendered = nllloss_template.render(
                 model_name=model.name,
                 op_name=f"{model.name}_op{index}",
@@ -2637,7 +2639,8 @@ class CEmitter:
                 c=op.c,
                 d=op.d,
                 reduction=op.reduction,
-                ignore_index=op.ignore_index,
+                use_ignore_index=use_ignore_index,
+                ignore_index=ignore_index,
                 zero_literal=zero_literal,
                 one_literal=CEmitter._format_literal(op.dtype, 1),
             ).rstrip()

--- a/src/onnx2c/lowering/negative_log_likelihood_loss.py
+++ b/src/onnx2c/lowering/negative_log_likelihood_loss.py
@@ -87,7 +87,9 @@ def lower_negative_log_likelihood_loss(
     n = input_shape[0]
     c = input_shape[1]
     d = _shape_product(input_shape[2:]) if len(input_shape) > 2 else 1
-    ignore_index = int(node.attrs.get("ignore_index", -1))
+    ignore_index = node.attrs.get("ignore_index")
+    if ignore_index is not None:
+        ignore_index = int(ignore_index)
     return NegativeLogLikelihoodLossOp(
         input0=input_name,
         target=target_name,

--- a/templates/negative_log_likelihood_loss_op.c.j2
+++ b/templates/negative_log_likelihood_loss_op.c.j2
@@ -9,17 +9,21 @@ static inline void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix 
     const size_t c = {{ c }};
     const size_t d = {{ d }};
     {{ c_type }} loss_sum = {{ zero_literal }};
+{% if reduction == "mean" and (weight or use_ignore_index) %}
     {{ c_type }} weight_sum = {{ zero_literal }};
+{% endif %}
     for (size_t n_idx = 0; n_idx < n; ++n_idx) {
         for (size_t d_idx = 0; d_idx < d; ++d_idx) {
             size_t target_index = n_idx * d + d_idx;
             {{ target_c_type }} target_value = target_flat[target_index];
+{% if use_ignore_index %}
             if ((int64_t)target_value == {{ ignore_index }}) {
 {% if reduction == "none" %}
                 output_flat[target_index] = {{ zero_literal }};
 {% endif %}
                 continue;
             }
+{% endif %}
             size_t class_index = (size_t)target_value;
             size_t input_index = (n_idx * c + class_index) * d + d_idx;
             {{ c_type }} value = -input_flat[input_index];
@@ -34,13 +38,23 @@ static inline void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix 
 {% else %}
             loss_sum += value;
 {% if reduction == "mean" %}
+{% if weight or use_ignore_index %}
             weight_sum += sample_weight;
+{% endif %}
 {% endif %}
 {% endif %}
         }
     }
 {% if reduction == "mean" %}
-    output_flat[0] = loss_sum / weight_sum;
+{% if weight or use_ignore_index %}
+    if (weight_sum == {{ zero_literal }}) {
+        output_flat[0] = {{ zero_literal }};
+    } else {
+        output_flat[0] = loss_sum / weight_sum;
+    }
+{% else %}
+    output_flat[0] = loss_sum / ({{ n }} * {{ d }});
+{% endif %}
 {% elif reduction == "sum" %}
     output_flat[0] = loss_sum;
 {% endif %}


### PR DESCRIPTION
### Motivation
- Treat `ignore_index` as optional to match the ONNX spec and existing `SoftmaxCrossEntropyLoss` handling.
- Ensure generated C and the runtime evaluator behave correctly when `ignore_index` is unset or when all samples are ignored or zero-weighted.
- Avoid divide-by-zero when computing `mean` reduction with zero total weight.

### Description
- Parse optional `ignore_index` in `lower_negative_log_likelihood_loss` and propagate it in the `NegativeLogLikelihoodLossOp` dataclass as `int | None`.
- Update `CEmitter` to pass `use_ignore_index` and a safe `ignore_index` value into the `negative_log_likelihood_loss_op.c.j2` template and extend the template to conditionally handle ignore logic and guard `mean` division by zero.
- Change the runtime evaluator `_apply_negative_log_likelihood_loss` to accept `ignore_index: int | None`, skip ignored targets correctly, and return zero for `mean` when total weight is zero.
- Add an ONNX Runtime comparison test for the default (unset) `ignore_index` behavior in `tests/test_negative_log_likelihood_loss.py`.

### Testing
- Ran `pytest tests/test_negative_log_likelihood_loss.py -q` and all tests passed (`3 passed in 1.54s`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69662397d2e083259e17008711157bbf)