### PR TITLE
Add local ONNX tests and include local ops histogram in reports

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1810,3 +1810,86 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | simple/test_strnorm_model_monday_empty_output/model.onnx | ❌ | Unsupported elem_type 8 (STRING) for tensor 'x'. |
 | simple/test_strnorm_model_monday_insensintive_upper_twodim/model.onnx | ❌ | Unsupported elem_type 8 (STRING) for tensor 'x'. |
 | simple/test_strnorm_model_nostopwords_nochangecase/model.onnx | ❌ | Unsupported elem_type 8 (STRING) for tensor 'x'. |
+
+## Local ONNX file support
+
+Local tests: `onnx2c-org/test/local_ops`.
+
+Support 47 / 74 local ONNX files.
+
+| File | Supported | Error |
+| --- | --- | --- |
+| test_gather_basic/model.onnx | ❌ | Unsupported op Gather |
+| test_gather_output_scalar/model.onnx | ❌ | Unsupported op Gather |
+| test_gather_scalar_axis0/model.onnx | ❌ | Unsupported op Gather |
+| test_gather_scalar_axis1/model.onnx | ❌ | Unsupported op Gather |
+| test_gemm_C1/model.onnx | ❌ | Gemm bias input must be broadcastable to output shape, got (1,) vs (2, 4) |
+| test_gemm_C1_transA/model.onnx | ❌ | Gemm bias input must be broadcastable to output shape, got (1,) vs (2, 4) |
+| test_gemm_C1_transB/model.onnx | ❌ | Gemm bias input must be broadcastable to output shape, got (1,) vs (2, 4) |
+| test_gemm_C1x1/model.onnx | ✅ |  |
+| test_gemm_C1x1_transA/model.onnx | ✅ |  |
+| test_gemm_C1xN/model.onnx | ✅ |  |
+| test_gemm_C1xN_transA/model.onnx | ✅ |  |
+| test_gemm_C1xN_transA_transB/model.onnx | ✅ |  |
+| test_gemm_CM_transA/model.onnx | ❌ | Gemm bias input must be broadcastable to output shape, got (2,) vs (2, 4) |
+| test_gemm_CMx1/model.onnx | ✅ |  |
+| test_gemm_CMx1_transA/model.onnx | ✅ |  |
+| test_gemm_CMx1_transA_transB/model.onnx | ✅ |  |
+| test_gemm_CMxN/model.onnx | ✅ |  |
+| test_gemm_CMxN_transA/model.onnx | ✅ |  |
+| test_gemm_CMxN_transA_transB/model.onnx | ✅ |  |
+| test_gemm_CMxN_transB/model.onnx | ✅ |  |
+| test_gemm_CN/model.onnx | ✅ |  |
+| test_gemm_CN_transA/model.onnx | ✅ |  |
+| test_gemm_CN_transA_transB/model.onnx | ✅ |  |
+| test_gemm_CN_transB/model.onnx | ✅ |  |
+| test_lstm_activations/model.onnx | ✅ |  |
+| test_lstm_all_outputs/model.onnx | ✅ |  |
+| test_lstm_bidirectional/model.onnx | ❌ | Unsupported LSTM direction b'bidirectional' |
+| test_lstm_clip/model.onnx | ✅ |  |
+| test_lstm_intermediate_h/model.onnx | ✅ |  |
+| test_lstm_missing_inputs/model.onnx | ✅ |  |
+| test_lstm_reverse/model.onnx | ❌ | Unsupported LSTM direction b'reverse' |
+| test_lstm_seq_length/model.onnx | ✅ |  |
+| test_lstm_simple/model.onnx | ✅ |  |
+| test_lstm_with_initial_state/model.onnx | ✅ |  |
+| test_lstm_y_c/model.onnx | ✅ |  |
+| test_matmul_1x1x3x4_2x3x4x5/model.onnx | ✅ |  |
+| test_matmul_1x3x4_2x3x4x5/model.onnx | ✅ |  |
+| test_matmul_1x3x4_3x4x5/model.onnx | ✅ |  |
+| test_matmul_2x1x3x4_2x3x4x5/model.onnx | ✅ |  |
+| test_matmul_2x3_3x4/model.onnx | ✅ |  |
+| test_matmul_2x3x3x4_1x4x5/model.onnx | ✅ |  |
+| test_matmul_2x3x4_4/model.onnx | ✅ |  |
+| test_matmul_2x3x4_4x5/model.onnx | ✅ |  |
+| test_matmul_2x3x4x5_5/model.onnx | ✅ |  |
+| test_matmul_3_2x3x4/model.onnx | ✅ |  |
+| test_matmul_3_3/model.onnx | ✅ |  |
+| test_matmul_3_3x4/model.onnx | ✅ |  |
+| test_matmul_3x4_2x4x5/model.onnx | ✅ |  |
+| test_matmul_3x4_4/model.onnx | ✅ |  |
+| test_matmul_4x5x2x3_4x5x3x4/model.onnx | ✅ |  |
+| test_matmul_5x2x3_5x3x4/model.onnx | ✅ |  |
+| test_matmul_precision/model.onnx | ✅ |  |
+| test_maxpool_stride_1/model.onnx | ❌ | MaxPool must have 1 input and 1 output |
+| test_maxpool_stride_2/model.onnx | ❌ | MaxPool must have 1 input and 1 output |
+| test_nodes_out_of_order/model.onnx | ✅ |  |
+| test_pad_constant_default/model.onnx | ❌ | Unsupported op Pad |
+| test_pad_constant_input/model.onnx | ❌ | Unsupported op Pad |
+| test_pad_edge/model.onnx | ❌ | Unsupported op Pad |
+| test_pad_edge_allaxes/model.onnx | ❌ | Unsupported op Pad |
+| test_pad_reflect_allaxes/model.onnx | ❌ | Unsupported op Pad |
+| test_pad_reflect_nopadding/model.onnx | ❌ | Unsupported op Pad |
+| test_qlinearadd_int8/model.onnx | ❌ | Unsupported op QLinearAdd |
+| test_qlinearadd_uint8/model.onnx | ❌ | Unsupported op QLinearAdd |
+| test_qlinearmul_int8/model.onnx | ❌ | Unsupported op QLinearMul |
+| test_qlinearmul_uint8/model.onnx | ❌ | Unsupported op QLinearMul |
+| test_resize_downsample_sizes_linear_1D/model.onnx | ✅ |  |
+| test_resize_downsample_sizes_linear_1D_align/model.onnx | ✅ |  |
+| test_scalar_input_to_node/model.onnx | ✅ |  |
+| test_scatternd_indices_1x1x2/model.onnx | ❌ | Unsupported op ScatterND |
+| test_scatternd_indices_1x2x2/model.onnx | ❌ | Unsupported op ScatterND |
+| test_scatternd_indices_2x2x2/model.onnx | ❌ | Unsupported op ScatterND |
+| test_scatternd_indices_3x2/model.onnx | ❌ | Unsupported op ScatterND |
+| test_shape_const_out/model.onnx | ❌ | Unsupported op Expand |
+| test_slice_end_INT64_MAX/model.onnx | ✅ |  |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -159,3 +159,20 @@
 | Unsupported op Swish | 1 | █ |
 | Unsupported op Upsample | 1 | █ |
 | Gemm bias input must be broadcastable to output shape, got (1,) vs (2, 4) | 1 | █ |
+
+## Local ONNX file support histogram
+
+### Error frequency
+
+| Error message | Count | Histogram |
+| --- | --- | --- |
+| Unsupported op Pad | 6 | ██████████████████████████████ |
+| Unsupported op Gather | 4 | ████████████████████ |
+| Unsupported op ScatterND | 4 | ████████████████████ |
+| Gemm bias input must be broadcastable to output shape, got (1,) vs (2, 4) | 3 | ███████████████ |
+| Unsupported LSTM direction b'*' | 2 | ██████████ |
+| MaxPool must have 1 input and 1 output | 2 | ██████████ |
+| Unsupported op QLinearAdd | 2 | ██████████ |
+| Unsupported op QLinearMul | 2 | ██████████ |
+| Gemm bias input must be broadcastable to output shape, got (2,) vs (2, 4) | 1 | █████ |
+| Unsupported op Expand | 1 | █████ |

--- a/tests/local_onnx_expected_errors.json
+++ b/tests/local_onnx_expected_errors.json
@@ -1,0 +1,298 @@
+[
+  [
+    "test_gather_basic/model.onnx",
+    "Unsupported op Gather"
+  ],
+  [
+    "test_gather_output_scalar/model.onnx",
+    "Unsupported op Gather"
+  ],
+  [
+    "test_gather_scalar_axis0/model.onnx",
+    "Unsupported op Gather"
+  ],
+  [
+    "test_gather_scalar_axis1/model.onnx",
+    "Unsupported op Gather"
+  ],
+  [
+    "test_gemm_C1/model.onnx",
+    "Gemm bias input must be broadcastable to output shape, got (1,) vs (2, 4)"
+  ],
+  [
+    "test_gemm_C1_transA/model.onnx",
+    "Gemm bias input must be broadcastable to output shape, got (1,) vs (2, 4)"
+  ],
+  [
+    "test_gemm_C1_transB/model.onnx",
+    "Gemm bias input must be broadcastable to output shape, got (1,) vs (2, 4)"
+  ],
+  [
+    "test_gemm_C1x1/model.onnx",
+    ""
+  ],
+  [
+    "test_gemm_C1x1_transA/model.onnx",
+    ""
+  ],
+  [
+    "test_gemm_C1xN/model.onnx",
+    ""
+  ],
+  [
+    "test_gemm_C1xN_transA/model.onnx",
+    ""
+  ],
+  [
+    "test_gemm_C1xN_transA_transB/model.onnx",
+    ""
+  ],
+  [
+    "test_gemm_CM_transA/model.onnx",
+    "Gemm bias input must be broadcastable to output shape, got (2,) vs (2, 4)"
+  ],
+  [
+    "test_gemm_CMx1/model.onnx",
+    ""
+  ],
+  [
+    "test_gemm_CMx1_transA/model.onnx",
+    ""
+  ],
+  [
+    "test_gemm_CMx1_transA_transB/model.onnx",
+    ""
+  ],
+  [
+    "test_gemm_CMxN/model.onnx",
+    ""
+  ],
+  [
+    "test_gemm_CMxN_transA/model.onnx",
+    ""
+  ],
+  [
+    "test_gemm_CMxN_transA_transB/model.onnx",
+    ""
+  ],
+  [
+    "test_gemm_CMxN_transB/model.onnx",
+    ""
+  ],
+  [
+    "test_gemm_CN/model.onnx",
+    ""
+  ],
+  [
+    "test_gemm_CN_transA/model.onnx",
+    ""
+  ],
+  [
+    "test_gemm_CN_transA_transB/model.onnx",
+    ""
+  ],
+  [
+    "test_gemm_CN_transB/model.onnx",
+    ""
+  ],
+  [
+    "test_lstm_activations/model.onnx",
+    ""
+  ],
+  [
+    "test_lstm_all_outputs/model.onnx",
+    ""
+  ],
+  [
+    "test_lstm_bidirectional/model.onnx",
+    "Unsupported LSTM direction b'bidirectional'"
+  ],
+  [
+    "test_lstm_clip/model.onnx",
+    ""
+  ],
+  [
+    "test_lstm_intermediate_h/model.onnx",
+    ""
+  ],
+  [
+    "test_lstm_missing_inputs/model.onnx",
+    ""
+  ],
+  [
+    "test_lstm_reverse/model.onnx",
+    "Unsupported LSTM direction b'reverse'"
+  ],
+  [
+    "test_lstm_seq_length/model.onnx",
+    ""
+  ],
+  [
+    "test_lstm_simple/model.onnx",
+    ""
+  ],
+  [
+    "test_lstm_with_initial_state/model.onnx",
+    ""
+  ],
+  [
+    "test_lstm_y_c/model.onnx",
+    ""
+  ],
+  [
+    "test_matmul_1x1x3x4_2x3x4x5/model.onnx",
+    ""
+  ],
+  [
+    "test_matmul_1x3x4_2x3x4x5/model.onnx",
+    ""
+  ],
+  [
+    "test_matmul_1x3x4_3x4x5/model.onnx",
+    ""
+  ],
+  [
+    "test_matmul_2x1x3x4_2x3x4x5/model.onnx",
+    ""
+  ],
+  [
+    "test_matmul_2x3_3x4/model.onnx",
+    ""
+  ],
+  [
+    "test_matmul_2x3x3x4_1x4x5/model.onnx",
+    ""
+  ],
+  [
+    "test_matmul_2x3x4_4/model.onnx",
+    ""
+  ],
+  [
+    "test_matmul_2x3x4_4x5/model.onnx",
+    ""
+  ],
+  [
+    "test_matmul_2x3x4x5_5/model.onnx",
+    ""
+  ],
+  [
+    "test_matmul_3_2x3x4/model.onnx",
+    ""
+  ],
+  [
+    "test_matmul_3_3/model.onnx",
+    ""
+  ],
+  [
+    "test_matmul_3_3x4/model.onnx",
+    ""
+  ],
+  [
+    "test_matmul_3x4_2x4x5/model.onnx",
+    ""
+  ],
+  [
+    "test_matmul_3x4_4/model.onnx",
+    ""
+  ],
+  [
+    "test_matmul_4x5x2x3_4x5x3x4/model.onnx",
+    ""
+  ],
+  [
+    "test_matmul_5x2x3_5x3x4/model.onnx",
+    ""
+  ],
+  [
+    "test_matmul_precision/model.onnx",
+    ""
+  ],
+  [
+    "test_maxpool_stride_1/model.onnx",
+    "MaxPool must have 1 input and 1 output"
+  ],
+  [
+    "test_maxpool_stride_2/model.onnx",
+    "MaxPool must have 1 input and 1 output"
+  ],
+  [
+    "test_nodes_out_of_order/model.onnx",
+    ""
+  ],
+  [
+    "test_pad_constant_default/model.onnx",
+    "Unsupported op Pad"
+  ],
+  [
+    "test_pad_constant_input/model.onnx",
+    "Unsupported op Pad"
+  ],
+  [
+    "test_pad_edge/model.onnx",
+    "Unsupported op Pad"
+  ],
+  [
+    "test_pad_edge_allaxes/model.onnx",
+    "Unsupported op Pad"
+  ],
+  [
+    "test_pad_reflect_allaxes/model.onnx",
+    "Unsupported op Pad"
+  ],
+  [
+    "test_pad_reflect_nopadding/model.onnx",
+    "Unsupported op Pad"
+  ],
+  [
+    "test_qlinearadd_int8/model.onnx",
+    "Unsupported op QLinearAdd"
+  ],
+  [
+    "test_qlinearadd_uint8/model.onnx",
+    "Unsupported op QLinearAdd"
+  ],
+  [
+    "test_qlinearmul_int8/model.onnx",
+    "Unsupported op QLinearMul"
+  ],
+  [
+    "test_qlinearmul_uint8/model.onnx",
+    "Unsupported op QLinearMul"
+  ],
+  [
+    "test_resize_downsample_sizes_linear_1D/model.onnx",
+    ""
+  ],
+  [
+    "test_resize_downsample_sizes_linear_1D_align/model.onnx",
+    ""
+  ],
+  [
+    "test_scalar_input_to_node/model.onnx",
+    ""
+  ],
+  [
+    "test_scatternd_indices_1x1x2/model.onnx",
+    "Unsupported op ScatterND"
+  ],
+  [
+    "test_scatternd_indices_1x2x2/model.onnx",
+    "Unsupported op ScatterND"
+  ],
+  [
+    "test_scatternd_indices_2x2x2/model.onnx",
+    "Unsupported op ScatterND"
+  ],
+  [
+    "test_scatternd_indices_3x2/model.onnx",
+    "Unsupported op ScatterND"
+  ],
+  [
+    "test_shape_const_out/model.onnx",
+    "Unsupported op Expand"
+  ],
+  [
+    "test_slice_end_INT64_MAX/model.onnx",
+    ""
+  ]
+]


### PR DESCRIPTION
### Motivation
- Track local operator models from `onnx2c-org/test/local_ops` alongside official ONNX test results so local coverage is visible. 
- Capture current compiler outcomes for local models as baseline expectations to detect regressions. 
- Avoid spurious failures when running local tests by auto-initializing the `onnx2c-org` submodule if needed. 
- Provide a histogram view for local-op failure modes to make error frequency easier to inspect.

### Description
- Added `LOCAL_ONNX_FILE_EXPECTATIONS_PATH` and the new `tests/local_onnx_expected_errors.json` and implemented `_load_local_onnx_file_expectations()` to load local expectations. 
- Introduced `_render_onnx_file_support_table()` and `_render_onnx_file_support_markdown()` to emit an "Local ONNX file support" section in `OFFICIAL_ONNX_FILE_SUPPORT.md`, and extended histogram rendering with `_render_support_histogram_markdown()` and a titled `_render_error_histogram_markdown()` variant. 
- Added `_maybe_init_onnx2c_org()` and `_ensure_local_onnx_files_present()` to auto-init the `onnx2c-org` submodule when needed, and added tests `test_local_onnx_files()` and `test_local_onnx_expected_errors()` to validate file lists and compiler outcomes. 
- Updated the support artifacts `OFFICIAL_ONNX_FILE_SUPPORT.md` and `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md` to include local ops results and histogram output.

### Testing
- Ran `UPDATE_REFS=1 pytest -n auto -q` which executed the full test suite and regenerated reference docs when enabled. 
- Test run result: `153 passed` (tests completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69662bd3c5508327b6526b0d94472921)