### PR TITLE
tests: update official ONNX support references

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1132 / 1802 official ONNX files.
+Support 1137 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -162,7 +162,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_attention_4d_causal/model.onnx | ✅ |  |
 | node/test_attention_4d_causal_expanded/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_mask4d_padded_kv/model.onnx | ✅ |  |
-| node/test_attention_4d_diff_heads_mask4d_padded_kv_expanded/model.onnx | ❌ | Pad axes input must be a constant initializer |
+| node/test_attention_4d_diff_heads_mask4d_padded_kv_expanded/model.onnx | ❌ | Pad value input must be a scalar |
 | node/test_attention_4d_diff_heads_sizes/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_sizes_attn_mask/model.onnx | ✅ |  |
 | node/test_attention_4d_diff_heads_sizes_attn_mask_expanded/model.onnx | ✅ |  |
@@ -463,12 +463,12 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_center_crop_pad_crop_and_pad/model.onnx | ❌ | Unsupported op CenterCropPad |
 | node/test_center_crop_pad_crop_and_pad_expanded/model.onnx | ✅ |  |
 | node/test_center_crop_pad_crop_axes_chw/model.onnx | ❌ | Unsupported op CenterCropPad |
-| node/test_center_crop_pad_crop_axes_chw_expanded/model.onnx | ❌ | Pad axes input must be a constant initializer |
+| node/test_center_crop_pad_crop_axes_chw_expanded/model.onnx | ✅ |  |
 | node/test_center_crop_pad_crop_axes_hwc/model.onnx | ❌ | Unsupported op CenterCropPad |
-| node/test_center_crop_pad_crop_axes_hwc_expanded/model.onnx | ❌ | Pad axes input must be a constant initializer |
+| node/test_center_crop_pad_crop_axes_hwc_expanded/model.onnx | ✅ |  |
 | node/test_center_crop_pad_crop_expanded/model.onnx | ✅ |  |
 | node/test_center_crop_pad_crop_negative_axes_hwc/model.onnx | ❌ | Unsupported op CenterCropPad |
-| node/test_center_crop_pad_crop_negative_axes_hwc_expanded/model.onnx | ❌ | Pad axes input must be a constant initializer |
+| node/test_center_crop_pad_crop_negative_axes_hwc_expanded/model.onnx | ✅ |  |
 | node/test_center_crop_pad_pad/model.onnx | ❌ | Unsupported op CenterCropPad |
 | node/test_center_crop_pad_pad_expanded/model.onnx | ✅ |  |
 | node/test_clip/model.onnx | ❌ | 'ClipOp' object has no attribute 'shape' |
@@ -518,8 +518,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_concat_3d_axis_negative_3/model.onnx | ✅ |  |
 | node/test_constant/model.onnx | ❌ | Graph must contain at least one node |
 | node/test_constant_pad/model.onnx | ✅ |  |
-| node/test_constant_pad_axes/model.onnx | ❌ | Pad axes input must be a constant initializer |
-| node/test_constant_pad_negative_axes/model.onnx | ❌ | Pad axes input must be a constant initializer |
+| node/test_constant_pad_axes/model.onnx | ✅ |  |
+| node/test_constant_pad_negative_axes/model.onnx | ✅ |  |
 | node/test_constantofshape_float_ones/model.onnx | ✅ |  |
 | node/test_constantofshape_int_shape_zero/model.onnx | ❌ | Output shape must be fully defined |
 | node/test_constantofshape_int_zeros/model.onnx | ✅ |  |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -32,7 +32,6 @@
 | Unsupported op Hardmax | 7 | ██████ |
 | Unsupported op TfIdfVectorizer | 7 | ██████ |
 | Unsupported op TopK | 7 | ██████ |
-| Pad axes input must be a constant initializer | 6 | █████ |
 | AveragePool has unsupported attributes | 6 | █████ |
 | Cast input and output shapes must match | 6 | █████ |
 | Unsupported elem_type 16 (BFLOAT16) for tensor '*'. | 6 | █████ |
@@ -103,6 +102,7 @@
 | Unsupported op Gradient | 2 | ██ |
 | Unsupported op ArrayFeatureExtractor | 1 | █ |
 | Unsupported op Binarizer | 1 | █ |
+| Pad value input must be a scalar | 1 | █ |
 | Graph must contain at least one node | 1 | █ |
 | Dropout mask output is not supported | 1 | █ |
 | Unsupported op MatMulInteger | 1 | █ |


### PR DESCRIPTION
### Motivation
- Refresh the official ONNX support report to reflect updated test outcomes and capture a new failure reason discovered during reference generation.

### Description
- Update `OFFICIAL_ONNX_FILE_SUPPORT.md` and `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md` to adjust the supported count, fix several per-file support statuses, and add the new error category `Pad value input must be a scalar` in the histogram.

### Testing
- Ran `UPDATE_REFS=1 pytest -n auto -q`, which completed successfully with `179 passed, 2 skipped, 2 warnings` in `40.72s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6968bc3de6d48325aa424d29fd956dc3)