### PR TITLE
lowering: handle unknown reduce output shapes

### DIFF
--- a/src/onnx2c/lowering/reduce.py
+++ b/src/onnx2c/lowering/reduce.py
@@ -235,6 +235,16 @@ def _all_ones_shape(shape: tuple[int, ...]) -> bool:
     return all(dim == 1 for dim in shape)
 
 
+def _allow_unknown_reduce_output_shape(
+    expected_output_shape: tuple[int, ...],
+    output_shape: tuple[int, ...],
+    input_shape: tuple[int, ...],
+) -> bool:
+    if expected_output_shape != () or not output_shape or not input_shape:
+        return False
+    return True
+
+
 def _infer_axes_from_shapes(
     input_shape: tuple[int, ...],
     output_shape: tuple[int, ...],
@@ -431,7 +441,11 @@ def _resolve_reduce_spec(graph: Graph, node: Node) -> _ReduceSpec | None:
         )
     expected_output_shape = _value_shape(graph, node.outputs[0], node)
     if expected_output_shape != output_shape:
-        if not (
+        if _allow_unknown_reduce_output_shape(
+            expected_output_shape, output_shape, input_shape
+        ):
+            pass
+        elif not (
             _all_ones_shape(expected_output_shape)
             and _all_ones_shape(output_shape)
             and _shape_product(expected_output_shape)

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -5185,7 +5185,7 @@
   ],
   [
     "node/test_rms_normalization_2d_axis1_expanded/model.onnx",
-    "ReduceMean output shape must be (3, 1), got ()"
+    ""
   ],
   [
     "node/test_rms_normalization_2d_axis_negative_1/model.onnx",
@@ -5193,7 +5193,7 @@
   ],
   [
     "node/test_rms_normalization_2d_axis_negative_1_expanded/model.onnx",
-    "ReduceMean output shape must be (3, 1), got ()"
+    ""
   ],
   [
     "node/test_rms_normalization_2d_axis_negative_2/model.onnx",
@@ -5217,7 +5217,7 @@
   ],
   [
     "node/test_rms_normalization_3d_axis1_epsilon_expanded/model.onnx",
-    "ReduceMean output shape must be (2, 1, 1), got ()"
+    ""
   ],
   [
     "node/test_rms_normalization_3d_axis2_epsilon/model.onnx",
@@ -5225,7 +5225,7 @@
   ],
   [
     "node/test_rms_normalization_3d_axis2_epsilon_expanded/model.onnx",
-    "ReduceMean output shape must be (2, 3, 1), got ()"
+    ""
   ],
   [
     "node/test_rms_normalization_3d_axis_negative_1_epsilon/model.onnx",
@@ -5233,7 +5233,7 @@
   ],
   [
     "node/test_rms_normalization_3d_axis_negative_1_epsilon_expanded/model.onnx",
-    "ReduceMean output shape must be (2, 3, 1), got ()"
+    ""
   ],
   [
     "node/test_rms_normalization_3d_axis_negative_2_epsilon/model.onnx",
@@ -5241,7 +5241,7 @@
   ],
   [
     "node/test_rms_normalization_3d_axis_negative_2_epsilon_expanded/model.onnx",
-    "ReduceMean output shape must be (2, 1, 1), got ()"
+    ""
   ],
   [
     "node/test_rms_normalization_3d_axis_negative_3_epsilon/model.onnx",
@@ -5265,7 +5265,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis1_expanded/model.onnx",
-    "ReduceMean output shape must be (2, 1, 1, 1), got ()"
+    ""
   ],
   [
     "node/test_rms_normalization_4d_axis2/model.onnx",
@@ -5273,7 +5273,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis2_expanded/model.onnx",
-    "ReduceMean output shape must be (2, 3, 1, 1), got ()"
+    ""
   ],
   [
     "node/test_rms_normalization_4d_axis3/model.onnx",
@@ -5281,7 +5281,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis3_expanded/model.onnx",
-    "ReduceMean output shape must be (2, 3, 4, 1), got ()"
+    ""
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_1/model.onnx",
@@ -5289,7 +5289,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_1_expanded/model.onnx",
-    "ReduceMean output shape must be (2, 3, 4, 1), got ()"
+    ""
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_2/model.onnx",
@@ -5297,7 +5297,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_2_expanded/model.onnx",
-    "ReduceMean output shape must be (2, 3, 1, 1), got ()"
+    ""
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_3/model.onnx",
@@ -5305,7 +5305,7 @@
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_3_expanded/model.onnx",
-    "ReduceMean output shape must be (2, 1, 1, 1), got ()"
+    ""
   ],
   [
     "node/test_rms_normalization_4d_axis_negative_4/model.onnx",
@@ -5321,7 +5321,7 @@
   ],
   [
     "node/test_rms_normalization_default_axis_expanded/model.onnx",
-    "ReduceMean output shape must be (2, 3, 4, 1), got ()"
+    ""
   ],
   [
     "node/test_rnn_seq_length/model.onnx",


### PR DESCRIPTION
### Motivation
- Avoid spurious `ShapeInferenceError` when ONNX shape inference returns an empty inferred output shape for Reduce nodes while the reducer axes imply a non-scalar result.

### Description
- Add helper `
_allow_unknown_reduce_output_shape` in `src/onnx2c/lowering/reduce.py` to detect when an inferred `expected_output_shape` is empty but a non-empty computed `output_shape` exists.
- Use the helper to relax the strict output-shape check in `_resolve_reduce_spec` so models with empty inferred Reduce outputs can still lower when axes indicate a non-scalar result.
- Refresh `tests/official_onnx_expected_errors.json` to remove prior ReduceMean output-shape error expectations that are no longer applicable.

### Testing
- Ran `pytest tests/test_ops.py -k ReduceMeanAxis1` which completed successfully (`1 passed, 129 deselected`).
- Ran `UPDATE_REFS=1 pytest -n auto -q` which completed successfully (`174 passed, 2 skipped, 2 warnings`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69688ced1e448325885cffe4d6cacf99)