### PR TITLE
lowering: infer NLLLoss shapes and guard mean-reduction divide-by-zero

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 734 / 1802 official ONNX files.
+Support 768 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -1376,73 +1376,73 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_scatternd_min/model.onnx | ❌ | Unsupported op ScatterND |
 | node/test_scatternd_multiply/model.onnx | ❌ | Unsupported op ScatterND |
 | node/test_sce_NCd1_mean_weight_negative_ii/model.onnx | ✅ |  |
-| node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx | ✅ |  |
 | node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx | ✅ |  |
-| node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3_none_no_weight_negative_ii/model.onnx | ✅ |  |
-| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob/model.onnx | ✅ |  |
-| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3_sum_weight_high_ii/model.onnx | ✅ |  |
-| node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob/model.onnx | ✅ |  |
-| node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx | ✅ |  |
-| node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx | ✅ |  |
-| node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx | ✅ |  |
-| node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx | ✅ |  |
-| node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean/model.onnx | ✅ |  |
 | node/test_sce_mean_3d/model.onnx | ✅ |  |
-| node/test_sce_mean_3d_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_mean_3d_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_3d_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_3d_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
-| node/test_sce_mean_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_mean_3d_log_prob_expanded/model.onnx | ✅ |  |
+| node/test_sce_mean_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_mean_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_no_weight_ii/model.onnx | ✅ |  |
 | node/test_sce_mean_no_weight_ii_3d/model.onnx | ✅ |  |
-| node/test_sce_mean_no_weight_ii_3d_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_mean_no_weight_ii_3d_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_no_weight_ii_3d_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_no_weight_ii_4d/model.onnx | ✅ |  |
-| node/test_sce_mean_no_weight_ii_4d_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_mean_no_weight_ii_4d_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_no_weight_ii_4d_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
-| node/test_sce_mean_no_weight_ii_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx | ✅ |  |
+| node/test_sce_mean_no_weight_ii_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_no_weight_ii_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_weight/model.onnx | ✅ |  |
-| node/test_sce_mean_weight_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_mean_weight_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_ii/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_ii_3d/model.onnx | ✅ |  |
-| node/test_sce_mean_weight_ii_3d_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_mean_weight_ii_3d_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_ii_3d_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_ii_4d/model.onnx | ✅ |  |
-| node/test_sce_mean_weight_ii_4d_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_mean_weight_ii_4d_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_ii_4d_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
-| node/test_sce_mean_weight_ii_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx | ✅ |  |
+| node/test_sce_mean_weight_ii_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_ii_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_weight_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_mean_weight_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_none/model.onnx | ✅ |  |
-| node/test_sce_none_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_none_expanded/model.onnx | ✅ |  |
 | node/test_sce_none_log_prob/model.onnx | ✅ |  |
-| node/test_sce_none_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_none_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_none_weights/model.onnx | ✅ |  |
-| node/test_sce_none_weights_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_none_weights_expanded/model.onnx | ✅ |  |
 | node/test_sce_none_weights_log_prob/model.onnx | ✅ |  |
-| node/test_sce_none_weights_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_none_weights_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_sum/model.onnx | ✅ |  |
-| node/test_sce_sum_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_sum_expanded/model.onnx | ✅ |  |
 | node/test_sce_sum_log_prob/model.onnx | ✅ |  |
-| node/test_sce_sum_log_prob_expanded/model.onnx | ❌ | NegativeLogLikelihoodLoss input must be at least 2D |
+| node/test_sce_sum_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_selu/model.onnx | ❌ | Unsupported op Selu |
 | node/test_selu_default/model.onnx | ❌ | Unsupported op Selu |
 | node/test_selu_default_expanded_ver18/model.onnx | ✅ |  |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -4,7 +4,6 @@
 | --- | --- | --- |
 | Dynamic dim for tensor '*' | 130 | ██████████████████████████████ |
 | Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 34 | ████████ |
-| NegativeLogLikelihoodLoss input must be at least 2D | 34 | ████████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████ |
 | Dynamic or zero dims are not supported | 26 | ██████ |
 | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 22 | █████ |

--- a/src/onnx2c/runtime/evaluator.py
+++ b/src/onnx2c/runtime/evaluator.py
@@ -761,7 +761,10 @@ def _apply_negative_log_likelihood_loss(
     if gather_weight is not None:
         loss = gather_weight * loss
         if reduction == "mean":
-            loss = loss.sum() / gather_weight.sum()
+            weight_sum = gather_weight.sum()
+            if weight_sum == 0:
+                return np.array(0, dtype=values.dtype)
+            loss = loss.sum() / weight_sum
             return loss.astype(values.dtype)
     if reduction == "mean":
         loss = np.mean(loss)

--- a/templates/negative_log_likelihood_loss_op.c.j2
+++ b/templates/negative_log_likelihood_loss_op.c.j2
@@ -40,7 +40,11 @@ static inline void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix 
         }
     }
 {% if reduction == "mean" %}
-    output_flat[0] = loss_sum / weight_sum;
+    if (weight_sum == {{ zero_literal }}) {
+        output_flat[0] = {{ zero_literal }};
+    } else {
+        output_flat[0] = loss_sum / weight_sum;
+    }
 {% elif reduction == "sum" %}
     output_flat[0] = loss_sum;
 {% endif %}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -5473,7 +5473,7 @@
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx",
@@ -5481,7 +5481,7 @@
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii/model.onnx",
@@ -5489,7 +5489,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob/model.onnx",
@@ -5497,7 +5497,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii/model.onnx",
@@ -5505,7 +5505,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob/model.onnx",
@@ -5513,7 +5513,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx",
@@ -5521,7 +5521,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx",
@@ -5529,7 +5529,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx",
@@ -5537,7 +5537,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx",
@@ -5545,7 +5545,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_mean/model.onnx",
@@ -5557,7 +5557,7 @@
   ],
   [
     "node/test_sce_mean_3d_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_mean_3d_log_prob/model.onnx",
@@ -5565,11 +5565,11 @@
   ],
   [
     "node/test_sce_mean_3d_log_prob_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_mean_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_mean_log_prob/model.onnx",
@@ -5577,7 +5577,7 @@
   ],
   [
     "node/test_sce_mean_log_prob_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii/model.onnx",
@@ -5589,7 +5589,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_log_prob/model.onnx",
@@ -5597,7 +5597,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d/model.onnx",
@@ -5605,7 +5605,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_log_prob/model.onnx",
@@ -5613,11 +5613,11 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii_log_prob/model.onnx",
@@ -5625,7 +5625,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_mean_weight/model.onnx",
@@ -5633,7 +5633,7 @@
   ],
   [
     "node/test_sce_mean_weight_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii/model.onnx",
@@ -5645,7 +5645,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_3d_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii_3d_log_prob/model.onnx",
@@ -5653,7 +5653,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii_4d/model.onnx",
@@ -5661,7 +5661,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_4d_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii_4d_log_prob/model.onnx",
@@ -5669,11 +5669,11 @@
   ],
   [
     "node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii_log_prob/model.onnx",
@@ -5681,7 +5681,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_mean_weight_log_prob/model.onnx",
@@ -5689,7 +5689,7 @@
   ],
   [
     "node/test_sce_mean_weight_log_prob_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_none/model.onnx",
@@ -5697,7 +5697,7 @@
   ],
   [
     "node/test_sce_none_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_none_log_prob/model.onnx",
@@ -5705,7 +5705,7 @@
   ],
   [
     "node/test_sce_none_log_prob_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_none_weights/model.onnx",
@@ -5713,7 +5713,7 @@
   ],
   [
     "node/test_sce_none_weights_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_none_weights_log_prob/model.onnx",
@@ -5721,7 +5721,7 @@
   ],
   [
     "node/test_sce_none_weights_log_prob_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_sum/model.onnx",
@@ -5729,7 +5729,7 @@
   ],
   [
     "node/test_sce_sum_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_sce_sum_log_prob/model.onnx",
@@ -5737,7 +5737,7 @@
   ],
   [
     "node/test_sce_sum_log_prob_expanded/model.onnx",
-    "NegativeLogLikelihoodLoss input must be at least 2D"
+    ""
   ],
   [
     "node/test_selu/model.onnx",


### PR DESCRIPTION
### Motivation
- Fix spurious "NegativeLogLikelihoodLoss input must be at least 2D" errors by inferring the NLLLoss `input` shape from upstream `Reshape`/`Shape` patterns and available `target`/`weight` metadata. 
- Ensure numeric stability for `mean` reduction when all sample weights sum to zero to match ONNX semantics and avoid division-by-zero. 
- Keep generated C and runtime evaluator behavior consistent with lowering and ONNX reference implementation. 

### Description
- Implement shape resolution helpers in `src/onnx2c/lowering/negative_log_likelihood_loss.py` to find `Shape`/`Reshape` producers and resolve target shapes when the `input` shape is not present. 
- Use resolved shape (or weight info) as a fallback for `input` shape and validate ranks/dimensions accordingly; preserve existing shape checks and error messages. 
- Guard `mean` reduction against zero total weight in the runtime evaluator (`src/onnx2c/runtime/evaluator.py`) by returning zero when the summed weight is zero. 
- Add the same zero-weight guard to the emitted C template (`templates/negative_log_likelihood_loss_op.c.j2`) and refresh official ONNX expectations/support files (`OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`, `tests/official_onnx_expected_errors.json`). 

### Testing
- Ran `pytest tests/test_negative_log_likelihood_loss.py -q` and it passed (`2 passed`, 1.81s). 
- Ran full suite with references update via `UPDATE_REFS=1 pytest -n auto -q` which completed successfully (`151 passed`, 30.69s).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69662b93bc8c832589116e616a528ba3)