### PR TITLE
codegen: avoid dim name collisions in emitted C signature

### DIFF
--- a/src/onnx2c/codegen/c_emitter.py
+++ b/src/onnx2c/codegen/c_emitter.py
@@ -5408,6 +5408,24 @@ class CEmitter:
         dim_order: list[str] = []
         dim_vars: dict[tuple[str, int, int], str] = {}
         dim_values: dict[str, int] = {}
+        reserved_names = set(model.input_names) | set(model.output_names)
+        used_names = set(reserved_names)
+        dim_aliases: dict[str, str] = {}
+
+        def _unique_dim_name(dim_name: str) -> str:
+            if dim_name in dim_aliases:
+                return dim_aliases[dim_name]
+            base_name = dim_name
+            if base_name in used_names:
+                base_name = f"{dim_name}_dim"
+            candidate = base_name
+            counter = 1
+            while candidate in used_names:
+                counter += 1
+                candidate = f"{base_name}{counter}"
+            dim_aliases[dim_name] = candidate
+            used_names.add(candidate)
+            return candidate
 
         def _register_dim(
             kind: str,
@@ -5417,6 +5435,7 @@ class CEmitter:
             dim_value: int,
         ) -> str:
             key = (kind, tensor_index, dim_index)
+            dim_name = _unique_dim_name(dim_name)
             if key not in dim_vars:
                 dim_vars[key] = dim_name
                 if dim_name not in dim_order:

--- a/tests/test_codegen_signature.py
+++ b/tests/test_codegen_signature.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from onnx import TensorProto, helper
+
+from onnx2c.compiler import Compiler, CompilerOptions
+
+
+def _signature_param_names(source: str) -> list[str]:
+    match = re.search(r"void\\s+model\\(([^)]*)\\)\\s*\\{", source)
+    assert match is not None, "model function signature not found"
+    signature = match.group(1)
+    names: list[str] = []
+    for param in signature.split(","):
+        param = param.strip()
+        name_match = re.search(r"([A-Za-z_][A-Za-z0-9_]*)\\s*(?:\\[|$)", param)
+        assert name_match is not None, f"param name not found for {param!r}"
+        names.append(name_match.group(1))
+    return names
+
+
+def test_compile_dedupes_dim_param_names() -> None:
+    input_info = helper.make_tensor_value_info(
+        "input0", TensorProto.FLOAT, ["input0", 2]
+    )
+    output_info = helper.make_tensor_value_info(
+        "output0", TensorProto.FLOAT, ["input0", 2]
+    )
+    identity_node = helper.make_node(
+        "Identity", inputs=["input0"], outputs=["output0"]
+    )
+    graph = helper.make_graph(
+        [identity_node],
+        "dup_dim_param_graph",
+        [input_info],
+        [output_info],
+    )
+    model = helper.make_model(graph)
+    compiler = Compiler(
+        CompilerOptions(template_dir=Path("templates"), model_name="model")
+    )
+    source = compiler.compile(model)
+
+    param_names = _signature_param_names(source)
+    assert len(param_names) == len(set(param_names))
+    assert "int input0_dim" in source


### PR DESCRIPTION
### Motivation
- Prevent symbolic dimension parameter names from colliding with input/output tensor names which caused duplicate parameter names in the generated C `model(...)` signature.
- Add a targeted regression test to ensure dimension parameter names are deduplicated and the expected renamed dim parameter is present in the emitted signature.

### Description
- Add a deterministic renaming mechanism in `CEmitter._build_variable_dim_names` by tracking `reserved_names`, `used_names`, and `dim_aliases`, and implementing a `_unique_dim_name` helper to produce conflict-free identifiers.
- Apply `_unique_dim_name` in `_register_dim` so variable dimension names are renamed to `_<dim>_dim` or suffixed with a counter when necessary to avoid collisions.
- Add `tests/test_codegen_signature.py` which compiles a minimal model with shared symbolic names and asserts there are no duplicate signature parameter names and that `int input0_dim` appears in the generated source.

### Testing
- Added the automated test file `tests/test_codegen_signature.py` which asserts unique parameter names in the emitted signature and the presence of `int input0_dim`.
- No automated test suite was executed as part of this change (tests were added but not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696792a62b18832bbf76edcfc725f593)