### PR TITLE
cli: omit binary from header command line

### DIFF
--- a/src/onnx2c/cli.py
+++ b/src/onnx2c/cli.py
@@ -307,7 +307,10 @@ def _handle_verify(args: argparse.Namespace) -> int:
 def _format_command_line(argv: Sequence[str] | None) -> str:
     if argv is None:
         argv = sys.argv
-    return shlex.join([str(arg) for arg in argv])
+    args = [str(arg) for arg in argv[1:]]
+    if not args:
+        return ""
+    return shlex.join(args)
 
 
 def _model_checksum(model_path: Path) -> str:


### PR DESCRIPTION
### Motivation

- The generated model header included the full executable path in the "Command line" metadata, but the intent is to record only the CLI arguments used to run the tool.

### Description

- Change `_format_command_line` in `src/onnx2c/cli.py` to omit `argv[0]` and return an empty string when no arguments are present while preserving proper shell quoting with `shlex.join`.

### Testing

- Ran `pytest -q tests/test_cli.py` and the suite passed (`2 passed` in 5.85s).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6968f7e987388325b099e8585a2a790a)