### PR TITLE
lowering: accept Identity with unresolved shapes

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1035 / 1802 official ONNX files.
+Support 1052 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -1378,71 +1378,71 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_sce_NCd1_mean_weight_negative_ii/model.onnx | ✅ |  |
 | node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx | ✅ |  |
 | node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx | ✅ |  |
-| node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Identity input and output shapes must match |
+| node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3_none_no_weight_negative_ii/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob/model.onnx | ✅ |  |
-| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx | ❌ | Identity input and output shapes must match |
+| node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3_sum_weight_high_ii/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob/model.onnx | ✅ |  |
-| node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx | ❌ | Identity input and output shapes must match |
+| node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx | ✅ |  |
-| node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx | ❌ | Identity input and output shapes must match |
+| node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx | ✅ |  |
 | node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx | ✅ |  |
-| node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx | ❌ | Identity input and output shapes must match |
+| node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean/model.onnx | ✅ |  |
 | node/test_sce_mean_3d/model.onnx | ✅ |  |
 | node/test_sce_mean_3d_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_3d_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_3d_log_prob_expanded/model.onnx | ❌ | Identity input and output shapes must match |
+| node/test_sce_mean_3d_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_log_prob_expanded/model.onnx | ❌ | Identity input and output shapes must match |
+| node/test_sce_mean_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_no_weight_ii/model.onnx | ✅ |  |
 | node/test_sce_mean_no_weight_ii_3d/model.onnx | ✅ |  |
 | node/test_sce_mean_no_weight_ii_3d_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_no_weight_ii_3d_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Identity input and output shapes must match |
+| node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_no_weight_ii_4d/model.onnx | ✅ |  |
 | node/test_sce_mean_no_weight_ii_4d_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_no_weight_ii_4d_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Identity input and output shapes must match |
+| node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_no_weight_ii_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_no_weight_ii_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx | ❌ | Identity input and output shapes must match |
+| node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_weight/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_ii/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_ii_3d/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_ii_3d_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_ii_3d_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx | ❌ | Identity input and output shapes must match |
+| node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_ii_4d/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_ii_4d_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_ii_4d_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx | ❌ | Identity input and output shapes must match |
+| node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_ii_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_ii_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx | ❌ | Identity input and output shapes must match |
+| node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_mean_weight_log_prob/model.onnx | ✅ |  |
-| node/test_sce_mean_weight_log_prob_expanded/model.onnx | ❌ | Identity input and output shapes must match |
+| node/test_sce_mean_weight_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_none/model.onnx | ✅ |  |
 | node/test_sce_none_expanded/model.onnx | ✅ |  |
 | node/test_sce_none_log_prob/model.onnx | ✅ |  |
-| node/test_sce_none_log_prob_expanded/model.onnx | ❌ | Identity input and output shapes must match |
+| node/test_sce_none_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_none_weights/model.onnx | ✅ |  |
 | node/test_sce_none_weights_expanded/model.onnx | ✅ |  |
 | node/test_sce_none_weights_log_prob/model.onnx | ✅ |  |
-| node/test_sce_none_weights_log_prob_expanded/model.onnx | ❌ | Identity input and output shapes must match |
+| node/test_sce_none_weights_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_sce_sum/model.onnx | ✅ |  |
 | node/test_sce_sum_expanded/model.onnx | ✅ |  |
 | node/test_sce_sum_log_prob/model.onnx | ✅ |  |
-| node/test_sce_sum_log_prob_expanded/model.onnx | ❌ | Identity input and output shapes must match |
+| node/test_sce_sum_log_prob_expanded/model.onnx | ✅ |  |
 | node/test_selu/model.onnx | ❌ | Selu only supports alpha=1.6732632423543772 |
 | node/test_selu_default/model.onnx | ✅ |  |
 | node/test_selu_default_expanded_ver18/model.onnx | ✅ |  |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -17,7 +17,6 @@
 | Unsupported elem_type 22 (INT4) for tensor '*'. | 17 | ██████████████ |
 | Unsupported elem_type 25 (UINT2) for tensor '*'. | 17 | ██████████████ |
 | Unsupported elem_type 21 (UINT4) for tensor '*'. | 17 | ██████████████ |
-| Identity input and output shapes must match | 17 | ██████████████ |
 | Unsupported op Trilu | 16 | █████████████ |
 | Reshape input and output element counts must match | 15 | ████████████ |
 | Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 14 | ████████████ |

--- a/src/onnx2c/lowering/identity.py
+++ b/src/onnx2c/lowering/identity.py
@@ -15,16 +15,18 @@ def lower_identity(graph: Graph, node: Node) -> IdentityOp:
     output_shape = value_shape(graph, node.outputs[0], node)
     input_dim_params = graph.find_value(node.inputs[0]).type.dim_params
     output_dim_params = graph.find_value(node.outputs[0]).type.dim_params
-    if len(input_shape) != len(output_shape):
-        raise ShapeInferenceError("Identity input and output shapes must match")
-    for index, (input_dim, output_dim) in enumerate(
-        zip(input_shape, output_shape)
-    ):
-        if input_dim == output_dim:
-            continue
-        if input_dim_params[index] or output_dim_params[index]:
-            continue
-        raise ShapeInferenceError("Identity input and output shapes must match")
+    resolved_shape = output_shape or input_shape
+    if input_shape and output_shape:
+        if len(input_shape) != len(output_shape):
+            raise ShapeInferenceError("Identity input and output shapes must match")
+        for index, (input_dim, output_dim) in enumerate(
+            zip(input_shape, output_shape)
+        ):
+            if input_dim == output_dim:
+                continue
+            if input_dim_params[index] or output_dim_params[index]:
+                continue
+            raise ShapeInferenceError("Identity input and output shapes must match")
     input_dtype = value_dtype(graph, node.inputs[0], node)
     output_dtype = value_dtype(graph, node.outputs[0], node)
     if input_dtype != output_dtype:
@@ -35,7 +37,7 @@ def lower_identity(graph: Graph, node: Node) -> IdentityOp:
     return IdentityOp(
         input0=node.inputs[0],
         output=node.outputs[0],
-        shape=output_shape,
+        shape=resolved_shape,
         dtype=output_dtype,
         input_dtype=input_dtype,
     )

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -5481,7 +5481,7 @@
   ],
   [
     "node/test_sce_NCd1_mean_weight_negative_ii_log_prob_expanded/model.onnx",
-    "Identity input and output shapes must match"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii/model.onnx",
@@ -5497,7 +5497,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob_expanded/model.onnx",
-    "Identity input and output shapes must match"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii/model.onnx",
@@ -5513,7 +5513,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx",
-    "Identity input and output shapes must match"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx",
@@ -5529,7 +5529,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx",
-    "Identity input and output shapes must match"
+    ""
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx",
@@ -5545,7 +5545,7 @@
   ],
   [
     "node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob_expanded/model.onnx",
-    "Identity input and output shapes must match"
+    ""
   ],
   [
     "node/test_sce_mean/model.onnx",
@@ -5565,7 +5565,7 @@
   ],
   [
     "node/test_sce_mean_3d_log_prob_expanded/model.onnx",
-    "Identity input and output shapes must match"
+    ""
   ],
   [
     "node/test_sce_mean_expanded/model.onnx",
@@ -5577,7 +5577,7 @@
   ],
   [
     "node/test_sce_mean_log_prob_expanded/model.onnx",
-    "Identity input and output shapes must match"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii/model.onnx",
@@ -5597,7 +5597,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_3d_log_prob_expanded/model.onnx",
-    "Identity input and output shapes must match"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d/model.onnx",
@@ -5613,7 +5613,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_4d_log_prob_expanded/model.onnx",
-    "Identity input and output shapes must match"
+    ""
   ],
   [
     "node/test_sce_mean_no_weight_ii_expanded/model.onnx",
@@ -5625,7 +5625,7 @@
   ],
   [
     "node/test_sce_mean_no_weight_ii_log_prob_expanded/model.onnx",
-    "Identity input and output shapes must match"
+    ""
   ],
   [
     "node/test_sce_mean_weight/model.onnx",
@@ -5653,7 +5653,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_3d_log_prob_expanded/model.onnx",
-    "Identity input and output shapes must match"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii_4d/model.onnx",
@@ -5669,7 +5669,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_4d_log_prob_expanded/model.onnx",
-    "Identity input and output shapes must match"
+    ""
   ],
   [
     "node/test_sce_mean_weight_ii_expanded/model.onnx",
@@ -5681,7 +5681,7 @@
   ],
   [
     "node/test_sce_mean_weight_ii_log_prob_expanded/model.onnx",
-    "Identity input and output shapes must match"
+    ""
   ],
   [
     "node/test_sce_mean_weight_log_prob/model.onnx",
@@ -5689,7 +5689,7 @@
   ],
   [
     "node/test_sce_mean_weight_log_prob_expanded/model.onnx",
-    "Identity input and output shapes must match"
+    ""
   ],
   [
     "node/test_sce_none/model.onnx",
@@ -5705,7 +5705,7 @@
   ],
   [
     "node/test_sce_none_log_prob_expanded/model.onnx",
-    "Identity input and output shapes must match"
+    ""
   ],
   [
     "node/test_sce_none_weights/model.onnx",
@@ -5721,7 +5721,7 @@
   ],
   [
     "node/test_sce_none_weights_log_prob_expanded/model.onnx",
-    "Identity input and output shapes must match"
+    ""
   ],
   [
     "node/test_sce_sum/model.onnx",
@@ -5737,7 +5737,7 @@
   ],
   [
     "node/test_sce_sum_log_prob_expanded/model.onnx",
-    "Identity input and output shapes must match"
+    ""
   ],
   [
     "node/test_selu/model.onnx",


### PR DESCRIPTION
### Motivation
- Some ONNX models contain `Identity` nodes where one side has an inferred shape and the other side is unresolved, causing spurious `ShapeInferenceError` failures during lowering.
- The intent is to accept `Identity` as compatible when one side is unknown and use the resolved side for downstream lowering and codegen.

### Description
- Relax `Identity` lowering in `src/onnx2c/lowering/identity.py` to resolve `shape = output_shape or input_shape` and only enforce per-dimension matching when both shapes are present.
- Use the resolved shape (`resolved_shape`) when constructing the `IdentityOp` instead of always using `output_shape`.
- Update `OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`, and `tests/official_onnx_expected_errors.json` to reflect the newly passing official ONNX test cases that previously failed with the identity shape error.

### Testing
- Ran the full test suite with reference updates using `UPDATE_REFS=1 pytest -n auto -q`, which completed with `179 passed, 1 skipped` in `54.84s`.
- The updated golden/reference files were generated as part of the test run and included in the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6967c330aca083258f7c56ab7df7ada2)