### PR TITLE
codegen: split LSTM seq_limit handling into step ranges

### DIFF
--- a/templates/lstm_op.c.j2
+++ b/templates/lstm_op.c.j2
@@ -30,31 +30,19 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
                 {% endif %}
             }
         }
-        for (int step = 0; step < {{ seq_length }}; ++step) {
-            int t = reverse ? ({{ seq_length }} - 1 - step) : step;
-            for (int b = 0; b < {{ batch_size }}; ++b) {
-                int seq_limit = {{ seq_length }};
-                {% if input_sequence_lens %}
-                seq_limit = (int){{ input_sequence_lens }}[b];
-                if (seq_limit < 0) {
-                    seq_limit = 0;
-                }
-                if (seq_limit > {{ seq_length }}) {
-                    seq_limit = {{ seq_length }};
-                }
-                {% endif %}
-                if (step >= seq_limit) {
-                    {% if output_y %}
-                    for (int h = 0; h < {{ hidden_size }}; ++h) {
-                        {% if layout == 0 %}
-                        {{ output_y }}[step][dir][b][h] = {{ zero_literal }};
-                        {% else %}
-                        {{ output_y }}[b][step][dir][h] = {{ zero_literal }};
-                        {% endif %}
-                    }
-                    {% endif %}
-                    continue;
-                }
+        for (int b = 0; b < {{ batch_size }}; ++b) {
+            int seq_limit = {{ seq_length }};
+            {% if input_sequence_lens %}
+            seq_limit = (int){{ input_sequence_lens }}[b];
+            if (seq_limit < 0) {
+                seq_limit = 0;
+            }
+            if (seq_limit > {{ seq_length }}) {
+                seq_limit = {{ seq_length }};
+            }
+            {% endif %}
+            for (int step = 0; step < seq_limit; ++step) {
+                int t = reverse ? ({{ seq_length }} - 1 - step) : step;
                 {{ c_type }} H_next[{{ hidden_size }}];
                 {{ c_type }} C_next[{{ hidden_size }}];
                 for (int h = 0; h < {{ hidden_size }}; ++h) {
@@ -148,6 +136,17 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
                     H_prev[b][h] = H_next[h];
                 }
             }
+            {% if output_y %}
+            for (int step = seq_limit; step < {{ seq_length }}; ++step) {
+                for (int h = 0; h < {{ hidden_size }}; ++h) {
+                    {% if layout == 0 %}
+                    {{ output_y }}[step][dir][b][h] = {{ zero_literal }};
+                    {% else %}
+                    {{ output_y }}[b][step][dir][h] = {{ zero_literal }};
+                    {% endif %}
+                }
+            }
+            {% endif %}
         }
         {% if output_y_h %}
         for (int b = 0; b < {{ batch_size }}; ++b) {

--- a/tests/golden/op_lstm_lstm.c
+++ b/tests/golden/op_lstm_lstm.c
@@ -59,16 +59,10 @@ static inline void model_op0(const float X[restrict 1][1][2], const float W[rest
                 C_prev[b][h] = 0.0f;
             }
         }
-        for (int step = 0; step < 1; ++step) {
-            int t = reverse ? (1 - 1 - step) : step;
-            for (int b = 0; b < 1; ++b) {
-                int seq_limit = 1;
-                if (step >= seq_limit) {
-                    for (int h = 0; h < 3; ++h) {
-                        Y[step][dir][b][h] = 0.0f;
-                    }
-                    continue;
-                }
+        for (int b = 0; b < 1; ++b) {
+            int seq_limit = 1;
+            for (int step = 0; step < seq_limit; ++step) {
+                int t = reverse ? (1 - 1 - step) : step;
                 float H_next[3];
                 float C_next[3];
                 for (int h = 0; h < 3; ++h) {
@@ -103,6 +97,11 @@ static inline void model_op0(const float X[restrict 1][1][2], const float W[rest
                 for (int h = 0; h < 3; ++h) {
                     C_prev[b][h] = C_next[h];
                     H_prev[b][h] = H_next[h];
+                }
+            }
+            for (int step = seq_limit; step < 1; ++step) {
+                for (int h = 0; h < 3; ++h) {
+                    Y[step][dir][b][h] = 0.0f;
                 }
             }
         }


### PR DESCRIPTION
### Motivation
- Remove the per-step `if (step >= seq_limit) { ... continue; }` branch inside the hot LSTM step loop to simplify control flow and avoid a branch in the inner loop.
- Move seq-limit calculation to per-batch scope so the inner loop iterates only valid steps and a short tail loop zero-fills remaining outputs.

### Description
- Refactored the LSTM codegen template to compute `seq_limit` per `b` and iterate `for (int step = 0; step < seq_limit; ++step)` for the active steps and a separate `for (step = seq_limit; step < seq_length; ++step)` to write zero outputs for the remainder.
- Updated generated golden output to reflect the new loop structure.
- Modified files: `templates/lstm_op.c.j2` and `tests/golden/op_lstm_lstm.c`.

### Testing
- Ran the targeted golden LSTM tests with `pytest -q tests/test_golden_ops.py -k lstm`, which passed: `1 passed, 48 deselected` in `2.79s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696901d820dc832596923e2aac013380)