### PR TITLE
tests: fix signature regex and refresh OFFICIAL_ONNX_FILE_SUPPORT.md

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1039 / 1802 official ONNX files.
+Support 1056 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 

--- a/tests/test_codegen_signature.py
+++ b/tests/test_codegen_signature.py
@@ -9,13 +9,15 @@ from onnx2c.compiler import Compiler, CompilerOptions
 
 
 def _signature_param_names(source: str) -> list[str]:
-    match = re.search(r"void\\s+model\\(([^)]*)\\)\\s*\\{", source)
+    match = re.search(r"void\s+model\(([^)]*)\)\s*\{", source)
     assert match is not None, "model function signature not found"
     signature = match.group(1)
     names: list[str] = []
     for param in signature.split(","):
         param = param.strip()
-        name_match = re.search(r"([A-Za-z_][A-Za-z0-9_]*)\\s*(?:\\[|$)", param)
+        name_match = re.search(
+            r"([A-Za-z_][A-Za-z0-9_]*)\s*(?:\[|$)", param
+        )
         assert name_match is not None, f"param name not found for {param!r}"
         names.append(name_match.group(1))
     return names


### PR DESCRIPTION
### Motivation
- A unit test (`test_compile_dedupes_dim_param_names`) failed because the regex used to find the generated `model` function signature did not match the emitter output. 
- The generated `OFFICIAL_ONNX_FILE_SUPPORT.md` was out of sync with current expectations and caused the support-doc comparison test to fail.

### Description
- Update the signature-parsing regex in `tests/test_codegen_signature.py` to correctly match the emitted `void model(...) {` signature and parameter name patterns (use unescaped `\s`/`\[` forms in the test regex). 
- Refresh `OFFICIAL_ONNX_FILE_SUPPORT.md` by regenerating the expected markdown output so the onnx-file support table and supported count reflect the current run.

### Testing
- Compiled a small in-memory ONNX model with `Compiler(CompilerOptions(...)).compile(model)` to verify the test regex now matches the generated `model` signature and inspected the produced C source (succeeded). 
- Compared the rendered support markdown using the test helper `_render_onnx_file_support_markdown(...)` against `OFFICIAL_ONNX_FILE_SUPPORT.md`, found a mismatch, regenerated the markdown, and re-checked equality (histogram matched and final markdown now matches the generated expectation).
- No full `pytest` run was executed in this change set; only targeted script-based checks described above were performed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6967c8273920832b90efb8eac44b514d)