### PR TITLE
Add ArgMax/ArgMin (ArgReduce) lowering, codegen, runtime and tests

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 988 / 1802 official ONNX files.
+Support 1020 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -58,38 +58,38 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_and_bcast4v2d/model.onnx | ✅ |  |
 | node/test_and_bcast4v3d/model.onnx | ✅ |  |
 | node/test_and_bcast4v4d/model.onnx | ✅ |  |
-| node/test_argmax_default_axis_example/model.onnx | ❌ | Unsupported op ArgMax |
-| node/test_argmax_default_axis_example_select_last_index/model.onnx | ❌ | Unsupported op ArgMax |
-| node/test_argmax_default_axis_random/model.onnx | ❌ | Unsupported op ArgMax |
-| node/test_argmax_default_axis_random_select_last_index/model.onnx | ❌ | Unsupported op ArgMax |
-| node/test_argmax_keepdims_example/model.onnx | ❌ | Unsupported op ArgMax |
-| node/test_argmax_keepdims_example_select_last_index/model.onnx | ❌ | Unsupported op ArgMax |
-| node/test_argmax_keepdims_random/model.onnx | ❌ | Unsupported op ArgMax |
-| node/test_argmax_keepdims_random_select_last_index/model.onnx | ❌ | Unsupported op ArgMax |
-| node/test_argmax_negative_axis_keepdims_example/model.onnx | ❌ | Unsupported op ArgMax |
-| node/test_argmax_negative_axis_keepdims_example_select_last_index/model.onnx | ❌ | Unsupported op ArgMax |
-| node/test_argmax_negative_axis_keepdims_random/model.onnx | ❌ | Unsupported op ArgMax |
-| node/test_argmax_negative_axis_keepdims_random_select_last_index/model.onnx | ❌ | Unsupported op ArgMax |
-| node/test_argmax_no_keepdims_example/model.onnx | ❌ | Unsupported op ArgMax |
-| node/test_argmax_no_keepdims_example_select_last_index/model.onnx | ❌ | Unsupported op ArgMax |
-| node/test_argmax_no_keepdims_random/model.onnx | ❌ | Unsupported op ArgMax |
-| node/test_argmax_no_keepdims_random_select_last_index/model.onnx | ❌ | Unsupported op ArgMax |
-| node/test_argmin_default_axis_example/model.onnx | ❌ | Unsupported op ArgMin |
-| node/test_argmin_default_axis_example_select_last_index/model.onnx | ❌ | Unsupported op ArgMin |
-| node/test_argmin_default_axis_random/model.onnx | ❌ | Unsupported op ArgMin |
-| node/test_argmin_default_axis_random_select_last_index/model.onnx | ❌ | Unsupported op ArgMin |
-| node/test_argmin_keepdims_example/model.onnx | ❌ | Unsupported op ArgMin |
-| node/test_argmin_keepdims_example_select_last_index/model.onnx | ❌ | Unsupported op ArgMin |
-| node/test_argmin_keepdims_random/model.onnx | ❌ | Unsupported op ArgMin |
-| node/test_argmin_keepdims_random_select_last_index/model.onnx | ❌ | Unsupported op ArgMin |
-| node/test_argmin_negative_axis_keepdims_example/model.onnx | ❌ | Unsupported op ArgMin |
-| node/test_argmin_negative_axis_keepdims_example_select_last_index/model.onnx | ❌ | Unsupported op ArgMin |
-| node/test_argmin_negative_axis_keepdims_random/model.onnx | ❌ | Unsupported op ArgMin |
-| node/test_argmin_negative_axis_keepdims_random_select_last_index/model.onnx | ❌ | Unsupported op ArgMin |
-| node/test_argmin_no_keepdims_example/model.onnx | ❌ | Unsupported op ArgMin |
-| node/test_argmin_no_keepdims_example_select_last_index/model.onnx | ❌ | Unsupported op ArgMin |
-| node/test_argmin_no_keepdims_random/model.onnx | ❌ | Unsupported op ArgMin |
-| node/test_argmin_no_keepdims_random_select_last_index/model.onnx | ❌ | Unsupported op ArgMin |
+| node/test_argmax_default_axis_example/model.onnx | ✅ |  |
+| node/test_argmax_default_axis_example_select_last_index/model.onnx | ✅ |  |
+| node/test_argmax_default_axis_random/model.onnx | ✅ |  |
+| node/test_argmax_default_axis_random_select_last_index/model.onnx | ✅ |  |
+| node/test_argmax_keepdims_example/model.onnx | ✅ |  |
+| node/test_argmax_keepdims_example_select_last_index/model.onnx | ✅ |  |
+| node/test_argmax_keepdims_random/model.onnx | ✅ |  |
+| node/test_argmax_keepdims_random_select_last_index/model.onnx | ✅ |  |
+| node/test_argmax_negative_axis_keepdims_example/model.onnx | ✅ |  |
+| node/test_argmax_negative_axis_keepdims_example_select_last_index/model.onnx | ✅ |  |
+| node/test_argmax_negative_axis_keepdims_random/model.onnx | ✅ |  |
+| node/test_argmax_negative_axis_keepdims_random_select_last_index/model.onnx | ✅ |  |
+| node/test_argmax_no_keepdims_example/model.onnx | ✅ |  |
+| node/test_argmax_no_keepdims_example_select_last_index/model.onnx | ✅ |  |
+| node/test_argmax_no_keepdims_random/model.onnx | ✅ |  |
+| node/test_argmax_no_keepdims_random_select_last_index/model.onnx | ✅ |  |
+| node/test_argmin_default_axis_example/model.onnx | ✅ |  |
+| node/test_argmin_default_axis_example_select_last_index/model.onnx | ✅ |  |
+| node/test_argmin_default_axis_random/model.onnx | ✅ |  |
+| node/test_argmin_default_axis_random_select_last_index/model.onnx | ✅ |  |
+| node/test_argmin_keepdims_example/model.onnx | ✅ |  |
+| node/test_argmin_keepdims_example_select_last_index/model.onnx | ✅ |  |
+| node/test_argmin_keepdims_random/model.onnx | ✅ |  |
+| node/test_argmin_keepdims_random_select_last_index/model.onnx | ✅ |  |
+| node/test_argmin_negative_axis_keepdims_example/model.onnx | ✅ |  |
+| node/test_argmin_negative_axis_keepdims_example_select_last_index/model.onnx | ✅ |  |
+| node/test_argmin_negative_axis_keepdims_random/model.onnx | ✅ |  |
+| node/test_argmin_negative_axis_keepdims_random_select_last_index/model.onnx | ✅ |  |
+| node/test_argmin_no_keepdims_example/model.onnx | ✅ |  |
+| node/test_argmin_no_keepdims_example_select_last_index/model.onnx | ✅ |  |
+| node/test_argmin_no_keepdims_random/model.onnx | ✅ |  |
+| node/test_argmin_no_keepdims_random_select_last_index/model.onnx | ✅ |  |
 | node/test_asin/model.onnx | ✅ |  |
 | node/test_asin_example/model.onnx | ✅ |  |
 | node/test_asinh/model.onnx | ✅ |  |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -18,8 +18,6 @@
 | Unsupported elem_type 22 (INT4) for tensor '*'. | 17 | ██████████████ |
 | Unsupported elem_type 25 (UINT2) for tensor '*'. | 17 | ██████████████ |
 | Unsupported elem_type 21 (UINT4) for tensor '*'. | 17 | ██████████████ |
-| Unsupported op ArgMax | 16 | █████████████ |
-| Unsupported op ArgMin | 16 | █████████████ |
 | Unsupported op Trilu | 16 | █████████████ |
 | Reshape input and output element counts must match | 15 | ████████████ |
 | Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 14 | ████████████ |

--- a/src/onnx2c/compiler.py
+++ b/src/onnx2c/compiler.py
@@ -39,6 +39,7 @@ from .codegen.c_emitter import (
     MatMulOp,
     MaxPoolOp,
     ReduceOp,
+    ArgReduceOp,
     ReshapeOp,
     ResizeOp,
     SoftmaxOp,
@@ -90,6 +91,7 @@ from .lowering.reduce import (
     REDUCE_KIND_BY_OP,
     REDUCE_OUTPUTS_FLOAT_ONLY,
 )
+from .lowering import arg_reduce as _arg_reduce  # noqa: F401
 from .lowering.reshape import lower_reshape
 from .lowering.resize import lower_resize
 from .lowering.slice import lower_slice
@@ -325,6 +327,7 @@ class Compiler:
             | SliceOp
             | ResizeOp
             | ReduceOp
+            | ArgReduceOp
             | ShapeOp
             | ExpandOp
             | RangeOp
@@ -359,6 +362,7 @@ class Compiler:
             | SliceOp
             | ResizeOp
             | ReduceOp
+            | ArgReduceOp
             | ShapeOp
             | ExpandOp
             | RangeOp

--- a/src/onnx2c/lowering/arg_reduce.py
+++ b/src/onnx2c/lowering/arg_reduce.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from shared.scalar_types import ScalarType
+
+from ..codegen.c_emitter import ArgReduceOp
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Node
+from .common import shape_product, value_dtype, value_shape
+from .registry import register_lowering
+
+ARG_REDUCE_KIND_BY_OP = {"ArgMax": "max", "ArgMin": "min"}
+
+
+def _normalize_axis(axis: int, rank: int, node: Node) -> int:
+    if rank <= 0:
+        raise ShapeInferenceError(
+            f"{node.op_type} requires input rank >= 1, got {rank}"
+        )
+    if axis < 0:
+        axis += rank
+    if axis < 0 or axis >= rank:
+        raise ShapeInferenceError(
+            f"{node.op_type} axis {axis} is out of range for rank {rank}"
+        )
+    return axis
+
+
+def _output_shape(
+    input_shape: tuple[int, ...], axis: int, keepdims: bool
+) -> tuple[int, ...]:
+    if keepdims:
+        return tuple(1 if idx == axis else dim for idx, dim in enumerate(input_shape))
+    return tuple(dim for idx, dim in enumerate(input_shape) if idx != axis)
+
+
+def _arg_reduce_dtype_supported(dtype: ScalarType) -> bool:
+    return dtype in {
+        ScalarType.F16,
+        ScalarType.F32,
+        ScalarType.F64,
+        ScalarType.I64,
+        ScalarType.I32,
+        ScalarType.I16,
+        ScalarType.I8,
+        ScalarType.U64,
+        ScalarType.U32,
+        ScalarType.U16,
+        ScalarType.U8,
+    }
+
+
+def lower_arg_reduce(graph: Graph, node: Node) -> ArgReduceOp:
+    if node.op_type not in ARG_REDUCE_KIND_BY_OP:
+        raise UnsupportedOpError(f"Unsupported op {node.op_type}")
+    if len(node.inputs) != 1 or len(node.outputs) != 1:
+        raise UnsupportedOpError(
+            f"{node.op_type} must have 1 input and 1 output"
+        )
+    input_name = node.inputs[0]
+    output_name = node.outputs[0]
+    input_shape = value_shape(graph, input_name, node)
+    shape_product(input_shape)
+    rank = len(input_shape)
+    axis = int(node.attrs.get("axis", 0))
+    axis = _normalize_axis(axis, rank, node)
+    keepdims = bool(int(node.attrs.get("keepdims", 1)))
+    select_last_index = bool(int(node.attrs.get("select_last_index", 0)))
+    expected_output_shape = _output_shape(input_shape, axis, keepdims)
+    output_shape = value_shape(graph, output_name, node)
+    if output_shape != expected_output_shape:
+        raise ShapeInferenceError(
+            f"{node.op_type} output shape must be {expected_output_shape}, got {output_shape}"
+        )
+    input_dtype = value_dtype(graph, input_name, node)
+    if not _arg_reduce_dtype_supported(input_dtype):
+        raise UnsupportedOpError(
+            f"{node.op_type} does not support dtype {input_dtype.onnx_name}"
+        )
+    output_dtype = value_dtype(graph, output_name, node)
+    if output_dtype != ScalarType.I64:
+        raise UnsupportedOpError(
+            f"{node.op_type} expects output dtype int64, got {output_dtype.onnx_name}"
+        )
+    return ArgReduceOp(
+        input0=input_name,
+        output=output_name,
+        input_shape=input_shape,
+        output_shape=output_shape,
+        axis=axis,
+        keepdims=keepdims,
+        select_last_index=select_last_index,
+        reduce_kind=ARG_REDUCE_KIND_BY_OP[node.op_type],
+        input_dtype=input_dtype,
+        output_dtype=output_dtype,
+    )
+
+
+register_lowering("ArgMax")(lower_arg_reduce)
+register_lowering("ArgMin")(lower_arg_reduce)

--- a/templates/arg_reduce_op.c.j2
+++ b/templates/arg_reduce_op.c.j2
@@ -1,0 +1,18 @@
+static inline void {{ op_name }}({{ dim_args }}const {{ input_c_type }} {{ input0 }}{{ input_suffix }}, {{ output_c_type }} {{ output }}{{ output_suffix }}) {
+{% for dim in output_shape %}
+for (size_t {{ output_loop_vars[loop.index0] }} = 0; {{ output_loop_vars[loop.index0] }} < {{ dim }}; ++{{ output_loop_vars[loop.index0] }}) {
+{% endfor %}
+{{ input_c_type }} best = {{ input0 }}{{ init_index_expr }};
+{{ output_c_type }} best_index = 0;
+for (size_t {{ reduce_var }} = 1; {{ reduce_var }} < {{ reduce_dim }}; ++{{ reduce_var }}) {
+    {{ input_c_type }} candidate = {{ input0 }}{{ input_index_expr }};
+    if (candidate {{ compare_op }} best) {
+        best = candidate;
+        best_index = ({{ output_c_type }}){{ reduce_var }};
+    }
+}
+{{ output }}{{ output_index_expr }} = best_index;
+{% for _ in output_shape %}
+}
+{% endfor %}
+}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -201,131 +201,131 @@
   ],
   [
     "node/test_argmax_default_axis_example/model.onnx",
-    "Unsupported op ArgMax"
+    ""
   ],
   [
     "node/test_argmax_default_axis_example_select_last_index/model.onnx",
-    "Unsupported op ArgMax"
+    ""
   ],
   [
     "node/test_argmax_default_axis_random/model.onnx",
-    "Unsupported op ArgMax"
+    ""
   ],
   [
     "node/test_argmax_default_axis_random_select_last_index/model.onnx",
-    "Unsupported op ArgMax"
+    ""
   ],
   [
     "node/test_argmax_keepdims_example/model.onnx",
-    "Unsupported op ArgMax"
+    ""
   ],
   [
     "node/test_argmax_keepdims_example_select_last_index/model.onnx",
-    "Unsupported op ArgMax"
+    ""
   ],
   [
     "node/test_argmax_keepdims_random/model.onnx",
-    "Unsupported op ArgMax"
+    ""
   ],
   [
     "node/test_argmax_keepdims_random_select_last_index/model.onnx",
-    "Unsupported op ArgMax"
+    ""
   ],
   [
     "node/test_argmax_negative_axis_keepdims_example/model.onnx",
-    "Unsupported op ArgMax"
+    ""
   ],
   [
     "node/test_argmax_negative_axis_keepdims_example_select_last_index/model.onnx",
-    "Unsupported op ArgMax"
+    ""
   ],
   [
     "node/test_argmax_negative_axis_keepdims_random/model.onnx",
-    "Unsupported op ArgMax"
+    ""
   ],
   [
     "node/test_argmax_negative_axis_keepdims_random_select_last_index/model.onnx",
-    "Unsupported op ArgMax"
+    ""
   ],
   [
     "node/test_argmax_no_keepdims_example/model.onnx",
-    "Unsupported op ArgMax"
+    ""
   ],
   [
     "node/test_argmax_no_keepdims_example_select_last_index/model.onnx",
-    "Unsupported op ArgMax"
+    ""
   ],
   [
     "node/test_argmax_no_keepdims_random/model.onnx",
-    "Unsupported op ArgMax"
+    ""
   ],
   [
     "node/test_argmax_no_keepdims_random_select_last_index/model.onnx",
-    "Unsupported op ArgMax"
+    ""
   ],
   [
     "node/test_argmin_default_axis_example/model.onnx",
-    "Unsupported op ArgMin"
+    ""
   ],
   [
     "node/test_argmin_default_axis_example_select_last_index/model.onnx",
-    "Unsupported op ArgMin"
+    ""
   ],
   [
     "node/test_argmin_default_axis_random/model.onnx",
-    "Unsupported op ArgMin"
+    ""
   ],
   [
     "node/test_argmin_default_axis_random_select_last_index/model.onnx",
-    "Unsupported op ArgMin"
+    ""
   ],
   [
     "node/test_argmin_keepdims_example/model.onnx",
-    "Unsupported op ArgMin"
+    ""
   ],
   [
     "node/test_argmin_keepdims_example_select_last_index/model.onnx",
-    "Unsupported op ArgMin"
+    ""
   ],
   [
     "node/test_argmin_keepdims_random/model.onnx",
-    "Unsupported op ArgMin"
+    ""
   ],
   [
     "node/test_argmin_keepdims_random_select_last_index/model.onnx",
-    "Unsupported op ArgMin"
+    ""
   ],
   [
     "node/test_argmin_negative_axis_keepdims_example/model.onnx",
-    "Unsupported op ArgMin"
+    ""
   ],
   [
     "node/test_argmin_negative_axis_keepdims_example_select_last_index/model.onnx",
-    "Unsupported op ArgMin"
+    ""
   ],
   [
     "node/test_argmin_negative_axis_keepdims_random/model.onnx",
-    "Unsupported op ArgMin"
+    ""
   ],
   [
     "node/test_argmin_negative_axis_keepdims_random_select_last_index/model.onnx",
-    "Unsupported op ArgMin"
+    ""
   ],
   [
     "node/test_argmin_no_keepdims_example/model.onnx",
-    "Unsupported op ArgMin"
+    ""
   ],
   [
     "node/test_argmin_no_keepdims_example_select_last_index/model.onnx",
-    "Unsupported op ArgMin"
+    ""
   ],
   [
     "node/test_argmin_no_keepdims_random/model.onnx",
-    "Unsupported op ArgMin"
+    ""
   ],
   [
     "node/test_argmin_no_keepdims_random_select_last_index/model.onnx",
-    "Unsupported op ArgMin"
+    ""
   ],
   [
     "node/test_asin/model.onnx",


### PR DESCRIPTION
### Motivation
- Provide native support for ArgMax and ArgMin (axis/keepdims/select_last_index semantics) so models using these ops can be lowered and emitted to C.
- Enable evaluator-side constant-folding / verification for ArgMax/ArgMin so end-to-end checks and numpy comparisons work.
- Keep codegen and template-driven emission consistent with the existing reduce/op patterns and preserve deterministic naming and shapes.

### Description
- Add a lowering pass `src/onnx2c/lowering/arg_reduce.py` that validates shapes/dtypes and produces a new `ArgReduceOp` for `ArgMax` and `ArgMin`.
- Introduce `ArgReduceOp` dataclass and wire it into the emitter (`src/onnx2c/codegen/c_emitter.py`) so arg-reduce ops are sanitized, rendered, and accounted for in include/dtype logic.
- Add a Jinja2 C template `templates/arg_reduce_op.c.j2` and render logic to emit efficient C kernels honoring `select_last_index` and `keepdims`.
- Implement runtime evaluation in `src/onnx2c/runtime/evaluator.py` using numpy (`np.argmax`/`np.argmin` with flip for `select_last_index`) for verification/constant folding.
- Extend end-to-end tests in `tests/test_endtoend_ops.py` with ArgMax/ArgMin cases and a `select_last_index` numpy comparison test, and refresh official ONNX support/golden reference files (`OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`, `tests/official_onnx_expected_errors.json`).

### Testing
- Ran the full pytest suite with reference updates via `UPDATE_REFS=1 pytest -n auto -q` and the suite completed successfully in 49.60s with `169 passed, 1 skipped`.
- Addressed an initial syntax issue in the new tests during iteration and re-ran the full suite until all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69679ae447fc832593c465d4e059a86e)