### PR TITLE
codegen: dedupe op parameters and emit explicit param lists

### DIFF
--- a/templates/attention_op.c.j2
+++ b/templates/attention_op.c.j2
@@ -1,14 +1,4 @@
-static inline void {{ op_name }}(const {{ c_type }} {{ input_q }}{{ input_q_suffix }},
-                   const {{ c_type }} {{ input_k }}{{ input_k_suffix }},
-                   const {{ c_type }} {{ input_v }}{{ input_v_suffix }}{% if input_attn_mask %},
-                   const {% if mask_is_bool %}bool{% else %}{{ c_type }}{% endif %} {{ input_attn_mask }}{{ input_mask_suffix }}{% endif %}{% if input_past_key %},
-                   const {{ c_type }} {{ input_past_key }}{{ input_past_key_suffix }}{% endif %}{% if input_past_value %},
-                   const {{ c_type }} {{ input_past_value }}{{ input_past_value_suffix }}{% endif %}{% if input_nonpad_kv_seqlen %},
-                   const {{ nonpad_c_type }} {{ input_nonpad_kv_seqlen }}{{ input_nonpad_suffix }}{% endif %},
-                   {{ c_type }} {{ output }}{{ output_suffix }}{% if output_present_key %},
-                   {{ c_type }} {{ output_present_key }}{{ output_present_key_suffix }}{% endif %}{% if output_present_value %},
-                   {{ c_type }} {{ output_present_value }}{{ output_present_value_suffix }}{% endif %}{% if output_qk_matmul %},
-                   {{ c_type }} {{ output_qk_matmul }}{{ output_qk_matmul_suffix }}{% endif %}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
     const {{ c_type }} scale = {{ scale_literal }};
     const {{ c_type }} softcap = {{ softcap_literal }};
     {% if output_present_key %}

--- a/templates/average_pool_op.c.j2
+++ b/templates/average_pool_op.c.j2
@@ -1,4 +1,4 @@
-static inline void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
     for (size_t n = 0; n < {{ batch }}; ++n) {
         for (size_t c = 0; c < {{ channels }}; ++c) {
             for (size_t oh = 0; oh < {{ out_h }}; ++oh) {

--- a/templates/batch_norm_op.c.j2
+++ b/templates/batch_norm_op.c.j2
@@ -1,4 +1,4 @@
-static inline void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix }}, const {{ c_type }} {{ scale }}{{ scale_suffix }}, const {{ c_type }} {{ bias }}{{ bias_suffix }}, const {{ c_type }} {{ mean }}{{ mean_suffix }}, const {{ c_type }} {{ variance }}{{ variance_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
 {% for dim in shape %}
 for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}

--- a/templates/binary_op.c.j2
+++ b/templates/binary_op.c.j2
@@ -1,4 +1,4 @@
-static inline void {{ op_name }}(const {{ input_c_type }} {{ input0 }}{{ array_suffix }}, const {{ input_c_type }} {{ input1 }}{{ array_suffix }}, {{ output_c_type }} {{ output }}{{ array_suffix }}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
 {% for dim in shape %}
 for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}

--- a/templates/cast_op.c.j2
+++ b/templates/cast_op.c.j2
@@ -1,4 +1,4 @@
-static inline void {{ op_name }}(const {{ input_c_type }} {{ input0 }}{{ array_suffix }}, {{ output_c_type }} {{ output }}{{ array_suffix }}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
 {% for dim in shape %}
 for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}

--- a/templates/concat_op.c.j2
+++ b/templates/concat_op.c.j2
@@ -1,4 +1,4 @@
-static inline void {{ op_name }}({% for input in inputs %}const {{ c_type }} {{ input }}{{ input_suffixes[loop.index0] }}, {% endfor %}{{ c_type }} {{ output }}{{ output_suffix }}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
     const void *inputs[] = { {% for input in inputs %}{{ input }}{% if not loop.last %}, {% endif %}{% endfor %} };
     const size_t axis_sizes[] = { {% for axis in axis_sizes %}{{ axis }}{% if not loop.last %}, {% endif %}{% endfor %} };
     size_t concat_axis = 0;

--- a/templates/constant_of_shape_op.c.j2
+++ b/templates/constant_of_shape_op.c.j2
@@ -1,4 +1,4 @@
-static inline void {{ op_name }}(const {{ input_c_type }} {{ input0 }}{{ input_suffix }}, {{ c_type }} {{ output }}{{ array_suffix }}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
     (void){{ input0 }};
 {% for dim in shape %}
 for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {

--- a/templates/conv_op.c.j2
+++ b/templates/conv_op.c.j2
@@ -1,4 +1,4 @@
-static inline void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix }}, const {{ c_type }} {{ weights }}{{ weight_suffix }},{% if bias %} const {{ c_type }} {{ bias }}{{ bias_suffix }},{% endif %} {{ c_type }} {{ output }}{{ output_suffix }}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
     for (size_t n = 0; n < {{ batch }}; ++n) {
         for (size_t g = 0; g < {{ group }}; ++g) {
             for (size_t oc = 0; oc < {{ group_out_channels }}; ++oc) {

--- a/templates/gather_elements_op.c.j2
+++ b/templates/gather_elements_op.c.j2
@@ -1,4 +1,4 @@
-static inline void {{ op_name }}(const {{ c_type }} {{ data }}{{ data_suffix }}, const {{ indices_c_type }} {{ indices }}{{ indices_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
 {% for dim in output_shape %}
 for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}

--- a/templates/gather_op.c.j2
+++ b/templates/gather_op.c.j2
@@ -1,4 +1,4 @@
-static inline void {{ op_name }}(const {{ c_type }} {{ data }}{{ data_suffix }}, const {{ indices_c_type }} {{ indices }}{{ indices_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
 {% for dim in output_shape %}
 for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}

--- a/templates/gemm_op.c.j2
+++ b/templates/gemm_op.c.j2
@@ -1,4 +1,4 @@
-static inline void {{ op_name }}(const {{ c_type }} {{ input_a }}{{ input_a_suffix }}, const {{ c_type }} {{ input_b }}{{ input_b_suffix }}{% if input_c %}, const {{ c_type }} {{ input_c }}{{ c_suffix }}{% endif %}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
     for (size_t i = 0; i < {{ m }}; ++i) {
         for (size_t j = 0; j < {{ n }}; ++j) {
             {{ acc_type }} acc = {{ zero_literal }};

--- a/templates/logsoftmax_op.c.j2
+++ b/templates/logsoftmax_op.c.j2
@@ -1,4 +1,4 @@
-static inline void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ array_suffix }}, {{ c_type }} {{ output }}{{ array_suffix }}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
     const {{ c_type }} *input_flat = (const {{ c_type }} *){{ input0 }};
     {{ c_type }} *output_flat = ({{ c_type }} *){{ output }};
     const size_t outer = {{ outer }};

--- a/templates/lrn_op.c.j2
+++ b/templates/lrn_op.c.j2
@@ -1,4 +1,4 @@
-static inline void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
 {% for dim in shape %}
 for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}

--- a/templates/lstm_op.c.j2
+++ b/templates/lstm_op.c.j2
@@ -34,17 +34,7 @@ static inline {{ c_type }} {{ op_name }}_activation(int kind, {{ c_type }} value
     }
 }
 
-static inline void {{ op_name }}(const {{ c_type }} {{ input_x }}{{ input_suffix }},
-                  const {{ c_type }} {{ input_w }}{{ w_suffix }},
-                  const {{ c_type }} {{ input_r }}{{ r_suffix }}{% if input_b %},
-                  const {{ c_type }} {{ input_b }}{{ b_suffix }}{% endif %}{% if input_sequence_lens %},
-                  const {{ seq_c_type }} {{ input_sequence_lens }}{{ seq_suffix }}{% endif %}{% if input_initial_h %},
-                  const {{ c_type }} {{ input_initial_h }}{{ h_suffix }}{% endif %}{% if input_initial_c %},
-                  const {{ c_type }} {{ input_initial_c }}{{ c_suffix }}{% endif %}{% if input_p %},
-                  const {{ c_type }} {{ input_p }}{{ p_suffix }}{% endif %}{% if output_y %},
-                  {{ c_type }} {{ output_y }}{{ y_suffix }}{% endif %}{% if output_y_h %},
-                  {{ c_type }} {{ output_y_h }}{{ y_h_suffix }}{% endif %}{% if output_y_c %},
-                  {{ c_type }} {{ output_y_c }}{{ y_c_suffix }}{% endif %}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
     const int activations[] = { {% for value in activation_kinds %}{{ value }}{% if not loop.last %}, {% endif %}{% endfor %} };
     const {{ c_type }} activation_alpha[] = { {% for value in activation_alphas %}{{ value }}{% if not loop.last %}, {% endif %}{% endfor %} };
     const {{ c_type }} activation_beta[] = { {% for value in activation_betas %}{{ value }}{% if not loop.last %}, {% endif %}{% endfor %} };

--- a/templates/matmul_op.c.j2
+++ b/templates/matmul_op.c.j2
@@ -1,4 +1,4 @@
-static inline void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input0_suffix }}, const {{ c_type }} {{ input1 }}{{ input1_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
 {% for idx in range(output_loop_vars | length) %}
     {% for indent in range(loop.index0) %}    {% endfor %}for (size_t {{ output_loop_vars[idx] }} = 0; {{ output_loop_vars[idx] }} < {{ output_loop_bounds[idx] }}; ++{{ output_loop_vars[idx] }}) {
 {% endfor %}

--- a/templates/maxpool_op.c.j2
+++ b/templates/maxpool_op.c.j2
@@ -1,4 +1,4 @@
-static inline void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}{% if indices %}, {{ indices_c_type }} {{ indices }}{{ indices_suffix }}{% endif %}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
     for (size_t n = 0; n < {{ batch }}; ++n) {
         for (size_t c = 0; c < {{ channels }}; ++c) {
 {% if spatial_rank == 1 %}

--- a/templates/negative_log_likelihood_loss_op.c.j2
+++ b/templates/negative_log_likelihood_loss_op.c.j2
@@ -1,7 +1,4 @@
-static inline void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix }},
-                   const {{ target_c_type }} {{ target }}{{ target_suffix }}{% if weight %},
-                   const {{ c_type }} {{ weight }}[{{ c }}]{% endif %},
-                   {{ c_type }} {{ output }}{{ output_suffix }}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
     const {{ c_type }} *input_flat = (const {{ c_type }} *){{ input0 }};
     const {{ target_c_type }} *target_flat = (const {{ target_c_type }} *){{ target }};
     {{ c_type }} *output_flat = ({{ c_type }} *){{ output }};

--- a/templates/reduce_op.c.j2
+++ b/templates/reduce_op.c.j2
@@ -1,4 +1,4 @@
-static inline void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
 {% for dim in output_shape %}
 for (size_t {{ output_loop_vars[loop.index0] }} = 0; {{ output_loop_vars[loop.index0] }} < {{ dim }}; ++{{ output_loop_vars[loop.index0] }}) {
 {% endfor %}

--- a/templates/reshape_op.c.j2
+++ b/templates/reshape_op.c.j2
@@ -1,3 +1,3 @@
-static inline void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
     memcpy({{ output }}, {{ input0 }}, sizeof({{ c_type }}) * {{ element_count }});
 }

--- a/templates/shape_op.c.j2
+++ b/templates/shape_op.c.j2
@@ -1,4 +1,4 @@
-static inline void {{ op_name }}(const {{ input_c_type }} {{ input0 }}{{ input_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
     (void){{ input0 }};
 {% for value in values %}
     {{ output }}[{{ loop.index0 }}] = {{ value }};

--- a/templates/size_op.c.j2
+++ b/templates/size_op.c.j2
@@ -1,4 +1,4 @@
-static inline void {{ op_name }}(const {{ input_c_type }} {{ input0 }}{{ input_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
     (void){{ input0 }};
     {{ output }}[0] = {{ value }};
 }

--- a/templates/slice_op.c.j2
+++ b/templates/slice_op.c.j2
@@ -1,4 +1,4 @@
-static inline void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
 {% for dim in output_shape %}
 for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}

--- a/templates/softmax_cross_entropy_loss_op.c.j2
+++ b/templates/softmax_cross_entropy_loss_op.c.j2
@@ -1,8 +1,4 @@
-static inline void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix }},
-                   const {{ target_c_type }} {{ target }}{{ target_suffix }}{% if weight %},
-                   const {{ c_type }} {{ weight }}[{{ c }}]{% endif %},
-                   {{ c_type }} {{ output }}{{ output_suffix }}{% if log_prob %},
-                   {{ c_type }} {{ log_prob }}{{ log_prob_suffix }}{% endif %}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
     const {{ c_type }} *input_flat = (const {{ c_type }} *){{ input0 }};
     const {{ target_c_type }} *target_flat = (const {{ target_c_type }} *){{ target }};
     {{ c_type }} *output_flat = ({{ c_type }} *){{ output }};

--- a/templates/softmax_op.c.j2
+++ b/templates/softmax_op.c.j2
@@ -1,4 +1,4 @@
-static inline void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ array_suffix }}, {{ c_type }} {{ output }}{{ array_suffix }}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
     const {{ c_type }} *input_flat = (const {{ c_type }} *){{ input0 }};
     {{ c_type }} *output_flat = ({{ c_type }} *){{ output }};
     const size_t outer = {{ outer }};

--- a/templates/transpose_op.c.j2
+++ b/templates/transpose_op.c.j2
@@ -1,4 +1,4 @@
-static inline void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ input_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
 {% for dim in output_shape %}
 for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}

--- a/templates/unary_op.c.j2
+++ b/templates/unary_op.c.j2
@@ -1,4 +1,4 @@
-static inline void {{ op_name }}(const {{ c_type }} {{ input0 }}{{ array_suffix }}, {{ c_type }} {{ output }}{{ array_suffix }}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
 {% for dim in shape %}
 for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}

--- a/templates/where_op.c.j2
+++ b/templates/where_op.c.j2
@@ -1,4 +1,4 @@
-static inline void {{ op_name }}(const {{ condition_c_type }} {{ condition }}{{ condition_array_suffix }}, const {{ input_c_type }} {{ input_x }}{{ x_array_suffix }}, const {{ input_c_type }} {{ input_y }}{{ y_array_suffix }}, {{ output_c_type }} {{ output }}{{ output_array_suffix }}) {
+static inline void {{ op_name }}({{ params | join(', ') }}) {
 {% for dim in output_shape %}
 for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}


### PR DESCRIPTION
### Motivation
- Prevent generating C functions with repeated parameter names when an op reuses the same input name in multiple positions. 
- Keep emitted function signatures stable and deterministic by constructing explicit parameter lists for templates. 
- Make templates receive a single canonical `params` list so deduplication can be applied consistently across ops. 

### Description
- Added a helper `CEmitter._unique_params` to build a deduplicated ordered list of parameter declarations. 
- Changed op renderers to build `params` (or `params_data`) using `CEmitter._param_array_suffix` / `dtype_info` and pass the deduped list into templates via the `params` context value. 
- Updated all relevant Jinja2 templates to accept `{{ params | join(', ') }}` as the function signature instead of inline parameter expansions. 
- Applied the new param construction to a wide set of ops (binary, where, matmul, gemm, attention, conv, pooling, reduce, reshape, cast, unary, etc.) so generated signatures no longer repeat aliased names. 

### Testing
- No automated tests were executed as part of this change. 
- Template and emitter changes are localized to codegen and should be covered by existing golden/reference tests when run. 
- Recommend running `pytest -n auto -q` and `UPDATE_REFS=1 pytest -n auto -q` to refresh golden outputs if intentional signature changes are expected. 
- Manual inspection and a subsequent compilation of generated C code is recommended to validate emitted signatures and compile-time correctness.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69666f7079b0832b8b41d6f443af5bc0)