### PR TITLE
codegen: fix LSTM state output shapes

### DIFF
--- a/src/onnx2c/codegen/c_emitter.py
+++ b/src/onnx2c/codegen/c_emitter.py
@@ -5969,14 +5969,19 @@ class CEmitter:
                 else None
             )
             seq_shape = (op.batch_size,) if op.input_sequence_lens is not None else None
-            h_shape = (
+            state_shape = (
                 (op.num_directions, op.batch_size, op.hidden_size)
-                if op.input_initial_h is not None
+                if op.layout == 0
+                else (op.batch_size, op.num_directions, op.hidden_size)
+            )
+            h_shape = (
+                state_shape
+                if op.input_initial_h is not None or op.output_y_h is not None
                 else None
             )
             c_shape = (
-                (op.num_directions, op.batch_size, op.hidden_size)
-                if op.input_initial_c is not None
+                state_shape
+                if op.input_initial_c is not None or op.output_y_c is not None
                 else None
             )
             p_shape = (


### PR DESCRIPTION
### Motivation
- Generated C for `LstmOp` produced pointer/array type mismatches because the state (hidden/cell) parameter shapes were not derived from the LSTM `layout`, causing compilation failures when initial or output state tensors were present.

### Description
- Compute a `state_shape` from `op.layout` so state tensors have the correct ordering for layout 0 vs 1.
- Use `state_shape` when constructing `h_shape` and `c_shape` so optional `input_initial_h`/`input_initial_c` and `output_y_h`/`output_y_c` get correct parameter declarations.
- Change implemented in `src/onnx2c/codegen/c_emitter.py` in the LSTM emission path.

### Testing
- Ran the full test suite with `pytest -q`, which completed successfully with `183 passed, 2 skipped, 2 warnings` in `50.25s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6968c7204790832591af322250bccdac)