### PR TITLE
codegen: fix MultiInputBinaryOp call arg handling

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 968 / 1802 official ONNX files.
+Support 1082 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -12,8 +12,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | light/light_densenet121.onnx | ✅ |  |
 | light/light_inception_v1.onnx | ✅ |  |
 | light/light_inception_v2.onnx | ✅ |  |
-| light/light_resnet50.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| light/light_shufflenet.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| light/light_resnet50.onnx | ✅ |  |
+| light/light_shufflenet.onnx | ✅ |  |
 | light/light_squeezenet.onnx | ✅ |  |
 | light/light_vgg19.onnx | ✅ |  |
 | light/light_zfnet512.onnx | ✅ |  |
@@ -50,9 +50,9 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_ai_onnx_ml_label_encoder_tensor_value_only_mapping/model.onnx | ❌ | Unsupported elem_type 8 (STRING) for tensor 'X'. |
 | node/test_ai_onnx_ml_tree_ensemble_set_membership/model.onnx | ❌ | Unsupported op TreeEnsemble |
 | node/test_ai_onnx_ml_tree_ensemble_single_tree/model.onnx | ❌ | Unsupported op TreeEnsemble |
-| node/test_and2d/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_and3d/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_and4d/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_and2d/model.onnx | ✅ |  |
+| node/test_and3d/model.onnx | ✅ |  |
+| node/test_and4d/model.onnx | ✅ |  |
 | node/test_and_bcast3v1d/model.onnx | ❌ | And expects identical input/output shapes |
 | node/test_and_bcast3v2d/model.onnx | ❌ | And expects identical input/output shapes |
 | node/test_and_bcast4v2d/model.onnx | ❌ | And expects identical input/output shapes |
@@ -100,22 +100,22 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_atanh_example/model.onnx | ✅ |  |
 | node/test_attention_3d/model.onnx | ✅ |  |
 | node/test_attention_3d_attn_mask/model.onnx | ✅ |  |
-| node/test_attention_3d_attn_mask_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_3d_attn_mask_expanded/model.onnx | ✅ |  |
 | node/test_attention_3d_causal/model.onnx | ✅ |  |
-| node/test_attention_3d_causal_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_3d_causal_expanded/model.onnx | ✅ |  |
 | node/test_attention_3d_diff_heads_sizes/model.onnx | ✅ |  |
 | node/test_attention_3d_diff_heads_sizes_attn_mask/model.onnx | ✅ |  |
-| node/test_attention_3d_diff_heads_sizes_attn_mask_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_3d_diff_heads_sizes_attn_mask_expanded/model.onnx | ✅ |  |
 | node/test_attention_3d_diff_heads_sizes_causal/model.onnx | ✅ |  |
-| node/test_attention_3d_diff_heads_sizes_causal_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_attention_3d_diff_heads_sizes_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_3d_diff_heads_sizes_causal_expanded/model.onnx | ✅ |  |
+| node/test_attention_3d_diff_heads_sizes_expanded/model.onnx | ✅ |  |
 | node/test_attention_3d_diff_heads_sizes_scaled/model.onnx | ✅ |  |
-| node/test_attention_3d_diff_heads_sizes_scaled_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_3d_diff_heads_sizes_scaled_expanded/model.onnx | ✅ |  |
 | node/test_attention_3d_diff_heads_sizes_softcap/model.onnx | ✅ |  |
-| node/test_attention_3d_diff_heads_sizes_softcap_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_3d_diff_heads_sizes_softcap_expanded/model.onnx | ✅ |  |
 | node/test_attention_3d_diff_heads_with_past_and_present/model.onnx | ✅ |  |
-| node/test_attention_3d_diff_heads_with_past_and_present_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_attention_3d_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_3d_diff_heads_with_past_and_present_expanded/model.onnx | ✅ |  |
+| node/test_attention_3d_expanded/model.onnx | ✅ |  |
 | node/test_attention_3d_gqa/model.onnx | ✅ |  |
 | node/test_attention_3d_gqa_attn_mask/model.onnx | ✅ |  |
 | node/test_attention_3d_gqa_attn_mask_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
@@ -129,59 +129,59 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_attention_3d_gqa_with_past_and_present/model.onnx | ✅ |  |
 | node/test_attention_3d_gqa_with_past_and_present_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_attention_3d_scaled/model.onnx | ✅ |  |
-| node/test_attention_3d_scaled_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_3d_scaled_expanded/model.onnx | ✅ |  |
 | node/test_attention_3d_softcap/model.onnx | ✅ |  |
-| node/test_attention_3d_softcap_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_3d_softcap_expanded/model.onnx | ✅ |  |
 | node/test_attention_3d_transpose_verification/model.onnx | ✅ |  |
-| node/test_attention_3d_transpose_verification_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_3d_transpose_verification_expanded/model.onnx | ✅ |  |
 | node/test_attention_3d_with_past_and_present/model.onnx | ✅ |  |
-| node/test_attention_3d_with_past_and_present_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_3d_with_past_and_present_expanded/model.onnx | ✅ |  |
 | node/test_attention_3d_with_past_and_present_qk_matmul/model.onnx | ✅ |  |
 | node/test_attention_3d_with_past_and_present_qk_matmul_bias/model.onnx | ✅ |  |
-| node/test_attention_3d_with_past_and_present_qk_matmul_bias_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_attention_3d_with_past_and_present_qk_matmul_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_3d_with_past_and_present_qk_matmul_bias_expanded/model.onnx | ✅ |  |
+| node/test_attention_3d_with_past_and_present_qk_matmul_expanded/model.onnx | ✅ |  |
 | node/test_attention_3d_with_past_and_present_qk_matmul_softcap/model.onnx | ✅ |  |
-| node/test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded/model.onnx | ✅ |  |
 | node/test_attention_3d_with_past_and_present_qk_matmul_softmax/model.onnx | ✅ |  |
-| node/test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded/model.onnx | ✅ |  |
 | node/test_attention_4d/model.onnx | ✅ |  |
 | node/test_attention_4d_attn_mask/model.onnx | ✅ |  |
 | node/test_attention_4d_attn_mask_3d/model.onnx | ✅ |  |
 | node/test_attention_4d_attn_mask_3d_causal/model.onnx | ✅ |  |
-| node/test_attention_4d_attn_mask_3d_causal_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_attention_4d_attn_mask_3d_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_4d_attn_mask_3d_causal_expanded/model.onnx | ✅ |  |
+| node/test_attention_4d_attn_mask_3d_expanded/model.onnx | ✅ |  |
 | node/test_attention_4d_attn_mask_4d/model.onnx | ✅ |  |
 | node/test_attention_4d_attn_mask_4d_causal/model.onnx | ✅ |  |
-| node/test_attention_4d_attn_mask_4d_causal_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_attention_4d_attn_mask_4d_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_4d_attn_mask_4d_causal_expanded/model.onnx | ✅ |  |
+| node/test_attention_4d_attn_mask_4d_expanded/model.onnx | ✅ |  |
 | node/test_attention_4d_attn_mask_bool/model.onnx | ✅ |  |
 | node/test_attention_4d_attn_mask_bool_4d/model.onnx | ✅ |  |
-| node/test_attention_4d_attn_mask_bool_4d_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_attention_4d_attn_mask_bool_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_attention_4d_attn_mask_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_4d_attn_mask_bool_4d_expanded/model.onnx | ✅ |  |
+| node/test_attention_4d_attn_mask_bool_expanded/model.onnx | ✅ |  |
+| node/test_attention_4d_attn_mask_expanded/model.onnx | ✅ |  |
 | node/test_attention_4d_causal/model.onnx | ✅ |  |
-| node/test_attention_4d_causal_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_4d_causal_expanded/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_mask4d_padded_kv/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_mask4d_padded_kv_expanded/model.onnx | ❌ | Unsupported op Pad |
 | node/test_attention_4d_diff_heads_sizes/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_sizes_attn_mask/model.onnx | ✅ |  |
-| node/test_attention_4d_diff_heads_sizes_attn_mask_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_4d_diff_heads_sizes_attn_mask_expanded/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_sizes_causal/model.onnx | ✅ |  |
-| node/test_attention_4d_diff_heads_sizes_causal_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_attention_4d_diff_heads_sizes_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_4d_diff_heads_sizes_causal_expanded/model.onnx | ✅ |  |
+| node/test_attention_4d_diff_heads_sizes_expanded/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_sizes_scaled/model.onnx | ✅ |  |
-| node/test_attention_4d_diff_heads_sizes_scaled_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_4d_diff_heads_sizes_scaled_expanded/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_sizes_softcap/model.onnx | ✅ |  |
-| node/test_attention_4d_diff_heads_sizes_softcap_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_4d_diff_heads_sizes_softcap_expanded/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_with_past_and_present/model.onnx | ✅ |  |
-| node/test_attention_4d_diff_heads_with_past_and_present_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_4d_diff_heads_with_past_and_present_expanded/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_with_past_and_present_mask3d/model.onnx | ✅ |  |
-| node/test_attention_4d_diff_heads_with_past_and_present_mask3d_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_4d_diff_heads_with_past_and_present_mask3d_expanded/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_with_past_and_present_mask4d/model.onnx | ✅ |  |
-| node/test_attention_4d_diff_heads_with_past_and_present_mask4d_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_attention_4d_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_4d_diff_heads_with_past_and_present_mask4d_expanded/model.onnx | ✅ |  |
+| node/test_attention_4d_expanded/model.onnx | ✅ |  |
 | node/test_attention_4d_fp16/model.onnx | ✅ |  |
-| node/test_attention_4d_fp16_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_4d_fp16_expanded/model.onnx | ✅ |  |
 | node/test_attention_4d_gqa/model.onnx | ✅ |  |
 | node/test_attention_4d_gqa_attn_mask/model.onnx | ✅ |  |
 | node/test_attention_4d_gqa_attn_mask_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
@@ -197,31 +197,31 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_attention_4d_gqa_with_past_and_present_fp16/model.onnx | ✅ |  |
 | node/test_attention_4d_gqa_with_past_and_present_fp16_expanded/model.onnx | ❌ | Reshape input and output element counts must match |
 | node/test_attention_4d_scaled/model.onnx | ✅ |  |
-| node/test_attention_4d_scaled_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_4d_scaled_expanded/model.onnx | ✅ |  |
 | node/test_attention_4d_softcap/model.onnx | ✅ |  |
-| node/test_attention_4d_softcap_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_4d_softcap_expanded/model.onnx | ✅ |  |
 | node/test_attention_4d_with_past_and_present/model.onnx | ✅ |  |
-| node/test_attention_4d_with_past_and_present_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_4d_with_past_and_present_expanded/model.onnx | ✅ |  |
 | node/test_attention_4d_with_past_and_present_qk_matmul/model.onnx | ✅ |  |
 | node/test_attention_4d_with_past_and_present_qk_matmul_bias/model.onnx | ✅ |  |
 | node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask/model.onnx | ✅ |  |
 | node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal/model.onnx | ✅ |  |
-| node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal_expanded/model.onnx | ✅ |  |
+| node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_expanded/model.onnx | ✅ |  |
 | node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask/model.onnx | ✅ |  |
 | node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal/model.onnx | ✅ |  |
-| node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_attention_4d_with_past_and_present_qk_matmul_bias_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_attention_4d_with_past_and_present_qk_matmul_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal_expanded/model.onnx | ✅ |  |
+| node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_expanded/model.onnx | ✅ |  |
+| node/test_attention_4d_with_past_and_present_qk_matmul_bias_expanded/model.onnx | ✅ |  |
+| node/test_attention_4d_with_past_and_present_qk_matmul_expanded/model.onnx | ✅ |  |
 | node/test_attention_4d_with_qk_matmul/model.onnx | ✅ |  |
 | node/test_attention_4d_with_qk_matmul_bias/model.onnx | ✅ |  |
-| node/test_attention_4d_with_qk_matmul_bias_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_attention_4d_with_qk_matmul_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_4d_with_qk_matmul_bias_expanded/model.onnx | ✅ |  |
+| node/test_attention_4d_with_qk_matmul_expanded/model.onnx | ✅ |  |
 | node/test_attention_4d_with_qk_matmul_softcap/model.onnx | ✅ |  |
-| node/test_attention_4d_with_qk_matmul_softcap_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_4d_with_qk_matmul_softcap_expanded/model.onnx | ✅ |  |
 | node/test_attention_4d_with_qk_matmul_softmax/model.onnx | ✅ |  |
-| node/test_attention_4d_with_qk_matmul_softmax_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_attention_4d_with_qk_matmul_softmax_expanded/model.onnx | ✅ |  |
 | node/test_averagepool_1d_default/model.onnx | ❌ | AveragePool expects 2D kernel_shape |
 | node/test_averagepool_2d_ceil/model.onnx | ❌ | AveragePool supports ceil_mode=0 only |
 | node/test_averagepool_2d_ceil_last_window_starts_on_pad/model.onnx | ❌ | AveragePool supports ceil_mode=0 only |
@@ -264,19 +264,19 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_bitshift_right_uint32/model.onnx | ✅ |  |
 | node/test_bitshift_right_uint64/model.onnx | ✅ |  |
 | node/test_bitshift_right_uint8/model.onnx | ✅ |  |
-| node/test_bitwise_and_i16_3d/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_bitwise_and_i32_2d/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_bitwise_and_i16_3d/model.onnx | ✅ |  |
+| node/test_bitwise_and_i32_2d/model.onnx | ✅ |  |
 | node/test_bitwise_and_ui64_bcast_3v1d/model.onnx | ❌ | BitwiseAnd expects identical input/output shapes |
 | node/test_bitwise_and_ui8_bcast_4v3d/model.onnx | ❌ | BitwiseAnd expects identical input/output shapes |
 | node/test_bitwise_not_2d/model.onnx | ✅ |  |
 | node/test_bitwise_not_3d/model.onnx | ❌ | Unsupported op BitwiseNot |
 | node/test_bitwise_not_4d/model.onnx | ❌ | Unsupported op BitwiseNot |
-| node/test_bitwise_or_i16_4d/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_bitwise_or_i32_2d/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_bitwise_or_i16_4d/model.onnx | ✅ |  |
+| node/test_bitwise_or_i32_2d/model.onnx | ✅ |  |
 | node/test_bitwise_or_ui64_bcast_3v1d/model.onnx | ❌ | BitwiseOr expects identical input/output shapes |
 | node/test_bitwise_or_ui8_bcast_4v3d/model.onnx | ❌ | BitwiseOr expects identical input/output shapes |
-| node/test_bitwise_xor_i16_3d/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_bitwise_xor_i32_2d/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_bitwise_xor_i16_3d/model.onnx | ✅ |  |
+| node/test_bitwise_xor_i32_2d/model.onnx | ✅ |  |
 | node/test_bitwise_xor_ui64_bcast_3v1d/model.onnx | ❌ | BitwiseXor expects identical input/output shapes |
 | node/test_bitwise_xor_ui8_bcast_4v3d/model.onnx | ❌ | BitwiseXor expects identical input/output shapes |
 | node/test_blackmanwindow/model.onnx | ❌ | Unsupported op BlackmanWindow |
@@ -679,20 +679,20 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_greater_bcast/model.onnx | ✅ |  |
 | node/test_greater_equal/model.onnx | ✅ |  |
 | node/test_greater_equal_bcast/model.onnx | ✅ |  |
-| node/test_greater_equal_bcast_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_greater_equal_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_greater_equal_bcast_expanded/model.onnx | ✅ |  |
+| node/test_greater_equal_expanded/model.onnx | ✅ |  |
 | node/test_greater_equal_int16/model.onnx | ✅ |  |
-| node/test_greater_equal_int16_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_greater_equal_int16_expanded/model.onnx | ✅ |  |
 | node/test_greater_equal_int8/model.onnx | ✅ |  |
-| node/test_greater_equal_int8_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_greater_equal_int8_expanded/model.onnx | ✅ |  |
 | node/test_greater_equal_uint16/model.onnx | ✅ |  |
-| node/test_greater_equal_uint16_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_greater_equal_uint16_expanded/model.onnx | ✅ |  |
 | node/test_greater_equal_uint32/model.onnx | ✅ |  |
-| node/test_greater_equal_uint32_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_greater_equal_uint32_expanded/model.onnx | ✅ |  |
 | node/test_greater_equal_uint64/model.onnx | ✅ |  |
-| node/test_greater_equal_uint64_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_greater_equal_uint64_expanded/model.onnx | ✅ |  |
 | node/test_greater_equal_uint8/model.onnx | ✅ |  |
-| node/test_greater_equal_uint8_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_greater_equal_uint8_expanded/model.onnx | ✅ |  |
 | node/test_greater_int16/model.onnx | ✅ |  |
 | node/test_greater_int8/model.onnx | ✅ |  |
 | node/test_greater_uint16/model.onnx | ✅ |  |
@@ -843,20 +843,20 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_less_bcast/model.onnx | ✅ |  |
 | node/test_less_equal/model.onnx | ✅ |  |
 | node/test_less_equal_bcast/model.onnx | ✅ |  |
-| node/test_less_equal_bcast_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_less_equal_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_less_equal_bcast_expanded/model.onnx | ✅ |  |
+| node/test_less_equal_expanded/model.onnx | ✅ |  |
 | node/test_less_equal_int16/model.onnx | ✅ |  |
-| node/test_less_equal_int16_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_less_equal_int16_expanded/model.onnx | ✅ |  |
 | node/test_less_equal_int8/model.onnx | ✅ |  |
-| node/test_less_equal_int8_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_less_equal_int8_expanded/model.onnx | ✅ |  |
 | node/test_less_equal_uint16/model.onnx | ✅ |  |
-| node/test_less_equal_uint16_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_less_equal_uint16_expanded/model.onnx | ✅ |  |
 | node/test_less_equal_uint32/model.onnx | ✅ |  |
-| node/test_less_equal_uint32_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_less_equal_uint32_expanded/model.onnx | ✅ |  |
 | node/test_less_equal_uint64/model.onnx | ✅ |  |
-| node/test_less_equal_uint64_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_less_equal_uint64_expanded/model.onnx | ✅ |  |
 | node/test_less_equal_uint8/model.onnx | ✅ |  |
-| node/test_less_equal_uint8_expanded/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_less_equal_uint8_expanded/model.onnx | ✅ |  |
 | node/test_less_int16/model.onnx | ✅ |  |
 | node/test_less_int8/model.onnx | ✅ |  |
 | node/test_less_uint16/model.onnx | ✅ |  |
@@ -912,20 +912,20 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_matmul_4d_1d/model.onnx | ✅ |  |
 | node/test_matmul_bcast/model.onnx | ✅ |  |
 | node/test_matmulinteger/model.onnx | ❌ | Unsupported op MatMulInteger |
-| node/test_max_example/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_max_float16/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_max_float32/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_max_float64/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_max_int16/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_max_int32/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_max_int64/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_max_int8/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_max_one_input/model.onnx | ❌ | Max must have at least 2 inputs and 1 output |
-| node/test_max_two_inputs/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_max_uint16/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_max_uint32/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_max_uint64/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_max_uint8/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_max_example/model.onnx | ✅ |  |
+| node/test_max_float16/model.onnx | ✅ |  |
+| node/test_max_float32/model.onnx | ✅ |  |
+| node/test_max_float64/model.onnx | ✅ |  |
+| node/test_max_int16/model.onnx | ✅ |  |
+| node/test_max_int32/model.onnx | ✅ |  |
+| node/test_max_int64/model.onnx | ✅ |  |
+| node/test_max_int8/model.onnx | ✅ |  |
+| node/test_max_one_input/model.onnx | ❌ | Max must have at least 2 inputs |
+| node/test_max_two_inputs/model.onnx | ✅ |  |
+| node/test_max_uint16/model.onnx | ✅ |  |
+| node/test_max_uint32/model.onnx | ✅ |  |
+| node/test_max_uint64/model.onnx | ✅ |  |
+| node/test_max_uint8/model.onnx | ✅ |  |
 | node/test_maxpool_1d_default/model.onnx | ✅ |  |
 | node/test_maxpool_2d_ceil/model.onnx | ✅ |  |
 | node/test_maxpool_2d_ceil_output_size_reduce_by_one/model.onnx | ✅ |  |
@@ -947,24 +947,24 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_maxpool_with_argmax_2d_precomputed_strides/model.onnx | ✅ |  |
 | node/test_maxunpool_export_with_output_shape/model.onnx | ❌ | Unsupported op MaxUnpool |
 | node/test_maxunpool_export_without_output_shape/model.onnx | ❌ | Unsupported op MaxUnpool |
-| node/test_mean_example/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_mean_one_input/model.onnx | ❌ | Mean must have at least 2 inputs and 1 output |
-| node/test_mean_two_inputs/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_mean_example/model.onnx | ✅ |  |
+| node/test_mean_one_input/model.onnx | ❌ | Mean must have at least 2 inputs |
+| node/test_mean_two_inputs/model.onnx | ✅ |  |
 | node/test_melweightmatrix/model.onnx | ❌ | Unsupported op MelWeightMatrix |
-| node/test_min_example/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_min_float16/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_min_float32/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_min_float64/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_min_int16/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_min_int32/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_min_int64/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_min_int8/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_min_one_input/model.onnx | ❌ | Min must have at least 2 inputs and 1 output |
-| node/test_min_two_inputs/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_min_uint16/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_min_uint32/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_min_uint64/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_min_uint8/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_min_example/model.onnx | ✅ |  |
+| node/test_min_float16/model.onnx | ✅ |  |
+| node/test_min_float32/model.onnx | ✅ |  |
+| node/test_min_float64/model.onnx | ✅ |  |
+| node/test_min_int16/model.onnx | ✅ |  |
+| node/test_min_int32/model.onnx | ✅ |  |
+| node/test_min_int64/model.onnx | ✅ |  |
+| node/test_min_int8/model.onnx | ✅ |  |
+| node/test_min_one_input/model.onnx | ❌ | Min must have at least 2 inputs |
+| node/test_min_two_inputs/model.onnx | ✅ |  |
+| node/test_min_uint16/model.onnx | ✅ |  |
+| node/test_min_uint32/model.onnx | ✅ |  |
+| node/test_min_uint64/model.onnx | ✅ |  |
+| node/test_min_uint8/model.onnx | ✅ |  |
 | node/test_mish/model.onnx | ❌ | Unsupported op Mish |
 | node/test_mish_expanded/model.onnx | ✅ |  |
 | node/test_mod_broadcast/model.onnx | ✅ |  |
@@ -1061,9 +1061,9 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_optional_has_element_empty_optional_input/model.onnx | ❌ | Unsupported value type 'optional_type' for 'optional_input'. Hint: export the model with tensor inputs/outputs. |
 | node/test_optional_has_element_optional_input/model.onnx | ❌ | Unsupported value type 'optional_type' for 'optional_input'. Hint: export the model with tensor inputs/outputs. |
 | node/test_optional_has_element_tensor_input/model.onnx | ❌ | Unsupported value type 'optional_type' for 'optional_input'. Hint: export the model with tensor inputs/outputs. |
-| node/test_or2d/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_or3d/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_or4d/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_or2d/model.onnx | ✅ |  |
+| node/test_or3d/model.onnx | ✅ |  |
+| node/test_or4d/model.onnx | ✅ |  |
 | node/test_or_bcast3v1d/model.onnx | ❌ | Or expects identical input/output shapes |
 | node/test_or_bcast3v2d/model.onnx | ❌ | Or expects identical input/output shapes |
 | node/test_or_bcast4v2d/model.onnx | ❌ | Or expects identical input/output shapes |
@@ -1580,9 +1580,9 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_sub_uint32/model.onnx | ✅ |  |
 | node/test_sub_uint64/model.onnx | ✅ |  |
 | node/test_sub_uint8/model.onnx | ✅ |  |
-| node/test_sum_example/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_sum_one_input/model.onnx | ❌ | Sum must have at least 2 inputs and 1 output |
-| node/test_sum_two_inputs/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_sum_example/model.onnx | ✅ |  |
+| node/test_sum_one_input/model.onnx | ❌ | Sum must have at least 2 inputs |
+| node/test_sum_two_inputs/model.onnx | ✅ |  |
 | node/test_swish/model.onnx | ✅ |  |
 | node/test_swish_expanded/model.onnx | ✅ |  |
 | node/test_tan/model.onnx | ✅ |  |
@@ -1662,9 +1662,9 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_where_example/model.onnx | ✅ |  |
 | node/test_where_long_example/model.onnx | ✅ |  |
 | node/test_wrap_pad/model.onnx | ❌ | Unsupported op Pad |
-| node/test_xor2d/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_xor3d/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
-| node/test_xor4d/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| node/test_xor2d/model.onnx | ✅ |  |
+| node/test_xor3d/model.onnx | ✅ |  |
+| node/test_xor4d/model.onnx | ✅ |  |
 | node/test_xor_bcast3v1d/model.onnx | ❌ | Xor expects identical input/output shapes |
 | node/test_xor_bcast3v2d/model.onnx | ❌ | Xor expects identical input/output shapes |
 | node/test_xor_bcast4v2d/model.onnx | ❌ | Xor expects identical input/output shapes |
@@ -1767,9 +1767,9 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | pytorch-operator/test_operator_exp/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_flatten/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_index/model.onnx | ✅ |  |
-| pytorch-operator/test_operator_max/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| pytorch-operator/test_operator_max/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_maxpool/model.onnx | ✅ |  |
-| pytorch-operator/test_operator_min/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| pytorch-operator/test_operator_min/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_mm/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_non_float_params/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_pad/model.onnx | ❌ | Unsupported op Pad |
@@ -1785,7 +1785,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | pytorch-operator/test_operator_selu/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_sqrt/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_symbolic_override/model.onnx | ✅ |  |
-| pytorch-operator/test_operator_symbolic_override_nested/model.onnx | ❌ | 'MultiInputBinaryOp' object has no attribute 'input0' |
+| pytorch-operator/test_operator_symbolic_override_nested/model.onnx | ✅ |  |
 | pytorch-operator/test_operator_view/model.onnx | ✅ |  |
 | simple/test_expand_shape_model1/model.onnx | ✅ |  |
 | simple/test_expand_shape_model2/model.onnx | ✅ |  |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -2,117 +2,117 @@
 
 | Error message | Count | Histogram |
 | --- | --- | --- |
-| '*' object has no attribute '*' | 127 | ██████████████████████████████ |
-| Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 36 | █████████ |
-| Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ████████ |
-| Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 22 | █████ |
-| Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 20 | █████ |
-| ReduceMean output shape rank must match input rank | 19 | ████ |
-| Unsupported op Pad | 18 | ████ |
-| Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 18 | ████ |
-| Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 18 | ████ |
-| Unsupported op GridSample | 18 | ████ |
-| Unsupported elem_type 26 (INT2) for tensor '*'. | 17 | ████ |
-| Unsupported elem_type 22 (INT4) for tensor '*'. | 17 | ████ |
-| Unsupported elem_type 25 (UINT2) for tensor '*'. | 17 | ████ |
-| Unsupported elem_type 21 (UINT4) for tensor '*'. | 17 | ████ |
-| Unsupported op Trilu | 16 | ████ |
-| Reshape input and output element counts must match | 15 | ████ |
-| Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 14 | ███ |
-| Unsupported op ConvTranspose | 14 | ███ |
-| ReduceSum output shape rank must match input rank | 12 | ███ |
-| Output shape must be fully defined | 9 | ██ |
-| Unsupported op CumSum | 9 | ██ |
-| Unsupported op QuantizeLinear | 9 | ██ |
-| Unsupported op ImageDecoder | 9 | ██ |
-| Unsupported op NonMaxSuppression | 9 | ██ |
-| Dropout supports only the data input and 1 or 2 outputs | 8 | ██ |
-| Unsupported op LpPool | 8 | ██ |
-| Unsupported op QLinearMatMul | 8 | ██ |
-| Unsupported op RotaryEmbedding | 8 | ██ |
-| tuple index out of range | 8 | ██ |
-| Unsupported op Hardmax | 7 | ██ |
-| Unsupported op TfIdfVectorizer | 7 | ██ |
-| Unsupported op TopK | 7 | ██ |
-| AveragePool has unsupported attributes | 6 | █ |
-| Cast input and output shapes must match | 6 | █ |
-| Unsupported elem_type 16 (BFLOAT16) for tensor '*'. | 6 | █ |
-| Unsupported op CenterCropPad | 6 | █ |
-| Unsupported op DFT | 6 | █ |
-| Unsupported op Einsum | 6 | █ |
-| Concat output shape must be (2,), got (1,) | 6 | █ |
-| Unsupported op ScatterElements | 6 | █ |
-| Unsupported op Unique | 6 | █ |
-| Unsupported op If | 5 | █ |
-| And expects identical input/output shapes | 5 | █ |
-| AveragePool expects 2D kernel_shape | 5 | █ |
-| Unsupported op Col2Im | 5 | █ |
-| Unsupported op DequantizeLinear | 5 | █ |
-| Or expects identical input/output shapes | 5 | █ |
-| ReduceSum output shape must be (1, 1, 1), got () | 5 | █ |
-| Unsupported op ScatterND | 5 | █ |
-| Xor expects identical input/output shapes | 5 | █ |
-| Unsupported op AffineGrid | 4 | █ |
-| Unsupported op DeformConv | 4 | █ |
-| Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 4 | █ |
-| Unsupported op Compress | 4 | █ |
-| Sum expects identical input/output shapes | 4 | █ |
-| Unsupported op GRU | 4 | █ |
-| Concat output shape must be (3,), got (1,) | 4 | █ |
-| Concat output shape must be (4,), got (1,) | 4 | █ |
-| Unsupported op OneHot | 4 | █ |
-| Unsupported op OptionalHasElement | 4 | █ |
-| CastLike input and output shapes must match | 4 | █ |
-| Unsupported op RNN | 4 | █ |
-| AveragePool supports auto_pad=NOTSET only | 3 | █ |
-| Unsupported op Bernoulli | 3 | █ |
-| Unsupported op RandomUniformLike | 3 | █ |
-| Unsupported op DynamicQuantizeLinear | 3 | █ |
-| Elu only supports alpha=1.0 | 3 | █ |
-| Unsupported op GatherND | 3 | █ |
-| HardSigmoid only supports alpha=0.2 | 3 | █ |
-| Min expects identical input/output shapes | 3 | █ |
-| LeakyRelu only supports alpha=0.01 | 3 | █ |
-| Unsupported op Loop | 3 | █ |
-| Unsupported op Momentum | 3 | █ |
-| Unsupported op RoiAlign | 3 | █ |
-| Unsupported op TensorScatter | 3 | █ |
-| Unsupported op Adagrad | 2 | █ |
-| Unsupported op Adam | 2 | █ |
-| Unsupported op TreeEnsemble | 2 | █ |
-| AveragePool supports ceil_mode=0 only | 2 | █ |
-| BatchNormalization must have 5 inputs and 1 output | 2 | █ |
-| BitwiseAnd expects identical input/output shapes | 2 | █ |
-| Unsupported op BitwiseNot | 2 | █ |
-| BitwiseOr expects identical input/output shapes | 2 | █ |
-| BitwiseXor expects identical input/output shapes | 2 | █ |
-| Unsupported op BlackmanWindow | 2 | █ |
-| Unsupported op ConvInteger | 2 | █ |
-| Unsupported op Det | 2 | █ |
-| Gelu only supports approximate=none | 2 | █ |
-| Unsupported op GlobalMaxPool | 2 | █ |
-| Unsupported op HammingWindow | 2 | █ |
-| Unsupported op HannWindow | 2 | █ |
-| Unsupported op MaxUnpool | 2 | █ |
-| Pow expects matching dtypes, got float, int32 | 2 | █ |
-| Pow expects matching dtypes, got float, int64 | 2 | █ |
-| Unsupported op ReverseSequence | 2 | █ |
-| Unsupported op Scan | 2 | █ |
-| Unsupported op Scatter | 2 | █ |
-| Selu only supports alpha=1.6732632423543772 | 2 | █ |
-| Unsupported op STFT | 2 | █ |
-| ThresholdedRelu only supports alpha=1.0 | 2 | █ |
-| Tile repeats input must be a constant initializer | 2 | █ |
-| Unsupported op Gradient | 2 | █ |
+| Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 36 | ██████████████████████████████ |
+| Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████████████████████████ |
+| Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 22 | ██████████████████ |
+| Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 20 | █████████████████ |
+| ReduceMean output shape rank must match input rank | 19 | ████████████████ |
+| Unsupported op Pad | 18 | ███████████████ |
+| Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 18 | ███████████████ |
+| Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 18 | ███████████████ |
+| Unsupported op GridSample | 18 | ███████████████ |
+| Unsupported elem_type 26 (INT2) for tensor '*'. | 17 | ██████████████ |
+| Unsupported elem_type 22 (INT4) for tensor '*'. | 17 | ██████████████ |
+| Unsupported elem_type 25 (UINT2) for tensor '*'. | 17 | ██████████████ |
+| Unsupported elem_type 21 (UINT4) for tensor '*'. | 17 | ██████████████ |
+| Unsupported op Trilu | 16 | █████████████ |
+| Reshape input and output element counts must match | 15 | ████████████ |
+| Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 14 | ████████████ |
+| Unsupported op ConvTranspose | 14 | ████████████ |
+| '*' object has no attribute '*' | 13 | ███████████ |
+| ReduceSum output shape rank must match input rank | 12 | ██████████ |
+| Output shape must be fully defined | 9 | ████████ |
+| Unsupported op CumSum | 9 | ████████ |
+| Unsupported op QuantizeLinear | 9 | ████████ |
+| Unsupported op ImageDecoder | 9 | ████████ |
+| Unsupported op NonMaxSuppression | 9 | ████████ |
+| Dropout supports only the data input and 1 or 2 outputs | 8 | ███████ |
+| Unsupported op LpPool | 8 | ███████ |
+| Unsupported op QLinearMatMul | 8 | ███████ |
+| Unsupported op RotaryEmbedding | 8 | ███████ |
+| tuple index out of range | 8 | ███████ |
+| Unsupported op Hardmax | 7 | ██████ |
+| Unsupported op TfIdfVectorizer | 7 | ██████ |
+| Unsupported op TopK | 7 | ██████ |
+| AveragePool has unsupported attributes | 6 | █████ |
+| Cast input and output shapes must match | 6 | █████ |
+| Unsupported elem_type 16 (BFLOAT16) for tensor '*'. | 6 | █████ |
+| Unsupported op CenterCropPad | 6 | █████ |
+| Unsupported op DFT | 6 | █████ |
+| Unsupported op Einsum | 6 | █████ |
+| Concat output shape must be (2,), got (1,) | 6 | █████ |
+| Unsupported op ScatterElements | 6 | █████ |
+| Unsupported op Unique | 6 | █████ |
+| Unsupported op If | 5 | ████ |
+| And expects identical input/output shapes | 5 | ████ |
+| AveragePool expects 2D kernel_shape | 5 | ████ |
+| Unsupported op Col2Im | 5 | ████ |
+| Unsupported op DequantizeLinear | 5 | ████ |
+| Or expects identical input/output shapes | 5 | ████ |
+| ReduceSum output shape must be (1, 1, 1), got () | 5 | ████ |
+| Unsupported op ScatterND | 5 | ████ |
+| Xor expects identical input/output shapes | 5 | ████ |
+| Unsupported op AffineGrid | 4 | ███ |
+| Unsupported op DeformConv | 4 | ███ |
+| Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 4 | ███ |
+| Unsupported op Compress | 4 | ███ |
+| Sum expects identical input/output shapes | 4 | ███ |
+| Unsupported op GRU | 4 | ███ |
+| Concat output shape must be (3,), got (1,) | 4 | ███ |
+| Concat output shape must be (4,), got (1,) | 4 | ███ |
+| Unsupported op OneHot | 4 | ███ |
+| Unsupported op OptionalHasElement | 4 | ███ |
+| CastLike input and output shapes must match | 4 | ███ |
+| Unsupported op RNN | 4 | ███ |
+| AveragePool supports auto_pad=NOTSET only | 3 | ██ |
+| Unsupported op Bernoulli | 3 | ██ |
+| Unsupported op RandomUniformLike | 3 | ██ |
+| Unsupported op DynamicQuantizeLinear | 3 | ██ |
+| Elu only supports alpha=1.0 | 3 | ██ |
+| Unsupported op GatherND | 3 | ██ |
+| HardSigmoid only supports alpha=0.2 | 3 | ██ |
+| Min expects identical input/output shapes | 3 | ██ |
+| LeakyRelu only supports alpha=0.01 | 3 | ██ |
+| Unsupported op Loop | 3 | ██ |
+| Unsupported op Momentum | 3 | ██ |
+| Unsupported op RoiAlign | 3 | ██ |
+| Unsupported op TensorScatter | 3 | ██ |
+| Unsupported op Adagrad | 2 | ██ |
+| Unsupported op Adam | 2 | ██ |
+| Unsupported op TreeEnsemble | 2 | ██ |
+| AveragePool supports ceil_mode=0 only | 2 | ██ |
+| BatchNormalization must have 5 inputs and 1 output | 2 | ██ |
+| BitwiseAnd expects identical input/output shapes | 2 | ██ |
+| Unsupported op BitwiseNot | 2 | ██ |
+| BitwiseOr expects identical input/output shapes | 2 | ██ |
+| BitwiseXor expects identical input/output shapes | 2 | ██ |
+| Unsupported op BlackmanWindow | 2 | ██ |
+| Unsupported op ConvInteger | 2 | ██ |
+| Unsupported op Det | 2 | ██ |
+| Gelu only supports approximate=none | 2 | ██ |
+| Unsupported op GlobalMaxPool | 2 | ██ |
+| Unsupported op HammingWindow | 2 | ██ |
+| Unsupported op HannWindow | 2 | ██ |
+| Unsupported op MaxUnpool | 2 | ██ |
+| Pow expects matching dtypes, got float, int32 | 2 | ██ |
+| Pow expects matching dtypes, got float, int64 | 2 | ██ |
+| Unsupported op ReverseSequence | 2 | ██ |
+| Unsupported op Scan | 2 | ██ |
+| Unsupported op Scatter | 2 | ██ |
+| Selu only supports alpha=1.6732632423543772 | 2 | ██ |
+| Unsupported op STFT | 2 | ██ |
+| ThresholdedRelu only supports alpha=1.0 | 2 | ██ |
+| Tile repeats input must be a constant initializer | 2 | ██ |
+| Unsupported op Gradient | 2 | ██ |
 | Unsupported op ArrayFeatureExtractor | 1 | █ |
 | Unsupported op Binarizer | 1 | █ |
 | Graph must contain at least one node | 1 | █ |
 | Dropout mask output is not supported | 1 | █ |
 | Unsupported op MatMulInteger | 1 | █ |
-| Max must have at least 2 inputs and 1 output | 1 | █ |
-| Mean must have at least 2 inputs and 1 output | 1 | █ |
+| Max must have at least 2 inputs | 1 | █ |
+| Mean must have at least 2 inputs | 1 | █ |
 | Unsupported op MelWeightMatrix | 1 | █ |
-| Min must have at least 2 inputs and 1 output | 1 | █ |
+| Min must have at least 2 inputs | 1 | █ |
 | Unsupported op Mish | 1 | █ |
 | Unsupported op NonZero | 1 | █ |
 | Unsupported op OptionalGetElement | 1 | █ |
@@ -122,7 +122,7 @@
 | ReduceMax does not support dtype bool | 1 | █ |
 | ReduceMin does not support dtype bool | 1 | █ |
 | Max expects identical input/output shapes | 1 | █ |
-| Sum must have at least 2 inputs and 1 output | 1 | █ |
+| Sum must have at least 2 inputs | 1 | █ |
 | Unsupported op Upsample | 1 | █ |
 | Dynamic dim for tensor '*' | 1 | █ |
 

--- a/src/onnx2c/codegen/c_emitter.py
+++ b/src/onnx2c/codegen/c_emitter.py
@@ -3260,6 +3260,9 @@ class CEmitter:
         if isinstance(op, BinaryOp):
             args.extend([op.input0, op.input1, op.output])
             return ", ".join(args)
+        if isinstance(op, MultiInputBinaryOp):
+            args.extend([*op.inputs, op.output])
+            return ", ".join(args)
         if isinstance(op, WhereOp):
             args.extend([op.condition, op.input_x, op.input_y, op.output])
             return ", ".join(args)

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -17,11 +17,11 @@
   ],
   [
     "light/light_resnet50.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "light/light_shufflenet.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "light/light_squeezenet.onnx",
@@ -169,15 +169,15 @@
   ],
   [
     "node/test_and2d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_and3d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_and4d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_and_bcast3v1d/model.onnx",
@@ -369,7 +369,7 @@
   ],
   [
     "node/test_attention_3d_attn_mask_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_causal/model.onnx",
@@ -377,7 +377,7 @@
   ],
   [
     "node/test_attention_3d_causal_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_diff_heads_sizes/model.onnx",
@@ -389,7 +389,7 @@
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_attn_mask_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_causal/model.onnx",
@@ -397,11 +397,11 @@
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_causal_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_scaled/model.onnx",
@@ -409,7 +409,7 @@
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_scaled_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_softcap/model.onnx",
@@ -417,7 +417,7 @@
   ],
   [
     "node/test_attention_3d_diff_heads_sizes_softcap_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_diff_heads_with_past_and_present/model.onnx",
@@ -425,11 +425,11 @@
   ],
   [
     "node/test_attention_3d_diff_heads_with_past_and_present_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_gqa/model.onnx",
@@ -485,7 +485,7 @@
   ],
   [
     "node/test_attention_3d_scaled_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_softcap/model.onnx",
@@ -493,7 +493,7 @@
   ],
   [
     "node/test_attention_3d_softcap_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_transpose_verification/model.onnx",
@@ -501,7 +501,7 @@
   ],
   [
     "node/test_attention_3d_transpose_verification_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_with_past_and_present/model.onnx",
@@ -509,7 +509,7 @@
   ],
   [
     "node/test_attention_3d_with_past_and_present_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul/model.onnx",
@@ -521,11 +521,11 @@
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_bias_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_softcap/model.onnx",
@@ -533,7 +533,7 @@
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_softmax/model.onnx",
@@ -541,7 +541,7 @@
   ],
   [
     "node/test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d/model.onnx",
@@ -561,11 +561,11 @@
   ],
   [
     "node/test_attention_4d_attn_mask_3d_causal_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_attn_mask_3d_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_attn_mask_4d/model.onnx",
@@ -577,11 +577,11 @@
   ],
   [
     "node/test_attention_4d_attn_mask_4d_causal_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_attn_mask_4d_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_attn_mask_bool/model.onnx",
@@ -593,15 +593,15 @@
   ],
   [
     "node/test_attention_4d_attn_mask_bool_4d_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_attn_mask_bool_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_attn_mask_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_causal/model.onnx",
@@ -609,7 +609,7 @@
   ],
   [
     "node/test_attention_4d_causal_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_diff_heads_mask4d_padded_kv/model.onnx",
@@ -629,7 +629,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_attn_mask_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_causal/model.onnx",
@@ -637,11 +637,11 @@
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_causal_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_scaled/model.onnx",
@@ -649,7 +649,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_scaled_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_softcap/model.onnx",
@@ -657,7 +657,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_sizes_softcap_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present/model.onnx",
@@ -665,7 +665,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_mask3d/model.onnx",
@@ -673,7 +673,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_mask3d_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_mask4d/model.onnx",
@@ -681,11 +681,11 @@
   ],
   [
     "node/test_attention_4d_diff_heads_with_past_and_present_mask4d_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_fp16/model.onnx",
@@ -693,7 +693,7 @@
   ],
   [
     "node/test_attention_4d_fp16_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_gqa/model.onnx",
@@ -757,7 +757,7 @@
   ],
   [
     "node/test_attention_4d_scaled_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_softcap/model.onnx",
@@ -765,7 +765,7 @@
   ],
   [
     "node/test_attention_4d_softcap_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_with_past_and_present/model.onnx",
@@ -773,7 +773,7 @@
   ],
   [
     "node/test_attention_4d_with_past_and_present_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul/model.onnx",
@@ -793,11 +793,11 @@
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask/model.onnx",
@@ -809,19 +809,19 @@
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_bias_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_with_past_and_present_qk_matmul_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_with_qk_matmul/model.onnx",
@@ -833,11 +833,11 @@
   ],
   [
     "node/test_attention_4d_with_qk_matmul_bias_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_with_qk_matmul_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_with_qk_matmul_softcap/model.onnx",
@@ -845,7 +845,7 @@
   ],
   [
     "node/test_attention_4d_with_qk_matmul_softcap_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_attention_4d_with_qk_matmul_softmax/model.onnx",
@@ -853,7 +853,7 @@
   ],
   [
     "node/test_attention_4d_with_qk_matmul_softmax_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_averagepool_1d_default/model.onnx",
@@ -1025,11 +1025,11 @@
   ],
   [
     "node/test_bitwise_and_i16_3d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_bitwise_and_i32_2d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_bitwise_and_ui64_bcast_3v1d/model.onnx",
@@ -1053,11 +1053,11 @@
   ],
   [
     "node/test_bitwise_or_i16_4d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_bitwise_or_i32_2d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_bitwise_or_ui64_bcast_3v1d/model.onnx",
@@ -1069,11 +1069,11 @@
   ],
   [
     "node/test_bitwise_xor_i16_3d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_bitwise_xor_i32_2d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_bitwise_xor_ui64_bcast_3v1d/model.onnx",
@@ -2685,11 +2685,11 @@
   ],
   [
     "node/test_greater_equal_bcast_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_greater_equal_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_greater_equal_int16/model.onnx",
@@ -2697,7 +2697,7 @@
   ],
   [
     "node/test_greater_equal_int16_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_greater_equal_int8/model.onnx",
@@ -2705,7 +2705,7 @@
   ],
   [
     "node/test_greater_equal_int8_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_greater_equal_uint16/model.onnx",
@@ -2713,7 +2713,7 @@
   ],
   [
     "node/test_greater_equal_uint16_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_greater_equal_uint32/model.onnx",
@@ -2721,7 +2721,7 @@
   ],
   [
     "node/test_greater_equal_uint32_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_greater_equal_uint64/model.onnx",
@@ -2729,7 +2729,7 @@
   ],
   [
     "node/test_greater_equal_uint64_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_greater_equal_uint8/model.onnx",
@@ -2737,7 +2737,7 @@
   ],
   [
     "node/test_greater_equal_uint8_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_greater_int16/model.onnx",
@@ -3341,11 +3341,11 @@
   ],
   [
     "node/test_less_equal_bcast_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_less_equal_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_less_equal_int16/model.onnx",
@@ -3353,7 +3353,7 @@
   ],
   [
     "node/test_less_equal_int16_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_less_equal_int8/model.onnx",
@@ -3361,7 +3361,7 @@
   ],
   [
     "node/test_less_equal_int8_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_less_equal_uint16/model.onnx",
@@ -3369,7 +3369,7 @@
   ],
   [
     "node/test_less_equal_uint16_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_less_equal_uint32/model.onnx",
@@ -3377,7 +3377,7 @@
   ],
   [
     "node/test_less_equal_uint32_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_less_equal_uint64/model.onnx",
@@ -3385,7 +3385,7 @@
   ],
   [
     "node/test_less_equal_uint64_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_less_equal_uint8/model.onnx",
@@ -3393,7 +3393,7 @@
   ],
   [
     "node/test_less_equal_uint8_expanded/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_less_int16/model.onnx",
@@ -3617,35 +3617,35 @@
   ],
   [
     "node/test_max_example/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_max_float16/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_max_float32/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_max_float64/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_max_int16/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_max_int32/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_max_int64/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_max_int8/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_max_one_input/model.onnx",
@@ -3653,23 +3653,23 @@
   ],
   [
     "node/test_max_two_inputs/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_max_uint16/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_max_uint32/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_max_uint64/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_max_uint8/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_maxpool_1d_default/model.onnx",
@@ -3757,7 +3757,7 @@
   ],
   [
     "node/test_mean_example/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_mean_one_input/model.onnx",
@@ -3765,7 +3765,7 @@
   ],
   [
     "node/test_mean_two_inputs/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_melweightmatrix/model.onnx",
@@ -3773,35 +3773,35 @@
   ],
   [
     "node/test_min_example/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_min_float16/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_min_float32/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_min_float64/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_min_int16/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_min_int32/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_min_int64/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_min_int8/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_min_one_input/model.onnx",
@@ -3809,23 +3809,23 @@
   ],
   [
     "node/test_min_two_inputs/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_min_uint16/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_min_uint32/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_min_uint64/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_min_uint8/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_mish/model.onnx",
@@ -4213,15 +4213,15 @@
   ],
   [
     "node/test_or2d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_or3d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_or4d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_or_bcast3v1d/model.onnx",
@@ -6289,7 +6289,7 @@
   ],
   [
     "node/test_sum_example/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_sum_one_input/model.onnx",
@@ -6297,7 +6297,7 @@
   ],
   [
     "node/test_sum_two_inputs/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_swish/model.onnx",
@@ -6617,15 +6617,15 @@
   ],
   [
     "node/test_xor2d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_xor3d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_xor4d/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "node/test_xor_bcast3v1d/model.onnx",
@@ -7037,7 +7037,7 @@
   ],
   [
     "pytorch-operator/test_operator_max/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "pytorch-operator/test_operator_maxpool/model.onnx",
@@ -7045,7 +7045,7 @@
   ],
   [
     "pytorch-operator/test_operator_min/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "pytorch-operator/test_operator_mm/model.onnx",
@@ -7109,7 +7109,7 @@
   ],
   [
     "pytorch-operator/test_operator_symbolic_override_nested/model.onnx",
-    "'MultiInputBinaryOp' object has no attribute 'input0'"
+    ""
   ],
   [
     "pytorch-operator/test_operator_view/model.onnx",


### PR DESCRIPTION
### Motivation
- Variadic/variadic-lowering ops (e.g., `Sum`, `Mean`, `Max`, `Min`, bitwise/logical variadics) produced "'MultiInputBinaryOp' object has no attribute 'input0'" when assembling call arguments for codegen.
- The call-argument assembly path assumed single named inputs (`input0`, `input1`) and therefore did not handle `MultiInputBinaryOp` values that store inputs as an `inputs` tuple.

### Description
- Add explicit handling for `MultiInputBinaryOp` in the codegen call-argument assembly so the emitter uses `(*op.inputs, op.output)` when rendering call argument lists in `CEmitter` (`src/onnx2c/codegen/c_emitter.py`).
- Regenerate/refresh the official ONNX expectations and support documentation (`tests/official_onnx_expected_errors.json`, `OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`) to reflect the newly supported variadic cases.

### Testing
- Ran the full test suite with reference updates via `UPDATE_REFS=1 pytest -n auto -q`, which completed in ~47.86s and resulted in `174 passed, 2 skipped, 2 warnings`.
- Ran the updated official ONNX support doc check via `UPDATE_REFS=1 pytest -q tests/test_official_onnx_files.py::test_official_onnx_file_support_doc`, which completed in ~0.82s and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69687fcbd8d48325ab3669da063c298d)