### PR TITLE
lowering: support Pad axes input

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1120 / 1802 official ONNX files.
+Support 1132 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 

--- a/templates/pad_op.c.j2
+++ b/templates/pad_op.c.j2
@@ -1,5 +1,24 @@
-static inline void {{ op_name }}({{ dim_args }}const {{ c_type }} {{ input0 }}{{ input_suffix }}{% if pads_input %}, const {{ pads_c_type }} {{ pads_input }}{{ pads_suffix }}{% endif %}{% if value_input %}, const {{ c_type }} {{ value_input }}{{ value_suffix }}{% endif %}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+static inline void {{ op_name }}({{ dim_args }}const {{ c_type }} {{ input0 }}{{ input_suffix }}{% if pads_input %}, const {{ pads_c_type }} {{ pads_input }}{{ pads_suffix }}{% endif %}{% if axes_input %}, const {{ axes_c_type }} {{ axes_input }}{{ axes_suffix }}{% endif %}{% if value_input %}, const {{ c_type }} {{ value_input }}{{ value_suffix }}{% endif %}, {{ c_type }} {{ output }}{{ output_suffix }}) {
 const {{ c_type }} *{{ input0_flat }} = (const {{ c_type }} *){{ input0 }};
+{% if axes_input %}
+{% if pads_values %}
+const {{ pads_c_type }} pad_values[] = { {% for value in pads_values %}{{ value }}{{ ", " if not loop.last else "" }}{% endfor %} };
+{% endif %}
+ptrdiff_t pad_begin[{{ output_shape|length }}];
+for (size_t pad_index = 0; pad_index < {{ output_shape|length }}; ++pad_index) {
+    pad_begin[pad_index] = 0;
+}
+for (size_t axis_index = 0; axis_index < {{ axes_length }}; ++axis_index) {
+    ptrdiff_t axis = (ptrdiff_t){{ axes_input }}[axis_index];
+    if (axis < 0) {
+        axis += {{ output_shape|length }};
+    }
+    if (axis < 0 || axis >= (ptrdiff_t){{ output_shape|length }}) {
+        continue;
+    }
+    pad_begin[axis] = {% if pads_input %}{{ pads_input }}[axis_index]{% else %}pad_values[axis_index]{% endif %};
+}
+{% endif %}
 {% for dim in output_shape %}
 for (size_t {{ out_loop_vars[loop.index0] }} = 0; {{ out_loop_vars[loop.index0] }} < {{ dim }}; ++{{ out_loop_vars[loop.index0] }}) {
 {% endfor %}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -617,7 +617,7 @@
   ],
   [
     "node/test_attention_4d_diff_heads_mask4d_padded_kv_expanded/model.onnx",
-    "Pad axes input must be a constant initializer"
+    "Pad value input must be a scalar"
   ],
   [
     "node/test_attention_4d_diff_heads_sizes/model.onnx",
@@ -1821,7 +1821,7 @@
   ],
   [
     "node/test_center_crop_pad_crop_axes_chw_expanded/model.onnx",
-    "Pad axes input must be a constant initializer"
+    ""
   ],
   [
     "node/test_center_crop_pad_crop_axes_hwc/model.onnx",
@@ -1829,7 +1829,7 @@
   ],
   [
     "node/test_center_crop_pad_crop_axes_hwc_expanded/model.onnx",
-    "Pad axes input must be a constant initializer"
+    ""
   ],
   [
     "node/test_center_crop_pad_crop_expanded/model.onnx",
@@ -1841,7 +1841,7 @@
   ],
   [
     "node/test_center_crop_pad_crop_negative_axes_hwc_expanded/model.onnx",
-    "Pad axes input must be a constant initializer"
+    ""
   ],
   [
     "node/test_center_crop_pad_pad/model.onnx",
@@ -2041,11 +2041,11 @@
   ],
   [
     "node/test_constant_pad_axes/model.onnx",
-    "Pad axes input must be a constant initializer"
+    ""
   ],
   [
     "node/test_constant_pad_negative_axes/model.onnx",
-    "Pad axes input must be a constant initializer"
+    ""
   ],
   [
     "node/test_constantofshape_float_ones/model.onnx",

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -2579,7 +2579,7 @@ def test_lower_flatten_negative_axis() -> None:
     assert op.output_shape == (6, 4)
 
 
-def test_lower_pad_dynamic_axes_rejected() -> None:
+def test_lower_pad_dynamic_axes_input() -> None:
     input_info = helper.make_tensor_value_info(
         "input", TensorProto.FLOAT, [2, 3]
     )
@@ -2608,10 +2608,13 @@ def test_lower_pad_dynamic_axes_rejected() -> None:
     model.ir_version = 7
     onnx.checker.check_model(model)
     graph = import_onnx(model)
-    with pytest.raises(
-        UnsupportedOpError, match="Pad axes input must be a constant initializer"
-    ):
-        get_lowering("Pad")(graph, graph.nodes[0])
+    op = get_lowering("Pad")(graph, graph.nodes[0])
+    assert op.pads_input == "pads"
+    assert op.pads_shape == (4,)
+    assert op.axes_input == "axes"
+    assert op.axes_shape == (2,)
+    assert op.pads_begin is None
+    assert op.pads_end is None
 
 
 def test_lower_squeeze_axes_input() -> None:


### PR DESCRIPTION
### Motivation

- ONNX `Pad` can provide `axes` as a runtime input and `pads` can be provided either as an input or attribute, so lowering must accept dynamic axes/pads instead of rejecting them. 
- Replace the previous test that expected rejection with a test that verifies proper lowering for dynamic axes/pads.

### Description

- Extend lowering for `Pad` to accept an `axes` input and to produce metadata for mapped pads (`pads_axis_map`, `pads_values`, `axes_input`, `axes_shape`, `axes_dtype`) when appropriate in `src/onnx2c/lowering/pad.py`.
- Extend the `PadOp` dataclass and propagate new fields through the emitter (`src/onnx2c/codegen/c_emitter.py`) so codegen can handle axis-indexed pads and dynamic axes inputs.
- Update the C emission template `templates/pad_op.c.j2` to compute `pad_begin` at runtime when `axes` is dynamic and to support pads provided as either an input array or baked-in values.
- Update runtime evaluator `src/onnx2c/runtime/evaluator.py` to compute `pad_width` correctly for cases where `axes`/`pads` are dynamic or partially mapped.
- Replace the test `test_lower_pad_dynamic_axes_rejected` with `test_lower_pad_dynamic_axes_input` to assert that dynamic `pads` + `axes` lower into the expected op fields, and refresh the official ONNX support/expected-errors references.

### Testing

- Ran the targeted test: `pytest -n auto -q tests/test_ops.py -k pad_dynamic_axes_input` which passed (1 test; duration 11.17s).
- Ran the full test run with references updated: `UPDATE_REFS=1 pytest -n auto -q` which completed successfully (179 passed, 2 skipped, 2 warnings; total test run 128.08s).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6968aab6c2cc8325b7b22863b8ca63f7)