### PR TITLE
lowering: resolve dynamic Reduce* axes from shape ops and relax keepdims validation

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1082 / 1802 official ONNX files.
+Support 1089 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -1132,9 +1132,9 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_l1_negative_axes_keep_dims_random/model.onnx | ✅ |  |
 | node/test_reduce_l1_negative_axes_keep_dims_random_expanded/model.onnx | ✅ |  |
 | node/test_reduce_l2_default_axes_keepdims_example/model.onnx | ✅ |  |
-| node/test_reduce_l2_default_axes_keepdims_example_expanded/model.onnx | ❌ | ReduceSum output shape must be (1, 1, 1), got () |
+| node/test_reduce_l2_default_axes_keepdims_example_expanded/model.onnx | ❌ | CastLike input and output shapes must match |
 | node/test_reduce_l2_default_axes_keepdims_random/model.onnx | ✅ |  |
-| node/test_reduce_l2_default_axes_keepdims_random_expanded/model.onnx | ❌ | ReduceSum output shape must be (1, 1, 1), got () |
+| node/test_reduce_l2_default_axes_keepdims_random_expanded/model.onnx | ❌ | CastLike input and output shapes must match |
 | node/test_reduce_l2_do_not_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_l2_do_not_keepdims_example_expanded/model.onnx | ❌ | CastLike input and output shapes must match |
 | node/test_reduce_l2_do_not_keepdims_random/model.onnx | ✅ |  |
@@ -1152,15 +1152,15 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reduce_log_sum_asc_axes/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_asc_axes_expanded/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_default/model.onnx | ✅ |  |
-| node/test_reduce_log_sum_default_expanded/model.onnx | ❌ | ReduceSum output shape must be (1, 1, 1), got () |
+| node/test_reduce_log_sum_default_expanded/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_desc_axes/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_desc_axes_expanded/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_empty_set/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_empty_set_expanded/model.onnx | ❌ | ReduceSum output shape rank must match input rank |
 | node/test_reduce_log_sum_exp_default_axes_keepdims_example/model.onnx | ✅ |  |
-| node/test_reduce_log_sum_exp_default_axes_keepdims_example_expanded/model.onnx | ❌ | ReduceSum output shape must be (1, 1, 1), got () |
+| node/test_reduce_log_sum_exp_default_axes_keepdims_example_expanded/model.onnx | ❌ | CastLike input and output shapes must match |
 | node/test_reduce_log_sum_exp_default_axes_keepdims_random/model.onnx | ✅ |  |
-| node/test_reduce_log_sum_exp_default_axes_keepdims_random_expanded/model.onnx | ❌ | ReduceSum output shape must be (1, 1, 1), got () |
+| node/test_reduce_log_sum_exp_default_axes_keepdims_random_expanded/model.onnx | ❌ | CastLike input and output shapes must match |
 | node/test_reduce_log_sum_exp_do_not_keepdims_example/model.onnx | ✅ |  |
 | node/test_reduce_log_sum_exp_do_not_keepdims_example_expanded/model.onnx | ❌ | CastLike input and output shapes must match |
 | node/test_reduce_log_sum_exp_do_not_keepdims_random/model.onnx | ✅ |  |
@@ -1302,43 +1302,43 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_reversesequence_batch/model.onnx | ❌ | Unsupported op ReverseSequence |
 | node/test_reversesequence_time/model.onnx | ❌ | Unsupported op ReverseSequence |
 | node/test_rms_normalization_2d_axis0/model.onnx | ✅ |  |
-| node/test_rms_normalization_2d_axis0_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
+| node/test_rms_normalization_2d_axis0_expanded/model.onnx | ✅ |  |
 | node/test_rms_normalization_2d_axis1/model.onnx | ✅ |  |
-| node/test_rms_normalization_2d_axis1_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
+| node/test_rms_normalization_2d_axis1_expanded/model.onnx | ❌ | ReduceMean output shape must be (3, 1), got () |
 | node/test_rms_normalization_2d_axis_negative_1/model.onnx | ✅ |  |
-| node/test_rms_normalization_2d_axis_negative_1_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
+| node/test_rms_normalization_2d_axis_negative_1_expanded/model.onnx | ❌ | ReduceMean output shape must be (3, 1), got () |
 | node/test_rms_normalization_2d_axis_negative_2/model.onnx | ✅ |  |
-| node/test_rms_normalization_2d_axis_negative_2_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
+| node/test_rms_normalization_2d_axis_negative_2_expanded/model.onnx | ✅ |  |
 | node/test_rms_normalization_3d_axis0_epsilon/model.onnx | ✅ |  |
-| node/test_rms_normalization_3d_axis0_epsilon_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
+| node/test_rms_normalization_3d_axis0_epsilon_expanded/model.onnx | ✅ |  |
 | node/test_rms_normalization_3d_axis1_epsilon/model.onnx | ✅ |  |
-| node/test_rms_normalization_3d_axis1_epsilon_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
+| node/test_rms_normalization_3d_axis1_epsilon_expanded/model.onnx | ❌ | ReduceMean output shape must be (2, 1, 1), got () |
 | node/test_rms_normalization_3d_axis2_epsilon/model.onnx | ✅ |  |
-| node/test_rms_normalization_3d_axis2_epsilon_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
+| node/test_rms_normalization_3d_axis2_epsilon_expanded/model.onnx | ❌ | ReduceMean output shape must be (2, 3, 1), got () |
 | node/test_rms_normalization_3d_axis_negative_1_epsilon/model.onnx | ✅ |  |
-| node/test_rms_normalization_3d_axis_negative_1_epsilon_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
+| node/test_rms_normalization_3d_axis_negative_1_epsilon_expanded/model.onnx | ❌ | ReduceMean output shape must be (2, 3, 1), got () |
 | node/test_rms_normalization_3d_axis_negative_2_epsilon/model.onnx | ✅ |  |
-| node/test_rms_normalization_3d_axis_negative_2_epsilon_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
+| node/test_rms_normalization_3d_axis_negative_2_epsilon_expanded/model.onnx | ❌ | ReduceMean output shape must be (2, 1, 1), got () |
 | node/test_rms_normalization_3d_axis_negative_3_epsilon/model.onnx | ✅ |  |
-| node/test_rms_normalization_3d_axis_negative_3_epsilon_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
+| node/test_rms_normalization_3d_axis_negative_3_epsilon_expanded/model.onnx | ✅ |  |
 | node/test_rms_normalization_4d_axis0/model.onnx | ✅ |  |
-| node/test_rms_normalization_4d_axis0_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
+| node/test_rms_normalization_4d_axis0_expanded/model.onnx | ✅ |  |
 | node/test_rms_normalization_4d_axis1/model.onnx | ✅ |  |
-| node/test_rms_normalization_4d_axis1_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
+| node/test_rms_normalization_4d_axis1_expanded/model.onnx | ❌ | ReduceMean output shape must be (2, 1, 1, 1), got () |
 | node/test_rms_normalization_4d_axis2/model.onnx | ✅ |  |
-| node/test_rms_normalization_4d_axis2_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
+| node/test_rms_normalization_4d_axis2_expanded/model.onnx | ❌ | ReduceMean output shape must be (2, 3, 1, 1), got () |
 | node/test_rms_normalization_4d_axis3/model.onnx | ✅ |  |
-| node/test_rms_normalization_4d_axis3_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
+| node/test_rms_normalization_4d_axis3_expanded/model.onnx | ❌ | ReduceMean output shape must be (2, 3, 4, 1), got () |
 | node/test_rms_normalization_4d_axis_negative_1/model.onnx | ✅ |  |
-| node/test_rms_normalization_4d_axis_negative_1_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
+| node/test_rms_normalization_4d_axis_negative_1_expanded/model.onnx | ❌ | ReduceMean output shape must be (2, 3, 4, 1), got () |
 | node/test_rms_normalization_4d_axis_negative_2/model.onnx | ✅ |  |
-| node/test_rms_normalization_4d_axis_negative_2_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
+| node/test_rms_normalization_4d_axis_negative_2_expanded/model.onnx | ❌ | ReduceMean output shape must be (2, 3, 1, 1), got () |
 | node/test_rms_normalization_4d_axis_negative_3/model.onnx | ✅ |  |
-| node/test_rms_normalization_4d_axis_negative_3_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
+| node/test_rms_normalization_4d_axis_negative_3_expanded/model.onnx | ❌ | ReduceMean output shape must be (2, 1, 1, 1), got () |
 | node/test_rms_normalization_4d_axis_negative_4/model.onnx | ✅ |  |
-| node/test_rms_normalization_4d_axis_negative_4_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
+| node/test_rms_normalization_4d_axis_negative_4_expanded/model.onnx | ✅ |  |
 | node/test_rms_normalization_default_axis/model.onnx | ✅ |  |
-| node/test_rms_normalization_default_axis_expanded/model.onnx | ❌ | ReduceMean output shape rank must match input rank |
+| node/test_rms_normalization_default_axis_expanded/model.onnx | ❌ | ReduceMean output shape must be (2, 3, 4, 1), got () |
 | node/test_rnn_seq_length/model.onnx | ❌ | Unsupported op RNN |
 | node/test_roialign_aligned_false/model.onnx | ❌ | Unsupported op RoiAlign |
 | node/test_roialign_aligned_true/model.onnx | ❌ | Unsupported op RoiAlign |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -6,7 +6,6 @@
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████████████████████████ |
 | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 22 | ██████████████████ |
 | Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 20 | █████████████████ |
-| ReduceMean output shape rank must match input rank | 19 | ████████████████ |
 | Unsupported op Pad | 18 | ███████████████ |
 | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 18 | ███████████████ |
 | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 18 | ███████████████ |
@@ -29,6 +28,7 @@
 | Dropout supports only the data input and 1 or 2 outputs | 8 | ███████ |
 | Unsupported op LpPool | 8 | ███████ |
 | Unsupported op QLinearMatMul | 8 | ███████ |
+| CastLike input and output shapes must match | 8 | ███████ |
 | Unsupported op RotaryEmbedding | 8 | ███████ |
 | tuple index out of range | 8 | ███████ |
 | Unsupported op Hardmax | 7 | ██████ |
@@ -49,7 +49,6 @@
 | Unsupported op Col2Im | 5 | ████ |
 | Unsupported op DequantizeLinear | 5 | ████ |
 | Or expects identical input/output shapes | 5 | ████ |
-| ReduceSum output shape must be (1, 1, 1), got () | 5 | ████ |
 | Unsupported op ScatterND | 5 | ████ |
 | Xor expects identical input/output shapes | 5 | ████ |
 | Unsupported op AffineGrid | 4 | ███ |
@@ -62,7 +61,6 @@
 | Concat output shape must be (4,), got (1,) | 4 | ███ |
 | Unsupported op OneHot | 4 | ███ |
 | Unsupported op OptionalHasElement | 4 | ███ |
-| CastLike input and output shapes must match | 4 | ███ |
 | Unsupported op RNN | 4 | ███ |
 | AveragePool supports auto_pad=NOTSET only | 3 | ██ |
 | Unsupported op Bernoulli | 3 | ██ |
@@ -75,6 +73,7 @@
 | LeakyRelu only supports alpha=0.01 | 3 | ██ |
 | Unsupported op Loop | 3 | ██ |
 | Unsupported op Momentum | 3 | ██ |
+| ReduceMean output shape must be (2, 3, 4, 1), got () | 3 | ██ |
 | Unsupported op RoiAlign | 3 | ██ |
 | Unsupported op TensorScatter | 3 | ██ |
 | Unsupported op Adagrad | 2 | ██ |
@@ -97,6 +96,11 @@
 | Pow expects matching dtypes, got float, int32 | 2 | ██ |
 | Pow expects matching dtypes, got float, int64 | 2 | ██ |
 | Unsupported op ReverseSequence | 2 | ██ |
+| ReduceMean output shape must be (3, 1), got () | 2 | ██ |
+| ReduceMean output shape must be (2, 1, 1), got () | 2 | ██ |
+| ReduceMean output shape must be (2, 3, 1), got () | 2 | ██ |
+| ReduceMean output shape must be (2, 1, 1, 1), got () | 2 | ██ |
+| ReduceMean output shape must be (2, 3, 1, 1), got () | 2 | ██ |
 | Unsupported op Scan | 2 | ██ |
 | Unsupported op Scatter | 2 | ██ |
 | Selu only supports alpha=1.6732632423543772 | 2 | ██ |

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -4497,7 +4497,7 @@
   ],
   [
     "node/test_reduce_l2_default_axes_keepdims_example_expanded/model.onnx",
-    "ReduceSum output shape must be (1, 1, 1), got ()"
+    "CastLike input and output shapes must match"
   ],
   [
     "node/test_reduce_l2_default_axes_keepdims_random/model.onnx",
@@ -4505,7 +4505,7 @@
   ],
   [
     "node/test_reduce_l2_default_axes_keepdims_random_expanded/model.onnx",
-    "ReduceSum output shape must be (1, 1, 1), got ()"
+    "CastLike input and output shapes must match"
   ],
   [
     "node/test_reduce_l2_do_not_keepdims_example/model.onnx",
@@ -4577,7 +4577,7 @@
   ],
   [
     "node/test_reduce_log_sum_default_expanded/model.onnx",
-    "ReduceSum output shape must be (1, 1, 1), got ()"
+    ""
   ],
   [
     "node/test_reduce_log_sum_desc_axes/model.onnx",
@@ -4601,7 +4601,7 @@
   ],
   [
     "node/test_reduce_log_sum_exp_default_axes_keepdims_example_expanded/model.onnx",
-    "ReduceSum output shape must be (1, 1, 1), got ()"
+    "CastLike input and output shapes must match"
   ],
   [
     "node/test_reduce_log_sum_exp_default_axes_keepdims_random/model.onnx",
@@ -4609,7 +4609,7 @@
   ],
   [
     "node/test_reduce_log_sum_exp_default_axes_keepdims_random_expanded/model.onnx",
-    "ReduceSum output shape must be (1, 1, 1), got ()"
+    "CastLike input and output shapes must match"
   ],
   [
     "node/test_reduce_log_sum_exp_do_not_keepdims_example/model.onnx",
@@ -5177,7 +5177,7 @@
   ],
   [
     "node/test_rms_normalization_2d_axis0_expanded/model.onnx",
-    "ReduceMean output shape rank must match input rank"
+    ""
   ],
   [
     "node/test_rms_normalization_2d_axis1/model.onnx",
@@ -5185,7 +5185,7 @@
   ],
   [
     "node/test_rms_normalization_2d_axis1_expanded/model.onnx",
-    "ReduceMean output shape rank must match input rank"
+    "ReduceMean output shape must be (3, 1), got ()"
   ],
   [
     "node/test_rms_normalization_2d_axis_negative_1/model.onnx",
@@ -5193,7 +5193,7 @@
   ],
   [
     "node/test_rms_normalization_2d_axis_negative_1_expanded/model.onnx",
-    "ReduceMean output shape rank must match input rank"
+    "ReduceMean output shape must be (3, 1), got ()"
   ],
   [
     "node/test_rms_normalization_2d_axis_negative_2/model.onnx",
@@ -5201,7 +5201,7 @@
   ],
   [
     "node/test_rms_normalization_2d_axis_negative_2_expanded/model.onnx",
-    "ReduceMean output shape rank must match input rank"
+    ""
   ],
   [
     "node/test_rms_normalization_3d_axis0_epsilon/model.onnx",
@@ -5209,7 +5209,7 @@
   ],
   [
     "node/test_rms_normalization_3d_axis0_epsilon_expanded/model.onnx",
-    "ReduceMean output shape rank must match input rank"
+    ""
   ],
   [
     "node/test_rms_normalization_3d_axis1_epsilon/model.onnx",
@@ -5217,7 +5217,7 @@
   ],
   [
     "node/test_rms_normalization_3d_axis1_epsilon_expanded/model.onnx",
-    "ReduceMean output shape rank must match input rank"
+    "ReduceMean output shape must be (2, 1, 1), got ()"
   ],
   [
     "node/test_rms_normalization_3d_axis2_epsilon/model.onnx",
@@ -5225,7 +5225,7 @@
   ],
   [
     "node/test_rms_normalization_3d_axis2_epsilon_expanded/model.onnx",
-    "ReduceMean output shape rank must match input rank"
+    "ReduceMean output shape must be (2, 3, 1), got ()"
   ],
   [
     "node/test_rms_normalization_3d_axis_negative_1_epsilon/model.onnx",
@@ -5233,7 +5233,7 @@
   ],
   [
     "node/test_rms_normalization_3d_axis_negative_1_epsilon_expanded/model.onnx",
-    "ReduceMean output shape rank must match input rank"
+    "ReduceMean output shape must be (2, 3, 1), got ()"
   ],
   [
     "node/test_rms_normalization_3d_axis_negative_2_epsilon/model.onnx",
@@ -5241,7 +5241,7 @@
   ],
   [
     "node/test_rms_normalization_3d_axis_negative_2_epsilon_expanded/model.onnx",
-    "ReduceMean output shape rank must match input rank"
+    "ReduceMean output shape must be (2, 1, 1), got ()"
   ],
   [
     "node/test_rms_normalization_3d_axis_negative_3_epsilon/model.onnx",
@@ -5249,7 +5249,7 @@
   ],
   [
     "node/test_rms_normalization_3d_axis_negative_3_epsilon_expanded/model.onnx",
-    "ReduceMean output shape rank must match input rank"
+    ""
   ],
   [
     "node/test_rms_normalization_4d_axis0/model.onnx",
@@ -5257,7 +5257,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis0_expanded/model.onnx",
-    "ReduceMean output shape rank must match input rank"
+    ""
   ],
   [
     "node/test_rms_normalization_4d_axis1/model.onnx",
@@ -5265,7 +5265,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis1_expanded/model.onnx",
-    "ReduceMean output shape rank must match input rank"
+    "ReduceMean output shape must be (2, 1, 1, 1), got ()"
   ],
   [
     "node/test_rms_normalization_4d_axis2/model.onnx",
@@ -5273,7 +5273,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis2_expanded/model.onnx",
-    "ReduceMean output shape rank must match input rank"
+    "ReduceMean output shape must be (2, 3, 1, 1), got ()"
   ],
   [
     "node/test_rms_normalization_4d_axis3/model.onnx",
@@ -5281,7 +5281,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis3_expanded/model.onnx",
-    "ReduceMean output shape rank must match input rank"
+    "ReduceMean output shape must be (2, 3, 4, 1), got ()"
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_1/model.onnx",
@@ -5289,7 +5289,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_1_expanded/model.onnx",
-    "ReduceMean output shape rank must match input rank"
+    "ReduceMean output shape must be (2, 3, 4, 1), got ()"
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_2/model.onnx",
@@ -5297,7 +5297,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_2_expanded/model.onnx",
-    "ReduceMean output shape rank must match input rank"
+    "ReduceMean output shape must be (2, 3, 1, 1), got ()"
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_3/model.onnx",
@@ -5305,7 +5305,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_3_expanded/model.onnx",
-    "ReduceMean output shape rank must match input rank"
+    "ReduceMean output shape must be (2, 1, 1, 1), got ()"
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_4/model.onnx",
@@ -5313,7 +5313,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_4_expanded/model.onnx",
-    "ReduceMean output shape rank must match input rank"
+    ""
   ],
   [
     "node/test_rms_normalization_default_axis/model.onnx",
@@ -5321,7 +5321,7 @@
   ],
   [
     "node/test_rms_normalization_default_axis_expanded/model.onnx",
-    "ReduceMean output shape rank must match input rank"
+    "ReduceMean output shape must be (2, 3, 4, 1), got ()"
   ],
   [
     "node/test_rnn_seq_length/model.onnx",


### PR DESCRIPTION
### Motivation
- Fix spurious "ReduceMean output shape rank must match input rank" failures when a Reduce's `axes` input is computed via shape-only ops (e.g., `Shape`/`Size`/`Range`/`Add`/`Sub`/`Cast`/`Identity`).
- Avoid false-positive shape mismatches for keepdims reduces when both expected and inferred shapes contain only ones but differ in rank representation.

### Description
- Add `_axes_values_from_shape_ops` to evaluate axes inputs derived from shape-only subgraphs (supports `Identity`, `Cast`, `Shape`, `Size`, `Range`, `Add`, and `Sub`) and wire it into `resolve_reduce_axes` to prefer resolved axes over shape-inference heuristics. 
- Use `scalar_type_from_onnx` for `Cast` handling and `_find_initializer` caching to resolve intermediate constant values. 
- Relax strict keepdims output-shape equality in `_resolve_reduce_spec` by accepting cases where both expected and computed shapes are all-ones and have equal element counts (use helper `_all_ones_shape` and `_shape_product`).
- Update golden/reference files to reflect new behavior: `tests/official_onnx_expected_errors.json`, `OFFICIAL_ONNX_FILE_SUPPORT.md`, and `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`.

### Testing
- Ran the full test suite with reference updates using `UPDATE_REFS=1 pytest -n auto -q`, which completed in ~49.05s with `174 passed, 2 skipped` and 2 warnings. 
- Ran the official support doc update check with `UPDATE_REFS=1 pytest tests/test_official_onnx_files.py::test_official_onnx_file_support_doc -q`, which passed in ~0.82s and regenerated the support docs/references.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696885450220832588a53836ddebb507)