### PR TITLE
codegen: add CumSum operator (lowering, runtime, codegen, tests)

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1137 / 1802 official ONNX files.
+Support 1146 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -544,15 +544,15 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | node/test_cos_example/model.onnx | ✅ |  |
 | node/test_cosh/model.onnx | ✅ |  |
 | node/test_cosh_example/model.onnx | ✅ |  |
-| node/test_cumsum_1d/model.onnx | ❌ | Unsupported op CumSum |
-| node/test_cumsum_1d_exclusive/model.onnx | ❌ | Unsupported op CumSum |
-| node/test_cumsum_1d_int32_exclusive/model.onnx | ❌ | Unsupported op CumSum |
-| node/test_cumsum_1d_reverse/model.onnx | ❌ | Unsupported op CumSum |
-| node/test_cumsum_1d_reverse_exclusive/model.onnx | ❌ | Unsupported op CumSum |
-| node/test_cumsum_2d_axis_0/model.onnx | ❌ | Unsupported op CumSum |
-| node/test_cumsum_2d_axis_1/model.onnx | ❌ | Unsupported op CumSum |
-| node/test_cumsum_2d_int32/model.onnx | ❌ | Unsupported op CumSum |
-| node/test_cumsum_2d_negative_axis/model.onnx | ❌ | Unsupported op CumSum |
+| node/test_cumsum_1d/model.onnx | ✅ |  |
+| node/test_cumsum_1d_exclusive/model.onnx | ✅ |  |
+| node/test_cumsum_1d_int32_exclusive/model.onnx | ✅ |  |
+| node/test_cumsum_1d_reverse/model.onnx | ✅ |  |
+| node/test_cumsum_1d_reverse_exclusive/model.onnx | ✅ |  |
+| node/test_cumsum_2d_axis_0/model.onnx | ✅ |  |
+| node/test_cumsum_2d_axis_1/model.onnx | ✅ |  |
+| node/test_cumsum_2d_int32/model.onnx | ✅ |  |
+| node/test_cumsum_2d_negative_axis/model.onnx | ✅ |  |
 | node/test_deform_conv_with_mask_bias/model.onnx | ❌ | Unsupported op DeformConv |
 | node/test_deform_conv_with_multiple_offset_groups/model.onnx | ❌ | Unsupported op DeformConv |
 | node/test_depthtospace_crd_mode_example/model.onnx | ✅ |  |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -19,7 +19,6 @@
 | '*' object has no attribute '*' | 13 | ███████████ |
 | ReduceSum output shape rank must match input rank | 12 | ██████████ |
 | Output shape must be fully defined | 9 | ████████ |
-| Unsupported op CumSum | 9 | ████████ |
 | Unsupported op QuantizeLinear | 9 | ████████ |
 | Unsupported op ImageDecoder | 9 | ████████ |
 | Unsupported op NonMaxSuppression | 9 | ████████ |

--- a/src/onnx2c/codegen/c_emitter.py
+++ b/src/onnx2c/codegen/c_emitter.py
@@ -831,6 +831,20 @@ class ExpandOp:
 
 
 @dataclass(frozen=True)
+class CumSumOp:
+    input0: str
+    axis_input: str | None
+    axis_input_dtype: ScalarType | None
+    axis: int | None
+    output: str
+    input_shape: tuple[int, ...]
+    dtype: ScalarType
+    input_dtype: ScalarType
+    exclusive: bool
+    reverse: bool
+
+
+@dataclass(frozen=True)
 class RangeOp:
     start: str
     limit: str
@@ -947,6 +961,7 @@ class LoweredModel:
         | ShapeOp
         | SizeOp
         | ExpandOp
+        | CumSumOp
         | RangeOp
         | SplitOp,
         ...,
@@ -1046,6 +1061,7 @@ class CEmitter:
         | ShapeOp
         | SizeOp
         | ExpandOp
+        | CumSumOp
         | RangeOp
         | SplitOp,
     ) -> tuple[str, ...]:
@@ -1177,6 +1193,12 @@ class CEmitter:
             return (op.input0, op.output)
         if isinstance(op, ExpandOp):
             return (op.input0, op.output)
+        if isinstance(op, CumSumOp):
+            names = [op.input0]
+            if op.axis_input is not None:
+                names.append(op.axis_input)
+            names.append(op.output)
+            return tuple(names)
         if isinstance(op, RangeOp):
             return (op.start, op.limit, op.delta, op.output)
         if isinstance(op, SplitOp):
@@ -1307,6 +1329,7 @@ class CEmitter:
         | ShapeOp
         | SizeOp
         | ExpandOp
+        | CumSumOp
         | RangeOp
         | SplitOp,
         name_map: dict[str, str],
@@ -1356,6 +1379,7 @@ class CEmitter:
         | ShapeOp
         | SizeOp
         | ExpandOp
+        | CumSumOp
         | RangeOp
         | SplitOp
     ):
@@ -2046,6 +2070,19 @@ class CEmitter:
                 dtype=op.dtype,
                 input_dtype=op.input_dtype,
             )
+        if isinstance(op, CumSumOp):
+            return CumSumOp(
+                input0=name_map.get(op.input0, op.input0),
+                axis_input=self._map_optional_name(name_map, op.axis_input),
+                axis_input_dtype=op.axis_input_dtype,
+                axis=op.axis,
+                output=name_map.get(op.output, op.output),
+                input_shape=op.input_shape,
+                dtype=op.dtype,
+                input_dtype=op.input_dtype,
+                exclusive=op.exclusive,
+                reverse=op.reverse,
+            )
         if isinstance(op, RangeOp):
             return RangeOp(
                 start=name_map.get(op.start, op.start),
@@ -2196,6 +2233,7 @@ class CEmitter:
                 "shape": self._env.get_template("shape_op.c.j2"),
                 "size": self._env.get_template("size_op.c.j2"),
                 "expand": self._env.get_template("expand_op.c.j2"),
+                "cumsum": self._env.get_template("cumsum_op.c.j2"),
                 "range": self._env.get_template("range_op.c.j2"),
                 "split": self._env.get_template("split_op.c.j2"),
             }
@@ -2284,6 +2322,7 @@ class CEmitter:
         shape_template = templates["shape"]
         size_template = templates["size"]
         expand_template = templates["expand"]
+        cumsum_template = templates["cumsum"]
         range_template = templates["range"]
         split_template = templates["split"]
         testbench_template = templates.get("testbench")
@@ -2357,6 +2396,7 @@ class CEmitter:
                 shape_template=shape_template,
                 size_template=size_template,
                 expand_template=expand_template,
+                cumsum_template=cumsum_template,
                 range_template=range_template,
                 split_template=split_template,
                 scalar_registry=scalar_registry,
@@ -2503,6 +2543,7 @@ class CEmitter:
         shape_template = templates["shape"]
         size_template = templates["size"]
         expand_template = templates["expand"]
+        cumsum_template = templates["cumsum"]
         range_template = templates["range"]
         split_template = templates["split"]
         testbench_template = templates.get("testbench")
@@ -2576,6 +2617,7 @@ class CEmitter:
                 shape_template=shape_template,
                 size_template=size_template,
                 expand_template=expand_template,
+                cumsum_template=cumsum_template,
                 range_template=range_template,
                 split_template=split_template,
                 scalar_registry=scalar_registry,
@@ -2897,6 +2939,7 @@ class CEmitter:
             | ShapeOp
             | SizeOp
             | ExpandOp
+            | CumSumOp
             | RangeOp
             | SplitOp
         ],
@@ -3077,6 +3120,7 @@ class CEmitter:
             | ShapeOp
             | SizeOp
             | ExpandOp
+            | CumSumOp
             | RangeOp
             | SplitOp
         ],
@@ -3221,6 +3265,7 @@ class CEmitter:
             | ShapeOp
             | SizeOp
             | ExpandOp
+            | CumSumOp
             | RangeOp
             | SplitOp
         ],
@@ -3300,6 +3345,7 @@ class CEmitter:
             | ShapeOp
             | SizeOp
             | ExpandOp
+            | CumSumOp
             | RangeOp
             | SplitOp
         ],
@@ -3385,6 +3431,7 @@ class CEmitter:
         | ShapeOp
         | SizeOp
         | ExpandOp
+        | CumSumOp
         | RangeOp
         | SplitOp,
         dim_order: Sequence[str],
@@ -3547,6 +3594,12 @@ class CEmitter:
         if isinstance(op, ExpandOp):
             args.extend([op.input0, op.output])
             return ", ".join(args)
+        if isinstance(op, CumSumOp):
+            args.append(op.input0)
+            if op.axis_input is not None:
+                args.append(op.axis_input)
+            args.append(op.output)
+            return ", ".join(args)
         if isinstance(op, RangeOp):
             args.extend([op.start, op.limit, op.delta, op.output])
             return ", ".join(args)
@@ -3691,6 +3744,7 @@ class CEmitter:
         | ShapeOp
         | SizeOp
         | ExpandOp
+        | CumSumOp
         | RangeOp
         | SplitOp,
         temp_map: dict[str, str],
@@ -3739,6 +3793,7 @@ class CEmitter:
         | ShapeOp
         | SizeOp
         | ExpandOp
+        | CumSumOp
         | RangeOp
         | SplitOp
     ):
@@ -4309,6 +4364,19 @@ class CEmitter:
                 dtype=op.dtype,
                 input_dtype=op.input_dtype,
             )
+        if isinstance(op, CumSumOp):
+            return CumSumOp(
+                input0=temp_map.get(op.input0, op.input0),
+                axis_input=CEmitter._map_optional_name(temp_map, op.axis_input),
+                axis_input_dtype=op.axis_input_dtype,
+                axis=op.axis,
+                output=temp_map.get(op.output, op.output),
+                input_shape=op.input_shape,
+                dtype=op.dtype,
+                input_dtype=op.input_dtype,
+                exclusive=op.exclusive,
+                reverse=op.reverse,
+            )
         if isinstance(op, RangeOp):
             return RangeOp(
                 start=temp_map.get(op.start, op.start),
@@ -4608,6 +4676,7 @@ class CEmitter:
         | ShapeOp
         | SizeOp
         | ExpandOp
+        | CumSumOp
         | RangeOp
         | SplitOp,
         index: int,
@@ -4665,6 +4734,7 @@ class CEmitter:
         shape_template,
         size_template,
         expand_template,
+        cumsum_template,
         range_template,
         split_template,
         scalar_registry: ScalarFunctionRegistry | None = None,
@@ -6750,6 +6820,44 @@ class CEmitter:
                 input_index_expr=input_index_expr,
             ).rstrip()
             return with_node_comment(rendered)
+        if isinstance(op, CumSumOp):
+            params = self._unique_param_map(
+                [
+                    ("input0", op.input0),
+                    ("axis_input", op.axis_input),
+                    ("output", op.output),
+                ]
+            )
+            input_dim_names = _dim_names_for(op.input0)
+            output_dim_names = _dim_names_for(op.output)
+            axis_c_type = (
+                op.axis_input_dtype.c_type if op.axis_input_dtype else "int64_t"
+            )
+            rendered = cumsum_template.render(
+                model_name=model.name,
+                op_name=f"{model.name}_op{index}",
+                input0=params["input0"],
+                axis_input=params["axis_input"],
+                axis_c_type=axis_c_type,
+                axis_suffix=self._param_array_suffix(()),
+                axis_literal=op.axis,
+                output=params["output"],
+                c_type=c_type,
+                input_suffix=self._param_array_suffix(
+                    op.input_shape, input_dim_names
+                ),
+                output_suffix=self._param_array_suffix(
+                    op.input_shape, output_dim_names
+                ),
+                input_shape=CEmitter._shape_dim_exprs(
+                    op.input_shape, input_dim_names
+                ),
+                rank=len(op.input_shape),
+                exclusive=op.exclusive,
+                reverse=op.reverse,
+                dim_args=dim_args,
+            ).rstrip()
+            return with_node_comment(rendered)
         if isinstance(op, RangeOp):
             params = self._unique_param_map(
                 [
@@ -7001,6 +7109,7 @@ class CEmitter:
         | ShapeOp
         | SizeOp
         | ExpandOp
+        | CumSumOp
         | RangeOp
         | SplitOp,
     ) -> str:
@@ -7054,6 +7163,7 @@ class CEmitter:
         | ShapeOp
         | SizeOp
         | ExpandOp
+        | CumSumOp
         | RangeOp
         | SplitOp,
     ) -> tuple[tuple[str, tuple[int, ...]], ...]:
@@ -7105,6 +7215,8 @@ class CEmitter:
             if op.value_input is not None and op.value_shape is not None:
                 inputs.append((op.value_input, op.value_shape))
             return tuple(inputs)
+        if isinstance(op, CumSumOp):
+            return ((op.input0, op.input_shape),)
         return ()
 
     def _propagate_tensor_dim_names(
@@ -7355,6 +7467,7 @@ class CEmitter:
         | ShapeOp
         | SizeOp
         | ExpandOp
+        | CumSumOp
         | RangeOp
         | SplitOp
         | PadOp,
@@ -7445,6 +7558,8 @@ class CEmitter:
             return op.output_shape
         if isinstance(op, ExpandOp):
             return op.output_shape
+        if isinstance(op, CumSumOp):
+            return op.input_shape
         if isinstance(op, RangeOp):
             return op.output_shape
         if op.output_rank == 3:
@@ -7488,6 +7603,7 @@ class CEmitter:
         | ShapeOp
         | SizeOp
         | ExpandOp
+        | CumSumOp
         | RangeOp
         | SplitOp
         | PadOp,

--- a/src/onnx2c/compiler.py
+++ b/src/onnx2c/compiler.py
@@ -29,6 +29,7 @@ from .codegen.c_emitter import (
     ConvOp,
     ConcatOp,
     ConstantOfShapeOp,
+    CumSumOp,
     GemmOp,
     GatherOp,
     GatherElementsOp,
@@ -79,6 +80,7 @@ from .lowering.common import (
 from .lowering.conv import ConvSpec, resolve_conv_spec
 from .lowering.constant_of_shape import lower_constant_of_shape
 from .lowering.dropout import lower_dropout
+from .lowering import cumsum as _cumsum  # noqa: F401
 from .lowering.flatten import lower_flatten
 from .lowering.gather import lower_gather
 from .lowering.gather_elements import lower_gather_elements
@@ -361,6 +363,7 @@ class Compiler:
             | ShapeOp
             | PadOp
             | ExpandOp
+            | CumSumOp
             | RangeOp
             | SplitOp
         ],
@@ -404,6 +407,7 @@ class Compiler:
             | ShapeOp
             | PadOp
             | ExpandOp
+            | CumSumOp
             | RangeOp
             | SplitOp
             | WhereOp

--- a/src/onnx2c/lowering/cumsum.py
+++ b/src/onnx2c/lowering/cumsum.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import numpy as np
+
+from shared.scalar_types import ScalarType
+
+from ..codegen.c_emitter import CumSumOp
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Initializer, Node
+from ..lowering.common import value_dtype, value_shape
+from ..validation import ensure_output_shape_matches_input, normalize_axis
+from .registry import register_lowering
+
+
+_SUPPORTED_CUMSUM_DTYPES = {
+    ScalarType.F16,
+    ScalarType.F32,
+    ScalarType.F64,
+    ScalarType.I32,
+    ScalarType.I64,
+    ScalarType.U32,
+    ScalarType.U64,
+}
+
+
+def _find_initializer(graph: Graph, name: str) -> Initializer | None:
+    for initializer in graph.initializers:
+        if initializer.name == name:
+            return initializer
+    return None
+
+
+def _is_scalar_shape(shape: tuple[int, ...]) -> bool:
+    return shape == () or shape == (1,)
+
+
+def _validate_static_shape(shape: tuple[int, ...], node: Node) -> None:
+    for dim in shape:
+        if dim < 0:
+            raise ShapeInferenceError(
+                f"{node.op_type} does not support dynamic dims"
+            )
+
+
+def _read_axis_initializer(
+    initializer: Initializer, node: Node
+) -> int:
+    if initializer.type.dtype not in {ScalarType.I64, ScalarType.I32}:
+        raise UnsupportedOpError(
+            f"{node.op_type} axis input must be int64 or int32"
+        )
+    axis_data = np.array(initializer.data, dtype=np.int64).reshape(-1)
+    if axis_data.size != 1:
+        raise UnsupportedOpError(f"{node.op_type} axis input must be scalar")
+    return int(axis_data[0])
+
+
+@register_lowering("CumSum")
+def lower_cumsum(graph: Graph, node: Node) -> CumSumOp:
+    if len(node.inputs) != 2 or len(node.outputs) != 1:
+        raise UnsupportedOpError("CumSum must have 2 inputs and 1 output")
+    input_name = node.inputs[0]
+    axis_name = node.inputs[1]
+    if not input_name or not axis_name:
+        raise UnsupportedOpError("CumSum requires input and axis values")
+    input_shape = value_shape(graph, input_name, node)
+    output_shape = value_shape(graph, node.outputs[0], node)
+    _validate_static_shape(input_shape, node)
+    ensure_output_shape_matches_input(node, input_shape, output_shape)
+    input_dtype = value_dtype(graph, input_name, node)
+    output_dtype = value_dtype(graph, node.outputs[0], node)
+    if input_dtype != output_dtype:
+        raise UnsupportedOpError(
+            "CumSum expects matching input/output dtypes, "
+            f"got {input_dtype.onnx_name} and {output_dtype.onnx_name}"
+        )
+    if input_dtype not in _SUPPORTED_CUMSUM_DTYPES:
+        raise UnsupportedOpError(
+            f"CumSum does not support dtype {input_dtype.onnx_name}"
+        )
+    axis_initializer = _find_initializer(graph, axis_name)
+    axis_value = None
+    axis_input = None
+    axis_input_dtype = None
+    if axis_initializer is not None:
+        axis_value = normalize_axis(
+            _read_axis_initializer(axis_initializer, node),
+            input_shape,
+            node,
+        )
+    else:
+        axis_shape = value_shape(graph, axis_name, node)
+        if not _is_scalar_shape(axis_shape):
+            raise UnsupportedOpError("CumSum axis input must be scalar")
+        axis_input_dtype = value_dtype(graph, axis_name, node)
+        if axis_input_dtype not in {ScalarType.I64, ScalarType.I32}:
+            raise UnsupportedOpError(
+                "CumSum axis input must be int64 or int32"
+            )
+        axis_input = axis_name
+    exclusive = int(node.attrs.get("exclusive", 0))
+    reverse = int(node.attrs.get("reverse", 0))
+    if exclusive not in {0, 1}:
+        raise UnsupportedOpError("CumSum exclusive must be 0 or 1")
+    if reverse not in {0, 1}:
+        raise UnsupportedOpError("CumSum reverse must be 0 or 1")
+    return CumSumOp(
+        input0=input_name,
+        axis_input=axis_input,
+        axis_input_dtype=axis_input_dtype,
+        axis=axis_value,
+        output=node.outputs[0],
+        input_shape=input_shape,
+        dtype=input_dtype,
+        input_dtype=input_dtype,
+        exclusive=bool(exclusive),
+        reverse=bool(reverse),
+    )

--- a/templates/cumsum_op.c.j2
+++ b/templates/cumsum_op.c.j2
@@ -1,0 +1,49 @@
+static inline void {{ op_name }}({{ dim_args }}const {{ c_type }} {{ input0 }}{{ input_suffix }}{% if axis_input %}, const {{ axis_c_type }} {{ axis_input }}{{ axis_suffix }}{% endif %}, {{ c_type }} {{ output }}{{ output_suffix }}) {
+    const size_t dims[{{ rank }}] = { {% for dim in input_shape %}{{ dim }}{% if not loop.last %}, {% endif %}{% endfor %} };
+    int axis = {% if axis_literal is not none %}{{ axis_literal }}{% else %}(int){{ axis_input }}[0]{% endif %};
+    if (axis < 0) {
+        axis += {{ rank }};
+    }
+    if (axis < 0 || axis >= {{ rank }}) {
+        return;
+    }
+    size_t outer = 1;
+    for (int i = 0; i < axis; ++i) {
+        outer *= dims[i];
+    }
+    size_t inner = 1;
+    for (int i = axis + 1; i < {{ rank }}; ++i) {
+        inner *= dims[i];
+    }
+    size_t axis_dim = dims[axis];
+    for (size_t outer_index = 0; outer_index < outer; ++outer_index) {
+        for (size_t inner_index = 0; inner_index < inner; ++inner_index) {
+            {{ c_type }} acc = ({{ c_type }})0;
+            size_t base = (outer_index * axis_dim * inner) + inner_index;
+{% if reverse %}
+            for (size_t axis_offset = 0; axis_offset < axis_dim; ++axis_offset) {
+                size_t axis_index = axis_dim - 1 - axis_offset;
+                size_t offset = base + axis_index * inner;
+{% if exclusive %}
+                {{ output }}[offset] = acc;
+                acc += {{ input0 }}[offset];
+{% else %}
+                acc += {{ input0 }}[offset];
+                {{ output }}[offset] = acc;
+{% endif %}
+            }
+{% else %}
+            for (size_t axis_index = 0; axis_index < axis_dim; ++axis_index) {
+                size_t offset = base + axis_index * inner;
+{% if exclusive %}
+                {{ output }}[offset] = acc;
+                acc += {{ input0 }}[offset];
+{% else %}
+                acc += {{ input0 }}[offset];
+                {{ output }}[offset] = acc;
+{% endif %}
+            }
+{% endif %}
+        }
+    }
+}

--- a/tests/official_onnx_expected_errors.json
+++ b/tests/official_onnx_expected_errors.json
@@ -2145,39 +2145,39 @@
   ],
   [
     "node/test_cumsum_1d/model.onnx",
-    "Unsupported op CumSum"
+    ""
   ],
   [
     "node/test_cumsum_1d_exclusive/model.onnx",
-    "Unsupported op CumSum"
+    ""
   ],
   [
     "node/test_cumsum_1d_int32_exclusive/model.onnx",
-    "Unsupported op CumSum"
+    ""
   ],
   [
     "node/test_cumsum_1d_reverse/model.onnx",
-    "Unsupported op CumSum"
+    ""
   ],
   [
     "node/test_cumsum_1d_reverse_exclusive/model.onnx",
-    "Unsupported op CumSum"
+    ""
   ],
   [
     "node/test_cumsum_2d_axis_0/model.onnx",
-    "Unsupported op CumSum"
+    ""
   ],
   [
     "node/test_cumsum_2d_axis_1/model.onnx",
-    "Unsupported op CumSum"
+    ""
   ],
   [
     "node/test_cumsum_2d_int32/model.onnx",
-    "Unsupported op CumSum"
+    ""
   ],
   [
     "node/test_cumsum_2d_negative_axis/model.onnx",
-    "Unsupported op CumSum"
+    ""
   ],
   [
     "node/test_deform_conv_with_mask_bias/model.onnx",


### PR DESCRIPTION
### Motivation

- Add support for the ONNX `CumSum` operator (opset 14) including `exclusive` and `reverse` behavior and axis handling. 
- Provide lowering, deterministic C emission and runtime evaluation so CumSum models can be compiled and verified against ONNX Runtime.

### Description

- Add lowering handler `lower_cumsum` in `src/onnx2c/lowering/cumsum.py` that validates shapes/dtypes, handles constant or input `axis`, and returns a `CumSumOp` dataclass. 
- Introduce `CumSumOp` dataclass in `src/onnx2c/codegen/c_emitter.py` and wire it into the emitter, resolver and name-mapping logic so it participates in codegen like other ops. 
- Add Jinja2 template `templates/cumsum_op.c.j2` for emitting the C implementation (handles axis normalization, `exclusive`, and `reverse`). 
- Implement evaluator support in `src/onnx2c/runtime/evaluator.py` to run CumSum in Python for verification and constant folding, including an `_exclusive_cumsum` helper and handling dynamic axis input. 
- Add unit and ORT comparison tests in `tests/test_ops.py` (`_make_cumsum_model`, `_cumsum_numpy`, `test_cumsum_matches_onnxruntime`, `test_cumsum_run_matches_numpy`). 
- Update compiler wiring (`src/onnx2c/compiler.py`) to import the lowering and refresh official ONNX support expectations and generated docs/golden references (`tests/official_onnx_expected_errors.json`, `OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`).

### Testing

- Ran the CumSum-focused tests: `pytest tests/test_ops.py -k cumsum -q` which passed (`4 passed, 135 deselected`) in 1.25s. 
- Ran full test suite with reference updates: `UPDATE_REFS=1 pytest -n auto -q` which completed successfully (`183 passed, 2 skipped, 2 warnings`) in ~78.9s. 
- Regenerated official support docs via `UPDATE_REFS=1 pytest tests/test_official_onnx_files.py::test_official_onnx_file_support_doc -q` which passed in 1.26s.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6968bd2cf8948325b5c5646f16e1bfae)