### PR TITLE
codegen: handle variadic binary ops & fix ClipOp shape propagation

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -920,7 +920,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_max_int32/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
 | node/test_max_int64/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
 | node/test_max_int8/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_max_one_input/model.onnx | ❌ | Max must have at least 2 inputs and 1 output |
+| node/test_max_one_input/model.onnx | ❌ | Max must have at least 2 inputs |
 | node/test_max_two_inputs/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
 | node/test_max_uint16/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
 | node/test_max_uint32/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
@@ -948,7 +948,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_maxunpool_export_with_output_shape/model.onnx | ❌ | Unsupported op MaxUnpool |
 | node/test_maxunpool_export_without_output_shape/model.onnx | ❌ | Unsupported op MaxUnpool |
 | node/test_mean_example/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_mean_one_input/model.onnx | ❌ | Mean must have at least 2 inputs and 1 output |
+| node/test_mean_one_input/model.onnx | ❌ | Mean must have at least 2 inputs |
 | node/test_mean_two_inputs/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
 | node/test_melweightmatrix/model.onnx | ❌ | Unsupported op MelWeightMatrix |
 | node/test_min_example/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
@@ -959,7 +959,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_min_int32/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
 | node/test_min_int64/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
 | node/test_min_int8/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_min_one_input/model.onnx | ❌ | Min must have at least 2 inputs and 1 output |
+| node/test_min_one_input/model.onnx | ❌ | Min must have at least 2 inputs |
 | node/test_min_two_inputs/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
 | node/test_min_uint16/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
 | node/test_min_uint32/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
@@ -1581,7 +1581,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_sub_uint64/model.onnx | ✅ |  |
 | node/test_sub_uint8/model.onnx | ✅ |  |
 | node/test_sum_example/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_sum_one_input/model.onnx | ❌ | Sum must have at least 2 inputs and 1 output |
+| node/test_sum_one_input/model.onnx | ❌ | Sum must have at least 2 inputs |
 | node/test_sum_two_inputs/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
 | node/test_swish/model.onnx | ✅ |  |
 | node/test_swish_expanded/model.onnx | ✅ |  |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -109,10 +109,10 @@
 | Graph must contain at least one node | 1 | █ |
 | Dropout mask output is not supported | 1 | █ |
 | Unsupported op MatMulInteger | 1 | █ |
-| Max must have at least 2 inputs and 1 output | 1 | █ |
-| Mean must have at least 2 inputs and 1 output | 1 | █ |
+| Max must have at least 2 inputs | 1 | █ |
+| Mean must have at least 2 inputs | 1 | █ |
 | Unsupported op MelWeightMatrix | 1 | █ |
-| Min must have at least 2 inputs and 1 output | 1 | █ |
+| Min must have at least 2 inputs | 1 | █ |
 | Unsupported op Mish | 1 | █ |
 | Unsupported op NonZero | 1 | █ |
 | Unsupported op OptionalGetElement | 1 | █ |
@@ -122,7 +122,7 @@
 | ReduceMax does not support dtype bool | 1 | █ |
 | ReduceMin does not support dtype bool | 1 | █ |
 | Max expects identical input/output shapes | 1 | █ |
-| Sum must have at least 2 inputs and 1 output | 1 | █ |
+| Sum must have at least 2 inputs | 1 | █ |
 | Unsupported op Upsample | 1 | █ |
 | Dynamic dim for tensor '*' | 1 | █ |
 

--- a/src/onnx2c/codegen/c_emitter.py
+++ b/src/onnx2c/codegen/c_emitter.py
@@ -3209,6 +3209,7 @@ class CEmitter:
     @staticmethod
     def _build_op_call(
         op: BinaryOp
+        | MultiInputBinaryOp
         | WhereOp
         | UnaryOp
         | ClipOp
@@ -3259,6 +3260,9 @@ class CEmitter:
             args.extend(dim_order)
         if isinstance(op, BinaryOp):
             args.extend([op.input0, op.input1, op.output])
+            return ", ".join(args)
+        if isinstance(op, MultiInputBinaryOp):
+            args.extend([*op.inputs, op.output])
             return ", ".join(args)
         if isinstance(op, WhereOp):
             args.extend([op.condition, op.input_x, op.input_y, op.output])
@@ -6469,7 +6473,7 @@ class CEmitter:
         if isinstance(op, RMSNormalizationOp):
             return ((op.input0, op.shape), (op.scale, op.scale_shape))
         if isinstance(op, ClipOp):
-            return ((op.input0, op.shape),)
+            return ((op.input0, op.input_shape),)
         if isinstance(op, CastOp):
             return ((op.input0, op.shape),)
         if isinstance(op, IdentityOp):

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -17,11 +17,11 @@
   ],
   [
     "light/light_resnet50.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "light/light_shufflenet.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "light/light_squeezenet.onnx",
@@ -169,15 +169,15 @@
   ],
   [
     "node/test_and2d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_and3d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_and4d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_and_bcast3v1d/model.onnx",
@@ -369,7 +369,7 @@
   ],
   [
     "node/test_attention_3d_attn_mask_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_causal/model.onnx",
@@ -377,7 +377,7 @@
   ],
   [
     "node/test_attention_3d_causal_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_diff_heads_sizes/model.onnx",
@@ -389,7 +389,7 @@
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_attn_mask_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_causal/model.onnx",
@@ -397,11 +397,11 @@
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_causal_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_scaled/model.onnx",
@@ -409,7 +409,7 @@
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_scaled_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_softcap/model.onnx",
@@ -417,7 +417,7 @@
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_softcap_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_diff_heads_with_past_and_present/model.onnx",
@@ -425,11 +425,11 @@
   ],
   [
     "node/test_attention_3d_diff_heads_with_past_and_present_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_gqa/model.onnx",
@@ -485,7 +485,7 @@
   ],
   [
     "node/test_attention_3d_scaled_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_softcap/model.onnx",
@@ -493,7 +493,7 @@
   ],
   [
     "node/test_attention_3d_softcap_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_transpose_verification/model.onnx",
@@ -501,7 +501,7 @@
   ],
   [
     "node/test_attention_3d_transpose_verification_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_with_past_and_present/model.onnx",
@@ -509,7 +509,7 @@
   ],
   [
     "node/test_attention_3d_with_past_and_present_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul/model.onnx",
@@ -521,11 +521,11 @@
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_bias_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_softcap/model.onnx",
@@ -533,7 +533,7 @@
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_softmax/model.onnx",
@@ -541,7 +541,7 @@
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d/model.onnx",
@@ -561,11 +561,11 @@
   ],
   [
     "node/test_attention_4d_attn_mask_3d_causal_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_attn_mask_3d_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_attn_mask_4d/model.onnx",
@@ -577,11 +577,11 @@
   ],
   [
     "node/test_attention_4d_attn_mask_4d_causal_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_attn_mask_4d_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_attn_mask_bool/model.onnx",
@@ -593,15 +593,15 @@
   ],
   [
     "node/test_attention_4d_attn_mask_bool_4d_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_attn_mask_bool_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_attn_mask_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_causal/model.onnx",
@@ -609,7 +609,7 @@
   ],
   [
     "node/test_attention_4d_causal_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_diff_heads_mask4d_padded_kv/model.onnx",
@@ -629,7 +629,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_attn_mask_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_causal/model.onnx",
@@ -637,11 +637,11 @@
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_causal_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_scaled/model.onnx",
@@ -649,7 +649,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_scaled_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_softcap/model.onnx",
@@ -657,7 +657,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_softcap_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present/model.onnx",
@@ -665,7 +665,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_mask3d/model.onnx",
@@ -673,7 +673,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_mask3d_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_mask4d/model.onnx",
@@ -681,11 +681,11 @@
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_mask4d_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_fp16/model.onnx",
@@ -693,7 +693,7 @@
   ],
   [
     "node/test_attention_4d_fp16_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_gqa/model.onnx",
@@ -757,7 +757,7 @@
   ],
   [
     "node/test_attention_4d_scaled_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_softcap/model.onnx",
@@ -765,7 +765,7 @@
   ],
   [
     "node/test_attention_4d_softcap_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_with_past_and_present/model.onnx",
@@ -773,7 +773,7 @@
   ],
   [
     "node/test_attention_4d_with_past_and_present_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul/model.onnx",
@@ -793,11 +793,11 @@
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask/model.onnx",
@@ -809,19 +809,19 @@
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_with_qk_matmul/model.onnx",
@@ -833,11 +833,11 @@
   ],
   [
     "node/test_attention_4d_with_qk_matmul_bias_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_with_qk_matmul_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_with_qk_matmul_softcap/model.onnx",
@@ -845,7 +845,7 @@
   ],
   [
     "node/test_attention_4d_with_qk_matmul_softcap_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_with_qk_matmul_softmax/model.onnx",
@@ -853,7 +853,7 @@
   ],
   [
     "node/test_attention_4d_with_qk_matmul_softmax_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_averagepool_1d_default/model.onnx",
@@ -1025,11 +1025,11 @@
   ],
   [
     "node/test_bitwise_and_i16_3d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_bitwise_and_i32_2d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_bitwise_and_ui64_bcast_3v1d/model.onnx",
@@ -1053,11 +1053,11 @@
   ],
   [
     "node/test_bitwise_or_i16_4d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_bitwise_or_i32_2d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_bitwise_or_ui64_bcast_3v1d/model.onnx",
@@ -1069,11 +1069,11 @@
   ],
   [
     "node/test_bitwise_xor_i16_3d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_bitwise_xor_i32_2d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_bitwise_xor_ui64_bcast_3v1d/model.onnx",
@@ -1853,11 +1853,11 @@
   ],
   [
     "node/test_clip/model.onnx",
-    "'ClipOp' object has no attribute 'shape'"
+    ""
   ],
   [
     "node/test_clip_default_inbounds/model.onnx",
-    "'ClipOp' object has no attribute 'shape'"
+    ""
   ],
   [
     "node/test_clip_default_inbounds_expanded/model.onnx",
@@ -1865,7 +1865,7 @@
   ],
   [
     "node/test_clip_default_int8_inbounds/model.onnx",
-    "'ClipOp' object has no attribute 'shape'"
+    ""
   ],
   [
     "node/test_clip_default_int8_inbounds_expanded/model.onnx",
@@ -1873,7 +1873,7 @@
   ],
   [
     "node/test_clip_default_int8_max/model.onnx",
-    "'ClipOp' object has no attribute 'shape'"
+    ""
   ],
   [
     "node/test_clip_default_int8_max_expanded/model.onnx",
@@ -1881,7 +1881,7 @@
   ],
   [
     "node/test_clip_default_int8_min/model.onnx",
-    "'ClipOp' object has no attribute 'shape'"
+    ""
   ],
   [
     "node/test_clip_default_int8_min_expanded/model.onnx",
@@ -1889,7 +1889,7 @@
   ],
   [
     "node/test_clip_default_max/model.onnx",
-    "'ClipOp' object has no attribute 'shape'"
+    ""
   ],
   [
     "node/test_clip_default_max_expanded/model.onnx",
@@ -1897,7 +1897,7 @@
   ],
   [
     "node/test_clip_default_min/model.onnx",
-    "'ClipOp' object has no attribute 'shape'"
+    ""
   ],
   [
     "node/test_clip_default_min_expanded/model.onnx",
@@ -1905,7 +1905,7 @@
   ],
   [
     "node/test_clip_example/model.onnx",
-    "'ClipOp' object has no attribute 'shape'"
+    ""
   ],
   [
     "node/test_clip_example_expanded/model.onnx",
@@ -1917,7 +1917,7 @@
   ],
   [
     "node/test_clip_inbounds/model.onnx",
-    "'ClipOp' object has no attribute 'shape'"
+    ""
   ],
   [
     "node/test_clip_inbounds_expanded/model.onnx",
@@ -1925,7 +1925,7 @@
   ],
   [
     "node/test_clip_min_greater_than_max/model.onnx",
-    "'ClipOp' object has no attribute 'shape'"
+    ""
   ],
   [
     "node/test_clip_min_greater_than_max_expanded/model.onnx",
@@ -1933,7 +1933,7 @@
   ],
   [
     "node/test_clip_outbounds/model.onnx",
-    "'ClipOp' object has no attribute 'shape'"
+    ""
   ],
   [
     "node/test_clip_outbounds_expanded/model.onnx",
@@ -1941,7 +1941,7 @@
   ],
   [
     "node/test_clip_splitbounds/model.onnx",
-    "'ClipOp' object has no attribute 'shape'"
+    ""
   ],
   [
     "node/test_clip_splitbounds_expanded/model.onnx",
@@ -2685,11 +2685,11 @@
   ],
   [
     "node/test_greater_equal_bcast_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_greater_equal_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_greater_equal_int16/model.onnx",
@@ -2697,7 +2697,7 @@
   ],
   [
     "node/test_greater_equal_int16_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_greater_equal_int8/model.onnx",
@@ -2705,7 +2705,7 @@
   ],
   [
     "node/test_greater_equal_int8_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_greater_equal_uint16/model.onnx",
@@ -2713,7 +2713,7 @@
   ],
   [
     "node/test_greater_equal_uint16_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_greater_equal_uint32/model.onnx",
@@ -2721,7 +2721,7 @@
   ],
   [
     "node/test_greater_equal_uint32_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_greater_equal_uint64/model.onnx",
@@ -2729,7 +2729,7 @@
   ],
   [
     "node/test_greater_equal_uint64_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_greater_equal_uint8/model.onnx",
@@ -2737,7 +2737,7 @@
   ],
   [
     "node/test_greater_equal_uint8_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_greater_int16/model.onnx",
@@ -3341,11 +3341,11 @@
   ],
   [
     "node/test_less_equal_bcast_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_less_equal_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_less_equal_int16/model.onnx",
@@ -3353,7 +3353,7 @@
   ],
   [
     "node/test_less_equal_int16_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_less_equal_int8/model.onnx",
@@ -3361,7 +3361,7 @@
   ],
   [
     "node/test_less_equal_int8_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_less_equal_uint16/model.onnx",
@@ -3369,7 +3369,7 @@
   ],
   [
     "node/test_less_equal_uint16_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_less_equal_uint32/model.onnx",
@@ -3377,7 +3377,7 @@
   ],
   [
     "node/test_less_equal_uint32_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_less_equal_uint64/model.onnx",
@@ -3385,7 +3385,7 @@
   ],
   [
     "node/test_less_equal_uint64_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_less_equal_uint8/model.onnx",
@@ -3393,7 +3393,7 @@
   ],
   [
     "node/test_less_equal_uint8_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_less_int16/model.onnx",
@@ -3617,35 +3617,35 @@
   ],
   [
     "node/test_max_example/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_max_float16/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_max_float32/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_max_float64/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_max_int16/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_max_int32/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_max_int64/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_max_int8/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_max_one_input/model.onnx",
@@ -3653,23 +3653,23 @@
   ],
   [
     "node/test_max_two_inputs/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_max_uint16/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_max_uint32/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_max_uint64/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_max_uint8/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_maxpool_1d_default/model.onnx",
@@ -3757,7 +3757,7 @@
   ],
   [
     "node/test_mean_example/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_mean_one_input/model.onnx",
@@ -3765,7 +3765,7 @@
   ],
   [
     "node/test_mean_two_inputs/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_melweightmatrix/model.onnx",
@@ -3773,35 +3773,35 @@
   ],
   [
     "node/test_min_example/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_min_float16/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_min_float32/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_min_float64/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_min_int16/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_min_int32/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_min_int64/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_min_int8/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_min_one_input/model.onnx",
@@ -3809,23 +3809,23 @@
   ],
   [
     "node/test_min_two_inputs/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_min_uint16/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_min_uint32/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_min_uint64/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_min_uint8/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_mish/model.onnx",
@@ -4213,15 +4213,15 @@
   ],
   [
     "node/test_or2d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_or3d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_or4d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_or_bcast3v1d/model.onnx",
@@ -6289,7 +6289,7 @@
   ],
   [
     "node/test_sum_example/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_sum_one_input/model.onnx",
@@ -6297,7 +6297,7 @@
   ],
   [
     "node/test_sum_two_inputs/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_swish/model.onnx",
@@ -6617,15 +6617,15 @@
   ],
   [
     "node/test_xor2d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_xor3d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_xor4d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_xor_bcast3v1d/model.onnx",
@@ -7009,7 +7009,7 @@
   ],
   [
     "pytorch-operator/test_operator_clip/model.onnx",
-    "'ClipOp' object has no attribute 'shape'"
+    ""
   ],
   [
     "pytorch-operator/test_operator_concat2/model.onnx",
@@ -7037,7 +7037,7 @@
   ],
   [
     "pytorch-operator/test_operator_max/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "pytorch-operator/test_operator_maxpool/model.onnx",
@@ -7045,7 +7045,7 @@
   ],
   [
     "pytorch-operator/test_operator_min/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "pytorch-operator/test_operator_mm/model.onnx",
@@ -7109,7 +7109,7 @@
   ],
   [
     "pytorch-operator/test_operator_symbolic_override_nested/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "pytorch-operator/test_operator_view/model.onnx",


### PR DESCRIPTION
### Motivation
- Variadic/binary ops (e.g., `Sum`, `Mean`, `Max`, `Min`) were not being passed correctly to generated op calls, causing `object has no attribute 'input0'` errors when lowering multi-input operators.
- `ClipOp` used the wrong shape field for propagating tensor dimension names which produced incorrect dimension-name propagation and test snapshot mismatches.

### Description
- Add support for `MultiInputBinaryOp` in the call argument builder by updating `_build_op_call` to emit `[*op.inputs, op.output]` for variadic binary ops in `src/onnx2c/codegen/c_emitter.py`.
- Use the actual `ClipOp` input shape (`op.input_shape`) when reporting op inputs for tensor-dimension propagation in `src/onnx2c/codegen/c_emitter.py`.
- Refresh ONNX support snapshots and the expected errors list to reflect the fixes in `OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`, and `tests/official_onnx_expected_errors.json`.

### Testing
- Ran the full test suite with references refreshed using `UPDATE_REFS=1 pytest -n auto -q` which completed in 48.48s and resulted in `174 passed, 2 skipped` with 2 warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69687a27f2fc83259fca688e90e496ec)