### PR TITLE
identity: relax shape check and emit loop nest

### DIFF
--- a/src/onnx2c/codegen/c_emitter.py
+++ b/src/onnx2c/codegen/c_emitter.py
@@ -4804,8 +4804,9 @@ class CEmitter:
             ).rstrip()
             return with_node_comment(rendered)
         if isinstance(op, IdentityOp):
-            shape = CEmitter._codegen_shape(op.shape)
             output_dim_names = _dim_names_for(op.output)
+            shape = CEmitter._shape_dim_exprs(op.shape, output_dim_names)
+            loop_vars = CEmitter._loop_vars(op.shape)
             output_suffix = self._param_array_suffix(shape, output_dim_names)
             input_suffix = self._param_array_suffix(shape, _dim_names_for(op.input0))
             rendered = identity_template.render(
@@ -4816,9 +4817,8 @@ class CEmitter:
                 c_type=c_type,
                 input_suffix=input_suffix,
                 output_suffix=output_suffix,
-                element_count=CEmitter._element_count_expr(
-                    CEmitter._shape_dim_exprs(op.shape, output_dim_names)
-                ),
+                shape=shape,
+                loop_vars=loop_vars,
             ).rstrip()
             return with_node_comment(rendered)
         if isinstance(op, EyeLikeOp):

--- a/src/onnx2c/lowering/identity.py
+++ b/src/onnx2c/lowering/identity.py
@@ -13,7 +13,17 @@ def lower_identity(graph: Graph, node: Node) -> IdentityOp:
         raise UnsupportedOpError("Identity must have 1 input and 1 output")
     input_shape = value_shape(graph, node.inputs[0], node)
     output_shape = value_shape(graph, node.outputs[0], node)
-    if input_shape != output_shape:
+    input_dim_params = graph.find_value(node.inputs[0]).type.dim_params
+    output_dim_params = graph.find_value(node.outputs[0]).type.dim_params
+    if len(input_shape) != len(output_shape):
+        raise ShapeInferenceError("Identity input and output shapes must match")
+    for index, (input_dim, output_dim) in enumerate(
+        zip(input_shape, output_shape)
+    ):
+        if input_dim == output_dim:
+            continue
+        if input_dim_params[index] or output_dim_params[index]:
+            continue
         raise ShapeInferenceError("Identity input and output shapes must match")
     input_dtype = value_dtype(graph, node.inputs[0], node)
     output_dtype = value_dtype(graph, node.outputs[0], node)

--- a/templates/identity_op.c.j2
+++ b/templates/identity_op.c.j2
@@ -1,3 +1,9 @@
 static inline void {{ op_name }}({{ dim_args }}const {{ c_type }} {{ input0 }}{{ input_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
-    memcpy({{ output }}, {{ input0 }}, sizeof({{ c_type }}) * {{ element_count }});
+{% for dim in shape %}
+    for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+{% endfor %}
+    {{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = {{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %};
+{% for _ in shape %}
+    }
+{% endfor %}
 }


### PR DESCRIPTION
### Motivation
- Fix false negatives from strict shape equality in `Identity` lowering when one side uses symbolic dim params, which caused "Identity input and output shapes must match" errors.
- Ensure the generated `Identity` C code uses an explicit loop nest like other ops instead of `memcpy` for consistency and element-wise semantics.

### Description
- Relaxed shape validation in `lower_identity` to require equal rank and allow differing concrete dims when either corresponding `dim_params` entry is present, while keeping a strict rank check (`src/onnx2c/lowering/identity.py`).
- Updated the C emitter to compute shape expressions and loop variable names with `CEmitter._shape_dim_exprs` and `CEmitter._loop_vars` and pass them to the template for `Identity` codegen (`src/onnx2c/codegen/c_emitter.py`).
- Replaced the `memcpy` in the `Identity` template with a generated nested `for` loop using the passed `shape` and `loop_vars` so the template emits an element-wise assignment (`templates/identity_op.c.j2`).

### Testing
- Ran `UPDATE_REFS=1 pytest -n auto -q` which completed successfully with `179 passed, 1 skipped` (≈68.3s).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6967b75f881c832588eff3953945ea1f)