### PR TITLE
codegen: track loss op input metadata

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 699 / 1802 official ONNX files.
+Support 785 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -997,41 +997,41 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_neg/model.onnx | ✅ |  |
 | node/test_neg_example/model.onnx | ✅ |  |
 | node/test_nesterov_momentum/model.onnx | ❌ | Unsupported op Momentum |
-| node/test_nllloss_NC/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
+| node/test_nllloss_NC/model.onnx | ✅ |  |
 | node/test_nllloss_NC_expanded/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
+| node/test_nllloss_NCd1/model.onnx | ✅ |  |
 | node/test_nllloss_NCd1_expanded/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1_ii/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
+| node/test_nllloss_NCd1_ii/model.onnx | ✅ |  |
 | node/test_nllloss_NCd1_ii_expanded/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1_mean_weight_negative_ii/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
+| node/test_nllloss_NCd1_mean_weight_negative_ii/model.onnx | ✅ |  |
 | node/test_nllloss_NCd1_mean_weight_negative_ii_expanded/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1_weight/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
+| node/test_nllloss_NCd1_weight/model.onnx | ✅ |  |
 | node/test_nllloss_NCd1_weight_expanded/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1_weight_ii/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
+| node/test_nllloss_NCd1_weight_ii/model.onnx | ✅ |  |
 | node/test_nllloss_NCd1_weight_ii_expanded/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
+| node/test_nllloss_NCd1d2/model.onnx | ✅ |  |
 | node/test_nllloss_NCd1d2_expanded/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2_no_weight_reduction_mean_ii/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
+| node/test_nllloss_NCd1d2_no_weight_reduction_mean_ii/model.onnx | ✅ |  |
 | node/test_nllloss_NCd1d2_no_weight_reduction_mean_ii_expanded/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2_reduction_mean/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
+| node/test_nllloss_NCd1d2_reduction_mean/model.onnx | ✅ |  |
 | node/test_nllloss_NCd1d2_reduction_mean_expanded/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2_reduction_sum/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
+| node/test_nllloss_NCd1d2_reduction_sum/model.onnx | ✅ |  |
 | node/test_nllloss_NCd1d2_reduction_sum_expanded/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2_with_weight/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
+| node/test_nllloss_NCd1d2_with_weight/model.onnx | ✅ |  |
 | node/test_nllloss_NCd1d2_with_weight_expanded/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2_with_weight_reduction_mean/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
+| node/test_nllloss_NCd1d2_with_weight_reduction_mean/model.onnx | ✅ |  |
 | node/test_nllloss_NCd1d2_with_weight_reduction_mean_expanded/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2_with_weight_reduction_sum/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
+| node/test_nllloss_NCd1d2_with_weight_reduction_sum/model.onnx | ✅ |  |
 | node/test_nllloss_NCd1d2_with_weight_reduction_sum_expanded/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2_with_weight_reduction_sum_ii/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
+| node/test_nllloss_NCd1d2_with_weight_reduction_sum_ii/model.onnx | ✅ |  |
 | node/test_nllloss_NCd1d2_with_weight_reduction_sum_ii_expanded/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2d3_none_no_weight_negative_ii/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
+| node/test_nllloss_NCd1d2d3_none_no_weight_negative_ii/model.onnx | ✅ |  |
 | node/test_nllloss_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2d3_sum_weight_high_ii/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
+| node/test_nllloss_NCd1d2d3_sum_weight_high_ii/model.onnx | ✅ |  |
 | node/test_nllloss_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2d3d4d5_mean_weight/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
+| node/test_nllloss_NCd1d2d3d4d5_mean_weight/model.onnx | ✅ |  |
 | node/test_nllloss_NCd1d2d3d4d5_mean_weight_expanded/model.onnx | ✅ |  |
-| node/test_nllloss_NCd1d2d3d4d5_none_no_weight/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
+| node/test_nllloss_NCd1d2d3d4d5_none_no_weight/model.onnx | ✅ |  |
 | node/test_nllloss_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx | ✅ |  |
 | node/test_nonmaxsuppression_center_point_box_format/model.onnx | ❌ | Unsupported op NonMaxSuppression |
 | node/test_nonmaxsuppression_flipped_coordinates/model.onnx | ❌ | Unsupported op NonMaxSuppression |
@@ -1375,74 +1375,74 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_scatternd_max/model.onnx | ❌ | Unsupported op ScatterND |
 | node/test_scatternd_min/model.onnx | ❌ | Unsupported op ScatterND |
 | node/test_scatternd_multiply/model.onnx | ❌ | Unsupported op ScatterND |
-| node/test_sce_NCd1_mean_weight_negative_ii/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_NCd1d2d3_none_no_weight_negative_ii/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_NCd1d2d3_sum_weight_high_ii/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_3d/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_3d_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_3d_log_prob/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_3d_log_prob_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_log_prob/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_log_prob_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_no_weight_ii/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_no_weight_ii_3d/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_no_weight_ii_3d_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_no_weight_ii_3d_log_prob/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_no_weight_ii_4d/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_no_weight_ii_4d_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_no_weight_ii_4d_log_prob/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_no_weight_ii_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_no_weight_ii_log_prob/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_weight/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_weight_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_weight_ii/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_weight_ii_3d/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_weight_ii_3d_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_weight_ii_3d_log_prob/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_weight_ii_4d/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_weight_ii_4d_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_weight_ii_4d_log_prob/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_weight_ii_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_weight_ii_log_prob/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_weight_log_prob/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_mean_weight_log_prob_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_none/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_none_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_none_log_prob/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_none_log_prob_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_none_weights/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_none_weights_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_none_weights_log_prob/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_none_weights_log_prob_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_sum/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_sum_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_sum_log_prob/model.onnx | ❌ | 'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype' |
-| node/test_sce_sum_log_prob_expanded/model.onnx | ❌ | 'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype' |
+| node/test_sce_NCd1_mean_weight_negative_ii/model.onnx | ✅ |  |
+| node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx | ✅ |  |
+| node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx | ✅ |  |
+| node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx | ✅ |  |
+| node/test_sce_NCd1d2d3_none_no_weight_negative_ii/model.onnx | ✅ |  |
+| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx | ✅ |  |
+| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob/model.onnx | ✅ |  |
+| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx | ✅ |  |
+| node/test_sce_NCd1d2d3_sum_weight_high_ii/model.onnx | ✅ |  |
+| node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx | ✅ |  |
+| node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob/model.onnx | ✅ |  |
+| node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx | ✅ |  |
+| node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx | ✅ |  |
+| node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx | ✅ |  |
+| node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx | ✅ |  |
+| node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx | ✅ |  |
+| node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx | ✅ |  |
+| node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx | ✅ |  |
+| node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx | ✅ |  |
+| node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx | ✅ |  |
+| node/test_sce_mean/model.onnx | ✅ |  |
+| node/test_sce_mean_3d/model.onnx | ✅ |  |
+| node/test_sce_mean_3d_expanded/model.onnx | ✅ |  |
+| node/test_sce_mean_3d_log_prob/model.onnx | ✅ |  |
+| node/test_sce_mean_3d_log_prob_expanded/model.onnx | ✅ |  |
+| node/test_sce_mean_expanded/model.onnx | ✅ |  |
+| node/test_sce_mean_log_prob/model.onnx | ✅ |  |
+| node/test_sce_mean_log_prob_expanded/model.onnx | ✅ |  |
+| node/test_sce_mean_no_weight_ii/model.onnx | ✅ |  |
+| node/test_sce_mean_no_weight_ii_3d/model.onnx | ✅ |  |
+| node/test_sce_mean_no_weight_ii_3d_expanded/model.onnx | ✅ |  |
+| node/test_sce_mean_no_weight_ii_3d_log_prob/model.onnx | ✅ |  |
+| node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx | ✅ |  |
+| node/test_sce_mean_no_weight_ii_4d/model.onnx | ✅ |  |
+| node/test_sce_mean_no_weight_ii_4d_expanded/model.onnx | ✅ |  |
+| node/test_sce_mean_no_weight_ii_4d_log_prob/model.onnx | ✅ |  |
+| node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx | ✅ |  |
+| node/test_sce_mean_no_weight_ii_expanded/model.onnx | ✅ |  |
+| node/test_sce_mean_no_weight_ii_log_prob/model.onnx | ✅ |  |
+| node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx | ✅ |  |
+| node/test_sce_mean_weight/model.onnx | ✅ |  |
+| node/test_sce_mean_weight_expanded/model.onnx | ✅ |  |
+| node/test_sce_mean_weight_ii/model.onnx | ✅ |  |
+| node/test_sce_mean_weight_ii_3d/model.onnx | ✅ |  |
+| node/test_sce_mean_weight_ii_3d_expanded/model.onnx | ✅ |  |
+| node/test_sce_mean_weight_ii_3d_log_prob/model.onnx | ✅ |  |
+| node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx | ✅ |  |
+| node/test_sce_mean_weight_ii_4d/model.onnx | ✅ |  |
+| node/test_sce_mean_weight_ii_4d_expanded/model.onnx | ✅ |  |
+| node/test_sce_mean_weight_ii_4d_log_prob/model.onnx | ✅ |  |
+| node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx | ✅ |  |
+| node/test_sce_mean_weight_ii_expanded/model.onnx | ✅ |  |
+| node/test_sce_mean_weight_ii_log_prob/model.onnx | ✅ |  |
+| node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx | ✅ |  |
+| node/test_sce_mean_weight_log_prob/model.onnx | ✅ |  |
+| node/test_sce_mean_weight_log_prob_expanded/model.onnx | ✅ |  |
+| node/test_sce_none/model.onnx | ✅ |  |
+| node/test_sce_none_expanded/model.onnx | ✅ |  |
+| node/test_sce_none_log_prob/model.onnx | ✅ |  |
+| node/test_sce_none_log_prob_expanded/model.onnx | ✅ |  |
+| node/test_sce_none_weights/model.onnx | ✅ |  |
+| node/test_sce_none_weights_expanded/model.onnx | ✅ |  |
+| node/test_sce_none_weights_log_prob/model.onnx | ✅ |  |
+| node/test_sce_none_weights_log_prob_expanded/model.onnx | ✅ |  |
+| node/test_sce_sum/model.onnx | ✅ |  |
+| node/test_sce_sum_expanded/model.onnx | ✅ |  |
+| node/test_sce_sum_log_prob/model.onnx | ✅ |  |
+| node/test_sce_sum_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_selu/model.onnx | ❌ | Unsupported op Selu |
 | node/test_selu_default/model.onnx | ❌ | Unsupported op Selu |
 | node/test_selu_default_expanded_ver18/model.onnx | ✅ |  |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -3,7 +3,6 @@
 | Error message | Count | Histogram |
 | --- | --- | --- |
 | Dynamic dim for tensor '*' | 130 | ██████████████████████████████ |
-| '*' object has no attribute '*' | 86 | ████████████████████ |
 | Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 34 | ████████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████ |
 | Dynamic or zero dims are not supported | 26 | ██████ |

--- a/src/onnx2c/codegen/c_emitter.py
+++ b/src/onnx2c/codegen/c_emitter.py
@@ -343,6 +343,9 @@ class NegativeLogLikelihoodLossOp:
     d: int
     reduction: str
     ignore_index: int
+    input_dtype: ScalarType
+    weight_dtype: ScalarType | None
+    weight_shape: tuple[int, ...] | None
     dtype: ScalarType
     target_dtype: ScalarType
 
@@ -363,6 +366,9 @@ class SoftmaxCrossEntropyLossOp:
     d: int
     reduction: str
     ignore_index: int | None
+    input_dtype: ScalarType
+    weight_dtype: ScalarType | None
+    weight_shape: tuple[int, ...] | None
     dtype: ScalarType
     target_dtype: ScalarType
 
@@ -1204,13 +1210,16 @@ class CEmitter:
                 input_shape=op.input_shape,
                 target_shape=op.target_shape,
                 output_shape=op.output_shape,
+                n=op.n,
+                c=op.c,
+                d=op.d,
                 ignore_index=op.ignore_index,
                 reduction=op.reduction,
-                dtype=op.dtype,
                 input_dtype=op.input_dtype,
-                target_dtype=op.target_dtype,
                 weight_dtype=op.weight_dtype,
                 weight_shape=op.weight_shape,
+                dtype=op.dtype,
+                target_dtype=op.target_dtype,
             )
         if isinstance(op, SoftmaxCrossEntropyLossOp):
             return SoftmaxCrossEntropyLossOp(
@@ -1223,13 +1232,16 @@ class CEmitter:
                 target_shape=op.target_shape,
                 output_shape=op.output_shape,
                 log_prob_shape=op.log_prob_shape,
+                n=op.n,
+                c=op.c,
+                d=op.d,
                 ignore_index=op.ignore_index,
                 reduction=op.reduction,
-                dtype=op.dtype,
                 input_dtype=op.input_dtype,
-                target_dtype=op.target_dtype,
                 weight_dtype=op.weight_dtype,
                 weight_shape=op.weight_shape,
+                dtype=op.dtype,
+                target_dtype=op.target_dtype,
             )
         if isinstance(op, MaxPoolOp):
             return MaxPoolOp(
@@ -2790,6 +2802,9 @@ class CEmitter:
                 d=op.d,
                 reduction=op.reduction,
                 ignore_index=op.ignore_index,
+                input_dtype=op.input_dtype,
+                weight_dtype=op.weight_dtype,
+                weight_shape=op.weight_shape,
                 dtype=op.dtype,
                 target_dtype=op.target_dtype,
             )
@@ -2817,6 +2832,9 @@ class CEmitter:
                 d=op.d,
                 reduction=op.reduction,
                 ignore_index=op.ignore_index,
+                input_dtype=op.input_dtype,
+                weight_dtype=op.weight_dtype,
+                weight_shape=op.weight_shape,
                 dtype=op.dtype,
                 target_dtype=op.target_dtype,
             )

--- a/src/onnx2c/lowering/negative_log_likelihood_loss.py
+++ b/src/onnx2c/lowering/negative_log_likelihood_loss.py
@@ -170,6 +170,8 @@ def lower_negative_log_likelihood_loss(
         raise UnsupportedOpError(
             "NegativeLogLikelihoodLoss target must be int32 or int64"
         )
+    weight_dtype = None
+    weight_shape: tuple[int, ...] | None = None
     if weight_name is not None:
         weight_dtype = _value_dtype(graph, weight_name, node)
         if weight_dtype != input_dtype:
@@ -240,6 +242,9 @@ def lower_negative_log_likelihood_loss(
         d=d,
         reduction=reduction,
         ignore_index=ignore_index,
+        input_dtype=input_dtype,
+        weight_dtype=weight_dtype,
+        weight_shape=weight_shape,
         dtype=input_dtype,
         target_dtype=target_dtype,
     )

--- a/src/onnx2c/lowering/softmax_cross_entropy_loss.py
+++ b/src/onnx2c/lowering/softmax_cross_entropy_loss.py
@@ -45,6 +45,8 @@ def lower_softmax_cross_entropy_loss(
         raise UnsupportedOpError(
             "SoftmaxCrossEntropyLoss target must be int32 or int64"
         )
+    weight_dtype = None
+    weight_shape: tuple[int, ...] | None = None
     if weight_name is not None:
         weight_dtype = _value_dtype(graph, weight_name, node)
         if weight_dtype != input_dtype:
@@ -119,6 +121,9 @@ def lower_softmax_cross_entropy_loss(
         d=d,
         reduction=reduction,
         ignore_index=ignore_index,
+        input_dtype=input_dtype,
+        weight_dtype=weight_dtype,
+        weight_shape=weight_shape,
         dtype=input_dtype,
         target_dtype=target_dtype,
     )

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -3957,7 +3957,7 @@
   ],
   [
     "node/test_nllloss_NC/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_nllloss_NC_expanded/model.onnx",
@@ -3965,7 +3965,7 @@
   ],
   [
     "node/test_nllloss_NCd1/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_nllloss_NCd1_expanded/model.onnx",
@@ -3973,7 +3973,7 @@
   ],
   [
     "node/test_nllloss_NCd1_ii/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_nllloss_NCd1_ii_expanded/model.onnx",
@@ -3981,7 +3981,7 @@
   ],
   [
     "node/test_nllloss_NCd1_mean_weight_negative_ii/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_nllloss_NCd1_mean_weight_negative_ii_expanded/model.onnx",
@@ -3989,7 +3989,7 @@
   ],
   [
     "node/test_nllloss_NCd1_weight/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_nllloss_NCd1_weight_expanded/model.onnx",
@@ -3997,7 +3997,7 @@
   ],
   [
     "node/test_nllloss_NCd1_weight_ii/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_nllloss_NCd1_weight_ii_expanded/model.onnx",
@@ -4005,7 +4005,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_nllloss_NCd1d2_expanded/model.onnx",
@@ -4013,7 +4013,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2_no_weight_reduction_mean_ii/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_nllloss_NCd1d2_no_weight_reduction_mean_ii_expanded/model.onnx",
@@ -4021,7 +4021,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2_reduction_mean/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_nllloss_NCd1d2_reduction_mean_expanded/model.onnx",
@@ -4029,7 +4029,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2_reduction_sum/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_nllloss_NCd1d2_reduction_sum_expanded/model.onnx",
@@ -4037,7 +4037,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight_expanded/model.onnx",
@@ -4045,7 +4045,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight_reduction_mean/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight_reduction_mean_expanded/model.onnx",
@@ -4053,7 +4053,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight_reduction_sum/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight_reduction_sum_expanded/model.onnx",
@@ -4061,7 +4061,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight_reduction_sum_ii/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_nllloss_NCd1d2_with_weight_reduction_sum_ii_expanded/model.onnx",
@@ -4069,7 +4069,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2d3_none_no_weight_negative_ii/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_nllloss_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx",
@@ -4077,7 +4077,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2d3_sum_weight_high_ii/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_nllloss_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx",
@@ -4085,7 +4085,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2d3d4d5_mean_weight/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_nllloss_NCd1d2d3d4d5_mean_weight_expanded/model.onnx",
@@ -4093,7 +4093,7 @@
   ],
   [
     "node/test_nllloss_NCd1d2d3d4d5_none_no_weight/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_nllloss_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx",
@@ -5469,275 +5469,275 @@
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_3d/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_3d_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_3d_log_prob/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_3d_log_prob_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_log_prob/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_log_prob_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_log_prob/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_log_prob/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii_log_prob/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_weight/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_weight_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii_3d/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii_3d_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii_3d_log_prob/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii_4d/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii_4d_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii_4d_log_prob/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii_log_prob/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_weight_log_prob/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_mean_weight_log_prob_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_none/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_none_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_none_log_prob/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_none_log_prob_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_none_weights/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_none_weights_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_none_weights_log_prob/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_none_weights_log_prob_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_sum/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_sum_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_sum_log_prob/model.onnx",
-    "'SoftmaxCrossEntropyLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_sce_sum_log_prob_expanded/model.onnx",
-    "'NegativeLogLikelihoodLossOp' object has no attribute 'input_dtype'"
+    ""
   ],
   [
     "node/test_selu/model.onnx",


### PR DESCRIPTION
### Motivation
- Fix AttributeError where loss op instances were missing input/weight metadata (e.g., `input_dtype`) during codegen and name remapping. 
- Ensure the C emitter and lowering passes have explicit dtype/shape information for NegativeLogLikelihoodLoss and SoftmaxCrossEntropyLoss so rendering and header includes are correct. 

### Description
- Added `input_dtype`, `weight_dtype`, and `weight_shape` fields to `NegativeLogLikelihoodLossOp` and `SoftmaxCrossEntropyLossOp` dataclasses in `src/onnx2c/codegen/c_emitter.py`. 
- Compute and attach `weight_dtype` and `weight_shape` (and propagate `input_dtype`) in the lowering functions `lower_negative_log_likelihood_loss` and `lower_softmax_cross_entropy_loss`. 
- Propagated the new fields through name remapping and rendering paths in `CEmitter` so templates and include logic can use them. 
- Refreshed official ONNX support/error snapshots (`OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`, and `tests/official_onnx_expected_errors.json`).

### Testing
- Ran the full test suite with reference updates via `UPDATE_REFS=1 pytest -n auto -q`. 
- All tests passed: `156 passed` in `32.74s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696687cf7db083258fc96b6febd087bc)