### PR TITLE
lowering: handle reshape zero-element inference

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1089 / 1802 official ONNX files.
+Support 1102 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -1304,41 +1304,41 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_rms_normalization_2d_axis0/model.onnx | ✅ |  |
 | node/test_rms_normalization_2d_axis0_expanded/model.onnx | ✅ |  |
 | node/test_rms_normalization_2d_axis1/model.onnx | ✅ |  |
-| node/test_rms_normalization_2d_axis1_expanded/model.onnx | ❌ | ReduceMean output shape must be (3, 1), got () |
+| node/test_rms_normalization_2d_axis1_expanded/model.onnx | ✅ |  |
 | node/test_rms_normalization_2d_axis_negative_1/model.onnx | ✅ |  |
-| node/test_rms_normalization_2d_axis_negative_1_expanded/model.onnx | ❌ | ReduceMean output shape must be (3, 1), got () |
+| node/test_rms_normalization_2d_axis_negative_1_expanded/model.onnx | ✅ |  |
 | node/test_rms_normalization_2d_axis_negative_2/model.onnx | ✅ |  |
 | node/test_rms_normalization_2d_axis_negative_2_expanded/model.onnx | ✅ |  |
 | node/test_rms_normalization_3d_axis0_epsilon/model.onnx | ✅ |  |
 | node/test_rms_normalization_3d_axis0_epsilon_expanded/model.onnx | ✅ |  |
 | node/test_rms_normalization_3d_axis1_epsilon/model.onnx | ✅ |  |
-| node/test_rms_normalization_3d_axis1_epsilon_expanded/model.onnx | ❌ | ReduceMean output shape must be (2, 1, 1), got () |
+| node/test_rms_normalization_3d_axis1_epsilon_expanded/model.onnx | ✅ |  |
 | node/test_rms_normalization_3d_axis2_epsilon/model.onnx | ✅ |  |
-| node/test_rms_normalization_3d_axis2_epsilon_expanded/model.onnx | ❌ | ReduceMean output shape must be (2, 3, 1), got () |
+| node/test_rms_normalization_3d_axis2_epsilon_expanded/model.onnx | ✅ |  |
 | node/test_rms_normalization_3d_axis_negative_1_epsilon/model.onnx | ✅ |  |
-| node/test_rms_normalization_3d_axis_negative_1_epsilon_expanded/model.onnx | ❌ | ReduceMean output shape must be (2, 3, 1), got () |
+| node/test_rms_normalization_3d_axis_negative_1_epsilon_expanded/model.onnx | ✅ |  |
 | node/test_rms_normalization_3d_axis_negative_2_epsilon/model.onnx | ✅ |  |
-| node/test_rms_normalization_3d_axis_negative_2_epsilon_expanded/model.onnx | ❌ | ReduceMean output shape must be (2, 1, 1), got () |
+| node/test_rms_normalization_3d_axis_negative_2_epsilon_expanded/model.onnx | ✅ |  |
 | node/test_rms_normalization_3d_axis_negative_3_epsilon/model.onnx | ✅ |  |
 | node/test_rms_normalization_3d_axis_negative_3_epsilon_expanded/model.onnx | ✅ |  |
 | node/test_rms_normalization_4d_axis0/model.onnx | ✅ |  |
 | node/test_rms_normalization_4d_axis0_expanded/model.onnx | ✅ |  |
 | node/test_rms_normalization_4d_axis1/model.onnx | ✅ |  |
-| node/test_rms_normalization_4d_axis1_expanded/model.onnx | ❌ | ReduceMean output shape must be (2, 1, 1, 1), got () |
+| node/test_rms_normalization_4d_axis1_expanded/model.onnx | ✅ |  |
 | node/test_rms_normalization_4d_axis2/model.onnx | ✅ |  |
-| node/test_rms_normalization_4d_axis2_expanded/model.onnx | ❌ | ReduceMean output shape must be (2, 3, 1, 1), got () |
+| node/test_rms_normalization_4d_axis2_expanded/model.onnx | ✅ |  |
 | node/test_rms_normalization_4d_axis3/model.onnx | ✅ |  |
-| node/test_rms_normalization_4d_axis3_expanded/model.onnx | ❌ | ReduceMean output shape must be (2, 3, 4, 1), got () |
+| node/test_rms_normalization_4d_axis3_expanded/model.onnx | ✅ |  |
 | node/test_rms_normalization_4d_axis_negative_1/model.onnx | ✅ |  |
-| node/test_rms_normalization_4d_axis_negative_1_expanded/model.onnx | ❌ | ReduceMean output shape must be (2, 3, 4, 1), got () |
+| node/test_rms_normalization_4d_axis_negative_1_expanded/model.onnx | ✅ |  |
 | node/test_rms_normalization_4d_axis_negative_2/model.onnx | ✅ |  |
-| node/test_rms_normalization_4d_axis_negative_2_expanded/model.onnx | ❌ | ReduceMean output shape must be (2, 3, 1, 1), got () |
+| node/test_rms_normalization_4d_axis_negative_2_expanded/model.onnx | ✅ |  |
 | node/test_rms_normalization_4d_axis_negative_3/model.onnx | ✅ |  |
-| node/test_rms_normalization_4d_axis_negative_3_expanded/model.onnx | ❌ | ReduceMean output shape must be (2, 1, 1, 1), got () |
+| node/test_rms_normalization_4d_axis_negative_3_expanded/model.onnx | ✅ |  |
 | node/test_rms_normalization_4d_axis_negative_4/model.onnx | ✅ |  |
 | node/test_rms_normalization_4d_axis_negative_4_expanded/model.onnx | ✅ |  |
 | node/test_rms_normalization_default_axis/model.onnx | ✅ |  |
-| node/test_rms_normalization_default_axis_expanded/model.onnx | ❌ | ReduceMean output shape must be (2, 3, 4, 1), got () |
+| node/test_rms_normalization_default_axis_expanded/model.onnx | ✅ |  |
 | node/test_rnn_seq_length/model.onnx | ❌ | Unsupported op RNN |
 | node/test_roialign_aligned_false/model.onnx | ❌ | Unsupported op RoiAlign |
 | node/test_roialign_aligned_true/model.onnx | ❌ | Unsupported op RoiAlign |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -73,7 +73,6 @@
 | LeakyRelu only supports alpha=0.01 | 3 | ██ |
 | Unsupported op Loop | 3 | ██ |
 | Unsupported op Momentum | 3 | ██ |
-| ReduceMean output shape must be (2, 3, 4, 1), got () | 3 | ██ |
 | Unsupported op RoiAlign | 3 | ██ |
 | Unsupported op TensorScatter | 3 | ██ |
 | Unsupported op Adagrad | 2 | ██ |
@@ -96,11 +95,6 @@
 | Pow expects matching dtypes, got float, int32 | 2 | ██ |
 | Pow expects matching dtypes, got float, int64 | 2 | ██ |
 | Unsupported op ReverseSequence | 2 | ██ |
-| ReduceMean output shape must be (3, 1), got () | 2 | ██ |
-| ReduceMean output shape must be (2, 1, 1), got () | 2 | ██ |
-| ReduceMean output shape must be (2, 3, 1), got () | 2 | ██ |
-| ReduceMean output shape must be (2, 1, 1, 1), got () | 2 | ██ |
-| ReduceMean output shape must be (2, 3, 1, 1), got () | 2 | ██ |
 | Unsupported op Scan | 2 | ██ |
 | Unsupported op Scatter | 2 | ██ |
 | Selu only supports alpha=1.6732632423543772 | 2 | ██ |

--- a/src/onnx2c/lowering/reshape.py
+++ b/src/onnx2c/lowering/reshape.py
@@ -75,6 +75,7 @@ def _resolve_target_shape(
     output_dims: list[int] = []
     unknown_index: int | None = None
     known_product = 1
+    contains_zero = False
     for index, dim in enumerate(shape_values):
         if dim == -1:
             if unknown_index is not None:
@@ -83,6 +84,7 @@ def _resolve_target_shape(
             output_dims.append(-1)
             continue
         if dim == 0:
+            contains_zero = True
             if allowzero == 0:
                 if index >= len(input_shape):
                     raise ShapeInferenceError(
@@ -93,13 +95,24 @@ def _resolve_target_shape(
             raise ShapeInferenceError("Reshape dims must be >= -1")
         output_dims.append(dim)
         known_product *= dim
+    if allowzero == 1 and contains_zero and unknown_index is not None:
+        raise ShapeInferenceError(
+            "Reshape allowzero cannot combine zero and -1 dimensions"
+        )
     input_product = _shape_product(input_shape)
     if unknown_index is not None:
-        if known_product == 0 or input_product % known_product != 0:
-            raise ShapeInferenceError(
-                "Reshape cannot infer dimension from input shape"
-            )
-        output_dims[unknown_index] = input_product // known_product
+        if known_product == 0:
+            if input_product != 0:
+                raise ShapeInferenceError(
+                    "Reshape cannot infer dimension from input shape"
+                )
+            output_dims[unknown_index] = 0
+        else:
+            if input_product % known_product != 0:
+                raise ShapeInferenceError(
+                    "Reshape cannot infer dimension from input shape"
+                )
+            output_dims[unknown_index] = input_product // known_product
     output_shape = tuple(output_dims)
     if _shape_product(output_shape) != input_product:
         raise ShapeInferenceError(


### PR DESCRIPTION
### Motivation
- Fix reshape shape inference failures where input/output element counts were reported as mismatched when zero-sized dimensions were involved.
- Ensure `Reshape` semantics follow ONNX: support inference when element counts are zero while enforcing `allowzero` constraints and predictable errors.

### Description
- Update `_resolve_target_shape` in `src/onnx2c/lowering/reshape.py` to track zero dimensions and handle the case where the known product is zero by permitting inference to yield a zero dimension when the input product is also zero, otherwise raising a `ShapeInferenceError`.
- Add validation that prohibits combining a zero dimension with a `-1` inference when `allowzero=1`, raising a `ShapeInferenceError` with a clear message.
- Left existing dtype/shape validations intact and refreshed the generated ONNX support reports (`OFFICIAL_ONNX_FILE_SUPPORT.md` and `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`) to reflect the updated behavior.

### Testing
- Ran `pytest -q tests/test_ops.py -k Reshape` which passed (`1 passed, 129 deselected`) in `2.37s`.
- Ran the full test run with reference updates `UPDATE_REFS=1 pytest -n auto -q` which completed successfully (`174 passed, 2 skipped`) in `48.23s` and refreshed the official support reports.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69688fd41808832596c60ddd7fde1c96)