### PR TITLE
normalization: add normalization ops support

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1056 / 1802 official ONNX files.
+Support 1106 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -717,9 +717,9 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_gridsample_volumetric_nearest_align_corners_0/model.onnx | ❌ | Unsupported op GridSample |
 | node/test_gridsample_volumetric_nearest_align_corners_1/model.onnx | ❌ | Unsupported op GridSample |
 | node/test_gridsample_zeros_padding/model.onnx | ❌ | Unsupported op GridSample |
-| node/test_group_normalization_epsilon/model.onnx | ❌ | Unsupported op GroupNormalization |
+| node/test_group_normalization_epsilon/model.onnx | ✅ |  |
 | node/test_group_normalization_epsilon_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
-| node/test_group_normalization_example/model.onnx | ❌ | Unsupported op GroupNormalization |
+| node/test_group_normalization_example/model.onnx | ✅ |  |
 | node/test_group_normalization_example_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_gru_batchwise/model.onnx | ❌ | Unsupported op GRU |
 | node/test_gru_defaults/model.onnx | ❌ | Unsupported op GRU |
@@ -763,74 +763,74 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_image_decoder_decode_pnm_rgb/model.onnx | ❌ | Unsupported op ImageDecoder |
 | node/test_image_decoder_decode_tiff_rgb/model.onnx | ❌ | Unsupported op ImageDecoder |
 | node/test_image_decoder_decode_webp_rgb/model.onnx | ❌ | Unsupported op ImageDecoder |
-| node/test_instancenorm_epsilon/model.onnx | ❌ | Unsupported op InstanceNormalization |
-| node/test_instancenorm_example/model.onnx | ❌ | Unsupported op InstanceNormalization |
+| node/test_instancenorm_epsilon/model.onnx | ✅ |  |
+| node/test_instancenorm_example/model.onnx | ✅ |  |
 | node/test_isinf/model.onnx | ✅ |  |
 | node/test_isinf_float16/model.onnx | ✅ |  |
 | node/test_isinf_negative/model.onnx | ✅ |  |
 | node/test_isinf_positive/model.onnx | ✅ |  |
 | node/test_isnan/model.onnx | ✅ |  |
 | node/test_isnan_float16/model.onnx | ✅ |  |
-| node/test_l1normalization_axis_0/model.onnx | ❌ | Unsupported op LpNormalization |
-| node/test_l1normalization_axis_1/model.onnx | ❌ | Unsupported op LpNormalization |
-| node/test_l1normalization_axis_last/model.onnx | ❌ | Unsupported op LpNormalization |
-| node/test_l2normalization_axis_0/model.onnx | ❌ | Unsupported op LpNormalization |
-| node/test_l2normalization_axis_1/model.onnx | ❌ | Unsupported op LpNormalization |
-| node/test_layer_normalization_2d_axis0/model.onnx | ❌ | Unsupported op LayerNormalization |
+| node/test_l1normalization_axis_0/model.onnx | ✅ |  |
+| node/test_l1normalization_axis_1/model.onnx | ✅ |  |
+| node/test_l1normalization_axis_last/model.onnx | ✅ |  |
+| node/test_l2normalization_axis_0/model.onnx | ✅ |  |
+| node/test_l2normalization_axis_1/model.onnx | ✅ |  |
+| node/test_layer_normalization_2d_axis0/model.onnx | ✅ |  |
 | node/test_layer_normalization_2d_axis0_expanded/model.onnx | ✅ |  |
 | node/test_layer_normalization_2d_axis0_expanded_ver18/model.onnx | ✅ |  |
-| node/test_layer_normalization_2d_axis1/model.onnx | ❌ | Unsupported op LayerNormalization |
+| node/test_layer_normalization_2d_axis1/model.onnx | ✅ |  |
 | node/test_layer_normalization_2d_axis1_expanded/model.onnx | ✅ |  |
 | node/test_layer_normalization_2d_axis1_expanded_ver18/model.onnx | ✅ |  |
-| node/test_layer_normalization_2d_axis_negative_1/model.onnx | ❌ | Unsupported op LayerNormalization |
+| node/test_layer_normalization_2d_axis_negative_1/model.onnx | ✅ |  |
 | node/test_layer_normalization_2d_axis_negative_1_expanded/model.onnx | ❌ | Concat output shape must be (2,), got (1,) |
 | node/test_layer_normalization_2d_axis_negative_1_expanded_ver18/model.onnx | ❌ | Concat output shape must be (2,), got (1,) |
-| node/test_layer_normalization_2d_axis_negative_2/model.onnx | ❌ | Unsupported op LayerNormalization |
+| node/test_layer_normalization_2d_axis_negative_2/model.onnx | ✅ |  |
 | node/test_layer_normalization_2d_axis_negative_2_expanded/model.onnx | ✅ |  |
 | node/test_layer_normalization_2d_axis_negative_2_expanded_ver18/model.onnx | ✅ |  |
-| node/test_layer_normalization_3d_axis0_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
+| node/test_layer_normalization_3d_axis0_epsilon/model.onnx | ✅ |  |
 | node/test_layer_normalization_3d_axis0_epsilon_expanded/model.onnx | ✅ |  |
 | node/test_layer_normalization_3d_axis0_epsilon_expanded_ver18/model.onnx | ✅ |  |
-| node/test_layer_normalization_3d_axis1_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
+| node/test_layer_normalization_3d_axis1_epsilon/model.onnx | ✅ |  |
 | node/test_layer_normalization_3d_axis1_epsilon_expanded/model.onnx | ✅ |  |
 | node/test_layer_normalization_3d_axis1_epsilon_expanded_ver18/model.onnx | ✅ |  |
-| node/test_layer_normalization_3d_axis2_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
+| node/test_layer_normalization_3d_axis2_epsilon/model.onnx | ✅ |  |
 | node/test_layer_normalization_3d_axis2_epsilon_expanded/model.onnx | ✅ |  |
 | node/test_layer_normalization_3d_axis2_epsilon_expanded_ver18/model.onnx | ✅ |  |
-| node/test_layer_normalization_3d_axis_negative_1_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
+| node/test_layer_normalization_3d_axis_negative_1_epsilon/model.onnx | ✅ |  |
 | node/test_layer_normalization_3d_axis_negative_1_epsilon_expanded/model.onnx | ❌ | Concat output shape must be (3,), got (1,) |
 | node/test_layer_normalization_3d_axis_negative_1_epsilon_expanded_ver18/model.onnx | ❌ | Concat output shape must be (3,), got (1,) |
-| node/test_layer_normalization_3d_axis_negative_2_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
+| node/test_layer_normalization_3d_axis_negative_2_epsilon/model.onnx | ✅ |  |
 | node/test_layer_normalization_3d_axis_negative_2_epsilon_expanded/model.onnx | ❌ | Concat output shape must be (2,), got (1,) |
 | node/test_layer_normalization_3d_axis_negative_2_epsilon_expanded_ver18/model.onnx | ❌ | Concat output shape must be (2,), got (1,) |
-| node/test_layer_normalization_3d_axis_negative_3_epsilon/model.onnx | ❌ | Unsupported op LayerNormalization |
+| node/test_layer_normalization_3d_axis_negative_3_epsilon/model.onnx | ✅ |  |
 | node/test_layer_normalization_3d_axis_negative_3_epsilon_expanded/model.onnx | ✅ |  |
 | node/test_layer_normalization_3d_axis_negative_3_epsilon_expanded_ver18/model.onnx | ✅ |  |
-| node/test_layer_normalization_4d_axis0/model.onnx | ❌ | Unsupported op LayerNormalization |
+| node/test_layer_normalization_4d_axis0/model.onnx | ✅ |  |
 | node/test_layer_normalization_4d_axis0_expanded/model.onnx | ✅ |  |
 | node/test_layer_normalization_4d_axis0_expanded_ver18/model.onnx | ✅ |  |
-| node/test_layer_normalization_4d_axis1/model.onnx | ❌ | Unsupported op LayerNormalization |
+| node/test_layer_normalization_4d_axis1/model.onnx | ✅ |  |
 | node/test_layer_normalization_4d_axis1_expanded/model.onnx | ✅ |  |
 | node/test_layer_normalization_4d_axis1_expanded_ver18/model.onnx | ✅ |  |
-| node/test_layer_normalization_4d_axis2/model.onnx | ❌ | Unsupported op LayerNormalization |
+| node/test_layer_normalization_4d_axis2/model.onnx | ✅ |  |
 | node/test_layer_normalization_4d_axis2_expanded/model.onnx | ✅ |  |
 | node/test_layer_normalization_4d_axis2_expanded_ver18/model.onnx | ✅ |  |
-| node/test_layer_normalization_4d_axis3/model.onnx | ❌ | Unsupported op LayerNormalization |
+| node/test_layer_normalization_4d_axis3/model.onnx | ✅ |  |
 | node/test_layer_normalization_4d_axis3_expanded/model.onnx | ✅ |  |
 | node/test_layer_normalization_4d_axis3_expanded_ver18/model.onnx | ✅ |  |
-| node/test_layer_normalization_4d_axis_negative_1/model.onnx | ❌ | Unsupported op LayerNormalization |
+| node/test_layer_normalization_4d_axis_negative_1/model.onnx | ✅ |  |
 | node/test_layer_normalization_4d_axis_negative_1_expanded/model.onnx | ❌ | Concat output shape must be (4,), got (1,) |
 | node/test_layer_normalization_4d_axis_negative_1_expanded_ver18/model.onnx | ❌ | Concat output shape must be (4,), got (1,) |
-| node/test_layer_normalization_4d_axis_negative_2/model.onnx | ❌ | Unsupported op LayerNormalization |
+| node/test_layer_normalization_4d_axis_negative_2/model.onnx | ✅ |  |
 | node/test_layer_normalization_4d_axis_negative_2_expanded/model.onnx | ❌ | Concat output shape must be (3,), got (1,) |
 | node/test_layer_normalization_4d_axis_negative_2_expanded_ver18/model.onnx | ❌ | Concat output shape must be (3,), got (1,) |
-| node/test_layer_normalization_4d_axis_negative_3/model.onnx | ❌ | Unsupported op LayerNormalization |
+| node/test_layer_normalization_4d_axis_negative_3/model.onnx | ✅ |  |
 | node/test_layer_normalization_4d_axis_negative_3_expanded/model.onnx | ❌ | Concat output shape must be (2,), got (1,) |
 | node/test_layer_normalization_4d_axis_negative_3_expanded_ver18/model.onnx | ❌ | Concat output shape must be (2,), got (1,) |
-| node/test_layer_normalization_4d_axis_negative_4/model.onnx | ❌ | Unsupported op LayerNormalization |
+| node/test_layer_normalization_4d_axis_negative_4/model.onnx | ✅ |  |
 | node/test_layer_normalization_4d_axis_negative_4_expanded/model.onnx | ✅ |  |
 | node/test_layer_normalization_4d_axis_negative_4_expanded_ver18/model.onnx | ✅ |  |
-| node/test_layer_normalization_default_axis/model.onnx | ❌ | Unsupported op LayerNormalization |
+| node/test_layer_normalization_default_axis/model.onnx | ✅ |  |
 | node/test_layer_normalization_default_axis_expanded/model.onnx | ❌ | Concat output shape must be (4,), got (1,) |
 | node/test_layer_normalization_default_axis_expanded_ver18/model.onnx | ❌ | Concat output shape must be (4,), got (1,) |
 | node/test_leakyrelu/model.onnx | ❌ | LeakyRelu only supports alpha=0.01 |
@@ -889,7 +889,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_loop11/model.onnx | ❌ | Unsupported op Loop |
 | node/test_loop13_seq/model.onnx | ❌ | Unsupported value type 'sequence_type' for 'seq_empty'. Hint: export the model with tensor inputs/outputs. |
 | node/test_loop16_seq_none/model.onnx | ❌ | Unsupported value type 'optional_type' for 'opt_seq'. Hint: export the model with tensor inputs/outputs. |
-| node/test_lpnormalization_default/model.onnx | ❌ | Unsupported op LpNormalization |
+| node/test_lpnormalization_default/model.onnx | ✅ |  |
 | node/test_lppool_1d_default/model.onnx | ❌ | Unsupported op LpPool |
 | node/test_lppool_2d_default/model.onnx | ❌ | Unsupported op LpPool |
 | node/test_lppool_2d_dilations/model.onnx | ❌ | Unsupported op LpPool |
@@ -991,7 +991,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_mul_uint32/model.onnx | ✅ |  |
 | node/test_mul_uint64/model.onnx | ✅ |  |
 | node/test_mul_uint8/model.onnx | ✅ |  |
-| node/test_mvn/model.onnx | ❌ | Unsupported op MeanVarianceNormalization |
+| node/test_mvn/model.onnx | ✅ |  |
 | node/test_mvn_expanded/model.onnx | ✅ |  |
 | node/test_mvn_expanded_ver18/model.onnx | ✅ |  |
 | node/test_neg/model.onnx | ✅ |  |
@@ -1301,43 +1301,43 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_resize_upsample_sizes_nearest_round_prefer_ceil_asymmetric/model.onnx | ✅ |  |
 | node/test_reversesequence_batch/model.onnx | ❌ | Unsupported op ReverseSequence |
 | node/test_reversesequence_time/model.onnx | ❌ | Unsupported op ReverseSequence |
-| node/test_rms_normalization_2d_axis0/model.onnx | ❌ | Unsupported op RMSNormalization |
+| node/test_rms_normalization_2d_axis0/model.onnx | ✅ |  |
 | node/test_rms_normalization_2d_axis0_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
-| node/test_rms_normalization_2d_axis1/model.onnx | ❌ | Unsupported op RMSNormalization |
+| node/test_rms_normalization_2d_axis1/model.onnx | ✅ |  |
 | node/test_rms_normalization_2d_axis1_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
-| node/test_rms_normalization_2d_axis_negative_1/model.onnx | ❌ | Unsupported op RMSNormalization |
+| node/test_rms_normalization_2d_axis_negative_1/model.onnx | ✅ |  |
 | node/test_rms_normalization_2d_axis_negative_1_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
-| node/test_rms_normalization_2d_axis_negative_2/model.onnx | ❌ | Unsupported op RMSNormalization |
+| node/test_rms_normalization_2d_axis_negative_2/model.onnx | ✅ |  |
 | node/test_rms_normalization_2d_axis_negative_2_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
-| node/test_rms_normalization_3d_axis0_epsilon/model.onnx | ❌ | Unsupported op RMSNormalization |
+| node/test_rms_normalization_3d_axis0_epsilon/model.onnx | ✅ |  |
 | node/test_rms_normalization_3d_axis0_epsilon_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
-| node/test_rms_normalization_3d_axis1_epsilon/model.onnx | ❌ | Unsupported op RMSNormalization |
+| node/test_rms_normalization_3d_axis1_epsilon/model.onnx | ✅ |  |
 | node/test_rms_normalization_3d_axis1_epsilon_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
-| node/test_rms_normalization_3d_axis2_epsilon/model.onnx | ❌ | Unsupported op RMSNormalization |
+| node/test_rms_normalization_3d_axis2_epsilon/model.onnx | ✅ |  |
 | node/test_rms_normalization_3d_axis2_epsilon_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
-| node/test_rms_normalization_3d_axis_negative_1_epsilon/model.onnx | ❌ | Unsupported op RMSNormalization |
+| node/test_rms_normalization_3d_axis_negative_1_epsilon/model.onnx | ✅ |  |
 | node/test_rms_normalization_3d_axis_negative_1_epsilon_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
-| node/test_rms_normalization_3d_axis_negative_2_epsilon/model.onnx | ❌ | Unsupported op RMSNormalization |
+| node/test_rms_normalization_3d_axis_negative_2_epsilon/model.onnx | ✅ |  |
 | node/test_rms_normalization_3d_axis_negative_2_epsilon_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
-| node/test_rms_normalization_3d_axis_negative_3_epsilon/model.onnx | ❌ | Unsupported op RMSNormalization |
+| node/test_rms_normalization_3d_axis_negative_3_epsilon/model.onnx | ✅ |  |
 | node/test_rms_normalization_3d_axis_negative_3_epsilon_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
-| node/test_rms_normalization_4d_axis0/model.onnx | ❌ | Unsupported op RMSNormalization |
+| node/test_rms_normalization_4d_axis0/model.onnx | ✅ |  |
 | node/test_rms_normalization_4d_axis0_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
-| node/test_rms_normalization_4d_axis1/model.onnx | ❌ | Unsupported op RMSNormalization |
+| node/test_rms_normalization_4d_axis1/model.onnx | ✅ |  |
 | node/test_rms_normalization_4d_axis1_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
-| node/test_rms_normalization_4d_axis2/model.onnx | ❌ | Unsupported op RMSNormalization |
+| node/test_rms_normalization_4d_axis2/model.onnx | ✅ |  |
 | node/test_rms_normalization_4d_axis2_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
-| node/test_rms_normalization_4d_axis3/model.onnx | ❌ | Unsupported op RMSNormalization |
+| node/test_rms_normalization_4d_axis3/model.onnx | ✅ |  |
 | node/test_rms_normalization_4d_axis3_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
-| node/test_rms_normalization_4d_axis_negative_1/model.onnx | ❌ | Unsupported op RMSNormalization |
+| node/test_rms_normalization_4d_axis_negative_1/model.onnx | ✅ |  |
 | node/test_rms_normalization_4d_axis_negative_1_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
-| node/test_rms_normalization_4d_axis_negative_2/model.onnx | ❌ | Unsupported op RMSNormalization |
+| node/test_rms_normalization_4d_axis_negative_2/model.onnx | ✅ |  |
 | node/test_rms_normalization_4d_axis_negative_2_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
-| node/test_rms_normalization_4d_axis_negative_3/model.onnx | ❌ | Unsupported op RMSNormalization |
+| node/test_rms_normalization_4d_axis_negative_3/model.onnx | ✅ |  |
 | node/test_rms_normalization_4d_axis_negative_3_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
-| node/test_rms_normalization_4d_axis_negative_4/model.onnx | ❌ | Unsupported op RMSNormalization |
+| node/test_rms_normalization_4d_axis_negative_4/model.onnx | ✅ |  |
 | node/test_rms_normalization_4d_axis_negative_4_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
-| node/test_rms_normalization_default_axis/model.onnx | ❌ | Unsupported op RMSNormalization |
+| node/test_rms_normalization_default_axis/model.onnx | ✅ |  |
 | node/test_rms_normalization_default_axis_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
 | node/test_rnn_seq_length/model.onnx | ❌ | Unsupported op RNN |
 | node/test_roialign_aligned_false/model.onnx | ❌ | Unsupported op RoiAlign |
@@ -1784,7 +1784,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | pytorch-operator/test_operator_repeat_dim_overflow/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_selu/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_sqrt/model.onnx | ✅ |  |
-| pytorch-operator/test_operator_symbolic_override/model.onnx | ❌ | Unsupported op InstanceNormalization |
+| pytorch-operator/test_operator_symbolic_override/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_symbolic_override_nested/model.onnx | ❌ | Sum must have 2 inputs and 1 output |
 | pytorch-operator/test_operator_view/model.onnx | ✅ |  |
 | simple/test_expand_shape_model1/model.onnx | ✅ |  |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -6,8 +6,6 @@
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████████████████████████ |
 | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 22 | ██████████████████ |
 | Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 20 | █████████████████ |
-| Unsupported op LayerNormalization | 19 | ████████████████ |
-| Unsupported op RMSNormalization | 19 | ████████████████ |
 | ReduceMean output shape rank must match input rank | 19 | ████████████████ |
 | Unsupported op Pad | 18 | ███████████████ |
 | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 18 | ███████████████ |
@@ -42,7 +40,6 @@
 | Unsupported op CenterCropPad | 6 | █████ |
 | Unsupported op DFT | 6 | █████ |
 | Unsupported op Einsum | 6 | █████ |
-| Unsupported op LpNormalization | 6 | █████ |
 | Concat output shape must be (2,), got (1,) | 6 | █████ |
 | Unsupported op ScatterElements | 6 | █████ |
 | Unsupported op Unique | 6 | █████ |
@@ -70,7 +67,6 @@
 | Elu only supports alpha=1.0 | 3 | ██ |
 | Unsupported op GatherND | 3 | ██ |
 | HardSigmoid only supports alpha=0.2 | 3 | ██ |
-| Unsupported op InstanceNormalization | 3 | ██ |
 | LeakyRelu only supports alpha=0.01 | 3 | ██ |
 | Unsupported op Loop | 3 | ██ |
 | Unsupported op Momentum | 3 | ██ |
@@ -88,7 +84,6 @@
 | Unsupported op Det | 2 | ██ |
 | Gelu only supports approximate=none | 2 | ██ |
 | Unsupported op GlobalMaxPool | 2 | ██ |
-| Unsupported op GroupNormalization | 2 | ██ |
 | Unsupported op HammingWindow | 2 | ██ |
 | Unsupported op HannWindow | 2 | ██ |
 | Max must have 2 inputs and 1 output | 2 | ██ |
@@ -112,7 +107,6 @@
 | Unsupported op MatMulInteger | 1 | █ |
 | Unsupported op MelWeightMatrix | 1 | █ |
 | Unsupported op Mish | 1 | █ |
-| Unsupported op MeanVarianceNormalization | 1 | █ |
 | Unsupported op NonZero | 1 | █ |
 | Unsupported op OptionalGetElement | 1 | █ |
 | Pow expects matching dtypes, got float, uint32 | 1 | █ |

--- a/src/onnx2c/compiler.py
+++ b/src/onnx2c/compiler.py
@@ -14,6 +14,12 @@ from .codegen.c_emitter import (
     AttentionOp,
     AveragePoolOp,
     BatchNormOp,
+    LpNormalizationOp,
+    InstanceNormalizationOp,
+    GroupNormalizationOp,
+    LayerNormalizationOp,
+    MeanVarianceNormalizationOp,
+    RMSNormalizationOp,
     BinaryOp,
     CastOp,
     ClipOp,
@@ -76,6 +82,11 @@ from .lowering.gather_elements import lower_gather_elements
 from .lowering.gemm import resolve_gemm_spec, validate_gemm_bias_shape
 from .lowering.lrn import LrnSpec, resolve_lrn_spec
 from .lowering.logsoftmax import lower_logsoftmax
+from .lowering import group_normalization as _group_normalization  # noqa: F401
+from .lowering import instance_normalization as _instance_normalization  # noqa: F401
+from .lowering import layer_normalization as _layer_normalization  # noqa: F401
+from .lowering import lp_normalization as _lp_normalization  # noqa: F401
+from .lowering import mean_variance_normalization as _mean_variance_normalization  # noqa: F401
 from .lowering.negative_log_likelihood_loss import (
     lower_negative_log_likelihood_loss,
 )
@@ -114,6 +125,7 @@ from .lowering.elementwise import (
     lower_shrink,
     lower_swish,
 )
+from .lowering import rms_normalization as _rms_normalization  # noqa: F401
 from .lowering.registry import get_lowering_registry, resolve_dispatch
 from .onnx_import import import_onnx
 from .ops import (
@@ -315,6 +327,12 @@ class Compiler:
             | ConvOp
             | AveragePoolOp
             | BatchNormOp
+            | LpNormalizationOp
+            | InstanceNormalizationOp
+            | GroupNormalizationOp
+            | LayerNormalizationOp
+            | MeanVarianceNormalizationOp
+            | RMSNormalizationOp
             | LrnOp
             | LstmOp
             | SoftmaxOp
@@ -350,6 +368,12 @@ class Compiler:
             | ConvOp
             | AveragePoolOp
             | BatchNormOp
+            | LpNormalizationOp
+            | InstanceNormalizationOp
+            | GroupNormalizationOp
+            | LayerNormalizationOp
+            | MeanVarianceNormalizationOp
+            | RMSNormalizationOp
             | LrnOp
             | LstmOp
             | SoftmaxOp

--- a/src/onnx2c/lowering/group_normalization.py
+++ b/src/onnx2c/lowering/group_normalization.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from ..codegen.c_emitter import GroupNormalizationOp
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Node
+from ..validation import ensure_output_shape_matches_input
+from .common import node_dtype, shape_product, value_shape
+from .registry import register_lowering
+
+
+@register_lowering("GroupNormalization")
+def lower_group_normalization(
+    graph: Graph, node: Node
+) -> GroupNormalizationOp:
+    if len(node.inputs) != 3 or len(node.outputs) != 1:
+        raise UnsupportedOpError(
+            "GroupNormalization must have 3 inputs and 1 output"
+        )
+    op_dtype = node_dtype(graph, node, *node.inputs, *node.outputs)
+    if not op_dtype.is_float:
+        raise UnsupportedOpError(
+            "GroupNormalization supports float16, float, and double inputs only"
+        )
+    input_shape = value_shape(graph, node.inputs[0], node)
+    output_shape = value_shape(graph, node.outputs[0], node)
+    ensure_output_shape_matches_input(node, input_shape, output_shape)
+    if len(input_shape) < 3:
+        raise ShapeInferenceError(
+            "GroupNormalization expects input rank of at least 3"
+        )
+    channels = input_shape[1]
+    num_groups_attr = node.attrs.get("num_groups")
+    if num_groups_attr is None:
+        raise UnsupportedOpError("GroupNormalization requires num_groups")
+    num_groups = int(num_groups_attr)
+    if num_groups <= 0:
+        raise ShapeInferenceError("GroupNormalization num_groups must be > 0")
+    if channels % num_groups != 0:
+        raise ShapeInferenceError(
+            "GroupNormalization num_groups must divide the channel dimension"
+        )
+    scale_shape = value_shape(graph, node.inputs[1], node)
+    bias_shape = value_shape(graph, node.inputs[2], node)
+    if scale_shape != (channels,) or bias_shape != (channels,):
+        raise ShapeInferenceError(
+            "GroupNormalization scale and bias must be 1D with length C"
+        )
+    spatial_size = shape_product(input_shape[2:])
+    group_size = channels // num_groups
+    epsilon = float(node.attrs.get("epsilon", 1e-5))
+    stash_type = int(node.attrs.get("stash_type", 1))
+    if stash_type != 1:
+        raise UnsupportedOpError(
+            "GroupNormalization supports stash_type=1 only"
+        )
+    return GroupNormalizationOp(
+        input0=node.inputs[0],
+        scale=node.inputs[1],
+        bias=node.inputs[2],
+        output=node.outputs[0],
+        shape=input_shape,
+        channels=channels,
+        num_groups=num_groups,
+        group_size=group_size,
+        spatial_size=spatial_size,
+        epsilon=epsilon,
+        dtype=op_dtype,
+    )

--- a/src/onnx2c/lowering/instance_normalization.py
+++ b/src/onnx2c/lowering/instance_normalization.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from ..codegen.c_emitter import InstanceNormalizationOp
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Node
+from ..validation import ensure_output_shape_matches_input
+from .common import node_dtype, shape_product, value_shape
+from .registry import register_lowering
+
+
+@register_lowering("InstanceNormalization")
+def lower_instance_normalization(
+    graph: Graph, node: Node
+) -> InstanceNormalizationOp:
+    if len(node.inputs) != 3 or len(node.outputs) != 1:
+        raise UnsupportedOpError(
+            "InstanceNormalization must have 3 inputs and 1 output"
+        )
+    op_dtype = node_dtype(graph, node, *node.inputs, *node.outputs)
+    if not op_dtype.is_float:
+        raise UnsupportedOpError(
+            "InstanceNormalization supports float16, float, and double inputs only"
+        )
+    input_shape = value_shape(graph, node.inputs[0], node)
+    output_shape = value_shape(graph, node.outputs[0], node)
+    ensure_output_shape_matches_input(node, input_shape, output_shape)
+    if len(input_shape) < 3:
+        raise ShapeInferenceError(
+            "InstanceNormalization expects input rank of at least 3"
+        )
+    channels = input_shape[1]
+    scale_shape = value_shape(graph, node.inputs[1], node)
+    bias_shape = value_shape(graph, node.inputs[2], node)
+    if scale_shape != (channels,) or bias_shape != (channels,):
+        raise ShapeInferenceError(
+            "InstanceNormalization scale and bias must be 1D with length C"
+        )
+    spatial_size = shape_product(input_shape[2:])
+    epsilon = float(node.attrs.get("epsilon", 1e-5))
+    return InstanceNormalizationOp(
+        input0=node.inputs[0],
+        scale=node.inputs[1],
+        bias=node.inputs[2],
+        output=node.outputs[0],
+        shape=input_shape,
+        channels=channels,
+        spatial_size=spatial_size,
+        epsilon=epsilon,
+        dtype=op_dtype,
+    )

--- a/src/onnx2c/lowering/layer_normalization.py
+++ b/src/onnx2c/lowering/layer_normalization.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from ..codegen.c_emitter import LayerNormalizationOp
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Node
+from ..validation import ensure_output_shape_matches_input
+from ..validation import normalize_axis
+from .common import node_dtype, shape_product, value_dtype, value_shape
+from .registry import register_lowering
+
+
+def _ensure_broadcastable(
+    name: str,
+    shape: tuple[int, ...],
+    normalized_shape: tuple[int, ...],
+) -> None:
+    if len(shape) != len(normalized_shape):
+        raise ShapeInferenceError(
+            f"LayerNormalization {name} rank must match normalized rank"
+        )
+    for dim, expected in zip(shape, normalized_shape):
+        if dim not in {1, expected}:
+            raise ShapeInferenceError(
+                f"LayerNormalization {name} shape {shape} must be broadcastable "
+                f"to {normalized_shape}"
+            )
+
+
+@register_lowering("LayerNormalization")
+def lower_layer_normalization(
+    graph: Graph, node: Node
+) -> LayerNormalizationOp:
+    if len(node.inputs) < 2 or len(node.inputs) > 3:
+        raise UnsupportedOpError(
+            "LayerNormalization must have 2 or 3 inputs"
+        )
+    if len(node.outputs) < 1 or len(node.outputs) > 3:
+        raise UnsupportedOpError(
+            "LayerNormalization must have 1 to 3 outputs"
+        )
+    op_dtype = node_dtype(graph, node, *node.inputs, node.outputs[0])
+    if not op_dtype.is_float:
+        raise UnsupportedOpError(
+            "LayerNormalization supports float16, float, and double inputs only"
+        )
+    input_shape = value_shape(graph, node.inputs[0], node)
+    output_shape = value_shape(graph, node.outputs[0], node)
+    ensure_output_shape_matches_input(node, input_shape, output_shape)
+    axis = normalize_axis(int(node.attrs.get("axis", -1)), input_shape, node)
+    normalized_shape = input_shape[axis:]
+    scale_shape = value_shape(graph, node.inputs[1], node)
+    _ensure_broadcastable("scale", scale_shape, normalized_shape)
+    bias_input = node.inputs[2] if len(node.inputs) > 2 and node.inputs[2] else None
+    bias_shape = None
+    if bias_input is not None:
+        bias_shape = value_shape(graph, bias_input, node)
+        _ensure_broadcastable("bias", bias_shape, normalized_shape)
+    epsilon = float(node.attrs.get("epsilon", 1e-5))
+    stash_type = int(node.attrs.get("stash_type", 1))
+    if stash_type != 1:
+        raise UnsupportedOpError(
+            "LayerNormalization supports stash_type=1 only"
+        )
+    mean_output = node.outputs[1] if len(node.outputs) > 1 else None
+    invstd_output = node.outputs[2] if len(node.outputs) > 2 else None
+    if mean_output is not None:
+        mean_dtype = value_dtype(graph, mean_output, node)
+        if mean_dtype != op_dtype:
+            raise UnsupportedOpError(
+                "LayerNormalization expects mean output dtype to match input"
+            )
+        expected_mean_shape = input_shape[:axis] + (1,) * len(normalized_shape)
+        mean_shape = value_shape(graph, mean_output, node)
+        if mean_shape != expected_mean_shape:
+            raise ShapeInferenceError(
+                "LayerNormalization mean output shape must be "
+                f"{expected_mean_shape}, got {mean_shape}"
+            )
+    if invstd_output is not None:
+        invstd_dtype = value_dtype(graph, invstd_output, node)
+        if invstd_dtype != op_dtype:
+            raise UnsupportedOpError(
+                "LayerNormalization expects invstd output dtype to match input"
+            )
+        expected_invstd_shape = input_shape[:axis] + (1,) * len(normalized_shape)
+        invstd_shape = value_shape(graph, invstd_output, node)
+        if invstd_shape != expected_invstd_shape:
+            raise ShapeInferenceError(
+                "LayerNormalization invstd output shape must be "
+                f"{expected_invstd_shape}, got {invstd_shape}"
+            )
+    outer = shape_product(input_shape[:axis]) if axis > 0 else 1
+    inner = shape_product(normalized_shape)
+    return LayerNormalizationOp(
+        input0=node.inputs[0],
+        scale=node.inputs[1],
+        bias=bias_input,
+        output=node.outputs[0],
+        mean_output=mean_output,
+        invstd_output=invstd_output,
+        shape=input_shape,
+        normalized_shape=normalized_shape,
+        scale_shape=scale_shape,
+        bias_shape=bias_shape,
+        outer=outer,
+        inner=inner,
+        axis=axis,
+        epsilon=epsilon,
+        dtype=op_dtype,
+    )

--- a/src/onnx2c/lowering/lp_normalization.py
+++ b/src/onnx2c/lowering/lp_normalization.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from ..codegen.c_emitter import LpNormalizationOp
+from ..errors import UnsupportedOpError
+from ..ir.model import Graph, Node
+from ..validation import ensure_output_shape_matches_input
+from ..validation import normalize_axis
+from .common import node_dtype, shape_product, value_shape
+from .registry import register_lowering
+
+
+@register_lowering("LpNormalization")
+def lower_lp_normalization(graph: Graph, node: Node) -> LpNormalizationOp:
+    if len(node.inputs) != 1 or len(node.outputs) != 1:
+        raise UnsupportedOpError("LpNormalization must have 1 input and 1 output")
+    op_dtype = node_dtype(graph, node, *node.inputs, *node.outputs)
+    if not op_dtype.is_float:
+        raise UnsupportedOpError(
+            "LpNormalization supports float16, float, and double inputs only"
+        )
+    input_shape = value_shape(graph, node.inputs[0], node)
+    output_shape = value_shape(graph, node.outputs[0], node)
+    ensure_output_shape_matches_input(node, input_shape, output_shape)
+    axis = normalize_axis(int(node.attrs.get("axis", -1)), input_shape, node)
+    p = int(node.attrs.get("p", 2))
+    if p not in {1, 2}:
+        raise UnsupportedOpError("LpNormalization only supports p=1 or p=2")
+    outer = shape_product(input_shape[:axis]) if axis > 0 else 1
+    axis_size = input_shape[axis]
+    inner = (
+        shape_product(input_shape[axis + 1 :])
+        if axis + 1 < len(input_shape)
+        else 1
+    )
+    return LpNormalizationOp(
+        input0=node.inputs[0],
+        output=node.outputs[0],
+        shape=input_shape,
+        axis=axis,
+        p=p,
+        outer=outer,
+        axis_size=axis_size,
+        inner=inner,
+        dtype=op_dtype,
+    )

--- a/src/onnx2c/lowering/mean_variance_normalization.py
+++ b/src/onnx2c/lowering/mean_variance_normalization.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from ..codegen.c_emitter import MeanVarianceNormalizationOp
+from ..errors import UnsupportedOpError
+from ..ir.model import Graph, Node
+from ..validation import ensure_output_shape_matches_input
+from .common import node_dtype, shape_product, value_shape
+from .reduce import normalize_reduce_axes
+from .registry import register_lowering
+
+
+@register_lowering("MeanVarianceNormalization")
+def lower_mean_variance_normalization(
+    graph: Graph, node: Node
+) -> MeanVarianceNormalizationOp:
+    if len(node.inputs) != 1 or len(node.outputs) != 1:
+        raise UnsupportedOpError(
+            "MeanVarianceNormalization must have 1 input and 1 output"
+        )
+    op_dtype = node_dtype(graph, node, *node.inputs, *node.outputs)
+    if not op_dtype.is_float:
+        raise UnsupportedOpError(
+            "MeanVarianceNormalization supports float16, float, and double inputs only"
+        )
+    input_shape = value_shape(graph, node.inputs[0], node)
+    output_shape = value_shape(graph, node.outputs[0], node)
+    ensure_output_shape_matches_input(node, input_shape, output_shape)
+    axes_attr = node.attrs.get("axes")
+    if axes_attr is None:
+        axes = (0, 2, 3)
+    else:
+        axes = tuple(int(axis) for axis in axes_attr)
+    axes = normalize_reduce_axes(axes, input_shape, node)
+    if not axes:
+        raise UnsupportedOpError(
+            "MeanVarianceNormalization requires non-empty reduction axes"
+        )
+    non_axes = tuple(i for i in range(len(input_shape)) if i not in axes)
+    reduce_count = shape_product(tuple(input_shape[axis] for axis in axes))
+    return MeanVarianceNormalizationOp(
+        input0=node.inputs[0],
+        output=node.outputs[0],
+        shape=input_shape,
+        axes=axes,
+        non_axes=non_axes,
+        reduce_count=reduce_count,
+        epsilon=1e-9,
+        dtype=op_dtype,
+    )

--- a/src/onnx2c/lowering/rms_normalization.py
+++ b/src/onnx2c/lowering/rms_normalization.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from ..codegen.c_emitter import RMSNormalizationOp
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Node
+from ..validation import ensure_output_shape_matches_input
+from ..validation import normalize_axis
+from .common import node_dtype, shape_product, value_shape
+from .registry import register_lowering
+
+
+def _ensure_broadcastable(
+    name: str,
+    shape: tuple[int, ...],
+    normalized_shape: tuple[int, ...],
+) -> None:
+    if len(shape) != len(normalized_shape):
+        raise ShapeInferenceError(
+            f"RMSNormalization {name} rank must match normalized rank"
+        )
+    for dim, expected in zip(shape, normalized_shape):
+        if dim not in {1, expected}:
+            raise ShapeInferenceError(
+                f"RMSNormalization {name} shape {shape} must be broadcastable "
+                f"to {normalized_shape}"
+            )
+
+
+@register_lowering("RMSNormalization")
+def lower_rms_normalization(
+    graph: Graph, node: Node
+) -> RMSNormalizationOp:
+    if len(node.inputs) != 2 or len(node.outputs) != 1:
+        raise UnsupportedOpError("RMSNormalization must have 2 inputs and 1 output")
+    op_dtype = node_dtype(graph, node, *node.inputs, *node.outputs)
+    if not op_dtype.is_float:
+        raise UnsupportedOpError(
+            "RMSNormalization supports float16, float, and double inputs only"
+        )
+    input_shape = value_shape(graph, node.inputs[0], node)
+    output_shape = value_shape(graph, node.outputs[0], node)
+    ensure_output_shape_matches_input(node, input_shape, output_shape)
+    axis = normalize_axis(int(node.attrs.get("axis", -1)), input_shape, node)
+    normalized_shape = input_shape[axis:]
+    scale_shape = value_shape(graph, node.inputs[1], node)
+    _ensure_broadcastable("scale", scale_shape, normalized_shape)
+    epsilon = float(node.attrs.get("epsilon", 1e-5))
+    stash_type = int(node.attrs.get("stash_type", 1))
+    if stash_type != 1:
+        raise UnsupportedOpError(
+            "RMSNormalization supports stash_type=1 only"
+        )
+    outer = shape_product(input_shape[:axis]) if axis > 0 else 1
+    inner = shape_product(normalized_shape)
+    return RMSNormalizationOp(
+        input0=node.inputs[0],
+        scale=node.inputs[1],
+        output=node.outputs[0],
+        shape=input_shape,
+        normalized_shape=normalized_shape,
+        scale_shape=scale_shape,
+        outer=outer,
+        inner=inner,
+        axis=axis,
+        epsilon=epsilon,
+        dtype=op_dtype,
+    )

--- a/templates/group_normalization_op.c.j2
+++ b/templates/group_normalization_op.c.j2
@@ -1,0 +1,46 @@
+static inline void {{ op_name }}({{ dim_args }}const {{ c_type }} {{ input0 }}{{ input_suffix }}, const {{ c_type }} {{ scale }}{{ scale_suffix }}, const {{ c_type }} {{ bias }}{{ bias_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+{% for dim in shape[:1] %}
+for (size_t {{ loop_vars[0] }} = 0; {{ loop_vars[0] }} < {{ dim }}; ++{{ loop_vars[0] }}) {
+{% endfor %}
+    for (size_t g = 0; g < {{ num_groups }}; ++g) {
+        {{ c_type }} sum = {{ zero_literal }};
+        for (size_t c_in_group = 0; c_in_group < {{ group_size }}; ++c_in_group) {
+            size_t c = g * {{ group_size }} + c_in_group;
+{% for dim in shape[2:] %}
+            for (size_t {{ loop_vars[loop.index0 + 2] }} = 0; {{ loop_vars[loop.index0 + 2] }} < {{ dim }}; ++{{ loop_vars[loop.index0 + 2] }}) {
+{% endfor %}
+                sum += {{ input0 }}[{{ loop_vars[0] }}][c]{% for var in loop_vars[2:] %}[{{ var }}]{% endfor %};
+{% for _ in shape[2:] %}
+            }
+{% endfor %}
+        }
+        {{ c_type }} mean = sum / ({{ group_size }} * {{ spatial_size }});
+        {{ c_type }} var = {{ zero_literal }};
+        for (size_t c_in_group = 0; c_in_group < {{ group_size }}; ++c_in_group) {
+            size_t c = g * {{ group_size }} + c_in_group;
+{% for dim in shape[2:] %}
+            for (size_t {{ loop_vars[loop.index0 + 2] }} = 0; {{ loop_vars[loop.index0 + 2] }} < {{ dim }}; ++{{ loop_vars[loop.index0 + 2] }}) {
+{% endfor %}
+                {{ c_type }} diff = {{ input0 }}[{{ loop_vars[0] }}][c]{% for var in loop_vars[2:] %}[{{ var }}]{% endfor %} - mean;
+                var += diff * diff;
+{% for _ in shape[2:] %}
+            }
+{% endfor %}
+        }
+        {{ c_type }} denom = {{ sqrt_fn }}(var / ({{ group_size }} * {{ spatial_size }}) + {{ epsilon_literal }});
+        for (size_t c_in_group = 0; c_in_group < {{ group_size }}; ++c_in_group) {
+            size_t c = g * {{ group_size }} + c_in_group;
+{% for dim in shape[2:] %}
+            for (size_t {{ loop_vars[loop.index0 + 2] }} = 0; {{ loop_vars[loop.index0 + 2] }} < {{ dim }}; ++{{ loop_vars[loop.index0 + 2] }}) {
+{% endfor %}
+                {{ output }}[{{ loop_vars[0] }}][c]{% for var in loop_vars[2:] %}[{{ var }}]{% endfor %} =
+                    ({{ input0 }}[{{ loop_vars[0] }}][c]{% for var in loop_vars[2:] %}[{{ var }}]{% endfor %} - mean) / denom * {{ scale }}[c] + {{ bias }}[c];
+{% for _ in shape[2:] %}
+            }
+{% endfor %}
+        }
+    }
+{% for _ in shape[:1] %}
+}
+{% endfor %}
+}

--- a/templates/instance_normalization_op.c.j2
+++ b/templates/instance_normalization_op.c.j2
@@ -1,0 +1,35 @@
+static inline void {{ op_name }}({{ dim_args }}const {{ c_type }} {{ input0 }}{{ input_suffix }}, const {{ c_type }} {{ scale }}{{ scale_suffix }}, const {{ c_type }} {{ bias }}{{ bias_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+{% for dim in shape[:2] %}
+for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+{% endfor %}
+    {{ c_type }} sum = {{ zero_literal }};
+{% for dim in shape[2:] %}
+    for (size_t {{ loop_vars[loop.index0 + 2] }} = 0; {{ loop_vars[loop.index0 + 2] }} < {{ dim }}; ++{{ loop_vars[loop.index0 + 2] }}) {
+{% endfor %}
+        sum += {{ input0 }}[{{ loop_vars[0] }}][{{ loop_vars[1] }}]{% for var in loop_vars[2:] %}[{{ var }}]{% endfor %};
+{% for _ in shape[2:] %}
+    }
+{% endfor %}
+    {{ c_type }} mean = sum / {{ spatial_size }};
+    {{ c_type }} var = {{ zero_literal }};
+{% for dim in shape[2:] %}
+    for (size_t {{ loop_vars[loop.index0 + 2] }} = 0; {{ loop_vars[loop.index0 + 2] }} < {{ dim }}; ++{{ loop_vars[loop.index0 + 2] }}) {
+{% endfor %}
+        {{ c_type }} diff = {{ input0 }}[{{ loop_vars[0] }}][{{ loop_vars[1] }}]{% for var in loop_vars[2:] %}[{{ var }}]{% endfor %} - mean;
+        var += diff * diff;
+{% for _ in shape[2:] %}
+    }
+{% endfor %}
+    {{ c_type }} denom = {{ sqrt_fn }}(var / {{ spatial_size }} + {{ epsilon_literal }});
+{% for dim in shape[2:] %}
+    for (size_t {{ loop_vars[loop.index0 + 2] }} = 0; {{ loop_vars[loop.index0 + 2] }} < {{ dim }}; ++{{ loop_vars[loop.index0 + 2] }}) {
+{% endfor %}
+        {{ output }}[{{ loop_vars[0] }}][{{ loop_vars[1] }}]{% for var in loop_vars[2:] %}[{{ var }}]{% endfor %} =
+            ({{ input0 }}[{{ loop_vars[0] }}][{{ loop_vars[1] }}]{% for var in loop_vars[2:] %}[{{ var }}]{% endfor %} - mean) / denom * {{ scale }}[{{ loop_vars[1] }}] + {{ bias }}[{{ loop_vars[1] }}];
+{% for _ in shape[2:] %}
+    }
+{% endfor %}
+{% for _ in shape[:2] %}
+}
+{% endfor %}
+}

--- a/templates/layer_normalization_op.c.j2
+++ b/templates/layer_normalization_op.c.j2
@@ -1,0 +1,43 @@
+static inline void {{ op_name }}({{ dim_args }}const {{ c_type }} {{ input0 }}{{ input_suffix }}, const {{ c_type }} {{ scale }}{{ scale_suffix }}{% if bias %}, const {{ c_type }} {{ bias }}{{ bias_suffix }}{% endif %}, {{ c_type }} {{ output }}{{ output_suffix }}{% if mean_output %}, {{ c_type }} {{ mean_output }}{{ mean_suffix }}{% endif %}{% if invstd_output %}, {{ c_type }} {{ invstd_output }}{{ invstd_suffix }}{% endif %}) {
+{% for dim in prefix_shape %}
+for (size_t {{ prefix_loop_vars[loop.index0] }} = 0; {{ prefix_loop_vars[loop.index0] }} < {{ dim }}; ++{{ prefix_loop_vars[loop.index0] }}) {
+{% endfor %}
+    {{ c_type }} sum = {{ zero_literal }};
+{% for dim in norm_shape %}
+    for (size_t {{ norm_loop_vars[loop.index0] }} = 0; {{ norm_loop_vars[loop.index0] }} < {{ dim }}; ++{{ norm_loop_vars[loop.index0] }}) {
+{% endfor %}
+        sum += {{ input0 }}{% for var in prefix_loop_vars %}[{{ var }}]{% endfor %}{% for var in norm_loop_vars %}[{{ var }}]{% endfor %};
+{% for _ in norm_shape %}
+    }
+{% endfor %}
+    {{ c_type }} mean = sum / {{ inner }};
+    {{ c_type }} var = {{ zero_literal }};
+{% for dim in norm_shape %}
+    for (size_t {{ norm_loop_vars[loop.index0] }} = 0; {{ norm_loop_vars[loop.index0] }} < {{ dim }}; ++{{ norm_loop_vars[loop.index0] }}) {
+{% endfor %}
+        {{ c_type }} diff = {{ input0 }}{% for var in prefix_loop_vars %}[{{ var }}]{% endfor %}{% for var in norm_loop_vars %}[{{ var }}]{% endfor %} - mean;
+        var += diff * diff;
+{% for _ in norm_shape %}
+    }
+{% endfor %}
+    var = var / {{ inner }};
+    {{ c_type }} inv_std = (({{ c_type }})1) / {{ sqrt_fn }}(var + {{ epsilon_literal }});
+{% if mean_output %}
+    {{ mean_output }}{% for var in mean_index_vars %}[{{ var }}]{% endfor %} = mean;
+{% endif %}
+{% if invstd_output %}
+    {{ invstd_output }}{% for var in mean_index_vars %}[{{ var }}]{% endfor %} = inv_std;
+{% endif %}
+{% for dim in norm_shape %}
+    for (size_t {{ norm_loop_vars[loop.index0] }} = 0; {{ norm_loop_vars[loop.index0] }} < {{ dim }}; ++{{ norm_loop_vars[loop.index0] }}) {
+{% endfor %}
+        {{ c_type }} value = ({{ input0 }}{% for var in prefix_loop_vars %}[{{ var }}]{% endfor %}{% for var in norm_loop_vars %}[{{ var }}]{% endfor %} - mean) * inv_std;
+        value = value * {{ scale }}{% for var in scale_index_vars %}[{{ var }}]{% endfor %}{% if bias %} + {{ bias }}{% for var in bias_index_vars %}[{{ var }}]{% endfor %}{% endif %};
+        {{ output }}{% for var in prefix_loop_vars %}[{{ var }}]{% endfor %}{% for var in norm_loop_vars %}[{{ var }}]{% endfor %} = value;
+{% for _ in norm_shape %}
+    }
+{% endfor %}
+{% for _ in prefix_shape %}
+}
+{% endfor %}
+}

--- a/templates/lp_normalization_op.c.j2
+++ b/templates/lp_normalization_op.c.j2
@@ -1,0 +1,27 @@
+static inline void {{ op_name }}({{ dim_args }}const {{ c_type }} {{ input0 }}{{ array_suffix }}, {{ c_type }} {{ output }}{{ array_suffix }}) {
+    const {{ c_type }} *input_flat = (const {{ c_type }} *){{ input0 }};
+    {{ c_type }} *output_flat = ({{ c_type }} *){{ output }};
+    const size_t outer = {{ outer }};
+    const size_t axis_size = {{ axis_size }};
+    const size_t inner = {{ inner }};
+    for (size_t outer_idx = 0; outer_idx < outer; ++outer_idx) {
+        for (size_t inner_idx = 0; inner_idx < inner; ++inner_idx) {
+            size_t base = (outer_idx * axis_size * inner) + inner_idx;
+            {{ c_type }} acc = {{ zero_literal }};
+            for (size_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
+                {{ c_type }} value = input_flat[base + axis_idx * inner];
+{% if p == 1 %}
+                acc += {{ abs_fn }}(value);
+{% else %}
+                acc += value * value;
+{% endif %}
+            }
+{% if p == 2 %}
+            acc = {{ sqrt_fn }}(acc);
+{% endif %}
+            for (size_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
+                output_flat[base + axis_idx * inner] = input_flat[base + axis_idx * inner] / acc;
+            }
+        }
+    }
+}

--- a/templates/mean_variance_normalization_op.c.j2
+++ b/templates/mean_variance_normalization_op.c.j2
@@ -1,0 +1,34 @@
+static inline void {{ op_name }}({{ dim_args }}const {{ c_type }} {{ input0 }}{{ input_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+{% for axis in non_axes %}
+for (size_t {{ loop_vars[axis] }} = 0; {{ loop_vars[axis] }} < {{ shape[axis] }}; ++{{ loop_vars[axis] }}) {
+{% endfor %}
+    {{ c_type }} sum = {{ zero_literal }};
+{% for axis in axes %}
+    for (size_t {{ loop_vars[axis] }} = 0; {{ loop_vars[axis] }} < {{ shape[axis] }}; ++{{ loop_vars[axis] }}) {
+{% endfor %}
+        sum += {{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %};
+{% for _ in axes %}
+    }
+{% endfor %}
+    {{ c_type }} mean = sum / {{ reduce_count }};
+    {{ c_type }} var = {{ zero_literal }};
+{% for axis in axes %}
+    for (size_t {{ loop_vars[axis] }} = 0; {{ loop_vars[axis] }} < {{ shape[axis] }}; ++{{ loop_vars[axis] }}) {
+{% endfor %}
+        {{ c_type }} diff = {{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %} - mean;
+        var += diff * diff;
+{% for _ in axes %}
+    }
+{% endfor %}
+    {{ c_type }} denom = {{ sqrt_fn }}(var / {{ reduce_count }} + {{ epsilon_literal }});
+{% for axis in axes %}
+    for (size_t {{ loop_vars[axis] }} = 0; {{ loop_vars[axis] }} < {{ shape[axis] }}; ++{{ loop_vars[axis] }}) {
+{% endfor %}
+        {{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = ({{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %} - mean) / denom;
+{% for _ in axes %}
+    }
+{% endfor %}
+{% for _ in non_axes %}
+}
+{% endfor %}
+}

--- a/templates/rms_normalization_op.c.j2
+++ b/templates/rms_normalization_op.c.j2
@@ -1,0 +1,28 @@
+static inline void {{ op_name }}({{ dim_args }}const {{ c_type }} {{ input0 }}{{ input_suffix }}, const {{ c_type }} {{ scale }}{{ scale_suffix }}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+{% for dim in prefix_shape %}
+for (size_t {{ prefix_loop_vars[loop.index0] }} = 0; {{ prefix_loop_vars[loop.index0] }} < {{ dim }}; ++{{ prefix_loop_vars[loop.index0] }}) {
+{% endfor %}
+    {{ c_type }} sum = {{ zero_literal }};
+{% for dim in norm_shape %}
+    for (size_t {{ norm_loop_vars[loop.index0] }} = 0; {{ norm_loop_vars[loop.index0] }} < {{ dim }}; ++{{ norm_loop_vars[loop.index0] }}) {
+{% endfor %}
+        {{ c_type }} value = {{ input0 }}{% for var in prefix_loop_vars %}[{{ var }}]{% endfor %}{% for var in norm_loop_vars %}[{{ var }}]{% endfor %};
+        sum += value * value;
+{% for _ in norm_shape %}
+    }
+{% endfor %}
+    {{ c_type }} mean_square = sum / {{ inner }};
+    {{ c_type }} denom = {{ sqrt_fn }}(mean_square + {{ epsilon_literal }});
+{% for dim in norm_shape %}
+    for (size_t {{ norm_loop_vars[loop.index0] }} = 0; {{ norm_loop_vars[loop.index0] }} < {{ dim }}; ++{{ norm_loop_vars[loop.index0] }}) {
+{% endfor %}
+        {{ c_type }} value = {{ input0 }}{% for var in prefix_loop_vars %}[{{ var }}]{% endfor %}{% for var in norm_loop_vars %}[{{ var }}]{% endfor %} / denom;
+        value = value * {{ scale }}{% for var in scale_index_vars %}[{{ var }}]{% endfor %};
+        {{ output }}{% for var in prefix_loop_vars %}[{{ var }}]{% endfor %}{% for var in norm_loop_vars %}[{{ var }}]{% endfor %} = value;
+{% for _ in norm_shape %}
+    }
+{% endfor %}
+{% for _ in prefix_shape %}
+}
+{% endfor %}
+}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -2837,7 +2837,7 @@
   ],
   [
     "node/test_group_normalization_epsilon/model.onnx",
-    "Unsupported op GroupNormalization"
+    ""
   ],
   [
     "node/test_group_normalization_epsilon_expanded/model.onnx",
@@ -2845,7 +2845,7 @@
   ],
   [
     "node/test_group_normalization_example/model.onnx",
-    "Unsupported op GroupNormalization"
+    ""
   ],
   [
     "node/test_group_normalization_example_expanded/model.onnx",
@@ -3021,11 +3021,11 @@
   ],
   [
     "node/test_instancenorm_epsilon/model.onnx",
-    "Unsupported op InstanceNormalization"
+    ""
   ],
   [
     "node/test_instancenorm_example/model.onnx",
-    "Unsupported op InstanceNormalization"
+    ""
   ],
   [
     "node/test_isinf/model.onnx",
@@ -3053,27 +3053,27 @@
   ],
   [
     "node/test_l1normalization_axis_0/model.onnx",
-    "Unsupported op LpNormalization"
+    ""
   ],
   [
     "node/test_l1normalization_axis_1/model.onnx",
-    "Unsupported op LpNormalization"
+    ""
   ],
   [
     "node/test_l1normalization_axis_last/model.onnx",
-    "Unsupported op LpNormalization"
+    ""
   ],
   [
     "node/test_l2normalization_axis_0/model.onnx",
-    "Unsupported op LpNormalization"
+    ""
   ],
   [
     "node/test_l2normalization_axis_1/model.onnx",
-    "Unsupported op LpNormalization"
+    ""
   ],
   [
     "node/test_layer_normalization_2d_axis0/model.onnx",
-    "Unsupported op LayerNormalization"
+    ""
   ],
   [
     "node/test_layer_normalization_2d_axis0_expanded/model.onnx",
@@ -3085,7 +3085,7 @@
   ],
   [
     "node/test_layer_normalization_2d_axis1/model.onnx",
-    "Unsupported op LayerNormalization"
+    ""
   ],
   [
     "node/test_layer_normalization_2d_axis1_expanded/model.onnx",
@@ -3097,7 +3097,7 @@
   ],
   [
     "node/test_layer_normalization_2d_axis_negative_1/model.onnx",
-    "Unsupported op LayerNormalization"
+    ""
   ],
   [
     "node/test_layer_normalization_2d_axis_negative_1_expanded/model.onnx",
@@ -3109,7 +3109,7 @@
   ],
   [
     "node/test_layer_normalization_2d_axis_negative_2/model.onnx",
-    "Unsupported op LayerNormalization"
+    ""
   ],
   [
     "node/test_layer_normalization_2d_axis_negative_2_expanded/model.onnx",
@@ -3121,7 +3121,7 @@
   ],
   [
     "node/test_layer_normalization_3d_axis0_epsilon/model.onnx",
-    "Unsupported op LayerNormalization"
+    ""
   ],
   [
     "node/test_layer_normalization_3d_axis0_epsilon_expanded/model.onnx",
@@ -3133,7 +3133,7 @@
   ],
   [
     "node/test_layer_normalization_3d_axis1_epsilon/model.onnx",
-    "Unsupported op LayerNormalization"
+    ""
   ],
   [
     "node/test_layer_normalization_3d_axis1_epsilon_expanded/model.onnx",
@@ -3145,7 +3145,7 @@
   ],
   [
     "node/test_layer_normalization_3d_axis2_epsilon/model.onnx",
-    "Unsupported op LayerNormalization"
+    ""
   ],
   [
     "node/test_layer_normalization_3d_axis2_epsilon_expanded/model.onnx",
@@ -3157,7 +3157,7 @@
   ],
   [
     "node/test_layer_normalization_3d_axis_negative_1_epsilon/model.onnx",
-    "Unsupported op LayerNormalization"
+    ""
   ],
   [
     "node/test_layer_normalization_3d_axis_negative_1_epsilon_expanded/model.onnx",
@@ -3169,7 +3169,7 @@
   ],
   [
     "node/test_layer_normalization_3d_axis_negative_2_epsilon/model.onnx",
-    "Unsupported op LayerNormalization"
+    ""
   ],
   [
     "node/test_layer_normalization_3d_axis_negative_2_epsilon_expanded/model.onnx",
@@ -3181,7 +3181,7 @@
   ],
   [
     "node/test_layer_normalization_3d_axis_negative_3_epsilon/model.onnx",
-    "Unsupported op LayerNormalization"
+    ""
   ],
   [
     "node/test_layer_normalization_3d_axis_negative_3_epsilon_expanded/model.onnx",
@@ -3193,7 +3193,7 @@
   ],
   [
     "node/test_layer_normalization_4d_axis0/model.onnx",
-    "Unsupported op LayerNormalization"
+    ""
   ],
   [
     "node/test_layer_normalization_4d_axis0_expanded/model.onnx",
@@ -3205,7 +3205,7 @@
   ],
   [
     "node/test_layer_normalization_4d_axis1/model.onnx",
-    "Unsupported op LayerNormalization"
+    ""
   ],
   [
     "node/test_layer_normalization_4d_axis1_expanded/model.onnx",
@@ -3217,7 +3217,7 @@
   ],
   [
     "node/test_layer_normalization_4d_axis2/model.onnx",
-    "Unsupported op LayerNormalization"
+    ""
   ],
   [
     "node/test_layer_normalization_4d_axis2_expanded/model.onnx",
@@ -3229,7 +3229,7 @@
   ],
   [
     "node/test_layer_normalization_4d_axis3/model.onnx",
-    "Unsupported op LayerNormalization"
+    ""
   ],
   [
     "node/test_layer_normalization_4d_axis3_expanded/model.onnx",
@@ -3241,7 +3241,7 @@
   ],
   [
     "node/test_layer_normalization_4d_axis_negative_1/model.onnx",
-    "Unsupported op LayerNormalization"
+    ""
   ],
   [
     "node/test_layer_normalization_4d_axis_negative_1_expanded/model.onnx",
@@ -3253,7 +3253,7 @@
   ],
   [
     "node/test_layer_normalization_4d_axis_negative_2/model.onnx",
-    "Unsupported op LayerNormalization"
+    ""
   ],
   [
     "node/test_layer_normalization_4d_axis_negative_2_expanded/model.onnx",
@@ -3265,7 +3265,7 @@
   ],
   [
     "node/test_layer_normalization_4d_axis_negative_3/model.onnx",
-    "Unsupported op LayerNormalization"
+    ""
   ],
   [
     "node/test_layer_normalization_4d_axis_negative_3_expanded/model.onnx",
@@ -3277,7 +3277,7 @@
   ],
   [
     "node/test_layer_normalization_4d_axis_negative_4/model.onnx",
-    "Unsupported op LayerNormalization"
+    ""
   ],
   [
     "node/test_layer_normalization_4d_axis_negative_4_expanded/model.onnx",
@@ -3289,7 +3289,7 @@
   ],
   [
     "node/test_layer_normalization_default_axis/model.onnx",
-    "Unsupported op LayerNormalization"
+    ""
   ],
   [
     "node/test_layer_normalization_default_axis_expanded/model.onnx",
@@ -3525,7 +3525,7 @@
   ],
   [
     "node/test_lpnormalization_default/model.onnx",
-    "Unsupported op LpNormalization"
+    ""
   ],
   [
     "node/test_lppool_1d_default/model.onnx",
@@ -3933,7 +3933,7 @@
   ],
   [
     "node/test_mvn/model.onnx",
-    "Unsupported op MeanVarianceNormalization"
+    ""
   ],
   [
     "node/test_mvn_expanded/model.onnx",
@@ -5173,7 +5173,7 @@
   ],
   [
     "node/test_rms_normalization_2d_axis0/model.onnx",
-    "Unsupported op RMSNormalization"
+    ""
   ],
   [
     "node/test_rms_normalization_2d_axis0_expanded/model.onnx",
@@ -5181,7 +5181,7 @@
   ],
   [
     "node/test_rms_normalization_2d_axis1/model.onnx",
-    "Unsupported op RMSNormalization"
+    ""
   ],
   [
     "node/test_rms_normalization_2d_axis1_expanded/model.onnx",
@@ -5189,7 +5189,7 @@
   ],
   [
     "node/test_rms_normalization_2d_axis_negative_1/model.onnx",
-    "Unsupported op RMSNormalization"
+    ""
   ],
   [
     "node/test_rms_normalization_2d_axis_negative_1_expanded/model.onnx",
@@ -5197,7 +5197,7 @@
   ],
   [
     "node/test_rms_normalization_2d_axis_negative_2/model.onnx",
-    "Unsupported op RMSNormalization"
+    ""
   ],
   [
     "node/test_rms_normalization_2d_axis_negative_2_expanded/model.onnx",
@@ -5205,7 +5205,7 @@
   ],
   [
     "node/test_rms_normalization_3d_axis0_epsilon/model.onnx",
-    "Unsupported op RMSNormalization"
+    ""
   ],
   [
     "node/test_rms_normalization_3d_axis0_epsilon_expanded/model.onnx",
@@ -5213,7 +5213,7 @@
   ],
   [
     "node/test_rms_normalization_3d_axis1_epsilon/model.onnx",
-    "Unsupported op RMSNormalization"
+    ""
   ],
   [
     "node/test_rms_normalization_3d_axis1_epsilon_expanded/model.onnx",
@@ -5221,7 +5221,7 @@
   ],
   [
     "node/test_rms_normalization_3d_axis2_epsilon/model.onnx",
-    "Unsupported op RMSNormalization"
+    ""
   ],
   [
     "node/test_rms_normalization_3d_axis2_epsilon_expanded/model.onnx",
@@ -5229,7 +5229,7 @@
   ],
   [
     "node/test_rms_normalization_3d_axis_negative_1_epsilon/model.onnx",
-    "Unsupported op RMSNormalization"
+    ""
   ],
   [
     "node/test_rms_normalization_3d_axis_negative_1_epsilon_expanded/model.onnx",
@@ -5237,7 +5237,7 @@
   ],
   [
     "node/test_rms_normalization_3d_axis_negative_2_epsilon/model.onnx",
-    "Unsupported op RMSNormalization"
+    ""
   ],
   [
     "node/test_rms_normalization_3d_axis_negative_2_epsilon_expanded/model.onnx",
@@ -5245,7 +5245,7 @@
   ],
   [
     "node/test_rms_normalization_3d_axis_negative_3_epsilon/model.onnx",
-    "Unsupported op RMSNormalization"
+    ""
   ],
   [
     "node/test_rms_normalization_3d_axis_negative_3_epsilon_expanded/model.onnx",
@@ -5253,7 +5253,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis0/model.onnx",
-    "Unsupported op RMSNormalization"
+    ""
   ],
   [
     "node/test_rms_normalization_4d_axis0_expanded/model.onnx",
@@ -5261,7 +5261,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis1/model.onnx",
-    "Unsupported op RMSNormalization"
+    ""
   ],
   [
     "node/test_rms_normalization_4d_axis1_expanded/model.onnx",
@@ -5269,7 +5269,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis2/model.onnx",
-    "Unsupported op RMSNormalization"
+    ""
   ],
   [
     "node/test_rms_normalization_4d_axis2_expanded/model.onnx",
@@ -5277,7 +5277,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis3/model.onnx",
-    "Unsupported op RMSNormalization"
+    ""
   ],
   [
     "node/test_rms_normalization_4d_axis3_expanded/model.onnx",
@@ -5285,7 +5285,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_1/model.onnx",
-    "Unsupported op RMSNormalization"
+    ""
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_1_expanded/model.onnx",
@@ -5293,7 +5293,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_2/model.onnx",
-    "Unsupported op RMSNormalization"
+    ""
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_2_expanded/model.onnx",
@@ -5301,7 +5301,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_3/model.onnx",
-    "Unsupported op RMSNormalization"
+    ""
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_3_expanded/model.onnx",
@@ -5309,7 +5309,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_4/model.onnx",
-    "Unsupported op RMSNormalization"
+    ""
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_4_expanded/model.onnx",
@@ -5317,7 +5317,7 @@
   ],
   [
     "node/test_rms_normalization_default_axis/model.onnx",
-    "Unsupported op RMSNormalization"
+    ""
   ],
   [
     "node/test_rms_normalization_default_axis_expanded/model.onnx",
@@ -7105,7 +7105,7 @@
   ],
   [
     "pytorch-operator/test_operator_symbolic_override/model.onnx",
-    "Unsupported op InstanceNormalization"
+    ""
   ],
   [
     "pytorch-operator/test_operator_symbolic_override_nested/model.onnx",


### PR DESCRIPTION
### Motivation
- Add support for a family of ONNX normalization operators so models using LpNormalization, InstanceNormalization, GroupNormalization, LayerNormalization, MeanVarianceNormalization and RMSNormalization can be lowered, evaluated and emitted to C.

### Description
- Introduce lowering passes for the new ops in `src/onnx2c/lowering/` (`lp_normalization.py`, `instance_normalization.py`, `group_normalization.py`, `layer_normalization.py`, `mean_variance_normalization.py`, `rms_normalization.py`) that validate shapes/dtypes and produce op dataclasses.
- Extend the IR/codegen surface in `src/onnx2c/codegen/c_emitter.py` with new `*Op` dataclasses, template wiring and rendering logic to emit C kernels, and add corresponding Jinja2 templates under `templates/` for each op.
- Add runtime/constant-evaluation support in `src/onnx2c/runtime/evaluator.py` to evaluate these ops for test-time verification and constant folding by calling the new lowerings and NumPy-based implementations.
- Wire the new lowerings into the compiler (`src/onnx2c/compiler.py`), add end-to-end tests in `tests/test_endtoend_ops.py`, and update official support snapshots (`OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`, `tests/official_onnx_expected_errors.json`).

### Testing
- Ran the targeted end-to-end operator tests with `pytest tests/test_endtoend_ops.py -q`, which completed with `132 passed, 1 skipped` in `130.24s` (the `LpNormalization` ONNXRuntime check was skipped when ORT reported not implemented). 
- Ran the full suite with updated references via `UPDATE_REFS=1 pytest -n auto -q`, which completed with `191 passed, 2 skipped` in `54.84s`.
- Added a small guard in the tests to skip ORT comparison when ORT reports `NOT_IMPLEMENTED` for the operator to keep CI robust.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6967d71f60e48325a8a7974795618d87)