### PR TITLE
lowering: allow zero-sized dimensions

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1020 / 1802 official ONNX files.
+Support 1043 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -521,7 +521,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_constant_pad_axes/model.onnx | ❌ | Unsupported op Pad |
 | node/test_constant_pad_negative_axes/model.onnx | ❌ | Unsupported op Pad |
 | node/test_constantofshape_float_ones/model.onnx | ✅ |  |
-| node/test_constantofshape_int_shape_zero/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_constantofshape_int_shape_zero/model.onnx | ❌ | Output shape must be fully defined |
 | node/test_constantofshape_int_zeros/model.onnx | ✅ |  |
 | node/test_conv_with_autopad_same/model.onnx | ✅ |  |
 | node/test_conv_with_strides_and_asymmetric_padding/model.onnx | ✅ |  |
@@ -777,8 +777,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_l2normalization_axis_0/model.onnx | ❌ | Unsupported op LpNormalization |
 | node/test_l2normalization_axis_1/model.onnx | ❌ | Unsupported op LpNormalization |
 | node/test_layer_normalization_2d_axis0/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_2d_axis0_expanded/model.onnx | ❌ | Dynamic or zero dims are not supported |
-| node/test_layer_normalization_2d_axis0_expanded_ver18/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_layer_normalization_2d_axis0_expanded/model.onnx | ✅ |  |
+| node/test_layer_normalization_2d_axis0_expanded_ver18/model.onnx | ✅ |  |
 | node/test_layer_normalization_2d_axis1/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_2d_axis1_expanded/model.onnx | ✅ |  |
 | node/test_layer_normalization_2d_axis1_expanded_ver18/model.onnx | ✅ |  |
@@ -786,11 +786,11 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_layer_normalization_2d_axis_negative_1_expanded/model.onnx | ❌ | Concat output shape must be (2,), got (1,) |
 | node/test_layer_normalization_2d_axis_negative_1_expanded_ver18/model.onnx | ❌ | Concat output shape must be (2,), got (1,) |
 | node/test_layer_normalization_2d_axis_negative_2/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_2d_axis_negative_2_expanded/model.onnx | ❌ | Dynamic or zero dims are not supported |
-| node/test_layer_normalization_2d_axis_negative_2_expanded_ver18/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_layer_normalization_2d_axis_negative_2_expanded/model.onnx | ✅ |  |
+| node/test_layer_normalization_2d_axis_negative_2_expanded_ver18/model.onnx | ✅ |  |
 | node/test_layer_normalization_3d_axis0_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_3d_axis0_epsilon_expanded/model.onnx | ❌ | Dynamic or zero dims are not supported |
-| node/test_layer_normalization_3d_axis0_epsilon_expanded_ver18/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_layer_normalization_3d_axis0_epsilon_expanded/model.onnx | ✅ |  |
+| node/test_layer_normalization_3d_axis0_epsilon_expanded_ver18/model.onnx | ✅ |  |
 | node/test_layer_normalization_3d_axis1_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_3d_axis1_epsilon_expanded/model.onnx | ✅ |  |
 | node/test_layer_normalization_3d_axis1_epsilon_expanded_ver18/model.onnx | ✅ |  |
@@ -804,11 +804,11 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_layer_normalization_3d_axis_negative_2_epsilon_expanded/model.onnx | ❌ | Concat output shape must be (2,), got (1,) |
 | node/test_layer_normalization_3d_axis_negative_2_epsilon_expanded_ver18/model.onnx | ❌ | Concat output shape must be (2,), got (1,) |
 | node/test_layer_normalization_3d_axis_negative_3_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_3d_axis_negative_3_epsilon_expanded/model.onnx | ❌ | Dynamic or zero dims are not supported |
-| node/test_layer_normalization_3d_axis_negative_3_epsilon_expanded_ver18/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_layer_normalization_3d_axis_negative_3_epsilon_expanded/model.onnx | ✅ |  |
+| node/test_layer_normalization_3d_axis_negative_3_epsilon_expanded_ver18/model.onnx | ✅ |  |
 | node/test_layer_normalization_4d_axis0/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_4d_axis0_expanded/model.onnx | ❌ | Dynamic or zero dims are not supported |
-| node/test_layer_normalization_4d_axis0_expanded_ver18/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_layer_normalization_4d_axis0_expanded/model.onnx | ✅ |  |
+| node/test_layer_normalization_4d_axis0_expanded_ver18/model.onnx | ✅ |  |
 | node/test_layer_normalization_4d_axis1/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_4d_axis1_expanded/model.onnx | ✅ |  |
 | node/test_layer_normalization_4d_axis1_expanded_ver18/model.onnx | ✅ |  |
@@ -828,8 +828,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_layer_normalization_4d_axis_negative_3_expanded/model.onnx | ❌ | Concat output shape must be (2,), got (1,) |
 | node/test_layer_normalization_4d_axis_negative_3_expanded_ver18/model.onnx | ❌ | Concat output shape must be (2,), got (1,) |
 | node/test_layer_normalization_4d_axis_negative_4/model.onnx | ❌ | Unsupported op LayerNormalization |
-| node/test_layer_normalization_4d_axis_negative_4_expanded/model.onnx | ❌ | Dynamic or zero dims are not supported |
-| node/test_layer_normalization_4d_axis_negative_4_expanded_ver18/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_layer_normalization_4d_axis_negative_4_expanded/model.onnx | ✅ |  |
+| node/test_layer_normalization_4d_axis_negative_4_expanded_ver18/model.onnx | ✅ |  |
 | node/test_layer_normalization_default_axis/model.onnx | ❌ | Unsupported op LayerNormalization |
 | node/test_layer_normalization_default_axis_expanded/model.onnx | ❌ | Concat output shape must be (4,), got (1,) |
 | node/test_layer_normalization_default_axis_expanded_ver18/model.onnx | ❌ | Concat output shape must be (4,), got (1,) |
@@ -1121,8 +1121,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_l1_do_not_keepdims_example_expanded/model.onnx | ✅ |  |
 | node/test_reduce_l1_do_not_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_l1_do_not_keepdims_random_expanded/model.onnx | ✅ |  |
-| node/test_reduce_l1_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
-| node/test_reduce_l1_empty_set_expanded/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_reduce_l1_empty_set/model.onnx | ✅ |  |
+| node/test_reduce_l1_empty_set_expanded/model.onnx | ✅ |  |
 | node/test_reduce_l1_keep_dims_example/model.onnx | ✅ |  |
 | node/test_reduce_l1_keep_dims_example_expanded/model.onnx | ✅ |  |
 | node/test_reduce_l1_keep_dims_random/model.onnx | ✅ |  |
@@ -1139,7 +1139,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_l2_do_not_keepdims_example_expanded/model.onnx | ❌ | CastLike input and output shapes must match |
 | node/test_reduce_l2_do_not_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_l2_do_not_keepdims_random_expanded/model.onnx | ❌ | CastLike input and output shapes must match |
-| node/test_reduce_l2_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_reduce_l2_empty_set/model.onnx | ✅ |  |
 | node/test_reduce_l2_empty_set_expanded/model.onnx | ❌ | ReduceSum output shape rank must match input rank |
 | node/test_reduce_l2_keep_dims_example/model.onnx | ✅ |  |
 | node/test_reduce_l2_keep_dims_example_expanded/model.onnx | ❌ | ReduceSum output shape rank must match input rank |
@@ -1155,7 +1155,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_log_sum_default_expanded/model.onnx | ❌ | ReduceSum output shape must be (1, 1, 1), got () |
 | node/test_reduce_log_sum_desc_axes/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_desc_axes_expanded/model.onnx | ✅ |  |
-| node/test_reduce_log_sum_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_reduce_log_sum_empty_set/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_empty_set_expanded/model.onnx | ❌ | ReduceSum output shape rank must match input rank |
 | node/test_reduce_log_sum_exp_default_axes_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_exp_default_axes_keepdims_example_expanded/model.onnx | ❌ | ReduceSum output shape must be (1, 1, 1), got () |
@@ -1165,7 +1165,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_log_sum_exp_do_not_keepdims_example_expanded/model.onnx | ❌ | CastLike input and output shapes must match |
 | node/test_reduce_log_sum_exp_do_not_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_exp_do_not_keepdims_random_expanded/model.onnx | ❌ | CastLike input and output shapes must match |
-| node/test_reduce_log_sum_exp_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_reduce_log_sum_exp_empty_set/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_exp_empty_set_expanded/model.onnx | ❌ | ReduceSum output shape rank must match input rank |
 | node/test_reduce_log_sum_exp_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_exp_keepdims_example_expanded/model.onnx | ❌ | ReduceSum output shape rank must match input rank |
@@ -1182,7 +1182,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_max_default_axes_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_max_do_not_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_max_do_not_keepdims_random/model.onnx | ✅ |  |
-| node/test_reduce_max_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_reduce_max_empty_set/model.onnx | ✅ |  |
 | node/test_reduce_max_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_max_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_max_negative_axes_keepdims_example/model.onnx | ✅ |  |
@@ -1200,7 +1200,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_min_default_axes_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_min_do_not_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_min_do_not_keepdims_random/model.onnx | ✅ |  |
-| node/test_reduce_min_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_reduce_min_empty_set/model.onnx | ✅ |  |
 | node/test_reduce_min_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_min_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_min_negative_axes_keepdims_example/model.onnx | ✅ |  |
@@ -1209,7 +1209,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_prod_default_axes_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_prod_do_not_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_prod_do_not_keepdims_random/model.onnx | ✅ |  |
-| node/test_reduce_prod_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_reduce_prod_empty_set/model.onnx | ✅ |  |
 | node/test_reduce_prod_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_prod_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_prod_negative_axes_keepdims_example/model.onnx | ✅ |  |
@@ -1220,8 +1220,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_sum_do_not_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_sum_empty_axes_input_noop/model.onnx | ✅ |  |
 | node/test_reduce_sum_empty_axes_input_noop_example/model.onnx | ✅ |  |
-| node/test_reduce_sum_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
-| node/test_reduce_sum_empty_set_non_reduced_axis_zero/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_reduce_sum_empty_set/model.onnx | ✅ |  |
+| node/test_reduce_sum_empty_set_non_reduced_axis_zero/model.onnx | ❌ | Output shape must be fully defined |
 | node/test_reduce_sum_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_sum_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_sum_negative_axes_keepdims_example/model.onnx | ✅ |  |
@@ -1234,8 +1234,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_sum_square_do_not_keepdims_example_expanded/model.onnx | ✅ |  |
 | node/test_reduce_sum_square_do_not_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_sum_square_do_not_keepdims_random_expanded/model.onnx | ✅ |  |
-| node/test_reduce_sum_square_empty_set/model.onnx | ❌ | Dynamic or zero dims are not supported |
-| node/test_reduce_sum_square_empty_set_expanded/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_reduce_sum_square_empty_set/model.onnx | ✅ |  |
+| node/test_reduce_sum_square_empty_set_expanded/model.onnx | ✅ |  |
 | node/test_reduce_sum_square_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_sum_square_keepdims_example_expanded/model.onnx | ✅ |  |
 | node/test_reduce_sum_square_keepdims_random/model.onnx | ✅ |  |
@@ -1250,7 +1250,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_regex_full_match_empty/model.onnx | ❌ | Unsupported elem_type 8 (STRING) for tensor 'X'. |
 | node/test_relu/model.onnx | ✅ |  |
 | node/test_relu_expanded_ver18/model.onnx | ✅ |  |
-| node/test_reshape_allowzero_reordered/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_reshape_allowzero_reordered/model.onnx | ❌ | Output shape must be fully defined |
 | node/test_reshape_extended_dims/model.onnx | ✅ |  |
 | node/test_reshape_negative_dim/model.onnx | ✅ |  |
 | node/test_reshape_negative_extended_dims/model.onnx | ✅ |  |
@@ -1472,7 +1472,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_shape_start_1/model.onnx | ✅ |  |
 | node/test_shape_start_1_end_2/model.onnx | ✅ |  |
 | node/test_shape_start_1_end_negative_1/model.onnx | ✅ |  |
-| node/test_shape_start_greater_than_end/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_shape_start_greater_than_end/model.onnx | ❌ | Output shape must be fully defined |
 | node/test_shape_start_negative_1/model.onnx | ✅ |  |
 | node/test_shrink_hard/model.onnx | ✅ |  |
 | node/test_shrink_hard_expanded_ver18/model.onnx | ✅ |  |
@@ -1497,7 +1497,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_slice_neg/model.onnx | ✅ |  |
 | node/test_slice_neg_steps/model.onnx | ✅ |  |
 | node/test_slice_negative_axes/model.onnx | ✅ |  |
-| node/test_slice_start_out_of_bounds/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_slice_start_out_of_bounds/model.onnx | ❌ | Output shape must be fully defined |
 | node/test_softmax_axis_0/model.onnx | ✅ |  |
 | node/test_softmax_axis_0_expanded/model.onnx | ✅ |  |
 | node/test_softmax_axis_0_expanded_ver18/model.onnx | ✅ |  |
@@ -1546,8 +1546,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_split_variable_parts_2d_opset18/model.onnx | ✅ |  |
 | node/test_split_variable_parts_default_axis_opset13/model.onnx | ✅ |  |
 | node/test_split_variable_parts_default_axis_opset18/model.onnx | ✅ |  |
-| node/test_split_zero_size_splits_opset13/model.onnx | ❌ | Dynamic or zero dims are not supported |
-| node/test_split_zero_size_splits_opset18/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_split_zero_size_splits_opset13/model.onnx | ❌ | Output shape must be fully defined |
+| node/test_split_zero_size_splits_opset18/model.onnx | ❌ | Output shape must be fully defined |
 | node/test_sqrt/model.onnx | ✅ |  |
 | node/test_sqrt_example/model.onnx | ✅ |  |
 | node/test_squeeze/model.onnx | ✅ |  |
@@ -1635,7 +1635,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_tril_pos/model.onnx | ❌ | Unsupported op Trilu |
 | node/test_tril_square/model.onnx | ❌ | Unsupported op Trilu |
 | node/test_tril_square_neg/model.onnx | ❌ | Unsupported op Trilu |
-| node/test_tril_zero/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_tril_zero/model.onnx | ❌ | Output shape must be fully defined |
 | node/test_triu/model.onnx | ❌ | Unsupported op Trilu |
 | node/test_triu_neg/model.onnx | ❌ | Unsupported op Trilu |
 | node/test_triu_one_row/model.onnx | ❌ | Unsupported op Trilu |
@@ -1644,7 +1644,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_triu_pos/model.onnx | ❌ | Unsupported op Trilu |
 | node/test_triu_square/model.onnx | ❌ | Unsupported op Trilu |
 | node/test_triu_square_neg/model.onnx | ❌ | Unsupported op Trilu |
-| node/test_triu_zero/model.onnx | ❌ | Dynamic or zero dims are not supported |
+| node/test_triu_zero/model.onnx | ❌ | Output shape must be fully defined |
 | node/test_unique_length_1/model.onnx | ❌ | Unsupported op Unique |
 | node/test_unique_not_sorted_without_axis/model.onnx | ❌ | Unsupported op Unique |
 | node/test_unique_sorted_with_axis/model.onnx | ❌ | Unsupported op Unique |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -4,7 +4,6 @@
 | --- | --- | --- |
 | Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 36 | ██████████████████████████████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████████████████████████ |
-| Dynamic or zero dims are not supported | 32 | ███████████████████████████ |
 | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 22 | ██████████████████ |
 | Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 20 | █████████████████ |
 | Unsupported op LayerNormalization | 19 | ████████████████ |
@@ -24,6 +23,7 @@
 | Unsupported op ConvTranspose | 14 | ████████████ |
 | '*' object has no attribute '*' | 13 | ███████████ |
 | ReduceSum output shape rank must match input rank | 12 | ██████████ |
+| Output shape must be fully defined | 9 | ████████ |
 | Unsupported op CumSum | 9 | ████████ |
 | Unsupported op ImageDecoder | 9 | ████████ |
 | Unsupported op NonMaxSuppression | 9 | ████████ |

--- a/src/onnx2c/codegen/c_emitter.py
+++ b/src/onnx2c/codegen/c_emitter.py
@@ -5809,8 +5809,10 @@ class CEmitter:
         shape = CEmitter._codegen_shape(shape)
         count = 1
         for dim in shape:
-            if dim <= 0:
-                raise CodegenError("Dynamic or zero dims are not supported")
+            if dim < 0:
+                raise CodegenError("Dynamic dims are not supported")
+            if dim == 0:
+                return 0
             count *= dim
         return count
 

--- a/src/onnx2c/lowering/average_pool.py
+++ b/src/onnx2c/lowering/average_pool.py
@@ -92,8 +92,10 @@ def _resolve_average_pool_spec(graph: Graph, node: Node) -> _AveragePoolSpec:
     stride_h, stride_w = strides
     out_h = (in_h + pad_top + pad_bottom - kernel_h) // stride_h + 1
     out_w = (in_w + pad_left + pad_right - kernel_w) // stride_w + 1
-    if out_h <= 0 or out_w <= 0:
-        raise ShapeInferenceError("AveragePool output shape must be positive")
+    if out_h < 0 or out_w < 0:
+        raise ShapeInferenceError(
+            "AveragePool output shape must be non-negative"
+        )
     output_shape = _value_shape(graph, node.outputs[0], node)
     expected_output_shape = (batch, channels, out_h, out_w)
     if output_shape != expected_output_shape:

--- a/src/onnx2c/lowering/common.py
+++ b/src/onnx2c/lowering/common.py
@@ -57,8 +57,10 @@ def shape_product(shape: tuple[int, ...]) -> int:
         return 1
     product = 1
     for dim in shape:
-        if dim <= 0:
-            raise ShapeInferenceError("Dynamic or zero dims are not supported")
+        if dim < 0:
+            raise ShapeInferenceError("Dynamic dims are not supported")
+        if dim == 0:
+            return 0
         product *= dim
     return product
 

--- a/src/onnx2c/lowering/constant_of_shape.py
+++ b/src/onnx2c/lowering/constant_of_shape.py
@@ -59,8 +59,8 @@ def lower_constant_of_shape(graph: Graph, node: Node) -> ConstantOfShapeOp:
             "ConstantOfShape input length must match output rank"
         )
     for dim in output_shape:
-        if dim <= 0:
-            raise ShapeInferenceError("Dynamic or zero dims are not supported")
+        if dim < 0:
+            raise ShapeInferenceError("Dynamic dims are not supported")
     input_dtype = _value_dtype(graph, node.inputs[0], node)
     if input_dtype != ScalarType.I64:
         raise UnsupportedOpError(

--- a/src/onnx2c/lowering/conv.py
+++ b/src/onnx2c/lowering/conv.py
@@ -137,8 +137,8 @@ def resolve_conv_spec(graph: Graph, node: Node) -> ConvSpec:
     ):
         effective_kernel = dilation * (kernel - 1) + 1
         out_dim = (dim + pad_start + pad_finish - effective_kernel) // stride + 1
-        if out_dim <= 0:
-            raise ShapeInferenceError("Conv output shape must be positive")
+        if out_dim < 0:
+            raise ShapeInferenceError("Conv output shape must be non-negative")
         out_spatial.append(out_dim)
     output_shape = _value_shape(graph, node.outputs[0], node)
     expected_output_shape = (batch, out_channels, *out_spatial)

--- a/src/onnx2c/lowering/expand.py
+++ b/src/onnx2c/lowering/expand.py
@@ -56,9 +56,9 @@ def _validate_shape_input(graph: Graph, name: str, node: Node) -> None:
 
 
 def _validate_static_dims(shape: tuple[int, ...], node: Node) -> None:
-    if any(dim <= 0 for dim in shape):
+    if any(dim < 0 for dim in shape):
         raise ShapeInferenceError(
-            f"{node.op_type} does not support zero or dynamic dims"
+            f"{node.op_type} does not support dynamic dims"
         )
 
 
@@ -67,9 +67,9 @@ def _broadcast_shape(
 ) -> tuple[int, ...]:
     _validate_static_dims(input_shape, node)
     for dim in shape_values:
-        if dim <= 0:
+        if dim < 0:
             raise ShapeInferenceError(
-                f"{node.op_type} does not support zero or dynamic dims"
+                f"{node.op_type} does not support dynamic dims"
             )
     output_rank = max(len(input_shape), len(shape_values))
     input_padded = (1,) * (output_rank - len(input_shape)) + input_shape

--- a/src/onnx2c/lowering/flatten.py
+++ b/src/onnx2c/lowering/flatten.py
@@ -23,8 +23,8 @@ def _flatten_output_shape(
     if rank == 0:
         return (1, 1)
     for dim in input_shape:
-        if dim <= 0:
-            raise ShapeInferenceError("Dynamic or zero dims are not supported")
+        if dim < 0:
+            raise ShapeInferenceError("Dynamic dims are not supported")
     first = shape_product(input_shape[:axis]) if axis else 1
     second = shape_product(input_shape[axis:]) if axis < rank else 1
     return (first, second)

--- a/src/onnx2c/lowering/maxpool.py
+++ b/src/onnx2c/lowering/maxpool.py
@@ -123,8 +123,10 @@ def resolve_maxpool_spec(graph: Graph, node: Node) -> MaxPoolSpec:
                 out_dim -= 1
         else:
             out_dim = numerator // stride + 1
-        if out_dim <= 0:
-            raise ShapeInferenceError("MaxPool output shape must be positive")
+        if out_dim < 0:
+            raise ShapeInferenceError(
+                "MaxPool output shape must be non-negative"
+            )
         out_spatial.append(out_dim)
     expected_output_shape = (batch, channels, *out_spatial)
     output_shape = _value_shape(graph, node.outputs[0], node)

--- a/src/onnx2c/lowering/range.py
+++ b/src/onnx2c/lowering/range.py
@@ -82,16 +82,16 @@ def lower_range(graph: Graph, node: Node) -> RangeOp:
             float(limit_value) - float(start_value)
         ) / float(delta_value)
         length = max(int(math.ceil(raw_count)), 0)
-        if length <= 0:
-            raise ShapeInferenceError("Range output length must be positive")
+        if length < 0:
+            raise ShapeInferenceError("Range output length must be non-negative")
         if output_shape[0] != length:
             raise ShapeInferenceError(
                 f"Range output length must be {length}, got {output_shape[0]}"
             )
     else:
         length = output_shape[0]
-        if length <= 0:
-            raise ShapeInferenceError("Range output length must be positive")
+        if length < 0:
+            raise ShapeInferenceError("Range output length must be non-negative")
     return RangeOp(
         start=node.inputs[0],
         limit=node.inputs[1],

--- a/src/onnx2c/lowering/reduce.py
+++ b/src/onnx2c/lowering/reduce.py
@@ -76,8 +76,10 @@ def _value_dtype(graph: Graph, name: str, node: Node) -> ScalarType:
 def _shape_product(shape: tuple[int, ...]) -> int:
     product = 1
     for dim in shape:
-        if dim <= 0:
-            raise ShapeInferenceError("Dynamic or zero dims are not supported")
+        if dim < 0:
+            raise ShapeInferenceError("Dynamic dims are not supported")
+        if dim == 0:
+            return 0
         product *= dim
     return product
 

--- a/src/onnx2c/lowering/resize.py
+++ b/src/onnx2c/lowering/resize.py
@@ -308,8 +308,8 @@ def _validate_output_shape(
         raise ShapeInferenceError(
             f"Resize output shape must be {expected}, got {actual}"
         )
-    if any(dim <= 0 for dim in actual):
-        raise ShapeInferenceError("Resize output shape must be positive")
+    if any(dim < 0 for dim in actual):
+        raise ShapeInferenceError("Resize output shape must be non-negative")
 
 
 @register_lowering("Resize")

--- a/src/onnx2c/lowering/shape.py
+++ b/src/onnx2c/lowering/shape.py
@@ -50,8 +50,8 @@ def lower_shape(graph: Graph, node: Node) -> ShapeOp:
     output_shape = _value_shape(graph, node.outputs[0], node)
     if len(output_shape) != 1:
         raise ShapeInferenceError("Shape output must be 1D")
-    if output_shape[0] <= 0:
-        raise ShapeInferenceError("Shape output length must be positive")
+    if output_shape[0] < 0:
+        raise ShapeInferenceError("Shape output length must be non-negative")
     input_dtype = _value_dtype(graph, node.inputs[0], node)
     output_dtype = _value_dtype(graph, node.outputs[0], node)
     if output_dtype != ScalarType.I64:
@@ -61,9 +61,7 @@ def lower_shape(graph: Graph, node: Node) -> ShapeOp:
     start_index, end_index = _normalize_slice_bounds(
         len(input_shape), start=start, end=end
     )
-    if end_index <= start_index:
-        raise ShapeInferenceError("Shape start must be less than end")
-    expected_shape = (end_index - start_index,)
+    expected_shape = (max(0, end_index - start_index),)
     if expected_shape != output_shape:
         raise ShapeInferenceError(
             "Shape output shape must be "

--- a/src/onnx2c/lowering/slice.py
+++ b/src/onnx2c/lowering/slice.py
@@ -278,11 +278,7 @@ def _normalize_slices(
             end += dim
         start = max(0, min(start, dim))
         end = max(0, min(end, dim))
-        if end <= start:
-            raise ShapeInferenceError("Dynamic or zero dims are not supported")
-        length = (end - start + step - 1) // step
-        if length <= 0:
-            raise ShapeInferenceError("Dynamic or zero dims are not supported")
+        length = max(0, (end - start + step - 1) // step)
         normalized_starts[normalized_axis] = start
         normalized_steps[normalized_axis] = step
         output_shape[normalized_axis] = length

--- a/src/onnx2c/lowering/squeeze.py
+++ b/src/onnx2c/lowering/squeeze.py
@@ -37,9 +37,9 @@ def _find_initializer(graph: Graph, name: str) -> Initializer | None:
 
 def _validate_shape(shape: tuple[int, ...], node: Node, label: str) -> None:
     for dim in shape:
-        if dim <= 0:
+        if dim < 0:
             raise ShapeInferenceError(
-                f"{node.op_type} does not support dynamic or zero dims in {label}"
+                f"{node.op_type} does not support dynamic dims in {label}"
             )
 
 

--- a/src/onnx2c/lowering/unsqueeze.py
+++ b/src/onnx2c/lowering/unsqueeze.py
@@ -37,9 +37,9 @@ def _find_initializer(graph: Graph, name: str) -> Initializer | None:
 
 def _validate_shape(shape: tuple[int, ...], node: Node, label: str) -> None:
     for dim in shape:
-        if dim <= 0:
+        if dim < 0:
             raise ShapeInferenceError(
-                f"{node.op_type} does not support dynamic or zero dims in {label}"
+                f"{node.op_type} does not support dynamic dims in {label}"
             )
 
 

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -2053,7 +2053,7 @@
   ],
   [
     "node/test_constantofshape_int_shape_zero/model.onnx",
-    "Dynamic or zero dims are not supported"
+    "Output shape must be fully defined"
   ],
   [
     "node/test_constantofshape_int_zeros/model.onnx",
@@ -3077,11 +3077,11 @@
   ],
   [
     "node/test_layer_normalization_2d_axis0_expanded/model.onnx",
-    "Dynamic or zero dims are not supported"
+    ""
   ],
   [
     "node/test_layer_normalization_2d_axis0_expanded_ver18/model.onnx",
-    "Dynamic or zero dims are not supported"
+    ""
   ],
   [
     "node/test_layer_normalization_2d_axis1/model.onnx",
@@ -3113,11 +3113,11 @@
   ],
   [
     "node/test_layer_normalization_2d_axis_negative_2_expanded/model.onnx",
-    "Dynamic or zero dims are not supported"
+    ""
   ],
   [
     "node/test_layer_normalization_2d_axis_negative_2_expanded_ver18/model.onnx",
-    "Dynamic or zero dims are not supported"
+    ""
   ],
   [
     "node/test_layer_normalization_3d_axis0_epsilon/model.onnx",
@@ -3125,11 +3125,11 @@
   ],
   [
     "node/test_layer_normalization_3d_axis0_epsilon_expanded/model.onnx",
-    "Dynamic or zero dims are not supported"
+    ""
   ],
   [
     "node/test_layer_normalization_3d_axis0_epsilon_expanded_ver18/model.onnx",
-    "Dynamic or zero dims are not supported"
+    ""
   ],
   [
     "node/test_layer_normalization_3d_axis1_epsilon/model.onnx",
@@ -3185,11 +3185,11 @@
   ],
   [
     "node/test_layer_normalization_3d_axis_negative_3_epsilon_expanded/model.onnx",
-    "Dynamic or zero dims are not supported"
+    ""
   ],
   [
     "node/test_layer_normalization_3d_axis_negative_3_epsilon_expanded_ver18/model.onnx",
-    "Dynamic or zero dims are not supported"
+    ""
   ],
   [
     "node/test_layer_normalization_4d_axis0/model.onnx",
@@ -3197,11 +3197,11 @@
   ],
   [
     "node/test_layer_normalization_4d_axis0_expanded/model.onnx",
-    "Dynamic or zero dims are not supported"
+    ""
   ],
   [
     "node/test_layer_normalization_4d_axis0_expanded_ver18/model.onnx",
-    "Dynamic or zero dims are not supported"
+    ""
   ],
   [
     "node/test_layer_normalization_4d_axis1/model.onnx",
@@ -3281,11 +3281,11 @@
   ],
   [
     "node/test_layer_normalization_4d_axis_negative_4_expanded/model.onnx",
-    "Dynamic or zero dims are not supported"
+    ""
   ],
   [
     "node/test_layer_normalization_4d_axis_negative_4_expanded_ver18/model.onnx",
-    "Dynamic or zero dims are not supported"
+    ""
   ],
   [
     "node/test_layer_normalization_default_axis/model.onnx",
@@ -4453,11 +4453,11 @@
   ],
   [
     "node/test_reduce_l1_empty_set/model.onnx",
-    "Dynamic or zero dims are not supported"
+    ""
   ],
   [
     "node/test_reduce_l1_empty_set_expanded/model.onnx",
-    "Dynamic or zero dims are not supported"
+    ""
   ],
   [
     "node/test_reduce_l1_keep_dims_example/model.onnx",
@@ -4525,7 +4525,7 @@
   ],
   [
     "node/test_reduce_l2_empty_set/model.onnx",
-    "Dynamic or zero dims are not supported"
+    ""
   ],
   [
     "node/test_reduce_l2_empty_set_expanded/model.onnx",
@@ -4589,7 +4589,7 @@
   ],
   [
     "node/test_reduce_log_sum_empty_set/model.onnx",
-    "Dynamic or zero dims are not supported"
+    ""
   ],
   [
     "node/test_reduce_log_sum_empty_set_expanded/model.onnx",
@@ -4629,7 +4629,7 @@
   ],
   [
     "node/test_reduce_log_sum_exp_empty_set/model.onnx",
-    "Dynamic or zero dims are not supported"
+    ""
   ],
   [
     "node/test_reduce_log_sum_exp_empty_set_expanded/model.onnx",
@@ -4697,7 +4697,7 @@
   ],
   [
     "node/test_reduce_max_empty_set/model.onnx",
-    "Dynamic or zero dims are not supported"
+    ""
   ],
   [
     "node/test_reduce_max_keepdims_example/model.onnx",
@@ -4769,7 +4769,7 @@
   ],
   [
     "node/test_reduce_min_empty_set/model.onnx",
-    "Dynamic or zero dims are not supported"
+    ""
   ],
   [
     "node/test_reduce_min_keepdims_example/model.onnx",
@@ -4805,7 +4805,7 @@
   ],
   [
     "node/test_reduce_prod_empty_set/model.onnx",
-    "Dynamic or zero dims are not supported"
+    ""
   ],
   [
     "node/test_reduce_prod_keepdims_example/model.onnx",
@@ -4849,11 +4849,11 @@
   ],
   [
     "node/test_reduce_sum_empty_set/model.onnx",
-    "Dynamic or zero dims are not supported"
+    ""
   ],
   [
     "node/test_reduce_sum_empty_set_non_reduced_axis_zero/model.onnx",
-    "Dynamic or zero dims are not supported"
+    "Output shape must be fully defined"
   ],
   [
     "node/test_reduce_sum_keepdims_example/model.onnx",
@@ -4905,11 +4905,11 @@
   ],
   [
     "node/test_reduce_sum_square_empty_set/model.onnx",
-    "Dynamic or zero dims are not supported"
+    ""
   ],
   [
     "node/test_reduce_sum_square_empty_set_expanded/model.onnx",
-    "Dynamic or zero dims are not supported"
+    ""
   ],
   [
     "node/test_reduce_sum_square_keepdims_example/model.onnx",
@@ -4969,7 +4969,7 @@
   ],
   [
     "node/test_reshape_allowzero_reordered/model.onnx",
-    "Dynamic or zero dims are not supported"
+    "Output shape must be fully defined"
   ],
   [
     "node/test_reshape_extended_dims/model.onnx",
@@ -5857,7 +5857,7 @@
   ],
   [
     "node/test_shape_start_greater_than_end/model.onnx",
-    "Dynamic or zero dims are not supported"
+    "Output shape must be fully defined"
   ],
   [
     "node/test_shape_start_negative_1/model.onnx",
@@ -5957,7 +5957,7 @@
   ],
   [
     "node/test_slice_start_out_of_bounds/model.onnx",
-    "Dynamic or zero dims are not supported"
+    "Output shape must be fully defined"
   ],
   [
     "node/test_softmax_axis_0/model.onnx",
@@ -6153,11 +6153,11 @@
   ],
   [
     "node/test_split_zero_size_splits_opset13/model.onnx",
-    "Dynamic or zero dims are not supported"
+    "Output shape must be fully defined"
   ],
   [
     "node/test_split_zero_size_splits_opset18/model.onnx",
-    "Dynamic or zero dims are not supported"
+    "Output shape must be fully defined"
   ],
   [
     "node/test_sqrt/model.onnx",
@@ -6509,7 +6509,7 @@
   ],
   [
     "node/test_tril_zero/model.onnx",
-    "Dynamic or zero dims are not supported"
+    "Output shape must be fully defined"
   ],
   [
     "node/test_triu/model.onnx",
@@ -6545,7 +6545,7 @@
   ],
   [
     "node/test_triu_zero/model.onnx",
-    "Dynamic or zero dims are not supported"
+    "Output shape must be fully defined"
   ],
   [
     "node/test_unique_length_1/model.onnx",


### PR DESCRIPTION
### Motivation

- ONNX models and test-cases include legitimate zero-sized (empty) dimensions that the compiler should accept instead of treating them as dynamic/unsupported.
- Several lowering and codegen checks conflated zero and dynamic dims and rejected valid empty outputs which prevented passing official ONNX tests.

### Description

- Treat negative dims as dynamic and still reject them, but accept zero-sized dimensions by returning `0` from `shape_product`/`_shape_product` and `_element_count` rather than raising; this preserves semantics while enabling empty tensors.
- Relax and adjust shape validation across lowering passes (`Slice`, `Shape`, `Range`, `Split`, `Flatten`, `ConstantOfShape`, `Squeeze`, `Unsqueeze`, `Expand`, etc.) to allow non-negative sizes and compute lengths using `max(0, ...)` where appropriate instead of raising for zeros.
- Update pooling/conv/resize checks to permit non-negative output spatial dims (allowing zero-sized outputs) while still rejecting dynamic (negative) dims.
- Regenerate official support artifacts and expected-error test data by updating `OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`, and `tests/official_onnx_expected_errors.json` to reflect the new behavior.

### Testing

- Ran the full test suite with reference updates using `UPDATE_REFS=1 pytest -n auto -q` which completed in `52.62s` and reported `169 passed, 1 skipped`.
- Golden/reference files were regenerated as part of the test run and the updated support matrices and histogram were committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6967aa4b14e483259fd01f857f95103c)