### PR TITLE
Add Expand, Range and Split operator support

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 909 / 1802 official ONNX files.
+Support 920 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -100,128 +100,128 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_atanh_example/model.onnx | ✅ |  |
 | node/test_attention_3d/model.onnx | ✅ |  |
 | node/test_attention_3d_attn_mask/model.onnx | ✅ |  |
-| node/test_attention_3d_attn_mask_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_3d_attn_mask_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_3d_causal/model.onnx | ✅ |  |
-| node/test_attention_3d_causal_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_attention_3d_causal_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
 | node/test_attention_3d_diff_heads_sizes/model.onnx | ✅ |  |
 | node/test_attention_3d_diff_heads_sizes_attn_mask/model.onnx | ✅ |  |
-| node/test_attention_3d_diff_heads_sizes_attn_mask_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_3d_diff_heads_sizes_attn_mask_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_3d_diff_heads_sizes_causal/model.onnx | ✅ |  |
-| node/test_attention_3d_diff_heads_sizes_causal_expanded/model.onnx | ❌ | Unsupported op Range |
-| node/test_attention_3d_diff_heads_sizes_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_3d_diff_heads_sizes_causal_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
+| node/test_attention_3d_diff_heads_sizes_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_3d_diff_heads_sizes_scaled/model.onnx | ✅ |  |
-| node/test_attention_3d_diff_heads_sizes_scaled_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_3d_diff_heads_sizes_scaled_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_3d_diff_heads_sizes_softcap/model.onnx | ✅ |  |
-| node/test_attention_3d_diff_heads_sizes_softcap_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_3d_diff_heads_sizes_softcap_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_3d_diff_heads_with_past_and_present/model.onnx | ✅ |  |
-| node/test_attention_3d_diff_heads_with_past_and_present_expanded/model.onnx | ❌ | Unsupported op Expand |
-| node/test_attention_3d_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_3d_diff_heads_with_past_and_present_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
+| node/test_attention_3d_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_3d_gqa/model.onnx | ✅ |  |
 | node/test_attention_3d_gqa_attn_mask/model.onnx | ✅ |  |
-| node/test_attention_3d_gqa_attn_mask_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_3d_gqa_attn_mask_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_3d_gqa_causal/model.onnx | ✅ |  |
-| node/test_attention_3d_gqa_causal_expanded/model.onnx | ❌ | Unsupported op Range |
-| node/test_attention_3d_gqa_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_3d_gqa_causal_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
+| node/test_attention_3d_gqa_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_3d_gqa_scaled/model.onnx | ✅ |  |
-| node/test_attention_3d_gqa_scaled_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_3d_gqa_scaled_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_3d_gqa_softcap/model.onnx | ✅ |  |
-| node/test_attention_3d_gqa_softcap_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_3d_gqa_softcap_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_3d_gqa_with_past_and_present/model.onnx | ✅ |  |
-| node/test_attention_3d_gqa_with_past_and_present_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_3d_gqa_with_past_and_present_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_3d_scaled/model.onnx | ✅ |  |
-| node/test_attention_3d_scaled_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_3d_scaled_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_3d_softcap/model.onnx | ✅ |  |
-| node/test_attention_3d_softcap_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_3d_softcap_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_3d_transpose_verification/model.onnx | ✅ |  |
-| node/test_attention_3d_transpose_verification_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_3d_transpose_verification_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_3d_with_past_and_present/model.onnx | ✅ |  |
-| node/test_attention_3d_with_past_and_present_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_3d_with_past_and_present_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_3d_with_past_and_present_qk_matmul/model.onnx | ✅ |  |
 | node/test_attention_3d_with_past_and_present_qk_matmul_bias/model.onnx | ✅ |  |
-| node/test_attention_3d_with_past_and_present_qk_matmul_bias_expanded/model.onnx | ❌ | Unsupported op Expand |
-| node/test_attention_3d_with_past_and_present_qk_matmul_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_3d_with_past_and_present_qk_matmul_bias_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
+| node/test_attention_3d_with_past_and_present_qk_matmul_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_3d_with_past_and_present_qk_matmul_softcap/model.onnx | ✅ |  |
-| node/test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_3d_with_past_and_present_qk_matmul_softmax/model.onnx | ✅ |  |
-| node/test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d/model.onnx | ✅ |  |
 | node/test_attention_4d_attn_mask/model.onnx | ✅ |  |
 | node/test_attention_4d_attn_mask_3d/model.onnx | ✅ |  |
 | node/test_attention_4d_attn_mask_3d_causal/model.onnx | ✅ |  |
-| node/test_attention_4d_attn_mask_3d_causal_expanded/model.onnx | ❌ | Unsupported op Range |
-| node/test_attention_4d_attn_mask_3d_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_attn_mask_3d_causal_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
+| node/test_attention_4d_attn_mask_3d_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d_attn_mask_4d/model.onnx | ✅ |  |
 | node/test_attention_4d_attn_mask_4d_causal/model.onnx | ✅ |  |
-| node/test_attention_4d_attn_mask_4d_causal_expanded/model.onnx | ❌ | Unsupported op Range |
-| node/test_attention_4d_attn_mask_4d_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_attn_mask_4d_causal_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
+| node/test_attention_4d_attn_mask_4d_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d_attn_mask_bool/model.onnx | ✅ |  |
 | node/test_attention_4d_attn_mask_bool_4d/model.onnx | ✅ |  |
-| node/test_attention_4d_attn_mask_bool_4d_expanded/model.onnx | ❌ | Unsupported op Expand |
-| node/test_attention_4d_attn_mask_bool_expanded/model.onnx | ❌ | Unsupported op Expand |
-| node/test_attention_4d_attn_mask_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_attn_mask_bool_4d_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
+| node/test_attention_4d_attn_mask_bool_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
+| node/test_attention_4d_attn_mask_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d_causal/model.onnx | ✅ |  |
-| node/test_attention_4d_causal_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_attention_4d_causal_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
 | node/test_attention_4d_diff_heads_mask4d_padded_kv/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_mask4d_padded_kv_expanded/model.onnx | ❌ | Unsupported op Pad |
 | node/test_attention_4d_diff_heads_sizes/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_sizes_attn_mask/model.onnx | ✅ |  |
-| node/test_attention_4d_diff_heads_sizes_attn_mask_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_diff_heads_sizes_attn_mask_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d_diff_heads_sizes_causal/model.onnx | ✅ |  |
-| node/test_attention_4d_diff_heads_sizes_causal_expanded/model.onnx | ❌ | Unsupported op Range |
-| node/test_attention_4d_diff_heads_sizes_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_diff_heads_sizes_causal_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
+| node/test_attention_4d_diff_heads_sizes_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d_diff_heads_sizes_scaled/model.onnx | ✅ |  |
-| node/test_attention_4d_diff_heads_sizes_scaled_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_diff_heads_sizes_scaled_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d_diff_heads_sizes_softcap/model.onnx | ✅ |  |
-| node/test_attention_4d_diff_heads_sizes_softcap_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_diff_heads_sizes_softcap_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d_diff_heads_with_past_and_present/model.onnx | ✅ |  |
-| node/test_attention_4d_diff_heads_with_past_and_present_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_diff_heads_with_past_and_present_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d_diff_heads_with_past_and_present_mask3d/model.onnx | ✅ |  |
-| node/test_attention_4d_diff_heads_with_past_and_present_mask3d_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_diff_heads_with_past_and_present_mask3d_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d_diff_heads_with_past_and_present_mask4d/model.onnx | ✅ |  |
-| node/test_attention_4d_diff_heads_with_past_and_present_mask4d_expanded/model.onnx | ❌ | Unsupported op Expand |
-| node/test_attention_4d_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_diff_heads_with_past_and_present_mask4d_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
+| node/test_attention_4d_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d_fp16/model.onnx | ✅ |  |
-| node/test_attention_4d_fp16_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_fp16_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d_gqa/model.onnx | ✅ |  |
 | node/test_attention_4d_gqa_attn_mask/model.onnx | ✅ |  |
-| node/test_attention_4d_gqa_attn_mask_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_gqa_attn_mask_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d_gqa_causal/model.onnx | ✅ |  |
-| node/test_attention_4d_gqa_causal_expanded/model.onnx | ❌ | Unsupported op Range |
-| node/test_attention_4d_gqa_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_gqa_causal_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
+| node/test_attention_4d_gqa_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d_gqa_scaled/model.onnx | ✅ |  |
-| node/test_attention_4d_gqa_scaled_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_gqa_scaled_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d_gqa_softcap/model.onnx | ✅ |  |
-| node/test_attention_4d_gqa_softcap_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_gqa_softcap_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d_gqa_with_past_and_present/model.onnx | ✅ |  |
-| node/test_attention_4d_gqa_with_past_and_present_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_gqa_with_past_and_present_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d_gqa_with_past_and_present_fp16/model.onnx | ✅ |  |
-| node/test_attention_4d_gqa_with_past_and_present_fp16_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_gqa_with_past_and_present_fp16_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d_scaled/model.onnx | ✅ |  |
-| node/test_attention_4d_scaled_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_scaled_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d_softcap/model.onnx | ✅ |  |
-| node/test_attention_4d_softcap_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_softcap_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d_with_past_and_present/model.onnx | ✅ |  |
-| node/test_attention_4d_with_past_and_present_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_with_past_and_present_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d_with_past_and_present_qk_matmul/model.onnx | ✅ |  |
 | node/test_attention_4d_with_past_and_present_qk_matmul_bias/model.onnx | ✅ |  |
 | node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask/model.onnx | ✅ |  |
 | node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal/model.onnx | ✅ |  |
-| node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal_expanded/model.onnx | ❌ | Unsupported op Range |
-| node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
+| node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask/model.onnx | ✅ |  |
 | node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal/model.onnx | ✅ |  |
-| node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal_expanded/model.onnx | ❌ | Unsupported op Range |
-| node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_expanded/model.onnx | ❌ | Unsupported op Expand |
-| node/test_attention_4d_with_past_and_present_qk_matmul_bias_expanded/model.onnx | ❌ | Unsupported op Expand |
-| node/test_attention_4d_with_past_and_present_qk_matmul_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
+| node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
+| node/test_attention_4d_with_past_and_present_qk_matmul_bias_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
+| node/test_attention_4d_with_past_and_present_qk_matmul_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d_with_qk_matmul/model.onnx | ✅ |  |
 | node/test_attention_4d_with_qk_matmul_bias/model.onnx | ✅ |  |
-| node/test_attention_4d_with_qk_matmul_bias_expanded/model.onnx | ❌ | Unsupported op Expand |
-| node/test_attention_4d_with_qk_matmul_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_with_qk_matmul_bias_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
+| node/test_attention_4d_with_qk_matmul_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d_with_qk_matmul_softcap/model.onnx | ✅ |  |
-| node/test_attention_4d_with_qk_matmul_softcap_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_with_qk_matmul_softcap_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_attention_4d_with_qk_matmul_softmax/model.onnx | ✅ |  |
-| node/test_attention_4d_with_qk_matmul_softmax_expanded/model.onnx | ❌ | Unsupported op Expand |
+| node/test_attention_4d_with_qk_matmul_softmax_expanded/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_averagepool_1d_default/model.onnx | ❌ | AveragePool expects 2D kernel_shape |
 | node/test_averagepool_2d_ceil/model.onnx | ❌ | AveragePool supports ceil_mode=0 only |
 | node/test_averagepool_2d_ceil_last_window_starts_on_pad/model.onnx | ❌ | AveragePool supports ceil_mode=0 only |
@@ -280,9 +280,9 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_bitwise_xor_ui64_bcast_3v1d/model.onnx | ✅ |  |
 | node/test_bitwise_xor_ui8_bcast_4v3d/model.onnx | ✅ |  |
 | node/test_blackmanwindow/model.onnx | ❌ | Unsupported op BlackmanWindow |
-| node/test_blackmanwindow_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_blackmanwindow_expanded/model.onnx | ❌ | Range limit input must be a constant initializer |
 | node/test_blackmanwindow_symmetric/model.onnx | ❌ | Unsupported op BlackmanWindow |
-| node/test_blackmanwindow_symmetric_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_blackmanwindow_symmetric_expanded/model.onnx | ❌ | Range limit input must be a constant initializer |
 | node/test_cast_BFLOAT16_to_FLOAT/model.onnx | ❌ | Unsupported elem_type 16 (BFLOAT16) for tensor 'input'. |
 | node/test_cast_DOUBLE_to_FLOAT/model.onnx | ✅ |  |
 | node/test_cast_DOUBLE_to_FLOAT16/model.onnx | ✅ |  |
@@ -626,8 +626,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_erf/model.onnx | ✅ |  |
 | node/test_exp/model.onnx | ✅ |  |
 | node/test_exp_example/model.onnx | ✅ |  |
-| node/test_expand_dim_changed/model.onnx | ❌ | Unsupported op Expand |
-| node/test_expand_dim_unchanged/model.onnx | ❌ | Unsupported op Expand |
+| node/test_expand_dim_changed/model.onnx | ❌ | Expand shape input must be a constant initializer |
+| node/test_expand_dim_unchanged/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | node/test_eyelike_populate_off_main_diagonal/model.onnx | ❌ | Unsupported op EyeLike |
 | node/test_eyelike_with_dtype/model.onnx | ❌ | Unsupported op EyeLike |
 | node/test_eyelike_without_dtype/model.onnx | ❌ | Unsupported op EyeLike |
@@ -726,13 +726,13 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_gru_seq_length/model.onnx | ❌ | Unsupported op GRU |
 | node/test_gru_with_initial_bias/model.onnx | ❌ | Unsupported op GRU |
 | node/test_hammingwindow/model.onnx | ❌ | Unsupported op HammingWindow |
-| node/test_hammingwindow_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_hammingwindow_expanded/model.onnx | ❌ | Range limit input must be a constant initializer |
 | node/test_hammingwindow_symmetric/model.onnx | ❌ | Unsupported op HammingWindow |
-| node/test_hammingwindow_symmetric_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_hammingwindow_symmetric_expanded/model.onnx | ❌ | Range limit input must be a constant initializer |
 | node/test_hannwindow/model.onnx | ❌ | Unsupported op HannWindow |
-| node/test_hannwindow_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_hannwindow_expanded/model.onnx | ❌ | Range limit input must be a constant initializer |
 | node/test_hannwindow_symmetric/model.onnx | ❌ | Unsupported op HannWindow |
-| node/test_hannwindow_symmetric_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_hannwindow_symmetric_expanded/model.onnx | ❌ | Range limit input must be a constant initializer |
 | node/test_hardmax_axis_0/model.onnx | ❌ | Unsupported op Hardmax |
 | node/test_hardmax_axis_1/model.onnx | ❌ | Unsupported op Hardmax |
 | node/test_hardmax_axis_2/model.onnx | ❌ | Unsupported op Hardmax |
@@ -1107,9 +1107,9 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_quantizelinear_uint16/model.onnx | ❌ | Unsupported op QuantizeLinear |
 | node/test_quantizelinear_uint2/model.onnx | ❌ | Unsupported elem_type 25 (UINT2) for tensor 'y_zero_point'. |
 | node/test_quantizelinear_uint4/model.onnx | ❌ | Unsupported elem_type 21 (UINT4) for tensor 'y_zero_point'. |
-| node/test_range_float_type_positive_delta/model.onnx | ❌ | Unsupported op Range |
+| node/test_range_float_type_positive_delta/model.onnx | ❌ | Range start input must be a constant initializer |
 | node/test_range_float_type_positive_delta_expanded/model.onnx | ❌ | Unsupported op Loop |
-| node/test_range_int32_type_negative_delta/model.onnx | ❌ | Unsupported op Range |
+| node/test_range_int32_type_negative_delta/model.onnx | ❌ | Range start input must be a constant initializer |
 | node/test_range_int32_type_negative_delta_expanded/model.onnx | ❌ | Unsupported op Loop |
 | node/test_reciprocal/model.onnx | ✅ |  |
 | node/test_reciprocal_example/model.onnx | ✅ |  |
@@ -1302,63 +1302,63 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reversesequence_batch/model.onnx | ❌ | Unsupported op ReverseSequence |
 | node/test_reversesequence_time/model.onnx | ❌ | Unsupported op ReverseSequence |
 | node/test_rms_normalization_2d_axis0/model.onnx | ❌ | Unsupported op RMSNormalization |
-| node/test_rms_normalization_2d_axis0_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_rms_normalization_2d_axis0_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
 | node/test_rms_normalization_2d_axis1/model.onnx | ❌ | Unsupported op RMSNormalization |
-| node/test_rms_normalization_2d_axis1_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_rms_normalization_2d_axis1_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
 | node/test_rms_normalization_2d_axis_negative_1/model.onnx | ❌ | Unsupported op RMSNormalization |
-| node/test_rms_normalization_2d_axis_negative_1_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_rms_normalization_2d_axis_negative_1_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
 | node/test_rms_normalization_2d_axis_negative_2/model.onnx | ❌ | Unsupported op RMSNormalization |
-| node/test_rms_normalization_2d_axis_negative_2_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_rms_normalization_2d_axis_negative_2_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
 | node/test_rms_normalization_3d_axis0_epsilon/model.onnx | ❌ | Unsupported op RMSNormalization |
-| node/test_rms_normalization_3d_axis0_epsilon_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_rms_normalization_3d_axis0_epsilon_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
 | node/test_rms_normalization_3d_axis1_epsilon/model.onnx | ❌ | Unsupported op RMSNormalization |
-| node/test_rms_normalization_3d_axis1_epsilon_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_rms_normalization_3d_axis1_epsilon_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
 | node/test_rms_normalization_3d_axis2_epsilon/model.onnx | ❌ | Unsupported op RMSNormalization |
-| node/test_rms_normalization_3d_axis2_epsilon_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_rms_normalization_3d_axis2_epsilon_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
 | node/test_rms_normalization_3d_axis_negative_1_epsilon/model.onnx | ❌ | Unsupported op RMSNormalization |
-| node/test_rms_normalization_3d_axis_negative_1_epsilon_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_rms_normalization_3d_axis_negative_1_epsilon_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
 | node/test_rms_normalization_3d_axis_negative_2_epsilon/model.onnx | ❌ | Unsupported op RMSNormalization |
-| node/test_rms_normalization_3d_axis_negative_2_epsilon_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_rms_normalization_3d_axis_negative_2_epsilon_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
 | node/test_rms_normalization_3d_axis_negative_3_epsilon/model.onnx | ❌ | Unsupported op RMSNormalization |
-| node/test_rms_normalization_3d_axis_negative_3_epsilon_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_rms_normalization_3d_axis_negative_3_epsilon_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
 | node/test_rms_normalization_4d_axis0/model.onnx | ❌ | Unsupported op RMSNormalization |
-| node/test_rms_normalization_4d_axis0_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_rms_normalization_4d_axis0_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
 | node/test_rms_normalization_4d_axis1/model.onnx | ❌ | Unsupported op RMSNormalization |
-| node/test_rms_normalization_4d_axis1_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_rms_normalization_4d_axis1_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
 | node/test_rms_normalization_4d_axis2/model.onnx | ❌ | Unsupported op RMSNormalization |
-| node/test_rms_normalization_4d_axis2_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_rms_normalization_4d_axis2_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
 | node/test_rms_normalization_4d_axis3/model.onnx | ❌ | Unsupported op RMSNormalization |
-| node/test_rms_normalization_4d_axis3_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_rms_normalization_4d_axis3_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
 | node/test_rms_normalization_4d_axis_negative_1/model.onnx | ❌ | Unsupported op RMSNormalization |
-| node/test_rms_normalization_4d_axis_negative_1_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_rms_normalization_4d_axis_negative_1_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
 | node/test_rms_normalization_4d_axis_negative_2/model.onnx | ❌ | Unsupported op RMSNormalization |
-| node/test_rms_normalization_4d_axis_negative_2_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_rms_normalization_4d_axis_negative_2_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
 | node/test_rms_normalization_4d_axis_negative_3/model.onnx | ❌ | Unsupported op RMSNormalization |
-| node/test_rms_normalization_4d_axis_negative_3_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_rms_normalization_4d_axis_negative_3_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
 | node/test_rms_normalization_4d_axis_negative_4/model.onnx | ❌ | Unsupported op RMSNormalization |
-| node/test_rms_normalization_4d_axis_negative_4_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_rms_normalization_4d_axis_negative_4_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
 | node/test_rms_normalization_default_axis/model.onnx | ❌ | Unsupported op RMSNormalization |
-| node/test_rms_normalization_default_axis_expanded/model.onnx | ❌ | Unsupported op Range |
+| node/test_rms_normalization_default_axis_expanded/model.onnx | ❌ | Range start input must be a constant initializer |
 | node/test_rnn_seq_length/model.onnx | ❌ | Unsupported op RNN |
 | node/test_roialign_aligned_false/model.onnx | ❌ | Unsupported op RoiAlign |
 | node/test_roialign_aligned_true/model.onnx | ❌ | Unsupported op RoiAlign |
 | node/test_roialign_mode_max/model.onnx | ❌ | Unsupported op RoiAlign |
 | node/test_rotary_embedding/model.onnx | ❌ | Unsupported op RotaryEmbedding |
 | node/test_rotary_embedding_3d_input/model.onnx | ❌ | Unsupported op RotaryEmbedding |
-| node/test_rotary_embedding_3d_input_expanded/model.onnx | ❌ | Unsupported op Split |
-| node/test_rotary_embedding_expanded/model.onnx | ❌ | Unsupported op Split |
+| node/test_rotary_embedding_3d_input_expanded/model.onnx | ❌ | Split split input must be a constant initializer |
+| node/test_rotary_embedding_expanded/model.onnx | ❌ | Split split input must be a constant initializer |
 | node/test_rotary_embedding_interleaved/model.onnx | ❌ | Unsupported op RotaryEmbedding |
-| node/test_rotary_embedding_interleaved_expanded/model.onnx | ❌ | Unsupported op Split |
+| node/test_rotary_embedding_interleaved_expanded/model.onnx | ❌ | Split split input must be a constant initializer |
 | node/test_rotary_embedding_no_position_ids/model.onnx | ❌ | Unsupported op RotaryEmbedding |
-| node/test_rotary_embedding_no_position_ids_expanded/model.onnx | ❌ | Unsupported op Split |
+| node/test_rotary_embedding_no_position_ids_expanded/model.onnx | ❌ | Split split input must be a constant initializer |
 | node/test_rotary_embedding_no_position_ids_interleaved/model.onnx | ❌ | Unsupported op RotaryEmbedding |
-| node/test_rotary_embedding_no_position_ids_interleaved_expanded/model.onnx | ❌ | Unsupported op Split |
+| node/test_rotary_embedding_no_position_ids_interleaved_expanded/model.onnx | ❌ | Split split input must be a constant initializer |
 | node/test_rotary_embedding_no_position_ids_rotary_dim/model.onnx | ❌ | Unsupported op RotaryEmbedding |
-| node/test_rotary_embedding_no_position_ids_rotary_dim_expanded/model.onnx | ❌ | Unsupported op Split |
+| node/test_rotary_embedding_no_position_ids_rotary_dim_expanded/model.onnx | ❌ | Split split input must be a constant initializer |
 | node/test_rotary_embedding_with_interleaved_rotary_dim/model.onnx | ❌ | Unsupported op RotaryEmbedding |
-| node/test_rotary_embedding_with_interleaved_rotary_dim_expanded/model.onnx | ❌ | Unsupported op Split |
+| node/test_rotary_embedding_with_interleaved_rotary_dim_expanded/model.onnx | ❌ | Split split input must be a constant initializer |
 | node/test_rotary_embedding_with_rotary_dim/model.onnx | ❌ | Unsupported op RotaryEmbedding |
-| node/test_rotary_embedding_with_rotary_dim_expanded/model.onnx | ❌ | Unsupported op Split |
+| node/test_rotary_embedding_with_rotary_dim_expanded/model.onnx | ❌ | Split split input must be a constant initializer |
 | node/test_round/model.onnx | ✅ |  |
 | node/test_scan9_sum/model.onnx | ❌ | Unsupported op Scan |
 | node/test_scan_sum/model.onnx | ❌ | Unsupported op Scan |
@@ -1529,23 +1529,23 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_softsign_expanded_ver18/model.onnx | ✅ |  |
 | node/test_spacetodepth/model.onnx | ❌ | Unsupported op SpaceToDepth |
 | node/test_spacetodepth_example/model.onnx | ❌ | Unsupported op SpaceToDepth |
-| node/test_split_1d_uneven_split_opset18/model.onnx | ❌ | Unsupported op Split |
-| node/test_split_2d_uneven_split_opset18/model.onnx | ❌ | Unsupported op Split |
-| node/test_split_equal_parts_1d_opset13/model.onnx | ❌ | Unsupported op Split |
-| node/test_split_equal_parts_1d_opset18/model.onnx | ❌ | Unsupported op Split |
-| node/test_split_equal_parts_2d/model.onnx | ❌ | Unsupported op Split |
-| node/test_split_equal_parts_2d_opset13/model.onnx | ❌ | Unsupported op Split |
-| node/test_split_equal_parts_default_axis_opset13/model.onnx | ❌ | Unsupported op Split |
-| node/test_split_equal_parts_default_axis_opset18/model.onnx | ❌ | Unsupported op Split |
+| node/test_split_1d_uneven_split_opset18/model.onnx | ✅ |  |
+| node/test_split_2d_uneven_split_opset18/model.onnx | ✅ |  |
+| node/test_split_equal_parts_1d_opset13/model.onnx | ✅ |  |
+| node/test_split_equal_parts_1d_opset18/model.onnx | ✅ |  |
+| node/test_split_equal_parts_2d/model.onnx | ✅ |  |
+| node/test_split_equal_parts_2d_opset13/model.onnx | ✅ |  |
+| node/test_split_equal_parts_default_axis_opset13/model.onnx | ✅ |  |
+| node/test_split_equal_parts_default_axis_opset18/model.onnx | ✅ |  |
 | node/test_split_to_sequence_1/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'seq'. Hint: export the model with tensor inputs/outputs. |
 | node/test_split_to_sequence_2/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'seq'. Hint: export the model with tensor inputs/outputs. |
 | node/test_split_to_sequence_nokeepdims/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'seq'. Hint: export the model with tensor inputs/outputs. |
-| node/test_split_variable_parts_1d_opset13/model.onnx | ❌ | Unsupported op Split |
-| node/test_split_variable_parts_1d_opset18/model.onnx | ❌ | Unsupported op Split |
-| node/test_split_variable_parts_2d_opset13/model.onnx | ❌ | Unsupported op Split |
-| node/test_split_variable_parts_2d_opset18/model.onnx | ❌ | Unsupported op Split |
-| node/test_split_variable_parts_default_axis_opset13/model.onnx | ❌ | Unsupported op Split |
-| node/test_split_variable_parts_default_axis_opset18/model.onnx | ❌ | Unsupported op Split |
+| node/test_split_variable_parts_1d_opset13/model.onnx | ❌ | Split split input must be a constant initializer |
+| node/test_split_variable_parts_1d_opset18/model.onnx | ❌ | Split split input must be a constant initializer |
+| node/test_split_variable_parts_2d_opset13/model.onnx | ❌ | Split split input must be a constant initializer |
+| node/test_split_variable_parts_2d_opset18/model.onnx | ❌ | Split split input must be a constant initializer |
+| node/test_split_variable_parts_default_axis_opset13/model.onnx | ❌ | Split split input must be a constant initializer |
+| node/test_split_variable_parts_default_axis_opset18/model.onnx | ❌ | Split split input must be a constant initializer |
 | node/test_split_zero_size_splits_opset13/model.onnx | ❌ | Dynamic or zero dims are not supported |
 | node/test_split_zero_size_splits_opset18/model.onnx | ❌ | Dynamic or zero dims are not supported |
 | node/test_sqrt/model.onnx | ✅ |  |
@@ -1714,8 +1714,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | pytorch-converted/test_ELU/model.onnx | ❌ | Elu only supports alpha=1.0 |
 | pytorch-converted/test_Embedding/model.onnx | ✅ |  |
 | pytorch-converted/test_Embedding_sparse/model.onnx | ✅ |  |
-| pytorch-converted/test_GLU/model.onnx | ❌ | Unsupported op Split |
-| pytorch-converted/test_GLU_dim/model.onnx | ❌ | Unsupported op Split |
+| pytorch-converted/test_GLU/model.onnx | ✅ |  |
+| pytorch-converted/test_GLU_dim/model.onnx | ✅ |  |
 | pytorch-converted/test_LeakyReLU/model.onnx | ✅ |  |
 | pytorch-converted/test_LeakyReLU_with_negval/model.onnx | ❌ | LeakyRelu only supports alpha=0.01 |
 | pytorch-converted/test_Linear/model.onnx | ✅ |  |
@@ -1759,7 +1759,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | pytorch-operator/test_operator_addconstant/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_addmm/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_basic/model.onnx | ✅ |  |
-| pytorch-operator/test_operator_chunk/model.onnx | ❌ | Unsupported op Split |
+| pytorch-operator/test_operator_chunk/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_clip/model.onnx | ❌ | 'ClipOp' object has no attribute 'shape' |
 | pytorch-operator/test_operator_concat2/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_conv/model.onnx | ✅ |  |
@@ -1787,10 +1787,10 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | pytorch-operator/test_operator_symbolic_override/model.onnx | ❌ | Unsupported op InstanceNormalization |
 | pytorch-operator/test_operator_symbolic_override_nested/model.onnx | ❌ | Sum must have 2 inputs and 1 output |
 | pytorch-operator/test_operator_view/model.onnx | ✅ |  |
-| simple/test_expand_shape_model1/model.onnx | ❌ | Unsupported op Expand |
-| simple/test_expand_shape_model2/model.onnx | ❌ | Unsupported op Expand |
-| simple/test_expand_shape_model3/model.onnx | ❌ | Unsupported op Expand |
-| simple/test_expand_shape_model4/model.onnx | ❌ | Unsupported op Expand |
+| simple/test_expand_shape_model1/model.onnx | ❌ | Expand shape input must be a constant initializer |
+| simple/test_expand_shape_model2/model.onnx | ❌ | Expand shape input must be a constant initializer |
+| simple/test_expand_shape_model3/model.onnx | ❌ | Expand shape input must be a constant initializer |
+| simple/test_expand_shape_model4/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | simple/test_gradient_of_add/model.onnx | ❌ | Unsupported op Gradient |
 | simple/test_gradient_of_add_and_mul/model.onnx | ❌ | Unsupported op Gradient |
 | simple/test_sequence_model1/model.onnx | ❌ | Dynamic dim for tensor 'out' |
@@ -1891,5 +1891,5 @@ Support 56 / 74 local ONNX files.
 | test_scatternd_indices_1x2x2/model.onnx | ❌ | Unsupported op ScatterND |
 | test_scatternd_indices_2x2x2/model.onnx | ❌ | Unsupported op ScatterND |
 | test_scatternd_indices_3x2/model.onnx | ❌ | Unsupported op ScatterND |
-| test_shape_const_out/model.onnx | ❌ | Unsupported op Expand |
+| test_shape_const_out/model.onnx | ❌ | Expand shape input must be a constant initializer |
 | test_slice_end_INT64_MAX/model.onnx | ✅ |  |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -2,12 +2,11 @@
 
 | Error message | Count | Histogram |
 | --- | --- | --- |
-| Unsupported op Expand | 57 | ██████████████████████████████ |
-| Unsupported op Range | 37 | ███████████████████ |
+| Expand shape input must be a constant initializer | 57 | ██████████████████████████████ |
 | Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 36 | ███████████████████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | █████████████████ |
 | Dynamic or zero dims are not supported | 32 | █████████████████ |
-| Unsupported op Split | 25 | █████████████ |
+| Range start input must be a constant initializer | 31 | ████████████████ |
 | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 22 | ████████████ |
 | Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 20 | ███████████ |
 | Unsupported op LayerNormalization | 19 | ██████████ |
@@ -25,6 +24,7 @@
 | Unsupported op Trilu | 16 | ████████ |
 | Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 14 | ███████ |
 | Unsupported op ConvTranspose | 14 | ███████ |
+| Split split input must be a constant initializer | 14 | ███████ |
 | '*' object has no attribute '*' | 13 | ███████ |
 | ReduceSum output shape rank must match input rank | 12 | ██████ |
 | Unsupported op CumSum | 9 | █████ |
@@ -39,6 +39,7 @@
 | Unsupported op TfIdfVectorizer | 7 | ████ |
 | Unsupported op TopK | 7 | ████ |
 | AveragePool has unsupported attributes | 6 | ███ |
+| Range limit input must be a constant initializer | 6 | ███ |
 | Unsupported elem_type 16 (BFLOAT16) for tensor '*'. | 6 | ███ |
 | Unsupported op CenterCropPad | 6 | ███ |
 | Unsupported op DFT | 6 | ███ |
@@ -143,4 +144,4 @@
 | Unsupported op QLinearAdd | 2 | ██████████ |
 | Unsupported op QLinearMul | 2 | ██████████ |
 | Gemm bias input must be broadcastable to output shape, got (2,) vs (2, 4) | 1 | █████ |
-| Unsupported op Expand | 1 | █████ |
+| Expand shape input must be a constant initializer | 1 | █████ |

--- a/src/onnx2c/compiler.py
+++ b/src/onnx2c/compiler.py
@@ -25,11 +25,14 @@ from .codegen.c_emitter import (
     GemmOp,
     GatherOp,
     GatherElementsOp,
+    ExpandOp,
+    RangeOp,
     LrnOp,
     LstmOp,
     LogSoftmaxOp,
     NegativeLogLikelihoodLossOp,
     NodeInfo,
+    SplitOp,
     SoftmaxCrossEntropyLossOp,
     LoweredModel,
     ModelHeader,
@@ -75,6 +78,9 @@ from .lowering.logsoftmax import lower_logsoftmax
 from .lowering.negative_log_likelihood_loss import (
     lower_negative_log_likelihood_loss,
 )
+from .lowering.expand import lower_expand
+from .lowering.range import lower_range
+from .lowering.split import lower_split
 from .lowering.softmax_cross_entropy_loss import (
     lower_softmax_cross_entropy_loss,
 )
@@ -320,6 +326,9 @@ class Compiler:
             | ResizeOp
             | ReduceOp
             | ShapeOp
+            | ExpandOp
+            | RangeOp
+            | SplitOp
         ],
         list[NodeInfo],
     ]:
@@ -351,6 +360,9 @@ class Compiler:
             | ResizeOp
             | ReduceOp
             | ShapeOp
+            | ExpandOp
+            | RangeOp
+            | SplitOp
             | WhereOp
         ] = []
         node_infos: list[NodeInfo] = []

--- a/src/onnx2c/lowering/expand.py
+++ b/src/onnx2c/lowering/expand.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import numpy as np
+
+from shared.scalar_types import ScalarType
+
+from ..codegen.c_emitter import ExpandOp
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Initializer, Node
+from ..lowering.common import value_dtype, value_shape
+from .registry import register_lowering
+
+
+def _find_initializer(graph: Graph, name: str) -> Initializer | None:
+    for initializer in graph.initializers:
+        if initializer.name == name:
+            return initializer
+    return None
+
+
+def _read_shape_values(graph: Graph, name: str, node: Node) -> list[int]:
+    initializer = _find_initializer(graph, name)
+    if initializer is None:
+        raise UnsupportedOpError(
+            f"{node.op_type} shape input must be a constant initializer"
+        )
+    if initializer.type.dtype not in {ScalarType.I64, ScalarType.I32}:
+        raise UnsupportedOpError(
+            f"{node.op_type} shape input must be int64 or int32"
+        )
+    if len(initializer.type.shape) != 1:
+        raise UnsupportedOpError(
+            f"{node.op_type} shape input must be a 1D tensor"
+        )
+    values = np.array(initializer.data, dtype=np.int64).reshape(-1)
+    if values.size == 0:
+        raise ShapeInferenceError(
+            f"{node.op_type} shape input cannot be empty"
+        )
+    return [int(value) for value in values]
+
+
+def _validate_static_dims(shape: tuple[int, ...], node: Node) -> None:
+    if any(dim <= 0 for dim in shape):
+        raise ShapeInferenceError(
+            f"{node.op_type} does not support zero or dynamic dims"
+        )
+
+
+def _broadcast_shape(
+    input_shape: tuple[int, ...], shape_values: list[int], node: Node
+) -> tuple[int, ...]:
+    _validate_static_dims(input_shape, node)
+    for dim in shape_values:
+        if dim <= 0:
+            raise ShapeInferenceError(
+                f"{node.op_type} does not support zero or dynamic dims"
+            )
+    output_rank = max(len(input_shape), len(shape_values))
+    input_padded = (1,) * (output_rank - len(input_shape)) + input_shape
+    shape_padded = (1,) * (output_rank - len(shape_values)) + tuple(shape_values)
+    result: list[int] = []
+    for input_dim, shape_dim in zip(input_padded, shape_padded):
+        if input_dim == 1:
+            result.append(shape_dim)
+        elif shape_dim == 1:
+            result.append(input_dim)
+        elif input_dim == shape_dim:
+            result.append(input_dim)
+        else:
+            raise ShapeInferenceError(
+                f"{node.op_type} input shape {input_shape} is not "
+                f"broadcastable to {shape_values}"
+            )
+    return tuple(result)
+
+
+def _compute_strides(shape: tuple[int, ...]) -> tuple[int, ...]:
+    strides: list[int] = []
+    stride = 1
+    for dim in reversed(shape):
+        strides.append(stride)
+        stride *= dim
+    return tuple(reversed(strides))
+
+
+@register_lowering("Expand")
+def lower_expand(graph: Graph, node: Node) -> ExpandOp:
+    if len(node.inputs) != 2 or len(node.outputs) != 1:
+        raise UnsupportedOpError("Expand must have 2 inputs and 1 output")
+    input_shape = value_shape(graph, node.inputs[0], node)
+    output_shape = value_shape(graph, node.outputs[0], node)
+    input_dtype = value_dtype(graph, node.inputs[0], node)
+    output_dtype = value_dtype(graph, node.outputs[0], node)
+    if input_dtype != output_dtype:
+        raise UnsupportedOpError(
+            f"{node.op_type} expects matching input/output dtypes, "
+            f"got {input_dtype} and {output_dtype}"
+        )
+    shape_values = _read_shape_values(graph, node.inputs[1], node)
+    expected_output_shape = _broadcast_shape(input_shape, shape_values, node)
+    _validate_static_dims(expected_output_shape, node)
+    if output_shape and output_shape != expected_output_shape:
+        raise ShapeInferenceError(
+            f"{node.op_type} output shape must be {expected_output_shape}, "
+            f"got {output_shape}"
+        )
+    input_shape_padded = (
+        (1,) * (len(expected_output_shape) - len(input_shape)) + input_shape
+    )
+    input_strides = _compute_strides(input_shape_padded)
+    return ExpandOp(
+        input0=node.inputs[0],
+        output=node.outputs[0],
+        input_shape=input_shape,
+        output_shape=expected_output_shape,
+        input_shape_padded=input_shape_padded,
+        input_strides=input_strides,
+        dtype=input_dtype,
+        input_dtype=input_dtype,
+    )

--- a/src/onnx2c/lowering/range.py
+++ b/src/onnx2c/lowering/range.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from shared.scalar_types import ScalarType
+
+from ..codegen.c_emitter import RangeOp
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Initializer, Node
+from ..lowering.common import node_dtype, value_shape
+from .registry import register_lowering
+
+
+_SUPPORTED_RANGE_DTYPES = {
+    ScalarType.F32,
+    ScalarType.F64,
+    ScalarType.I16,
+    ScalarType.I32,
+    ScalarType.I64,
+}
+
+
+def _find_initializer(graph: Graph, name: str) -> Initializer | None:
+    for initializer in graph.initializers:
+        if initializer.name == name:
+            return initializer
+    return None
+
+
+def _read_scalar_initializer(graph: Graph, name: str, node: Node, label: str) -> float | int:
+    initializer = _find_initializer(graph, name)
+    if initializer is None:
+        raise UnsupportedOpError(
+            f"{node.op_type} {label} input must be a constant initializer"
+        )
+    data = np.array(initializer.data)
+    if data.size != 1:
+        raise UnsupportedOpError(
+            f"{node.op_type} {label} input must be a scalar"
+        )
+    return data.reshape(-1)[0].item()
+
+
+def _is_scalar_shape(shape: tuple[int, ...]) -> bool:
+    return shape == () or shape == (1,)
+
+
+@register_lowering("Range")
+def lower_range(graph: Graph, node: Node) -> RangeOp:
+    if len(node.inputs) != 3 or len(node.outputs) != 1:
+        raise UnsupportedOpError("Range must have 3 inputs and 1 output")
+    start_shape = value_shape(graph, node.inputs[0], node)
+    limit_shape = value_shape(graph, node.inputs[1], node)
+    delta_shape = value_shape(graph, node.inputs[2], node)
+    if not (
+        _is_scalar_shape(start_shape)
+        and _is_scalar_shape(limit_shape)
+        and _is_scalar_shape(delta_shape)
+    ):
+        raise UnsupportedOpError("Range inputs must be scalars")
+    dtype = node_dtype(graph, node, *node.inputs, *node.outputs)
+    if dtype not in _SUPPORTED_RANGE_DTYPES:
+        raise UnsupportedOpError(
+            f"Range does not support dtype {dtype.onnx_name}"
+        )
+    start_value = _read_scalar_initializer(graph, node.inputs[0], node, "start")
+    limit_value = _read_scalar_initializer(graph, node.inputs[1], node, "limit")
+    delta_value = _read_scalar_initializer(graph, node.inputs[2], node, "delta")
+    if float(delta_value) == 0.0:
+        raise UnsupportedOpError("Range delta must be non-zero")
+    raw_count = (float(limit_value) - float(start_value)) / float(delta_value)
+    length = max(int(math.ceil(raw_count)), 0)
+    if length <= 0:
+        raise ShapeInferenceError("Range output length must be positive")
+    output_shape = value_shape(graph, node.outputs[0], node)
+    if len(output_shape) != 1:
+        raise ShapeInferenceError("Range output must be 1D")
+    if output_shape[0] != length:
+        raise ShapeInferenceError(
+            f"Range output length must be {length}, got {output_shape[0]}"
+        )
+    return RangeOp(
+        start=node.inputs[0],
+        limit=node.inputs[1],
+        delta=node.inputs[2],
+        output=node.outputs[0],
+        output_shape=output_shape,
+        length=length,
+        dtype=dtype,
+        input_dtype=dtype,
+    )

--- a/src/onnx2c/lowering/split.py
+++ b/src/onnx2c/lowering/split.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import numpy as np
+
+from shared.scalar_types import ScalarType
+
+from ..codegen.c_emitter import SplitOp
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Initializer, Node
+from ..lowering.common import optional_name, value_dtype, value_shape
+from ..validation import normalize_axis
+from .registry import register_lowering
+
+
+def _find_initializer(graph: Graph, name: str) -> Initializer | None:
+    for initializer in graph.initializers:
+        if initializer.name == name:
+            return initializer
+    return None
+
+
+def _read_split_sizes(graph: Graph, name: str, node: Node) -> list[int]:
+    initializer = _find_initializer(graph, name)
+    if initializer is None:
+        raise UnsupportedOpError(
+            f"{node.op_type} split input must be a constant initializer"
+        )
+    if initializer.type.dtype not in {ScalarType.I64, ScalarType.I32}:
+        raise UnsupportedOpError(
+            f"{node.op_type} split input must be int64 or int32"
+        )
+    if len(initializer.type.shape) != 1:
+        raise UnsupportedOpError(
+            f"{node.op_type} split input must be a 1D tensor"
+        )
+    values = np.array(initializer.data, dtype=np.int64).reshape(-1)
+    if values.size == 0:
+        raise ShapeInferenceError(
+            f"{node.op_type} split input cannot be empty"
+        )
+    return [int(value) for value in values]
+
+
+def _validate_static_dims(shape: tuple[int, ...], node: Node) -> None:
+    if any(dim <= 0 for dim in shape):
+        raise ShapeInferenceError(
+            f"{node.op_type} does not support zero or dynamic dims"
+        )
+
+
+def _normalize_num_outputs(node: Node, output_count: int) -> int:
+    num_outputs_attr = node.attrs.get("num_outputs")
+    if num_outputs_attr is None:
+        return output_count
+    num_outputs = int(num_outputs_attr)
+    if num_outputs <= 0:
+        raise UnsupportedOpError("Split num_outputs must be positive")
+    if output_count != num_outputs:
+        raise ShapeInferenceError(
+            f"Split expects {num_outputs} outputs, got {output_count}"
+        )
+    return num_outputs
+
+
+@register_lowering("Split")
+def lower_split(graph: Graph, node: Node) -> SplitOp:
+    if len(node.inputs) < 1 or len(node.outputs) < 1:
+        raise UnsupportedOpError("Split must have at least 1 input and 1 output")
+    if len(node.inputs) > 2:
+        raise UnsupportedOpError("Split supports up to 2 inputs")
+    input_name = node.inputs[0]
+    if not input_name:
+        raise UnsupportedOpError("Split input must be provided")
+    input_shape = value_shape(graph, input_name, node)
+    _validate_static_dims(input_shape, node)
+    axis = normalize_axis(int(node.attrs.get("axis", 0)), input_shape, node)
+    output_shapes = [
+        value_shape(graph, output, node) for output in node.outputs
+    ]
+    input_dtype = value_dtype(graph, input_name, node)
+    output_dtypes = {value_dtype(graph, output, node) for output in node.outputs}
+    if output_dtypes != {input_dtype}:
+        dtype_names = ", ".join(
+            dtype.onnx_name for dtype in sorted(output_dtypes, key=str)
+        )
+        raise UnsupportedOpError(
+            f"Split expects matching dtypes, got {dtype_names}"
+        )
+    split_name = optional_name(node.inputs, 1)
+    if split_name is not None and "num_outputs" in node.attrs:
+        raise UnsupportedOpError(
+            "Split cannot specify both split input and num_outputs"
+        )
+    if split_name is not None:
+        split_sizes = _read_split_sizes(graph, split_name, node)
+        if len(split_sizes) != len(node.outputs):
+            raise ShapeInferenceError(
+                f"Split expects {len(split_sizes)} outputs, got {len(node.outputs)}"
+            )
+        if any(size <= 0 for size in split_sizes):
+            raise ShapeInferenceError("Split sizes must be positive")
+        if sum(split_sizes) != input_shape[axis]:
+            raise ShapeInferenceError(
+                "Split sizes must sum to the axis dimension"
+            )
+    else:
+        num_outputs = _normalize_num_outputs(node, len(node.outputs))
+        axis_dim = input_shape[axis]
+        if axis_dim < num_outputs:
+            raise ShapeInferenceError(
+                "Split axis dimension must be >= num_outputs"
+            )
+        base = axis_dim // num_outputs
+        remainder = axis_dim % num_outputs
+        if base <= 0:
+            raise ShapeInferenceError("Split axis size must be positive")
+        split_sizes = [base + 1] * remainder + [base] * (
+            num_outputs - remainder
+        )
+    computed_shapes: list[tuple[int, ...]] = []
+    for size, output_shape in zip(split_sizes, output_shapes):
+        if size <= 0:
+            raise ShapeInferenceError("Split output size must be positive")
+        shape = list(input_shape)
+        shape[axis] = size
+        computed_shape = tuple(shape)
+        if output_shape != computed_shape:
+            raise ShapeInferenceError(
+                f"Split output shape must be {computed_shape}, got {output_shape}"
+            )
+        computed_shapes.append(computed_shape)
+    return SplitOp(
+        input0=input_name,
+        outputs=tuple(node.outputs),
+        input_shape=input_shape,
+        output_shapes=tuple(computed_shapes),
+        axis=axis,
+        split_sizes=tuple(split_sizes),
+        dtype=input_dtype,
+        input_dtype=input_dtype,
+    )

--- a/templates/expand_op.c.j2
+++ b/templates/expand_op.c.j2
@@ -1,0 +1,14 @@
+static inline void {{ op_name }}({{ dim_args }}const {{ c_type }} {{ input0 }}{{ input_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+    const {{ c_type }} *input_data = (const {{ c_type }} *){{ input0 }};
+    {{ c_type }} *output_data = ({{ c_type }} *){{ output }};
+    size_t output_index = 0;
+{% for dim in output_shape %}
+    for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+{% endfor %}
+        size_t input_index = {{ input_index_expr }};
+        output_data[output_index] = input_data[input_index];
+        output_index++;
+{% for _ in output_shape %}
+    }
+{% endfor %}
+}

--- a/templates/range_op.c.j2
+++ b/templates/range_op.c.j2
@@ -1,0 +1,8 @@
+static inline void {{ op_name }}({{ dim_args }}const {{ c_type }} {{ start }}{{ input_suffix }}, const {{ c_type }} {{ limit }}{{ input_suffix }}, const {{ c_type }} {{ delta }}{{ input_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+    (void){{ limit }};
+    const {{ c_type }} start_value = {{ start }}[0];
+    const {{ c_type }} delta_value = {{ delta }}[0];
+    for (size_t idx = 0; idx < {{ length }}; ++idx) {
+        {{ output }}[idx] = start_value + (({{ c_type }})idx * delta_value);
+    }
+}

--- a/templates/split_op.c.j2
+++ b/templates/split_op.c.j2
@@ -1,0 +1,18 @@
+static inline void {{ op_name }}({{ dim_args }}const {{ c_type }} {{ input0 }}{{ input_suffix }}, {% for output in outputs %}{{ c_type }} {{ output }}{{ output_suffixes[loop.index0] }}{% if not loop.last %}, {% endif %}{% endfor %}) {
+    const {{ c_type }} *input_data = (const {{ c_type }} *){{ input0 }};
+    {{ c_type }} *output_ptrs[] = { {% for output in outputs %}({{ c_type }} *){{ output }}{% if not loop.last %}, {% endif %}{% endfor %} };
+    const size_t axis_sizes[] = { {% for axis in axis_sizes %}{{ axis }}{% if not loop.last %}, {% endif %}{% endfor %} };
+    for (size_t outer_idx = 0; outer_idx < {{ outer }}; ++outer_idx) {
+        size_t input_base = outer_idx * {{ axis_total }} * {{ inner }};
+        size_t axis_offset = 0;
+        for (size_t output_idx = 0; output_idx < {{ output_count }}; ++output_idx) {
+            size_t copy_elems = axis_sizes[output_idx] * {{ inner }};
+            memcpy(
+                output_ptrs[output_idx] + outer_idx * copy_elems,
+                input_data + input_base + axis_offset,
+                copy_elems * sizeof({{ c_type }})
+            );
+            axis_offset += copy_elems;
+        }
+    }
+}

--- a/tests/local_onnx_expected_errors.json
+++ b/tests/local_onnx_expected_errors.json
@@ -289,7 +289,7 @@
   ],
   [
     "test_shape_const_out/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "test_slice_end_INT64_MAX/model.onnx",

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -369,7 +369,7 @@
   ],
   [
     "node/test_attention_3d_attn_mask_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_3d_causal/model.onnx",
@@ -377,7 +377,7 @@
   ],
   [
     "node/test_attention_3d_causal_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_attention_3d_diff_heads_sizes/model.onnx",
@@ -389,7 +389,7 @@
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_attn_mask_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_causal/model.onnx",
@@ -397,11 +397,11 @@
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_causal_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_scaled/model.onnx",
@@ -409,7 +409,7 @@
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_scaled_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_softcap/model.onnx",
@@ -417,7 +417,7 @@
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_softcap_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_3d_diff_heads_with_past_and_present/model.onnx",
@@ -425,11 +425,11 @@
   ],
   [
     "node/test_attention_3d_diff_heads_with_past_and_present_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_3d_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_3d_gqa/model.onnx",
@@ -441,7 +441,7 @@
   ],
   [
     "node/test_attention_3d_gqa_attn_mask_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_3d_gqa_causal/model.onnx",
@@ -449,11 +449,11 @@
   ],
   [
     "node/test_attention_3d_gqa_causal_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_attention_3d_gqa_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_3d_gqa_scaled/model.onnx",
@@ -461,7 +461,7 @@
   ],
   [
     "node/test_attention_3d_gqa_scaled_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_3d_gqa_softcap/model.onnx",
@@ -469,7 +469,7 @@
   ],
   [
     "node/test_attention_3d_gqa_softcap_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_3d_gqa_with_past_and_present/model.onnx",
@@ -477,7 +477,7 @@
   ],
   [
     "node/test_attention_3d_gqa_with_past_and_present_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_3d_scaled/model.onnx",
@@ -485,7 +485,7 @@
   ],
   [
     "node/test_attention_3d_scaled_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_3d_softcap/model.onnx",
@@ -493,7 +493,7 @@
   ],
   [
     "node/test_attention_3d_softcap_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_3d_transpose_verification/model.onnx",
@@ -501,7 +501,7 @@
   ],
   [
     "node/test_attention_3d_transpose_verification_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_3d_with_past_and_present/model.onnx",
@@ -509,7 +509,7 @@
   ],
   [
     "node/test_attention_3d_with_past_and_present_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul/model.onnx",
@@ -521,11 +521,11 @@
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_bias_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_softcap/model.onnx",
@@ -533,7 +533,7 @@
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_softmax/model.onnx",
@@ -541,7 +541,7 @@
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d/model.onnx",
@@ -561,11 +561,11 @@
   ],
   [
     "node/test_attention_4d_attn_mask_3d_causal_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_attn_mask_3d_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_attn_mask_4d/model.onnx",
@@ -577,11 +577,11 @@
   ],
   [
     "node/test_attention_4d_attn_mask_4d_causal_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_attn_mask_4d_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_attn_mask_bool/model.onnx",
@@ -593,15 +593,15 @@
   ],
   [
     "node/test_attention_4d_attn_mask_bool_4d_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_attn_mask_bool_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_attn_mask_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_causal/model.onnx",
@@ -609,7 +609,7 @@
   ],
   [
     "node/test_attention_4d_causal_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_diff_heads_mask4d_padded_kv/model.onnx",
@@ -629,7 +629,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_attn_mask_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_causal/model.onnx",
@@ -637,11 +637,11 @@
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_causal_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_scaled/model.onnx",
@@ -649,7 +649,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_scaled_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_softcap/model.onnx",
@@ -657,7 +657,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_softcap_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present/model.onnx",
@@ -665,7 +665,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_mask3d/model.onnx",
@@ -673,7 +673,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_mask3d_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_mask4d/model.onnx",
@@ -681,11 +681,11 @@
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_mask4d_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_fp16/model.onnx",
@@ -693,7 +693,7 @@
   ],
   [
     "node/test_attention_4d_fp16_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_gqa/model.onnx",
@@ -705,7 +705,7 @@
   ],
   [
     "node/test_attention_4d_gqa_attn_mask_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_gqa_causal/model.onnx",
@@ -713,11 +713,11 @@
   ],
   [
     "node/test_attention_4d_gqa_causal_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_gqa_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_gqa_scaled/model.onnx",
@@ -725,7 +725,7 @@
   ],
   [
     "node/test_attention_4d_gqa_scaled_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_gqa_softcap/model.onnx",
@@ -733,7 +733,7 @@
   ],
   [
     "node/test_attention_4d_gqa_softcap_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_gqa_with_past_and_present/model.onnx",
@@ -741,7 +741,7 @@
   ],
   [
     "node/test_attention_4d_gqa_with_past_and_present_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_gqa_with_past_and_present_fp16/model.onnx",
@@ -749,7 +749,7 @@
   ],
   [
     "node/test_attention_4d_gqa_with_past_and_present_fp16_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_scaled/model.onnx",
@@ -757,7 +757,7 @@
   ],
   [
     "node/test_attention_4d_scaled_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_softcap/model.onnx",
@@ -765,7 +765,7 @@
   ],
   [
     "node/test_attention_4d_softcap_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_with_past_and_present/model.onnx",
@@ -773,7 +773,7 @@
   ],
   [
     "node/test_attention_4d_with_past_and_present_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul/model.onnx",
@@ -793,11 +793,11 @@
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask/model.onnx",
@@ -809,19 +809,19 @@
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_with_qk_matmul/model.onnx",
@@ -833,11 +833,11 @@
   ],
   [
     "node/test_attention_4d_with_qk_matmul_bias_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_with_qk_matmul_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_with_qk_matmul_softcap/model.onnx",
@@ -845,7 +845,7 @@
   ],
   [
     "node/test_attention_4d_with_qk_matmul_softcap_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_attention_4d_with_qk_matmul_softmax/model.onnx",
@@ -853,7 +853,7 @@
   ],
   [
     "node/test_attention_4d_with_qk_matmul_softmax_expanded/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_averagepool_1d_default/model.onnx",
@@ -1089,7 +1089,7 @@
   ],
   [
     "node/test_blackmanwindow_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range limit input must be a constant initializer"
   ],
   [
     "node/test_blackmanwindow_symmetric/model.onnx",
@@ -1097,7 +1097,7 @@
   ],
   [
     "node/test_blackmanwindow_symmetric_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range limit input must be a constant initializer"
   ],
   [
     "node/test_cast_BFLOAT16_to_FLOAT/model.onnx",
@@ -2473,11 +2473,11 @@
   ],
   [
     "node/test_expand_dim_changed/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_expand_dim_unchanged/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "node/test_eyelike_populate_off_main_diagonal/model.onnx",
@@ -2873,7 +2873,7 @@
   ],
   [
     "node/test_hammingwindow_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range limit input must be a constant initializer"
   ],
   [
     "node/test_hammingwindow_symmetric/model.onnx",
@@ -2881,7 +2881,7 @@
   ],
   [
     "node/test_hammingwindow_symmetric_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range limit input must be a constant initializer"
   ],
   [
     "node/test_hannwindow/model.onnx",
@@ -2889,7 +2889,7 @@
   ],
   [
     "node/test_hannwindow_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range limit input must be a constant initializer"
   ],
   [
     "node/test_hannwindow_symmetric/model.onnx",
@@ -2897,7 +2897,7 @@
   ],
   [
     "node/test_hannwindow_symmetric_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range limit input must be a constant initializer"
   ],
   [
     "node/test_hardmax_axis_0/model.onnx",
@@ -4397,7 +4397,7 @@
   ],
   [
     "node/test_range_float_type_positive_delta/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_range_float_type_positive_delta_expanded/model.onnx",
@@ -4405,7 +4405,7 @@
   ],
   [
     "node/test_range_int32_type_negative_delta/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_range_int32_type_negative_delta_expanded/model.onnx",
@@ -5177,7 +5177,7 @@
   ],
   [
     "node/test_rms_normalization_2d_axis0_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_rms_normalization_2d_axis1/model.onnx",
@@ -5185,7 +5185,7 @@
   ],
   [
     "node/test_rms_normalization_2d_axis1_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_rms_normalization_2d_axis_negative_1/model.onnx",
@@ -5193,7 +5193,7 @@
   ],
   [
     "node/test_rms_normalization_2d_axis_negative_1_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_rms_normalization_2d_axis_negative_2/model.onnx",
@@ -5201,7 +5201,7 @@
   ],
   [
     "node/test_rms_normalization_2d_axis_negative_2_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_rms_normalization_3d_axis0_epsilon/model.onnx",
@@ -5209,7 +5209,7 @@
   ],
   [
     "node/test_rms_normalization_3d_axis0_epsilon_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_rms_normalization_3d_axis1_epsilon/model.onnx",
@@ -5217,7 +5217,7 @@
   ],
   [
     "node/test_rms_normalization_3d_axis1_epsilon_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_rms_normalization_3d_axis2_epsilon/model.onnx",
@@ -5225,7 +5225,7 @@
   ],
   [
     "node/test_rms_normalization_3d_axis2_epsilon_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_rms_normalization_3d_axis_negative_1_epsilon/model.onnx",
@@ -5233,7 +5233,7 @@
   ],
   [
     "node/test_rms_normalization_3d_axis_negative_1_epsilon_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_rms_normalization_3d_axis_negative_2_epsilon/model.onnx",
@@ -5241,7 +5241,7 @@
   ],
   [
     "node/test_rms_normalization_3d_axis_negative_2_epsilon_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_rms_normalization_3d_axis_negative_3_epsilon/model.onnx",
@@ -5249,7 +5249,7 @@
   ],
   [
     "node/test_rms_normalization_3d_axis_negative_3_epsilon_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_rms_normalization_4d_axis0/model.onnx",
@@ -5257,7 +5257,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis0_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_rms_normalization_4d_axis1/model.onnx",
@@ -5265,7 +5265,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis1_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_rms_normalization_4d_axis2/model.onnx",
@@ -5273,7 +5273,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis2_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_rms_normalization_4d_axis3/model.onnx",
@@ -5281,7 +5281,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis3_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_1/model.onnx",
@@ -5289,7 +5289,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_1_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_2/model.onnx",
@@ -5297,7 +5297,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_2_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_3/model.onnx",
@@ -5305,7 +5305,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_3_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_4/model.onnx",
@@ -5313,7 +5313,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_4_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_rms_normalization_default_axis/model.onnx",
@@ -5321,7 +5321,7 @@
   ],
   [
     "node/test_rms_normalization_default_axis_expanded/model.onnx",
-    "Unsupported op Range"
+    "Range start input must be a constant initializer"
   ],
   [
     "node/test_rnn_seq_length/model.onnx",
@@ -5349,11 +5349,11 @@
   ],
   [
     "node/test_rotary_embedding_3d_input_expanded/model.onnx",
-    "Unsupported op Split"
+    "Split split input must be a constant initializer"
   ],
   [
     "node/test_rotary_embedding_expanded/model.onnx",
-    "Unsupported op Split"
+    "Split split input must be a constant initializer"
   ],
   [
     "node/test_rotary_embedding_interleaved/model.onnx",
@@ -5361,7 +5361,7 @@
   ],
   [
     "node/test_rotary_embedding_interleaved_expanded/model.onnx",
-    "Unsupported op Split"
+    "Split split input must be a constant initializer"
   ],
   [
     "node/test_rotary_embedding_no_position_ids/model.onnx",
@@ -5369,7 +5369,7 @@
   ],
   [
     "node/test_rotary_embedding_no_position_ids_expanded/model.onnx",
-    "Unsupported op Split"
+    "Split split input must be a constant initializer"
   ],
   [
     "node/test_rotary_embedding_no_position_ids_interleaved/model.onnx",
@@ -5377,7 +5377,7 @@
   ],
   [
     "node/test_rotary_embedding_no_position_ids_interleaved_expanded/model.onnx",
-    "Unsupported op Split"
+    "Split split input must be a constant initializer"
   ],
   [
     "node/test_rotary_embedding_no_position_ids_rotary_dim/model.onnx",
@@ -5385,7 +5385,7 @@
   ],
   [
     "node/test_rotary_embedding_no_position_ids_rotary_dim_expanded/model.onnx",
-    "Unsupported op Split"
+    "Split split input must be a constant initializer"
   ],
   [
     "node/test_rotary_embedding_with_interleaved_rotary_dim/model.onnx",
@@ -5393,7 +5393,7 @@
   ],
   [
     "node/test_rotary_embedding_with_interleaved_rotary_dim_expanded/model.onnx",
-    "Unsupported op Split"
+    "Split split input must be a constant initializer"
   ],
   [
     "node/test_rotary_embedding_with_rotary_dim/model.onnx",
@@ -5401,7 +5401,7 @@
   ],
   [
     "node/test_rotary_embedding_with_rotary_dim_expanded/model.onnx",
-    "Unsupported op Split"
+    "Split split input must be a constant initializer"
   ],
   [
     "node/test_round/model.onnx",
@@ -6085,35 +6085,35 @@
   ],
   [
     "node/test_split_1d_uneven_split_opset18/model.onnx",
-    "Unsupported op Split"
+    ""
   ],
   [
     "node/test_split_2d_uneven_split_opset18/model.onnx",
-    "Unsupported op Split"
+    ""
   ],
   [
     "node/test_split_equal_parts_1d_opset13/model.onnx",
-    "Unsupported op Split"
+    ""
   ],
   [
     "node/test_split_equal_parts_1d_opset18/model.onnx",
-    "Unsupported op Split"
+    ""
   ],
   [
     "node/test_split_equal_parts_2d/model.onnx",
-    "Unsupported op Split"
+    ""
   ],
   [
     "node/test_split_equal_parts_2d_opset13/model.onnx",
-    "Unsupported op Split"
+    ""
   ],
   [
     "node/test_split_equal_parts_default_axis_opset13/model.onnx",
-    "Unsupported op Split"
+    ""
   ],
   [
     "node/test_split_equal_parts_default_axis_opset18/model.onnx",
-    "Unsupported op Split"
+    ""
   ],
   [
     "node/test_split_to_sequence_1/model.onnx",
@@ -6129,27 +6129,27 @@
   ],
   [
     "node/test_split_variable_parts_1d_opset13/model.onnx",
-    "Unsupported op Split"
+    "Split split input must be a constant initializer"
   ],
   [
     "node/test_split_variable_parts_1d_opset18/model.onnx",
-    "Unsupported op Split"
+    "Split split input must be a constant initializer"
   ],
   [
     "node/test_split_variable_parts_2d_opset13/model.onnx",
-    "Unsupported op Split"
+    "Split split input must be a constant initializer"
   ],
   [
     "node/test_split_variable_parts_2d_opset18/model.onnx",
-    "Unsupported op Split"
+    "Split split input must be a constant initializer"
   ],
   [
     "node/test_split_variable_parts_default_axis_opset13/model.onnx",
-    "Unsupported op Split"
+    "Split split input must be a constant initializer"
   ],
   [
     "node/test_split_variable_parts_default_axis_opset18/model.onnx",
-    "Unsupported op Split"
+    "Split split input must be a constant initializer"
   ],
   [
     "node/test_split_zero_size_splits_opset13/model.onnx",
@@ -6825,11 +6825,11 @@
   ],
   [
     "pytorch-converted/test_GLU/model.onnx",
-    "Unsupported op Split"
+    ""
   ],
   [
     "pytorch-converted/test_GLU_dim/model.onnx",
-    "Unsupported op Split"
+    ""
   ],
   [
     "pytorch-converted/test_LeakyReLU/model.onnx",
@@ -7005,7 +7005,7 @@
   ],
   [
     "pytorch-operator/test_operator_chunk/model.onnx",
-    "Unsupported op Split"
+    ""
   ],
   [
     "pytorch-operator/test_operator_clip/model.onnx",
@@ -7117,19 +7117,19 @@
   ],
   [
     "simple/test_expand_shape_model1/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "simple/test_expand_shape_model2/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "simple/test_expand_shape_model3/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "simple/test_expand_shape_model4/model.onnx",
-    "Unsupported op Expand"
+    "Expand shape input must be a constant initializer"
   ],
   [
     "simple/test_gradient_of_add/model.onnx",


### PR DESCRIPTION
### Motivation

- Reduce unsupported-op coverage and enable ONNX models that use `Expand`, `Range`, and `Split` to be lowered and codegen'd by the compiler.  
- Provide both lowering-time validation (shape/dtype checks) and runtime/evaluator support for constant folding and verification.  
- Emit C kernels for the operators to allow end-to-end code generation and testbench verification.

### Description

- Added lowering implementations for the new operators in `src/onnx2c/lowering/` (`expand.py`, `range.py`, `split.py`) that validate shapes/dtypes and produce op dataclasses.  
- Extended the codegen surface in `src/onnx2c/codegen/c_emitter.py` with `ExpandOp`, `RangeOp`, and `SplitOp` dataclasses, rendering paths, template loading, and inclusion logic.  
- Added C templates `templates/expand_op.c.j2`, `templates/range_op.c.j2`, and `templates/split_op.c.j2` and hooked them into the emitter.  
- Implemented evaluator handlers in `src/onnx2c/runtime/evaluator.py` to support `Expand`, `Range`, and `Split` at runtime/constant-fold evaluation.  
- Integrated the new ops into the compiler lowering flow (`src/onnx2c/compiler.py`) and updated tests and reference expectations accordingly, including updated `tests/test_endtoend_ops.py` and refreshed official/local ONNX expected-error snapshots and support markdown files.

### Testing

- Ran the full test suite with reference updates via `UPDATE_REFS=1 pytest -n auto -q`, which completed in 66.05s and reported `165 passed, 1 skipped` (all tests passed).  
- Updated golden/reference files (`OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`, and corresponding JSON expectations) to reflect the new operator support and improved error messages.  
- Added end-to-end and numerical comparison tests for `Expand`, `Range`, and `Split` in `tests/test_endtoend_ops.py`, which were exercised during the test run and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6967872e77208325974657582bcebe17)