### PR TITLE
codegen: integrate scalar function generator

### DIFF
--- a/src/onnx2c/codegen/c_emitter.py
+++ b/src/onnx2c/codegen/c_emitter.py
@@ -7,6 +7,13 @@ from jinja2 import Environment, FileSystemLoader, Template, select_autoescape
 
 from ..errors import CodegenError
 from ..dtypes import dtype_info
+from ..ops import COMPARE_OP_TYPES
+from shared.scalar_functions import (
+    ScalarFunction,
+    ScalarFunctionKey,
+    ScalarFunctionRegistry,
+)
+from shared.scalar_types import ScalarFunctionError, ScalarType
 
 
 def _format_c_indentation(source: str, *, indent: str = "    ") -> str:
@@ -27,6 +34,48 @@ def _format_c_indentation(source: str, *, indent: str = "    ") -> str:
         indent_level += open_count - close_count
         indent_level = max(indent_level, 0)
     return "\n".join(formatted_lines)
+
+
+_SCALAR_TYPE_BY_DTYPE: dict[str, ScalarType] = {
+    "float": ScalarType.F32,
+    "double": ScalarType.F64,
+    "int8": ScalarType.I8,
+    "int16": ScalarType.I16,
+    "int32": ScalarType.I32,
+    "int64": ScalarType.I64,
+    "uint8": ScalarType.U8,
+    "uint16": ScalarType.U16,
+    "uint32": ScalarType.U32,
+    "uint64": ScalarType.U64,
+    "bool": ScalarType.BOOL,
+}
+
+_SCALAR_FUNCTION_BY_ONNX_OP: dict[str, ScalarFunction] = {
+    "Abs": ScalarFunction.ABS,
+    "Add": ScalarFunction.ADD,
+    "And": ScalarFunction.LOGICAL_AND,
+    "Atanh": ScalarFunction.ATANH,
+    "Ceil": ScalarFunction.CEIL,
+    "Cos": ScalarFunction.COS,
+    "Div": ScalarFunction.DIV,
+    "Exp": ScalarFunction.EXP,
+    "Floor": ScalarFunction.FLOOR,
+    "Log": ScalarFunction.LOG,
+    "Mod": ScalarFunction.FMOD,
+    "Mul": ScalarFunction.MUL,
+    "Neg": ScalarFunction.NEG,
+    "Not": ScalarFunction.LOGICAL_NOT,
+    "Or": ScalarFunction.LOGICAL_OR,
+    "Pow": ScalarFunction.POW,
+    "Relu": ScalarFunction.RELU,
+    "Sin": ScalarFunction.SIN,
+    "Sqrt": ScalarFunction.SQRT,
+    "Sub": ScalarFunction.SUB,
+    "Sum": ScalarFunction.ADD,
+    "Tan": ScalarFunction.TAN,
+    "Tanh": ScalarFunction.TANH,
+    "Xor": ScalarFunction.LOGICAL_XOR,
+}
 
 
 @dataclass(frozen=True)
@@ -627,6 +676,7 @@ class CEmitter:
 
     def emit_model(self, model: LoweredModel, *, emit_testbench: bool = False) -> str:
         templates = self._load_templates(emit_testbench)
+        scalar_registry = ScalarFunctionRegistry()
         binary_template = templates["binary"]
         where_template = templates["where"]
         unary_template = templates["unary"]
@@ -700,6 +750,7 @@ class CEmitter:
                 constant_of_shape_template=constant_of_shape_template,
                 shape_template=shape_template,
                 size_template=size_template,
+                scalar_registry=scalar_registry,
             )
             for index, op in enumerate(resolved_ops)
         )
@@ -708,13 +759,31 @@ class CEmitter:
             resolved_ops,
             tuple(temp_buffers.values()),
         )
-        includes = self._collect_includes(
-            model, resolved_ops, emit_testbench=emit_testbench
+        scalar_functions = scalar_registry.render()
+        scalar_include_lines = (
+            scalar_registry.include_lines() if scalar_functions else []
         )
-        sections = [self._emit_header_comment(model.header), "", *includes, ""]
+        scalar_includes = {
+            line for line in scalar_include_lines if line.startswith("#include ")
+        }
+        scalar_preamble = [
+            line for line in scalar_include_lines if not line.startswith("#include ")
+        ]
+        includes = self._collect_includes(
+            model,
+            resolved_ops,
+            emit_testbench=emit_testbench,
+            extra_includes=scalar_includes,
+        )
+        sections = [self._emit_header_comment(model.header), "", *includes]
+        if scalar_preamble:
+            sections.extend(("", *scalar_preamble))
+        sections.append("")
         constants_section = self._emit_constant_definitions(model.constants)
         if constants_section:
             sections.extend((constants_section.rstrip(), ""))
+        if scalar_functions:
+            sections.extend(("\n".join(scalar_functions), ""))
         sections.extend(
             (
                 operator_fns.rstrip(),
@@ -734,6 +803,7 @@ class CEmitter:
         self, model: LoweredModel, *, emit_testbench: bool = False
     ) -> tuple[str, str]:
         templates = self._load_templates(emit_testbench)
+        scalar_registry = ScalarFunctionRegistry()
         binary_template = templates["binary"]
         where_template = templates["where"]
         unary_template = templates["unary"]
@@ -807,6 +877,7 @@ class CEmitter:
                 constant_of_shape_template=constant_of_shape_template,
                 shape_template=shape_template,
                 size_template=size_template,
+                scalar_registry=scalar_registry,
             )
             for index, op in enumerate(resolved_ops)
         )
@@ -815,13 +886,31 @@ class CEmitter:
             resolved_ops,
             tuple(temp_buffers.values()),
         )
-        includes = self._collect_includes(
-            model, resolved_ops, emit_testbench=emit_testbench
+        scalar_functions = scalar_registry.render()
+        scalar_include_lines = (
+            scalar_registry.include_lines() if scalar_functions else []
         )
-        sections = [self._emit_header_comment(model.header), "", *includes, ""]
+        scalar_includes = {
+            line for line in scalar_include_lines if line.startswith("#include ")
+        }
+        scalar_preamble = [
+            line for line in scalar_include_lines if not line.startswith("#include ")
+        ]
+        includes = self._collect_includes(
+            model,
+            resolved_ops,
+            emit_testbench=emit_testbench,
+            extra_includes=scalar_includes,
+        )
+        sections = [self._emit_header_comment(model.header), "", *includes]
+        if scalar_preamble:
+            sections.extend(("", *scalar_preamble))
+        sections.append("")
         constants_section = self._emit_constant_declarations(model.constants)
         if constants_section:
             sections.extend((constants_section.rstrip(), ""))
+        if scalar_functions:
+            sections.extend(("\n".join(scalar_functions), ""))
         sections.extend(
             (
                 operator_fns.rstrip(),
@@ -961,6 +1050,39 @@ class CEmitter:
         return includes
 
     @staticmethod
+    def _scalar_function_name(
+        op_type: str,
+        dtype: str,
+        registry: ScalarFunctionRegistry,
+    ) -> str | None:
+        scalar_type = _SCALAR_TYPE_BY_DTYPE.get(dtype)
+        if scalar_type is None:
+            return None
+        if op_type in {"Max", "Min"}:
+            if scalar_type in {ScalarType.F32, ScalarType.F64}:
+                scalar_function = (
+                    ScalarFunction.FMAX
+                    if op_type == "Max"
+                    else ScalarFunction.FMIN
+                )
+            else:
+                scalar_function = (
+                    ScalarFunction.MAXIMUM
+                    if op_type == "Max"
+                    else ScalarFunction.MINIMUM
+                )
+        else:
+            scalar_function = _SCALAR_FUNCTION_BY_ONNX_OP.get(op_type)
+        if scalar_function is None:
+            return None
+        try:
+            return registry.request(
+                ScalarFunctionKey(function=scalar_function, return_type=scalar_type)
+            )
+        except ScalarFunctionError:
+            return None
+
+    @staticmethod
     def _collect_includes(
         model: LoweredModel,
         resolved_ops: list[
@@ -994,10 +1116,13 @@ class CEmitter:
         ],
         *,
         emit_testbench: bool,
+        extra_includes: set[str] | None = None,
     ) -> list[str]:
         includes: set[str] = {"#include <stddef.h>"}
         if emit_testbench:
             includes.update({"#include <stdio.h>", "#include <stdint.h>"})
+        if extra_includes:
+            includes.update(extra_includes)
         constant_of_shape_inputs = {
             op.input_dtype
             for op in resolved_ops
@@ -1057,6 +1182,7 @@ class CEmitter:
             "#include <stdbool.h>",
             "#include <stdlib.h>",
             "#include <math.h>",
+            "#include <float.h>",
             "#include <limits.h>",
             "#include <string.h>",
         )
@@ -2072,13 +2198,23 @@ class CEmitter:
         constant_of_shape_template,
         shape_template,
         size_template,
+        scalar_registry: ScalarFunctionRegistry | None = None,
     ) -> str:
-        node_comment = CEmitter._emit_node_comment(model.node_infos[index], index)
+        node_info = model.node_infos[index]
+        node_comment = CEmitter._emit_node_comment(node_info, index)
 
         def with_node_comment(rendered: str) -> str:
             return f"{node_comment}\n{_format_c_indentation(rendered)}"
 
         if isinstance(op, BinaryOp):
+            scalar_operator = None
+            if (
+                scalar_registry is not None
+                and node_info.op_type not in COMPARE_OP_TYPES
+            ):
+                scalar_operator = self._scalar_function_name(
+                    node_info.op_type, op.input_dtype, scalar_registry
+                )
             shape = CEmitter._codegen_shape(op.shape)
             loop_vars = CEmitter._loop_vars(shape)
             array_suffix = self._param_array_suffix(shape)
@@ -2102,7 +2238,12 @@ class CEmitter:
                 f"[{var}]" for var in loop_vars
             )
             operator_expr = None
-            if op.operator_kind == "expr":
+            operator = op.operator
+            operator_kind = op.operator_kind
+            if scalar_operator is not None:
+                operator = scalar_operator
+                operator_kind = "func"
+            if operator_kind == "expr":
                 operator_expr = op.operator.format(
                     left=left_expr, right=right_expr
                 )
@@ -2111,8 +2252,8 @@ class CEmitter:
                 input0=op.input0,
                 input1=op.input1,
                 output=op.output,
-                operator=op.operator,
-                operator_kind=op.operator_kind,
+                operator=operator,
+                operator_kind=operator_kind,
                 left_expr=left_expr,
                 right_expr=right_expr,
                 operator_expr=operator_expr,
@@ -3209,6 +3350,11 @@ class CEmitter:
             ).rstrip()
             return with_node_comment(rendered)
         if isinstance(op, UnaryOp):
+            scalar_operator = None
+            if scalar_registry is not None:
+                scalar_operator = self._scalar_function_name(
+                    node_info.op_type, op.dtype, scalar_registry
+                )
             shape = CEmitter._codegen_shape(op.shape)
             loop_vars = CEmitter._loop_vars(shape)
             array_suffix = self._param_array_suffix(shape)
@@ -3226,7 +3372,7 @@ class CEmitter:
                 **common,
                 input0=op.input0,
                 output=op.output,
-                operator=op.operator,
+                operator=scalar_operator or op.operator,
             ).rstrip()
             return with_node_comment(rendered)
         raise CodegenError(f"Unsupported op for rendering: {type(op).__name__}")

--- a/tests/golden/add_initializer_model.c
+++ b/tests/golden/add_initializer_model.c
@@ -20,10 +20,23 @@
  */
 
 #include <stddef.h>
+#include <math.h>
+#include <float.h>
+
+#ifndef REF_PI_F
+#define REF_PI_F 3.14159265358979323846f
+#endif
+#ifndef REF_PI_D
+#define REF_PI_D 3.14159265358979323846
+#endif
 
 static const float weight[2][3] = {
     0.100000001f, 0.200000003f, 0.300000012f, 0.400000006f, 0.5f, 0.600000024f
 };
+
+static inline float ref_scalar_f32_add(float a, float b) {
+    return a + b;
+}
 
 /*
  * Node 0:
@@ -35,7 +48,7 @@ static const float weight[2][3] = {
 static inline void model_op0(const float in0[restrict 2][3], const float weight[restrict 2][3], float out[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            out[i0][i1] = in0[i0][i1] + weight[i0][i1];
+            out[i0][i1] = ref_scalar_f32_add(in0[i0][i1], weight[i0][i1]);
         }
     }
 }

--- a/tests/golden/add_model.c
+++ b/tests/golden/add_model.c
@@ -20,6 +20,19 @@
  */
 
 #include <stddef.h>
+#include <math.h>
+#include <float.h>
+
+#ifndef REF_PI_F
+#define REF_PI_F 3.14159265358979323846f
+#endif
+#ifndef REF_PI_D
+#define REF_PI_D 3.14159265358979323846
+#endif
+
+static inline float ref_scalar_f32_add(float a, float b) {
+    return a + b;
+}
 
 /*
  * Node 0:
@@ -32,7 +45,7 @@ static inline void model_op0(const float a[restrict 2][3][4], const float b[rest
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
-                out[i0][i1][i2] = a[i0][i1][i2] + b[i0][i1][i2];
+                out[i0][i1][i2] = ref_scalar_f32_add(a[i0][i1][i2], b[i0][i1][i2]);
             }
         }
     }

--- a/tests/golden/add_model_no_restrict.c
+++ b/tests/golden/add_model_no_restrict.c
@@ -20,6 +20,19 @@
  */
 
 #include <stddef.h>
+#include <math.h>
+#include <float.h>
+
+#ifndef REF_PI_F
+#define REF_PI_F 3.14159265358979323846f
+#endif
+#ifndef REF_PI_D
+#define REF_PI_D 3.14159265358979323846
+#endif
+
+static inline float ref_scalar_f32_add(float a, float b) {
+    return a + b;
+}
 
 /*
  * Node 0:
@@ -32,7 +45,7 @@ static inline void model_op0(const float a[2][3][4], const float b[2][3][4], flo
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
-                out[i0][i1][i2] = a[i0][i1][i2] + b[i0][i1][i2];
+                out[i0][i1][i2] = ref_scalar_f32_add(a[i0][i1][i2], b[i0][i1][i2]);
             }
         }
     }

--- a/tests/golden/add_model_testbench.c
+++ b/tests/golden/add_model_testbench.c
@@ -22,6 +22,19 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <math.h>
+#include <float.h>
+
+#ifndef REF_PI_F
+#define REF_PI_F 3.14159265358979323846f
+#endif
+#ifndef REF_PI_D
+#define REF_PI_D 3.14159265358979323846
+#endif
+
+static inline float ref_scalar_f32_add(float a, float b) {
+    return a + b;
+}
 
 /*
  * Node 0:
@@ -34,7 +47,7 @@ static inline void model_op0(const float a[restrict 2][3][4], const float b[rest
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
-                out[i0][i1][i2] = a[i0][i1][i2] + b[i0][i1][i2];
+                out[i0][i1][i2] = ref_scalar_f32_add(a[i0][i1][i2], b[i0][i1][i2]);
             }
         }
     }

--- a/tests/golden/mul_add_model.c
+++ b/tests/golden/mul_add_model.c
@@ -20,6 +20,23 @@
  */
 
 #include <stddef.h>
+#include <math.h>
+#include <float.h>
+
+#ifndef REF_PI_F
+#define REF_PI_F 3.14159265358979323846f
+#endif
+#ifndef REF_PI_D
+#define REF_PI_D 3.14159265358979323846
+#endif
+
+static inline float ref_scalar_f32_mul(float a, float b) {
+    return a * b;
+}
+
+static inline float ref_scalar_f32_add(float a, float b) {
+    return a + b;
+}
 
 /*
  * Node 0:
@@ -31,7 +48,7 @@
 static inline void model_op0(const float a[restrict 2][3], const float b[restrict 2][3], float tmp[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            tmp[i0][i1] = a[i0][i1] * b[i0][i1];
+            tmp[i0][i1] = ref_scalar_f32_mul(a[i0][i1], b[i0][i1]);
         }
     }
 }
@@ -46,7 +63,7 @@ static inline void model_op0(const float a[restrict 2][3], const float b[restric
 static inline void model_op1(const float tmp[restrict 2][3], const float c[restrict 2][3], float out[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            out[i0][i1] = tmp[i0][i1] + c[i0][i1];
+            out[i0][i1] = ref_scalar_f32_add(tmp[i0][i1], c[i0][i1]);
         }
     }
 }

--- a/tests/golden/mul_add_relu_model.c
+++ b/tests/golden/mul_add_relu_model.c
@@ -20,6 +20,27 @@
  */
 
 #include <stddef.h>
+#include <math.h>
+#include <float.h>
+
+#ifndef REF_PI_F
+#define REF_PI_F 3.14159265358979323846f
+#endif
+#ifndef REF_PI_D
+#define REF_PI_D 3.14159265358979323846
+#endif
+
+static inline float ref_scalar_f32_mul(float a, float b) {
+    return a * b;
+}
+
+static inline float ref_scalar_f32_add(float a, float b) {
+    return a + b;
+}
+
+static inline float ref_scalar_f32_relu(float a) {
+    return a > 0.0f ? a : 0.0f;
+}
 
 /*
  * Node 0:
@@ -31,7 +52,7 @@
 static inline void model_op0(const float a[restrict 2][3], const float b[restrict 2][3], float tmp0[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            tmp0[i0][i1] = a[i0][i1] * b[i0][i1];
+            tmp0[i0][i1] = ref_scalar_f32_mul(a[i0][i1], b[i0][i1]);
         }
     }
 }
@@ -46,7 +67,7 @@ static inline void model_op0(const float a[restrict 2][3], const float b[restric
 static inline void model_op1(const float tmp0[restrict 2][3], const float c[restrict 2][3], float tmp1[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            tmp1[i0][i1] = tmp0[i0][i1] + c[i0][i1];
+            tmp1[i0][i1] = ref_scalar_f32_add(tmp0[i0][i1], c[i0][i1]);
         }
     }
 }
@@ -61,7 +82,7 @@ static inline void model_op1(const float tmp0[restrict 2][3], const float c[rest
 static inline void model_op2(const float tmp1[restrict 2][3], float out[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            out[i0][i1] = tmp1[i0][i1] > 0.0f ? tmp1[i0][i1] : 0.0f;
+            out[i0][i1] = ref_scalar_f32_relu(tmp1[i0][i1]);
         }
     }
 }

--- a/tests/golden/mul_model.c
+++ b/tests/golden/mul_model.c
@@ -20,6 +20,19 @@
  */
 
 #include <stddef.h>
+#include <math.h>
+#include <float.h>
+
+#ifndef REF_PI_F
+#define REF_PI_F 3.14159265358979323846f
+#endif
+#ifndef REF_PI_D
+#define REF_PI_D 3.14159265358979323846
+#endif
+
+static inline float ref_scalar_f32_mul(float a, float b) {
+    return a * b;
+}
 
 /*
  * Node 0:
@@ -31,7 +44,7 @@
 static inline void model_op0(const float a[restrict 2][3], const float b[restrict 2][3], float out[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            out[i0][i1] = a[i0][i1] * b[i0][i1];
+            out[i0][i1] = ref_scalar_f32_mul(a[i0][i1], b[i0][i1]);
         }
     }
 }

--- a/tests/golden/relu_model.c
+++ b/tests/golden/relu_model.c
@@ -20,6 +20,19 @@
  */
 
 #include <stddef.h>
+#include <math.h>
+#include <float.h>
+
+#ifndef REF_PI_F
+#define REF_PI_F 3.14159265358979323846f
+#endif
+#ifndef REF_PI_D
+#define REF_PI_D 3.14159265358979323846
+#endif
+
+static inline float ref_scalar_f32_relu(float a) {
+    return a > 0.0f ? a : 0.0f;
+}
 
 /*
  * Node 0:
@@ -31,7 +44,7 @@
 static inline void model_op0(const float x[restrict 2][3], float out[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            out[i0][i1] = x[i0][i1] > 0.0f ? x[i0][i1] : 0.0f;
+            out[i0][i1] = ref_scalar_f32_relu(x[i0][i1]);
         }
     }
 }

--- a/tests/golden/tanh_model.c
+++ b/tests/golden/tanh_model.c
@@ -21,6 +21,18 @@
 
 #include <stddef.h>
 #include <math.h>
+#include <float.h>
+
+#ifndef REF_PI_F
+#define REF_PI_F 3.14159265358979323846f
+#endif
+#ifndef REF_PI_D
+#define REF_PI_D 3.14159265358979323846
+#endif
+
+static inline float ref_scalar_f32_tanh(float a) {
+    return tanhf(a);
+}
 
 /*
  * Node 0:
@@ -32,7 +44,7 @@
 static inline void model_op0(const float x[restrict 2][3], float out[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            out[i0][i1] = tanhf(x[i0][i1]);
+            out[i0][i1] = ref_scalar_f32_tanh(x[i0][i1]);
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Reuse the shared scalar function generator to centralize scalar helper implementations and avoid duplicating logic in the C emitter.
- Allow the C code generator to emit small, deterministic scalar helper functions (and their includes/preamble) and call them for elementwise unary/binary ops.
- Keep changes minimal to the copied classes while wiring the registry into the emitter pipeline.
- Ensure generated C remains deterministic and includes any math/float headers required by emitted scalar helpers.

### Description
- Imported `shared.scalar_functions` and `shared.scalar_types` into the C emitter and added mappings from ONNX dtypes/ops to the shared `ScalarFunction` enums.
- Created a `ScalarFunctionRegistry` per emission and wired it into `_render_op` so unary and binary ops may use generated scalar helper function names via `_scalar_function_name`.
- Collected scalar-generated includes/preamble and appended the rendered scalar function definitions into emitted C output via `emit_model` and `emit_model_with_data_file`.
- Updated golden outputs to reflect use of scalar helper functions for elementwise ops (several files under `tests/golden/`).

### Testing
- Ran the full test suite with reference updates using `UPDATE_REFS=1 pytest -n auto -q`, which completed successfully: `154 passed in 29.98s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69665a38029c83258a46fcdddf7d44e2)