### PR TITLE
Allow scalar bias for Gemm lowering and codegen

### DIFF
--- a/src/onnx2c/codegen/c_emitter.py
+++ b/src/onnx2c/codegen/c_emitter.py
@@ -2197,6 +2197,10 @@ class CEmitter:
                 c_rank = 0
                 c_dim0 = 0
                 c_dim1 = 0
+            elif len(op.c_shape) == 0:
+                c_rank = 0
+                c_dim0 = 0
+                c_dim1 = 0
             elif len(op.c_shape) == 1:
                 c_rank = 1
                 c_dim0 = 1

--- a/src/onnx2c/lowering/gemm.py
+++ b/src/onnx2c/lowering/gemm.py
@@ -94,6 +94,8 @@ def _resolve_gemm_attrs(
 def validate_gemm_bias_shape(
     output_shape: tuple[int, int], bias_shape: tuple[int, ...], node: Node
 ) -> tuple[int, ...]:
+    if len(bias_shape) == 0:
+        return bias_shape
     if len(bias_shape) == 1:
         if bias_shape[0] != output_shape[1]:
             raise ShapeInferenceError(

--- a/templates/gemm_op.c.j2
+++ b/templates/gemm_op.c.j2
@@ -22,6 +22,8 @@ static inline void {{ op_name }}(const {{ c_type }} {{ input_a }}{{ input_a_suff
             const {{ c_type }} bias = {{ input_c }}[c_i][c_j];
             {% elif c_rank == 1 %}
             const {{ c_type }} bias = {{ input_c }}[j];
+            {% else %}
+            const {{ c_type }} bias = {{ input_c }}[0];
             {% endif %}
             {{ output }}[i][j] = acc * {{ alpha_literal }} + bias * {{ beta_literal }};
             {% else %}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -2629,7 +2629,7 @@
   ],
   [
     "node/test_gemm_default_scalar_bias/model.onnx",
-    "Gemm bias input must be rank 1 or 2, got ()"
+    ""
   ],
   [
     "node/test_gemm_default_single_elem_vector_bias/model.onnx",

--- a/tests/test_endtoend_ops.py
+++ b/tests/test_endtoend_ops.py
@@ -1412,6 +1412,15 @@ OPERATOR_CASES = [
         "opset": 13,
     },
     {
+        "name": "GemmScalarBias",
+        "op_type": "Gemm",
+        "input_shapes": [[2, 3], [3, 4], []],
+        "output_shape": [2, 4],
+        "dtype": TensorProto.FLOAT,
+        "attrs": {"beta": 0.5},
+        "opset": 13,
+    },
+    {
         "name": "GemmTransBColumnBias",
         "op_type": "Gemm",
         "input_shapes": [[2, 3], [4, 3], [2, 1]],


### PR DESCRIPTION
### Motivation
- Support Gemm nodes that provide a scalar (rank-0) bias and follow ONNX broadcast semantics.
- Resolve failing Gemm end-to-end tests which expected scalar bias inputs to be accepted.

### Description
- Treat rank-0 bias shapes as valid in `validate_gemm_bias_shape` by returning the shape for scalar biases.
- Make `CEmitter` handle `c_shape` with length 0 by mapping it to `c_rank == 0` and zeroed dims when rendering.
- Update the Gemm C template `templates/gemm_op.c.j2` to load scalar bias as `input_c[0]` when present.
- Add a `GemmScalarBias` test case in `tests/test_endtoend_ops.py` and update `tests/official_onnx_expected_errors.json` to reflect the change.

### Testing
- Ran `pytest tests/test_endtoend_ops.py -k Gemm -q`, which completed successfully with `5 passed, 94 deselected` in `4.91s`.
- The modified Gemm operator end-to-end tests now pass and the official expected errors were updated accordingly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69664c7713d0832798ae2006db60abef)