### PR TITLE
Support scalar (rank-0) Gemm bias in lowering, codegen, and docs

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 768 / 1802 official ONNX files.
+Support 769 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -665,7 +665,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_gemm_beta/model.onnx | ✅ |  |
 | node/test_gemm_default_matrix_bias/model.onnx | ✅ |  |
 | node/test_gemm_default_no_bias/model.onnx | ✅ |  |
-| node/test_gemm_default_scalar_bias/model.onnx | ❌ | Gemm bias input must be rank 1 or 2, got () |
+| node/test_gemm_default_scalar_bias/model.onnx | ✅ |  |
 | node/test_gemm_default_single_elem_vector_bias/model.onnx | ❌ | Gemm bias input must be broadcastable to output shape, got (1,) vs (3, 3) |
 | node/test_gemm_default_vector_bias/model.onnx | ✅ |  |
 | node/test_gemm_default_zero_bias/model.onnx | ✅ |  |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -139,7 +139,6 @@
 | Unsupported op Celu | 1 | █ |
 | Graph must contain at least one node | 1 | █ |
 | Dropout mask output is not supported | 1 | █ |
-| Gemm bias input must be rank 1 or 2, got () | 1 | █ |
 | Gemm bias input must be broadcastable to output shape, got (1,) vs (3, 3) | 1 | █ |
 | Unsupported op HardSwish | 1 | █ |
 | Unsupported op If | 1 | █ |

--- a/src/onnx2c/codegen/c_emitter.py
+++ b/src/onnx2c/codegen/c_emitter.py
@@ -2197,6 +2197,10 @@ class CEmitter:
                 c_rank = 0
                 c_dim0 = 0
                 c_dim1 = 0
+            elif len(op.c_shape) == 0:
+                c_rank = 0
+                c_dim0 = 0
+                c_dim1 = 0
             elif len(op.c_shape) == 1:
                 c_rank = 1
                 c_dim0 = 1

--- a/src/onnx2c/lowering/gemm.py
+++ b/src/onnx2c/lowering/gemm.py
@@ -94,6 +94,8 @@ def _resolve_gemm_attrs(
 def validate_gemm_bias_shape(
     output_shape: tuple[int, int], bias_shape: tuple[int, ...], node: Node
 ) -> tuple[int, ...]:
+    if len(bias_shape) == 0:
+        return bias_shape
     if len(bias_shape) == 1:
         if bias_shape[0] != output_shape[1]:
             raise ShapeInferenceError(

--- a/templates/gemm_op.c.j2
+++ b/templates/gemm_op.c.j2
@@ -22,6 +22,8 @@ static inline void {{ op_name }}(const {{ c_type }} {{ input_a }}{{ input_a_suff
             const {{ c_type }} bias = {{ input_c }}[c_i][c_j];
             {% elif c_rank == 1 %}
             const {{ c_type }} bias = {{ input_c }}[j];
+            {% else %}
+            const {{ c_type }} bias = {{ input_c }}[0];
             {% endif %}
             {{ output }}[i][j] = acc * {{ alpha_literal }} + bias * {{ beta_literal }};
             {% else %}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -2629,7 +2629,7 @@
   ],
   [
     "node/test_gemm_default_scalar_bias/model.onnx",
-    "Gemm bias input must be rank 1 or 2, got ()"
+    ""
   ],
   [
     "node/test_gemm_default_single_elem_vector_bias/model.onnx",

--- a/tests/test_endtoend_ops.py
+++ b/tests/test_endtoend_ops.py
@@ -1412,6 +1412,15 @@ OPERATOR_CASES = [
         "opset": 13,
     },
     {
+        "name": "GemmScalarBias",
+        "op_type": "Gemm",
+        "input_shapes": [[2, 3], [3, 4], []],
+        "output_shape": [2, 4],
+        "dtype": TensorProto.FLOAT,
+        "attrs": {"beta": 0.5},
+        "opset": 13,
+    },
+    {
         "name": "GemmTransBColumnBias",
         "op_type": "Gemm",
         "input_shapes": [[2, 3], [4, 3], [2, 1]],


### PR DESCRIPTION
### Motivation
- Allow Gemm nodes that provide a scalar (rank-0) bias to be accepted according to ONNX broadcasting semantics.
- Fix failing Gemm end-to-end cases that previously rejected scalar bias inputs as invalid shapes.
- Ensure generated C code correctly reads a scalar bias when present so runtime behavior matches shape validation.
- Update the official ONNX support tables and expected-errors references to reflect the resolved case.

### Description
- Treat rank-0 bias shapes as valid in `validate_gemm_bias_shape` by returning the shape for scalar biases instead of raising an error.
- Make `CEmitter` map an empty `c_shape` (length 0) to `c_rank == 0` with zeroed dims for downstream template rendering.
- Update the Gemm C template `templates/gemm_op.c.j2` to load a scalar bias as `input_c[0]` when `c_rank == 0`.
- Add a `GemmScalarBias` case in `tests/test_endtoend_ops.py` and update `tests/official_onnx_expected_errors.json` plus the official support docs to mark the scalar-bias model as supported.

### Testing
- Ran the full test suite with `UPDATE_REFS=1 pytest -n auto -q`, which completed successfully with `154 passed`.
- The updated end-to-end Gemm behavior is covered by the added `GemmScalarBias` case in `tests/test_endtoend_ops.py` and the official references were refreshed accordingly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69664c7713d0832798ae2006db60abef)