### PR TITLE
build: add README metadata for PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "emx-onnx2c"
 version = "0.1.0"
 description = "emmtrix ONNX to C Compiler"
+readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"
 
 [project.scripts]


### PR DESCRIPTION
### Motivation
- Ensure the package long description on PyPI is populated from the repository `README.md` so releases show the project README on the package page.

### Description
- Add a `readme = { file = "README.md", content-type = "text/markdown" }` entry to `pyproject.toml` so setuptools/PEP 621 metadata includes the README for PyPI.

### Testing
- Ran the test suite with `UPDATE_REFS=1 pytest -n auto -q` and all tests passed: `169 passed, 1 skipped` in `65.66s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6967a3040c188325b093d2b845a81157)