### PR TITLE
cli: disable ccache for verify builds

### DIFF
--- a/src/onnx2c/cli.py
+++ b/src/onnx2c/cli.py
@@ -190,7 +190,7 @@ def _handle_verify(args: argparse.Namespace) -> int:
     model_path: Path = args.model
     model_name = args.model_name or model_path.stem
     model_checksum = _model_checksum(model_path)
-    compiler_cmd = _resolve_compiler(args.cc, prefer_ccache=True)
+    compiler_cmd = _resolve_compiler(args.cc, prefer_ccache=False)
     if compiler_cmd is None:
         LOGGER.error("No C compiler found (set --cc or CC environment variable).")
         return 1


### PR DESCRIPTION
### Motivation
- The verify path should compile test-generated C directly without `ccache` to avoid cached artifacts affecting verification runs.

### Description
- Call `_resolve_compiler(..., prefer_ccache=False)` in `_handle_verify` so the verify invocation is not prefixed with `ccache` (change in `src/onnx2c/cli.py`).

### Testing
- Ran `UPDATE_REFS=1 pytest -n auto -q`; the suite ran in `25.26s` with `1 failed, 182 passed, 2 skipped, 2 warnings`, failing test: `tests/test_official_onnx_files.py::test_local_onnx_test_data_matches_testbench`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6968c93feaac832584156bd48f04d6b9)