### PR TITLE
shared: simplify int copysign implementation

### DIFF
--- a/src/shared/scalar_functions.py
+++ b/src/shared/scalar_functions.py
@@ -1311,20 +1311,12 @@ def _int_floor_divide(dtype_info: _ScalarTypeInfo) -> _GeneratedScalar:
 
 
 def _int_copysign(dtype_info: _ScalarTypeInfo) -> _GeneratedScalar:
-    if not dtype_info.is_signed:
-        lines = [
-            f"static inline {dtype_info.c_type} {dtype_info.prefix}copysign({dtype_info.c_type} a, {dtype_info.c_type} b) {{",
-            f"    {dtype_info.c_type} magnitude = {dtype_info.prefix}abs(a);",
-            "    return b < 0 ? -magnitude : magnitude;",
-            "}",
-        ]
-    else:
-        lines = [
-            f"static inline {dtype_info.c_type} {dtype_info.prefix}copysign({dtype_info.c_type} a, {dtype_info.c_type} b) {{",
-            f"    {dtype_info.c_type} magnitude = {dtype_info.prefix}abs(a);",
-            "    return b < 0 ? -magnitude : magnitude;",
-            "}",
-        ]
+    lines = [
+        f"static inline {dtype_info.c_type} {dtype_info.prefix}copysign({dtype_info.c_type} a, {dtype_info.c_type} b) {{",
+        f"    {dtype_info.c_type} magnitude = {dtype_info.prefix}abs(a);",
+        "    return b < 0 ? -magnitude : magnitude;",
+        "}",
+    ]
     deps = {f"{dtype_info.prefix}abs"}
     return _GeneratedScalar(lines=lines, deps=deps, includes=set())
 


### PR DESCRIPTION
### Motivation
- Remove a duplicated signed/unsigned branch in the integer `copysign` generator to make the code simpler and clearer.
- Preserve the existing dependency on `abs` and keep the generated function's return semantics unchanged.
- Reduce code duplication in `src/shared/scalar_functions.py` to improve maintainability.

### Description
- Replace the duplicated `if/else` branches in `_int_copysign` with a single shared implementation that uses `abs` to compute the magnitude.
- Keep the `deps` set including the `abs` helper via `deps = {f"{dtype_info.prefix}abs"}` unchanged.
- Change only the generator output lines for `_int_copysign` in `src/shared/scalar_functions.py` and do not alter behavior for signed or unsigned types.

### Testing
- Ran the test suite with `pytest -n auto -q` and all tests passed.
- Test summary: `156 passed in 32.07s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6966927bbc288325a707e0e8befc3507)