### PR TITLE
runtime/codegen: fix LSTM layout=1 state handling

### DIFF
--- a/src/onnx2c/runtime/evaluator.py
+++ b/src/onnx2c/runtime/evaluator.py
@@ -2117,6 +2117,9 @@ def _apply_lstm(
         initial_h = np.zeros((num_directions, batch_size, hidden_size), dtype=x.dtype)
     if initial_c is None:
         initial_c = np.zeros((num_directions, batch_size, hidden_size), dtype=x.dtype)
+    if spec.layout == 1:
+        initial_h = np.swapaxes(initial_h, 0, 1)
+        initial_c = np.swapaxes(initial_c, 0, 1)
     output_y = None
     if spec.output_y is not None:
         output_y = np.zeros(
@@ -2193,6 +2196,11 @@ def _apply_lstm(
             output_y_h[dir_index] = h_prev
         if output_y_c is not None:
             output_y_c[dir_index] = c_prev
-    if output_y is not None and spec.layout == 1:
-        output_y = np.transpose(output_y, (2, 0, 1, 3))
+    if spec.layout == 1:
+        if output_y is not None:
+            output_y = np.transpose(output_y, (2, 0, 1, 3))
+        if output_y_h is not None:
+            output_y_h = np.swapaxes(output_y_h, 0, 1)
+        if output_y_c is not None:
+            output_y_c = np.swapaxes(output_y_c, 0, 1)
     return output_y, output_y_h, output_y_c

--- a/templates/lstm_op.c.j2
+++ b/templates/lstm_op.c.j2
@@ -60,12 +60,20 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
         for (int b = 0; b < {{ batch_size }}; ++b) {
             for (int h = 0; h < {{ hidden_size }}; ++h) {
                 {% if input_initial_h %}
+                {% if layout == 0 %}
                 H_prev[b][h] = {{ input_initial_h }}[dir][b][h];
+                {% else %}
+                H_prev[b][h] = {{ input_initial_h }}[b][dir][h];
+                {% endif %}
                 {% else %}
                 H_prev[b][h] = {{ zero_literal }};
                 {% endif %}
                 {% if input_initial_c %}
+                {% if layout == 0 %}
                 C_prev[b][h] = {{ input_initial_c }}[dir][b][h];
+                {% else %}
+                C_prev[b][h] = {{ input_initial_c }}[b][dir][h];
+                {% endif %}
                 {% else %}
                 C_prev[b][h] = {{ zero_literal }};
                 {% endif %}
@@ -194,14 +202,22 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
         {% if output_y_h %}
         for (int b = 0; b < {{ batch_size }}; ++b) {
             for (int h = 0; h < {{ hidden_size }}; ++h) {
+                {% if layout == 0 %}
                 {{ output_y_h }}[dir][b][h] = H_prev[b][h];
+                {% else %}
+                {{ output_y_h }}[b][dir][h] = H_prev[b][h];
+                {% endif %}
             }
         }
         {% endif %}
         {% if output_y_c %}
         for (int b = 0; b < {{ batch_size }}; ++b) {
             for (int h = 0; h < {{ hidden_size }}; ++h) {
+                {% if layout == 0 %}
                 {{ output_y_c }}[dir][b][h] = C_prev[b][h];
+                {% else %}
+                {{ output_y_c }}[b][dir][h] = C_prev[b][h];
+                {% endif %}
             }
         }
         {% endif %}


### PR DESCRIPTION
### Motivation
- Fix incorrect indexing and shape handling for LSTM initial/final hidden and cell states when `layout=1`, which produced wrong/generated C and caused runtime shape/index errors.

### Description
- Make the LSTM C template (`templates/lstm_op.c.j2`) layout-aware when reading `initial_h`/`initial_c` and when writing `Y_h`/`Y_c` so indices use `[dir][b][h]` for layout=0 and `[b][dir][h]` for layout=1.
- Adjust the runtime evaluator (`src/onnx2c/runtime/evaluator.py`) to `swapaxes` the provided `initial_h`/`initial_c` for `layout==1` and to `swapaxes` `output_y_h`/`output_y_c` before returning, and to transpose `output_y` consistently for layout=1.
- Update the LSTM test helpers and reference implementation (`tests/test_ops.py`) to declare state input/output shapes according to `layout` and to normalize state axes in `_lstm_reference`.
- Add a regression test `test_lstm_layout1_run_matches_numpy` that exercises `layout=1` and validates compiler runtime against the NumPy reference.

### Testing
- Ran the targeted regression `pytest -q -k "lstm_layout1_run_matches_numpy"`, which passed (1 test, ~0.75s).
- Ran the full test suite with reference updates `UPDATE_REFS=1 pytest -n auto -q`, which completed in 38.24s with results: 184 passed, 2 skipped, 2 warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6968d63984748325a3fba70ed259df7d)