### PR TITLE
compiler: enrich output shape errors and preserve 'shape' in histograms

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -521,7 +521,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_constant_pad_axes/model.onnx | ❌ | Unsupported op Pad |
 | node/test_constant_pad_negative_axes/model.onnx | ❌ | Unsupported op Pad |
 | node/test_constantofshape_float_ones/model.onnx | ✅ |  |
-| node/test_constantofshape_int_shape_zero/model.onnx | ❌ | Output shape must be fully defined |
+| node/test_constantofshape_int_shape_zero/model.onnx | ❌ | Output shape must be fully defined for output 'y', got (0,). Hint: run ONNX shape inference or export with static shapes. |
 | node/test_constantofshape_int_zeros/model.onnx | ✅ |  |
 | node/test_conv_with_autopad_same/model.onnx | ✅ |  |
 | node/test_conv_with_strides_and_asymmetric_padding/model.onnx | ✅ |  |
@@ -1221,7 +1221,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_sum_empty_axes_input_noop/model.onnx | ✅ |  |
 | node/test_reduce_sum_empty_axes_input_noop_example/model.onnx | ✅ |  |
 | node/test_reduce_sum_empty_set/model.onnx | ✅ |  |
-| node/test_reduce_sum_empty_set_non_reduced_axis_zero/model.onnx | ❌ | Output shape must be fully defined |
+| node/test_reduce_sum_empty_set_non_reduced_axis_zero/model.onnx | ❌ | Output shape must be fully defined for output 'reduced', got (2, 0, 1). Hint: run ONNX shape inference or export with static shapes. |
 | node/test_reduce_sum_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_sum_keepdims_random/model.onnx | ✅ |  |
 | node/test_reduce_sum_negative_axes_keepdims_example/model.onnx | ✅ |  |
@@ -1250,7 +1250,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_regex_full_match_empty/model.onnx | ❌ | Unsupported elem_type 8 (STRING) for tensor 'X'. |
 | node/test_relu/model.onnx | ✅ |  |
 | node/test_relu_expanded_ver18/model.onnx | ✅ |  |
-| node/test_reshape_allowzero_reordered/model.onnx | ❌ | Output shape must be fully defined |
+| node/test_reshape_allowzero_reordered/model.onnx | ❌ | Output shape must be fully defined for output 'reshaped', got (3, 4, 0). Hint: run ONNX shape inference or export with static shapes. |
 | node/test_reshape_extended_dims/model.onnx | ✅ |  |
 | node/test_reshape_negative_dim/model.onnx | ✅ |  |
 | node/test_reshape_negative_extended_dims/model.onnx | ✅ |  |
@@ -1472,7 +1472,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_shape_start_1/model.onnx | ✅ |  |
 | node/test_shape_start_1_end_2/model.onnx | ✅ |  |
 | node/test_shape_start_1_end_negative_1/model.onnx | ✅ |  |
-| node/test_shape_start_greater_than_end/model.onnx | ❌ | Output shape must be fully defined |
+| node/test_shape_start_greater_than_end/model.onnx | ❌ | Output shape must be fully defined for output 'y', got (0,). Hint: run ONNX shape inference or export with static shapes. |
 | node/test_shape_start_negative_1/model.onnx | ✅ |  |
 | node/test_shrink_hard/model.onnx | ✅ |  |
 | node/test_shrink_hard_expanded_ver18/model.onnx | ✅ |  |
@@ -1497,7 +1497,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_slice_neg/model.onnx | ✅ |  |
 | node/test_slice_neg_steps/model.onnx | ✅ |  |
 | node/test_slice_negative_axes/model.onnx | ✅ |  |
-| node/test_slice_start_out_of_bounds/model.onnx | ❌ | Output shape must be fully defined |
+| node/test_slice_start_out_of_bounds/model.onnx | ❌ | Output shape must be fully defined for output 'y', got (20, 0, 5). Hint: run ONNX shape inference or export with static shapes. |
 | node/test_softmax_axis_0/model.onnx | ✅ |  |
 | node/test_softmax_axis_0_expanded/model.onnx | ✅ |  |
 | node/test_softmax_axis_0_expanded_ver18/model.onnx | ✅ |  |
@@ -1546,8 +1546,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_split_variable_parts_2d_opset18/model.onnx | ✅ |  |
 | node/test_split_variable_parts_default_axis_opset13/model.onnx | ✅ |  |
 | node/test_split_variable_parts_default_axis_opset18/model.onnx | ✅ |  |
-| node/test_split_zero_size_splits_opset13/model.onnx | ❌ | Output shape must be fully defined |
-| node/test_split_zero_size_splits_opset18/model.onnx | ❌ | Output shape must be fully defined |
+| node/test_split_zero_size_splits_opset13/model.onnx | ❌ | Output shape must be fully defined for output 'output_1', got (0,). Hint: run ONNX shape inference or export with static shapes. |
+| node/test_split_zero_size_splits_opset18/model.onnx | ❌ | Output shape must be fully defined for output 'output_1', got (0,). Hint: run ONNX shape inference or export with static shapes. |
 | node/test_sqrt/model.onnx | ✅ |  |
 | node/test_sqrt_example/model.onnx | ✅ |  |
 | node/test_squeeze/model.onnx | ✅ |  |
@@ -1635,7 +1635,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_tril_pos/model.onnx | ❌ | Unsupported op Trilu |
 | node/test_tril_square/model.onnx | ❌ | Unsupported op Trilu |
 | node/test_tril_square_neg/model.onnx | ❌ | Unsupported op Trilu |
-| node/test_tril_zero/model.onnx | ❌ | Output shape must be fully defined |
+| node/test_tril_zero/model.onnx | ❌ | Output shape must be fully defined for output 'y', got (3, 0, 5). Hint: run ONNX shape inference or export with static shapes. |
 | node/test_triu/model.onnx | ❌ | Unsupported op Trilu |
 | node/test_triu_neg/model.onnx | ❌ | Unsupported op Trilu |
 | node/test_triu_one_row/model.onnx | ❌ | Unsupported op Trilu |
@@ -1644,7 +1644,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_triu_pos/model.onnx | ❌ | Unsupported op Trilu |
 | node/test_triu_square/model.onnx | ❌ | Unsupported op Trilu |
 | node/test_triu_square_neg/model.onnx | ❌ | Unsupported op Trilu |
-| node/test_triu_zero/model.onnx | ❌ | Output shape must be fully defined |
+| node/test_triu_zero/model.onnx | ❌ | Output shape must be fully defined for output 'y', got (0, 5). Hint: run ONNX shape inference or export with static shapes. |
 | node/test_unique_length_1/model.onnx | ❌ | Unsupported op Unique |
 | node/test_unique_not_sorted_without_axis/model.onnx | ❌ | Unsupported op Unique |
 | node/test_unique_sorted_with_axis/model.onnx | ❌ | Unsupported op Unique |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -19,9 +19,8 @@
 | Reshape input and output element counts must match | 15 | ████████████ |
 | Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 14 | ████████████ |
 | Unsupported op ConvTranspose | 14 | ████████████ |
-| '*' object has no attribute '*' | 13 | ███████████ |
+| '*' object has no attribute 'shape' | 13 | ███████████ |
 | ReduceSum output shape rank must match input rank | 12 | ██████████ |
-| Output shape must be fully defined | 9 | ████████ |
 | Unsupported op CumSum | 9 | ████████ |
 | Unsupported op QuantizeLinear | 9 | ████████ |
 | Unsupported op ImageDecoder | 9 | ████████ |
@@ -53,6 +52,7 @@
 | Unsupported op DeformConv | 4 | ███ |
 | Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 4 | ███ |
 | Unsupported op Compress | 4 | ███ |
+| Output shape must be fully defined for output '*', got (0,). Hint: run ONNX shape inference or export with static shapes. | 4 | ███ |
 | Unsupported op GRU | 4 | ███ |
 | Concat output shape must be (3,), got (1,) | 4 | ███ |
 | Concat output shape must be (4,), got (1,) | 4 | ███ |
@@ -114,6 +114,11 @@
 | Unsupported op QLinearConv | 1 | █ |
 | ReduceMax does not support dtype bool | 1 | █ |
 | ReduceMin does not support dtype bool | 1 | █ |
+| Output shape must be fully defined for output '*', got (2, 0, 1). Hint: run ONNX shape inference or export with static shapes. | 1 | █ |
+| Output shape must be fully defined for output '*', got (3, 4, 0). Hint: run ONNX shape inference or export with static shapes. | 1 | █ |
+| Output shape must be fully defined for output '*', got (20, 0, 5). Hint: run ONNX shape inference or export with static shapes. | 1 | █ |
+| Output shape must be fully defined for output '*', got (3, 0, 5). Hint: run ONNX shape inference or export with static shapes. | 1 | █ |
+| Output shape must be fully defined for output '*', got (0, 5). Hint: run ONNX shape inference or export with static shapes. | 1 | █ |
 | Unsupported op Upsample | 1 | █ |
 | Dynamic dim for tensor '*' | 1 | █ |
 

--- a/src/onnx2c/compiler.py
+++ b/src/onnx2c/compiler.py
@@ -282,7 +282,11 @@ class Compiler:
         for value in graph.outputs:
             element_count = shape_product(value.type.shape)
             if element_count <= 0:
-                raise ShapeInferenceError("Output shape must be fully defined")
+                raise ShapeInferenceError(
+                    "Output shape must be fully defined for output "
+                    f"'{value.name}', got {value.type.shape}. "
+                    "Hint: run ONNX shape inference or export with static shapes."
+                )
 
     def _collect_io_specs(
         self, graph: Graph

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -2053,7 +2053,7 @@
   ],
   [
     "node/test_constantofshape_int_shape_zero/model.onnx",
-    "Output shape must be fully defined"
+    "Output shape must be fully defined for output 'y', got (0,). Hint: run ONNX shape inference or export with static shapes."
   ],
   [
     "node/test_constantofshape_int_zeros/model.onnx",
@@ -4853,7 +4853,7 @@
   ],
   [
     "node/test_reduce_sum_empty_set_non_reduced_axis_zero/model.onnx",
-    "Output shape must be fully defined"
+    "Output shape must be fully defined for output 'reduced', got (2, 0, 1). Hint: run ONNX shape inference or export with static shapes."
   ],
   [
     "node/test_reduce_sum_keepdims_example/model.onnx",
@@ -4969,7 +4969,7 @@
   ],
   [
     "node/test_reshape_allowzero_reordered/model.onnx",
-    "Output shape must be fully defined"
+    "Output shape must be fully defined for output 'reshaped', got (3, 4, 0). Hint: run ONNX shape inference or export with static shapes."
   ],
   [
     "node/test_reshape_extended_dims/model.onnx",
@@ -5857,7 +5857,7 @@
   ],
   [
     "node/test_shape_start_greater_than_end/model.onnx",
-    "Output shape must be fully defined"
+    "Output shape must be fully defined for output 'y', got (0,). Hint: run ONNX shape inference or export with static shapes."
   ],
   [
     "node/test_shape_start_negative_1/model.onnx",
@@ -5957,7 +5957,7 @@
   ],
   [
     "node/test_slice_start_out_of_bounds/model.onnx",
-    "Output shape must be fully defined"
+    "Output shape must be fully defined for output 'y', got (20, 0, 5). Hint: run ONNX shape inference or export with static shapes."
   ],
   [
     "node/test_softmax_axis_0/model.onnx",
@@ -6153,11 +6153,11 @@
   ],
   [
     "node/test_split_zero_size_splits_opset13/model.onnx",
-    "Output shape must be fully defined"
+    "Output shape must be fully defined for output 'output_1', got (0,). Hint: run ONNX shape inference or export with static shapes."
   ],
   [
     "node/test_split_zero_size_splits_opset18/model.onnx",
-    "Output shape must be fully defined"
+    "Output shape must be fully defined for output 'output_1', got (0,). Hint: run ONNX shape inference or export with static shapes."
   ],
   [
     "node/test_sqrt/model.onnx",
@@ -6509,7 +6509,7 @@
   ],
   [
     "node/test_tril_zero/model.onnx",
-    "Output shape must be fully defined"
+    "Output shape must be fully defined for output 'y', got (3, 0, 5). Hint: run ONNX shape inference or export with static shapes."
   ],
   [
     "node/test_triu/model.onnx",
@@ -6545,7 +6545,7 @@
   ],
   [
     "node/test_triu_zero/model.onnx",
-    "Output shape must be fully defined"
+    "Output shape must be fully defined for output 'y', got (0, 5). Hint: run ONNX shape inference or export with static shapes."
   ],
   [
     "node/test_unique_length_1/model.onnx",

--- a/tests/test_official_onnx_files.py
+++ b/tests/test_official_onnx_files.py
@@ -1898,7 +1898,13 @@ def _render_error_histogram_markdown(
     title: str = "# Error frequency",
 ) -> str:
     def _sanitize_error(error: str) -> str:
-        return re.sub(r"'[^']*'", "'*'", error)
+        def _replace(match: re.Match[str]) -> str:
+            value = match.group(1)
+            if value in {"shape"}:
+                return f"'{value}'"
+            return "'*'"
+
+        return re.sub(r"'([^']*)'", _replace, error)
 
     errors = [_sanitize_error(error) for _, error in expectations if error]
     counts = Counter(errors)


### PR DESCRIPTION
### Motivation
- Make output-shape validation errors more actionable by including the output name, actual shape, and a short hint when shapes are not fully defined.
- Preserve the literal `'shape'` token in the error histogram so shape-related failures remain identifiable after anonymization.
- Refresh the official expectations and histogram to reflect the new, more informative error text.

### Description
- Replace the generic output-shape error with an enriched message in `src/onnx2c/compiler.py` that includes the output name, the concrete shape, and a guidance hint.
- Update the sanitizer in `tests/test_official_onnx_files.py` to keep the literal `'shape'` token while continuing to anonymize other quoted values.
- Regenerate `OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`, and `tests/official_onnx_expected_errors.json` so recorded expectations and histogram entries match the new message.

### Testing
- Ran the test suite with updated references using `UPDATE_REFS=1 pytest -n auto -q`, which completed successfully with `191 passed, 2 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6967e1b1b06883258d4dd6f957622da0)