### PR TITLE
codegen: use fixed op parameter names

### DIFF
--- a/src/onnx2c/codegen/c_emitter.py
+++ b/src/onnx2c/codegen/c_emitter.py
@@ -1023,7 +1023,8 @@ class CEmitter:
             if name is None:
                 mapped[key] = None
                 continue
-            unique = self._ensure_unique_identifier(name, used)
+            sanitized = self._sanitize_identifier(key)
+            unique = self._ensure_unique_identifier(sanitized, used)
             used.add(unique)
             mapped[key] = unique
         return mapped
@@ -1038,12 +1039,13 @@ class CEmitter:
             if name is None:
                 mapped[key] = None
                 continue
-            if name in name_map:
-                mapped[key] = name_map[name]
+            if key in name_map:
+                mapped[key] = name_map[key]
                 continue
-            unique = self._ensure_unique_identifier(name, used)
+            sanitized = self._sanitize_identifier(key)
+            unique = self._ensure_unique_identifier(sanitized, used)
             used.add(unique)
-            name_map[name] = unique
+            name_map[key] = unique
             mapped[key] = unique
         return mapped
 

--- a/tests/golden/add_initializer_model.c
+++ b/tests/golden/add_initializer_model.c
@@ -45,10 +45,10 @@ static inline float ref_scalar_f32_add(float a, float b) {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float in0[restrict 2][3], const float weight[restrict 2][3], float out[restrict 2][3]) {
+static inline void model_op0(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            out[i0][i1] = ref_scalar_f32_add(in0[i0][i1], weight[i0][i1]);
+            output[i0][i1] = ref_scalar_f32_add(input0[i0][i1], input1[i0][i1]);
         }
     }
 }

--- a/tests/golden/add_model.c
+++ b/tests/golden/add_model.c
@@ -41,11 +41,11 @@ static inline float ref_scalar_f32_add(float a, float b) {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float a[restrict 2][3][4], const float b[restrict 2][3][4], float out[restrict 2][3][4]) {
+static inline void model_op0(const float input0[restrict 2][3][4], const float input1[restrict 2][3][4], float output[restrict 2][3][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
-                out[i0][i1][i2] = ref_scalar_f32_add(a[i0][i1][i2], b[i0][i1][i2]);
+                output[i0][i1][i2] = ref_scalar_f32_add(input0[i0][i1][i2], input1[i0][i1][i2]);
             }
         }
     }

--- a/tests/golden/add_model_no_restrict.c
+++ b/tests/golden/add_model_no_restrict.c
@@ -41,11 +41,11 @@ static inline float ref_scalar_f32_add(float a, float b) {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float a[2][3][4], const float b[2][3][4], float out[2][3][4]) {
+static inline void model_op0(const float input0[2][3][4], const float input1[2][3][4], float output[2][3][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
-                out[i0][i1][i2] = ref_scalar_f32_add(a[i0][i1][i2], b[i0][i1][i2]);
+                output[i0][i1][i2] = ref_scalar_f32_add(input0[i0][i1][i2], input1[i0][i1][i2]);
             }
         }
     }

--- a/tests/golden/add_model_testbench.c
+++ b/tests/golden/add_model_testbench.c
@@ -43,11 +43,11 @@ static inline float ref_scalar_f32_add(float a, float b) {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float a[restrict 2][3][4], const float b[restrict 2][3][4], float out[restrict 2][3][4]) {
+static inline void model_op0(const float input0[restrict 2][3][4], const float input1[restrict 2][3][4], float output[restrict 2][3][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
-                out[i0][i1][i2] = ref_scalar_f32_add(a[i0][i1][i2], b[i0][i1][i2]);
+                output[i0][i1][i2] = ref_scalar_f32_add(input0[i0][i1][i2], input1[i0][i1][i2]);
             }
         }
     }

--- a/tests/golden/dynamic_dims_model.c
+++ b/tests/golden/dynamic_dims_model.c
@@ -41,10 +41,10 @@ static inline float ref_scalar_f32_relu(float a) {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void dynamic_dims_model_op0(int N, int C, const float x[restrict N][C], float out[restrict N][C]) {
+static inline void dynamic_dims_model_op0(int N, int C, const float input0[restrict N][C], float output[restrict N][C]) {
     for (size_t i0 = 0; i0 < N; ++i0) {
         for (size_t i1 = 0; i1 < C; ++i1) {
-            out[i0][i1] = ref_scalar_f32_relu(x[i0][i1]);
+            output[i0][i1] = ref_scalar_f32_relu(input0[i0][i1]);
         }
     }
 }

--- a/tests/golden/matmul_model.c
+++ b/tests/golden/matmul_model.c
@@ -28,14 +28,14 @@
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float a[restrict 2][3], const float b[restrict 3][4], float out[restrict 2][4]) {
+static inline void model_op0(const float input0[restrict 2][3], const float input1[restrict 3][4], float output[restrict 2][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 4; ++i1) {
             float acc = 0.0f;
             for (size_t k = 0; k < 3; ++k) {
-                acc += a[i0][k] * b[k][i1];
+                acc += input0[i0][k] * input1[k][i1];
             }
-            out[i0][i1] = acc;
+            output[i0][i1] = acc;
         }
     }
 }

--- a/tests/golden/mul_add_model.c
+++ b/tests/golden/mul_add_model.c
@@ -45,10 +45,10 @@ static inline float ref_scalar_f32_add(float a, float b) {
  * Outputs: mul_out
  * Attrs: n/a
  */
-static inline void model_op0(const float a[restrict 2][3], const float b[restrict 2][3], float tmp[restrict 2][3]) {
+static inline void model_op0(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            tmp[i0][i1] = ref_scalar_f32_mul(a[i0][i1], b[i0][i1]);
+            output[i0][i1] = ref_scalar_f32_mul(input0[i0][i1], input1[i0][i1]);
         }
     }
 }
@@ -60,10 +60,10 @@ static inline void model_op0(const float a[restrict 2][3], const float b[restric
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op1(const float tmp[restrict 2][3], const float c[restrict 2][3], float out[restrict 2][3]) {
+static inline void model_op1(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            out[i0][i1] = ref_scalar_f32_add(tmp[i0][i1], c[i0][i1]);
+            output[i0][i1] = ref_scalar_f32_add(input0[i0][i1], input1[i0][i1]);
         }
     }
 }

--- a/tests/golden/mul_add_relu_model.c
+++ b/tests/golden/mul_add_relu_model.c
@@ -49,10 +49,10 @@ static inline float ref_scalar_f32_relu(float a) {
  * Outputs: mul_out
  * Attrs: n/a
  */
-static inline void model_op0(const float a[restrict 2][3], const float b[restrict 2][3], float tmp0[restrict 2][3]) {
+static inline void model_op0(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            tmp0[i0][i1] = ref_scalar_f32_mul(a[i0][i1], b[i0][i1]);
+            output[i0][i1] = ref_scalar_f32_mul(input0[i0][i1], input1[i0][i1]);
         }
     }
 }
@@ -64,10 +64,10 @@ static inline void model_op0(const float a[restrict 2][3], const float b[restric
  * Outputs: add_out
  * Attrs: n/a
  */
-static inline void model_op1(const float tmp0[restrict 2][3], const float c[restrict 2][3], float tmp1[restrict 2][3]) {
+static inline void model_op1(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            tmp1[i0][i1] = ref_scalar_f32_add(tmp0[i0][i1], c[i0][i1]);
+            output[i0][i1] = ref_scalar_f32_add(input0[i0][i1], input1[i0][i1]);
         }
     }
 }
@@ -79,10 +79,10 @@ static inline void model_op1(const float tmp0[restrict 2][3], const float c[rest
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op2(const float tmp1[restrict 2][3], float out[restrict 2][3]) {
+static inline void model_op2(const float input0[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            out[i0][i1] = ref_scalar_f32_relu(tmp1[i0][i1]);
+            output[i0][i1] = ref_scalar_f32_relu(input0[i0][i1]);
         }
     }
 }

--- a/tests/golden/mul_model.c
+++ b/tests/golden/mul_model.c
@@ -41,10 +41,10 @@ static inline float ref_scalar_f32_mul(float a, float b) {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float a[restrict 2][3], const float b[restrict 2][3], float out[restrict 2][3]) {
+static inline void model_op0(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            out[i0][i1] = ref_scalar_f32_mul(a[i0][i1], b[i0][i1]);
+            output[i0][i1] = ref_scalar_f32_mul(input0[i0][i1], input1[i0][i1]);
         }
     }
 }

--- a/tests/golden/op_argreduce_arg_max.c
+++ b/tests/golden/op_argreduce_arg_max.c
@@ -32,14 +32,14 @@
  *   keepdims: 1
  *   select_last_index: 0
  */
-static inline void model_op0(const float input[restrict 2][3][4], int64_t output[restrict 2][1][4]) {
+static inline void model_op0(const float input0[restrict 2][3][4], int64_t output[restrict 2][1][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 1; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
-                float best = input[i0][0][i2];
+                float best = input0[i0][0][i2];
                 int64_t best_index = 0;
                 for (size_t r0 = 1; r0 < 3; ++r0) {
-                    float candidate = input[i0][r0][i2];
+                    float candidate = input0[i0][r0][i2];
                     if (candidate > best) {
                         best = candidate;
                         best_index = (int64_t)r0;

--- a/tests/golden/op_attention_attention.c
+++ b/tests/golden/op_attention_attention.c
@@ -29,7 +29,7 @@
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float in0[restrict 1][2][3][4], const float in1[restrict 1][2][5][4], const float in2[restrict 1][2][5][4], float out[restrict 1][2][3][4]) {
+static inline void model_op0(const float input_q[restrict 1][2][3][4], const float input_k[restrict 1][2][5][4], const float input_v[restrict 1][2][5][4], float output[restrict 1][2][3][4]) {
     const float scale = 0.5f;
     const float softcap = 0.0f;
     for (int b = 0; b < 1; ++b) {
@@ -44,8 +44,8 @@ static inline void model_op0(const float in0[restrict 1][2][3][4], const float i
                     for (int d = 0; d < 4; ++d) {
                         float q_val;
                         float k_val;
-                        q_val = in0[b][h][qi][d];
-                        k_val = in1[b][kv_head][k_index][d];
+                        q_val = input_q[b][h][qi][d];
+                        k_val = input_k[b][kv_head][k_index][d];
                         score += q_val * k_val;
                     }
                     score *= scale;
@@ -78,9 +78,9 @@ static inline void model_op0(const float in0[restrict 1][2][3][4], const float i
                     float acc = 0.0f;
                     for (int ki = 0; ki < 5; ++ki) {
                         float weight = weights[ki] * inv_sum;
-                        acc += weight * in2[b][kv_head][ki][vd];
+                        acc += weight * input_v[b][kv_head][ki][vd];
                     }
-                    out[b][h][qi][vd] = acc;
+                    output[b][h][qi][vd] = acc;
                 }
             }
         }

--- a/tests/golden/op_averagepool_average_pool.c
+++ b/tests/golden/op_averagepool_average_pool.c
@@ -30,7 +30,7 @@
  *   kernel_shape: [2, 2]
  *   strides: [2, 2]
  */
-static inline void model_op0(const float input[restrict 1][1][4][4], float output[restrict 1][1][2][2]) {
+static inline void model_op0(const float input0[restrict 1][1][4][4], float output[restrict 1][1][2][2]) {
     for (size_t n = 0; n < 1; ++n) {
         for (size_t c = 0; c < 1; ++c) {
             for (size_t oh = 0; oh < 2; ++oh) {
@@ -53,7 +53,7 @@ static inline void model_op0(const float input[restrict 1][1][4][4], float outpu
                                 }
                                 continue;
                             }
-                            acc += input[n][c][ih][iw];
+                            acc += input0[n][c][ih][iw];
                             count += 1;
                         }
                     }

--- a/tests/golden/op_batchnorm_batch_normalization.c
+++ b/tests/golden/op_batchnorm_batch_normalization.c
@@ -46,14 +46,14 @@ static const float var[3] = {
  * Attrs:
  *   epsilon: 9.999999747378752e-06
  */
-static inline void model_op0(const float in0[restrict 2][3][2][2], const float scale[restrict 3], const float bias[restrict 3], const float mean[restrict 3], const float var[restrict 3], float out[restrict 2][3][2][2]) {
+static inline void model_op0(const float input0[restrict 2][3][2][2], const float scale[restrict 3], const float bias[restrict 3], const float mean[restrict 3], const float variance[restrict 3], float output[restrict 2][3][2][2]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 2; ++i2) {
                 for (size_t i3 = 0; i3 < 2; ++i3) {
                     size_t c = i1;
-                    float denom = sqrtf(var[c] + 9.99999975e-06f);
-                    out[i0][i1][i2][i3] = (in0[i0][i1][i2][i3] - mean[c]) / denom * scale[c] + bias[c];
+                    float denom = sqrtf(variance[c] + 9.99999975e-06f);
+                    output[i0][i1][i2][i3] = (input0[i0][i1][i2][i3] - mean[c]) / denom * scale[c] + bias[c];
                 }
             }
         }

--- a/tests/golden/op_binary_mul.c
+++ b/tests/golden/op_binary_mul.c
@@ -41,10 +41,10 @@ static inline float ref_scalar_f32_mul(float a, float b) {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float in0[restrict 2][3], const float in1[restrict 2][3], float out[restrict 2][3]) {
+static inline void model_op0(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            out[i0][i1] = ref_scalar_f32_mul(in0[i0][i1], in1[i0][i1]);
+            output[i0][i1] = ref_scalar_f32_mul(input0[i0][i1], input1[i0][i1]);
         }
     }
 }

--- a/tests/golden/op_cast_cast.c
+++ b/tests/golden/op_cast_cast.c
@@ -30,10 +30,10 @@
  * Attrs:
  *   to: 6
  */
-static inline void model_op0(const float in0[restrict 2][3], int32_t out[restrict 2][3]) {
+static inline void model_op0(const float input0[restrict 2][3], int32_t output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            out[i0][i1] = (int32_t)in0[i0][i1];
+            output[i0][i1] = (int32_t)input0[i0][i1];
         }
     }
 }

--- a/tests/golden/op_clip_clip.c
+++ b/tests/golden/op_clip_clip.c
@@ -36,15 +36,15 @@ static const float max[1] = {
  * Outputs: output
  * Attrs: n/a
  */
-static inline void model_op0(const float input[restrict 2][3], const float min[restrict 1], const float max[restrict 1], float output[restrict 2][3]) {
+static inline void model_op0(const float input0[restrict 2][3], const float input_min[restrict 1], const float input_max[restrict 1], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            float value = input[i0][i1];
-            if (value < min[0]) {
-                value = min[0];
+            float value = input0[i0][i1];
+            if (value < input_min[0]) {
+                value = input_min[0];
             }
-            if (value > max[0]) {
-                value = max[0];
+            if (value > input_max[0]) {
+                value = input_max[0];
             }
             output[i0][i1] = value;
         }

--- a/tests/golden/op_concat_concat.c
+++ b/tests/golden/op_concat_concat.c
@@ -30,8 +30,8 @@
  * Attrs:
  *   axis: 2
  */
-static inline void model_op0(const float in0[restrict 1][2][3], const float in1[restrict 1][2][1], float out[restrict 1][2][4]) {
-    const void *inputs[] = { in0, in1 };
+static inline void model_op0(const float input_0[restrict 1][2][3], const float input_1[restrict 1][2][1], float output[restrict 1][2][4]) {
+    const void *inputs[] = { input_0, input_1 };
     const size_t axis_sizes[] = { 3, 1 };
     size_t concat_axis = 0;
     for (size_t idx = 0; idx < 2; ++idx) {
@@ -50,7 +50,7 @@ static inline void model_op0(const float in0[restrict 1][2][3], const float in1[
             (const unsigned char *)inputs[input_idx];
             size_t input_offset = outer_idx * copy_elems;
             memcpy(
-            ((unsigned char *)out) + (output_offset + axis_offset) * sizeof(float),
+            ((unsigned char *)output) + (output_offset + axis_offset) * sizeof(float),
             input_bytes + input_offset * sizeof(float),
             copy_elems * sizeof(float)
             );

--- a/tests/golden/op_constantofshape_constant_of_shape.c
+++ b/tests/golden/op_constantofshape_constant_of_shape.c
@@ -38,12 +38,12 @@ float_data: 1.25
 name: "fill"
 
  */
-static inline void model_op0(const int64_t shape[restrict 3], float out[restrict 2][3][4]) {
-    (void)shape;
+static inline void model_op0(const int64_t input0[restrict 3], float output[restrict 2][3][4]) {
+    (void)input0;
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
-                out[i0][i1][i2] = 1.25f;
+                output[i0][i1][i2] = 1.25f;
             }
         }
     }

--- a/tests/golden/op_conv_conv.c
+++ b/tests/golden/op_conv_conv.c
@@ -39,7 +39,7 @@ static const float bias[1] = {
  *   pads: [1, 1, 1, 1]
  *   strides: [1, 1]
  */
-static inline void model_op0(const float in0[restrict 1][1][4][4], const float weight[restrict 1][1][3][3], const float bias[restrict 1], float out[restrict 1][1][4][4]) {
+static inline void model_op0(const float input0[restrict 1][1][4][4], const float weights[restrict 1][1][3][3], const float bias[restrict 1], float output[restrict 1][1][4][4]) {
     for (size_t n = 0; n < 1; ++n) {
         for (size_t g = 0; g < 1; ++g) {
             for (size_t oc = 0; oc < 1; ++oc) {
@@ -56,11 +56,11 @@ static inline void model_op0(const float in0[restrict 1][1][4][4], const float w
                                     if (id0 < 0 || id0 >= 4 || id1 < 0 || id1 >= 4) {
                                         continue;
                                     }
-                                    acc += in0[n][ic_global][id0][id1] * weight[oc_global][ic][kd0][kd1];
+                                    acc += input0[n][ic_global][id0][id1] * weights[oc_global][ic][kd0][kd1];
                                 }
                             }
                         }
-                        out[n][oc_global][od0][od1] = acc;
+                        output[n][oc_global][od0][od1] = acc;
                     }
                 }
             }

--- a/tests/golden/op_cumsum_cumsum.c
+++ b/tests/golden/op_cumsum_cumsum.c
@@ -35,7 +35,7 @@ static const int64_t axis[1] = {
  *   exclusive: 0
  *   reverse: 0
  */
-static inline void model_op0(const float input[restrict 2][3], float output[restrict 2][3]) {
+static inline void model_op0(const float input0[restrict 2][3], float output[restrict 2][3]) {
     const size_t dims[2] = { 2, 3 };
     int axis = 1;
     if (axis < 0) {
@@ -59,7 +59,7 @@ static inline void model_op0(const float input[restrict 2][3], float output[rest
             size_t base = (outer_index * axis_dim * inner) + inner_index;
             for (size_t axis_index = 0; axis_index < axis_dim; ++axis_index) {
                 size_t offset = base + axis_index * inner;
-                acc += input[offset];
+                acc += input0[offset];
                 output[offset] = acc;
             }
         }

--- a/tests/golden/op_depthtospace_depth_to_space.c
+++ b/tests/golden/op_depthtospace_depth_to_space.c
@@ -30,9 +30,9 @@
  *   blocksize: 2
  *   mode: DCR
  */
-static inline void model_op0(const float in0[restrict 1][4][2][2], float out[restrict 1][1][4][4]) {
-    const float *input_data = (const float *)in0;
-    float *output_data = (float *)out;
+static inline void model_op0(const float input0[restrict 1][4][2][2], float output[restrict 1][1][4][4]) {
+    const float *input_data = (const float *)input0;
+    float *output_data = (float *)output;
     size_t output_index = 0;
     for (size_t n = 0; n < 1; ++n) {
         for (size_t c_out = 0; c_out < 1; ++c_out) {

--- a/tests/golden/op_expand_expand.c
+++ b/tests/golden/op_expand_expand.c
@@ -33,8 +33,8 @@ static const int64_t shape[2] = {
  * Outputs: output
  * Attrs: n/a
  */
-static inline void model_op0(const float input[restrict 1][3], float output[restrict 2][3]) {
-    const float *input_data = (const float *)input;
+static inline void model_op0(const float input0[restrict 1][3], float output[restrict 2][3]) {
+    const float *input_data = (const float *)input0;
     float *output_data = (float *)output;
     size_t output_index = 0;
     for (size_t i0 = 0; i0 < 2; ++i0) {

--- a/tests/golden/op_eyelike_eye_like.c
+++ b/tests/golden/op_eyelike_eye_like.c
@@ -29,8 +29,8 @@
  * Attrs:
  *   k: 0
  */
-static inline void model_op0(const float input[restrict 3][3], float output[restrict 3][3]) {
-    (void)input;
+static inline void model_op0(const float input0[restrict 3][3], float output[restrict 3][3]) {
+    (void)input0;
     float *output_data = (float *)output;
     size_t total = (size_t)1 * 3 * 3;
     for (size_t index = 0; index < total; ++index) {

--- a/tests/golden/op_gather_gather.c
+++ b/tests/golden/op_gather_gather.c
@@ -30,14 +30,14 @@
  * Attrs:
  *   axis: 0
  */
-static inline void model_op0(const float data[restrict 3][2], const int64_t indices[restrict 2], float out[restrict 2][2]) {
+static inline void model_op0(const float data[restrict 3][2], const int64_t indices[restrict 2], float output[restrict 2][2]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 2; ++i1) {
             int64_t gather_index = (int64_t)indices[i0];
             if (gather_index < 0) {
                 gather_index += 3;
             }
-            out[i0][i1] = data[gather_index][i1];
+            output[i0][i1] = data[gather_index][i1];
         }
     }
 }

--- a/tests/golden/op_gatherelements_gather_elements.c
+++ b/tests/golden/op_gatherelements_gather_elements.c
@@ -30,14 +30,14 @@
  * Attrs:
  *   axis: 0
  */
-static inline void model_op0(const float data[restrict 2][3], const int64_t indices[restrict 2][3], float out[restrict 2][3]) {
+static inline void model_op0(const float data[restrict 2][3], const int64_t indices[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             int64_t gather_index = (int64_t)indices[i0][i1];
             if (gather_index < 0) {
                 gather_index += 2;
             }
-            out[i0][i1] = data[gather_index][i1];
+            output[i0][i1] = data[gather_index][i1];
         }
     }
 }

--- a/tests/golden/op_gemm_gemm.c
+++ b/tests/golden/op_gemm_gemm.c
@@ -30,19 +30,19 @@
  *   alpha: 1.0
  *   beta: 1.0
  */
-static inline void model_op0(const float in0[restrict 2][3], const float in1[restrict 3][4], const float in2[restrict 2][4], float out[restrict 2][4]) {
+static inline void model_op0(const float input_a[restrict 2][3], const float input_b[restrict 3][4], const float input_c[restrict 2][4], float output[restrict 2][4]) {
     for (size_t i = 0; i < 2; ++i) {
         for (size_t j = 0; j < 4; ++j) {
             float acc = 0.0f;
             for (size_t k = 0; k < 3; ++k) {
-                const float a_val = in0[i][k];
-                const float b_val = in1[k][j];
+                const float a_val = input_a[i][k];
+                const float b_val = input_b[k][j];
                 acc += a_val * b_val;
             }
             size_t c_i = i;
             size_t c_j = j;
-            const float bias = in2[c_i][c_j];
-            out[i][j] = acc * 1.0f + bias * 1.0f;
+            const float bias = input_c[c_i][c_j];
+            output[i][j] = acc * 1.0f + bias * 1.0f;
         }
     }
 }

--- a/tests/golden/op_groupnormalization_group_normalization.c
+++ b/tests/golden/op_groupnormalization_group_normalization.c
@@ -31,7 +31,7 @@
  *   epsilon: 9.999999747378752e-06
  *   num_groups: 2
  */
-static inline void model_op0(const float in0[restrict 1][4][2][2], const float in1[restrict 4], const float in2[restrict 4], float out[restrict 1][4][2][2]) {
+static inline void model_op0(const float input0[restrict 1][4][2][2], const float scale[restrict 4], const float bias[restrict 4], float output[restrict 1][4][2][2]) {
     for (size_t i0 = 0; i0 < 1; ++i0) {
         for (size_t g = 0; g < 2; ++g) {
             float sum = 0.0f;
@@ -39,7 +39,7 @@ static inline void model_op0(const float in0[restrict 1][4][2][2], const float i
                 size_t c = g * 2 + c_in_group;
                 for (size_t i2 = 0; i2 < 2; ++i2) {
                     for (size_t i3 = 0; i3 < 2; ++i3) {
-                        sum += in0[i0][c][i2][i3];
+                        sum += input0[i0][c][i2][i3];
                     }
                 }
             }
@@ -49,7 +49,7 @@ static inline void model_op0(const float in0[restrict 1][4][2][2], const float i
                 size_t c = g * 2 + c_in_group;
                 for (size_t i2 = 0; i2 < 2; ++i2) {
                     for (size_t i3 = 0; i3 < 2; ++i3) {
-                        float diff = in0[i0][c][i2][i3] - mean;
+                        float diff = input0[i0][c][i2][i3] - mean;
                         var += diff * diff;
                     }
                 }
@@ -59,8 +59,8 @@ static inline void model_op0(const float in0[restrict 1][4][2][2], const float i
                 size_t c = g * 2 + c_in_group;
                 for (size_t i2 = 0; i2 < 2; ++i2) {
                     for (size_t i3 = 0; i3 < 2; ++i3) {
-                        out[i0][c][i2][i3] =
-                        (in0[i0][c][i2][i3] - mean) / denom * in1[c] + in2[c];
+                        output[i0][c][i2][i3] =
+                        (input0[i0][c][i2][i3] - mean) / denom * scale[c] + bias[c];
                     }
                 }
             }

--- a/tests/golden/op_identity_identity.c
+++ b/tests/golden/op_identity_identity.c
@@ -29,10 +29,10 @@
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float in0[restrict 2][3], float out[restrict 2][3]) {
+static inline void model_op0(const float input0[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            out[i0][i1] = in0[i0][i1];
+            output[i0][i1] = input0[i0][i1];
         }
     }
 }

--- a/tests/golden/op_instancenormalization_instance_normalization.c
+++ b/tests/golden/op_instancenormalization_instance_normalization.c
@@ -30,28 +30,28 @@
  * Attrs:
  *   epsilon: 9.999999747378752e-06
  */
-static inline void model_op0(const float in0[restrict 1][3][2][2], const float in1[restrict 3], const float in2[restrict 3], float out[restrict 1][3][2][2]) {
+static inline void model_op0(const float input0[restrict 1][3][2][2], const float scale[restrict 3], const float bias[restrict 3], float output[restrict 1][3][2][2]) {
     for (size_t i0 = 0; i0 < 1; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             float sum = 0.0f;
             for (size_t i2 = 0; i2 < 2; ++i2) {
                 for (size_t i3 = 0; i3 < 2; ++i3) {
-                    sum += in0[i0][i1][i2][i3];
+                    sum += input0[i0][i1][i2][i3];
                 }
             }
             float mean = sum / 4;
             float var = 0.0f;
             for (size_t i2 = 0; i2 < 2; ++i2) {
                 for (size_t i3 = 0; i3 < 2; ++i3) {
-                    float diff = in0[i0][i1][i2][i3] - mean;
+                    float diff = input0[i0][i1][i2][i3] - mean;
                     var += diff * diff;
                 }
             }
             float denom = sqrtf(var / 4 + 9.99999975e-06f);
             for (size_t i2 = 0; i2 < 2; ++i2) {
                 for (size_t i3 = 0; i3 < 2; ++i3) {
-                    out[i0][i1][i2][i3] =
-                    (in0[i0][i1][i2][i3] - mean) / denom * in1[i1] + in2[i1];
+                    output[i0][i1][i2][i3] =
+                    (input0[i0][i1][i2][i3] - mean) / denom * scale[i1] + bias[i1];
                 }
             }
         }

--- a/tests/golden/op_layernormalization_layer_normalization.c
+++ b/tests/golden/op_layernormalization_layer_normalization.c
@@ -31,19 +31,19 @@
  *   axis: 1
  *   epsilon: 9.999999747378752e-06
  */
-static inline void model_op0(const float in0[restrict 2][3][4], const float in1[restrict 3][4], const float in2[restrict 3][4], float out[restrict 2][3][4]) {
+static inline void model_op0(const float input0[restrict 2][3][4], const float scale[restrict 3][4], const float bias[restrict 3][4], float output[restrict 2][3][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         float sum = 0.0f;
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
-                sum += in0[i0][i1][i2];
+                sum += input0[i0][i1][i2];
             }
         }
         float mean = sum / 12;
         float var = 0.0f;
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
-                float diff = in0[i0][i1][i2] - mean;
+                float diff = input0[i0][i1][i2] - mean;
                 var += diff * diff;
             }
         }
@@ -51,9 +51,9 @@ static inline void model_op0(const float in0[restrict 2][3][4], const float in1[
         float inv_std = ((float)1) / sqrtf(var + 9.99999975e-06f);
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
-                float value = (in0[i0][i1][i2] - mean) * inv_std;
-                value = value * in1[i1][i2] + in2[i1][i2];
-                out[i0][i1][i2] = value;
+                float value = (input0[i0][i1][i2] - mean) * inv_std;
+                value = value * scale[i1][i2] + bias[i1][i2];
+                output[i0][i1][i2] = value;
             }
         }
     }

--- a/tests/golden/op_logsoftmax_logsoftmax.c
+++ b/tests/golden/op_logsoftmax_logsoftmax.c
@@ -30,9 +30,9 @@
  * Attrs:
  *   axis: 1
  */
-static inline void model_op0(const float in0[restrict 2][3], float out[restrict 2][3]) {
-    const float *input_flat = (const float *)in0;
-    float *output_flat = (float *)out;
+static inline void model_op0(const float input0[restrict 2][3], float output[restrict 2][3]) {
+    const float *input_flat = (const float *)input0;
+    float *output_flat = (float *)output;
     const size_t outer = 2;
     const size_t axis_size = 3;
     const size_t inner = 1;

--- a/tests/golden/op_lpnormalization_lp_normalization.c
+++ b/tests/golden/op_lpnormalization_lp_normalization.c
@@ -31,9 +31,9 @@
  *   axis: -1
  *   p: 1
  */
-static inline void model_op0(const float in0[restrict 2][3], float out[restrict 2][3]) {
-    const float *input_flat = (const float *)in0;
-    float *output_flat = (float *)out;
+static inline void model_op0(const float input0[restrict 2][3], float output[restrict 2][3]) {
+    const float *input_flat = (const float *)input0;
+    float *output_flat = (float *)output;
     const size_t outer = 2;
     const size_t axis_size = 3;
     const size_t inner = 1;

--- a/tests/golden/op_lrn_lrn.c
+++ b/tests/golden/op_lrn_lrn.c
@@ -33,7 +33,7 @@
  *   bias: 1.0
  *   size: 3
  */
-static inline void model_op0(const float in0[restrict 1][3][4][4], float out[restrict 1][3][4][4]) {
+static inline void model_op0(const float input0[restrict 1][3][4][4], float output[restrict 1][3][4][4]) {
     for (size_t i0 = 0; i0 < 1; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
@@ -45,11 +45,11 @@ static inline void model_op0(const float in0[restrict 1][3][4][4], float out[res
                     }
                     float sum = 0.0f;
                     for (size_t c = channel_start; c <= channel_end; ++c) {
-                        float val = in0[i0][c][i2][i3];
+                        float val = input0[i0][c][i2][i3];
                         sum += val * val;
                     }
                     float scale = 1.0f + 3.33333325e-05f * sum;
-                    out[i0][i1][i2][i3] = in0[i0][i1][i2][i3] / powf(scale, 0.75f);
+                    output[i0][i1][i2][i3] = input0[i0][i1][i2][i3] / powf(scale, 0.75f);
                 }
             }
         }

--- a/tests/golden/op_lstm_lstm.c
+++ b/tests/golden/op_lstm_lstm.c
@@ -47,7 +47,7 @@ static inline float ref_scalar_f32_tanh(float a) {
  *   hidden_size: 3
  *   layout: 0
  */
-static inline void model_op0(const float X[restrict 1][1][2], const float W[restrict 1][12][2], const float R[restrict 1][12][3], float Y[restrict 1][1][1][3], float Y_h[restrict 1][1][3], float Y_c[restrict 1][1][3]) {
+static inline void model_op0(const float input_x[restrict 1][1][2], const float input_w[restrict 1][12][2], const float input_r[restrict 1][12][3], float output_y[restrict 1][1][1][3], float output_y_h[restrict 1][1][3], float output_y_c[restrict 1][1][3]) {
     {
         const int dir = 0;
         const int reverse = 0;
@@ -71,18 +71,18 @@ static inline void model_op0(const float X[restrict 1][1][2], const float W[rest
                     float gate_f = 0.0f;
                     float gate_c = 0.0f;
                     for (int i = 0; i < 2; ++i) {
-                        float x_val = X[t][b][i];
-                        gate_i += x_val * W[dir][h][i];
-                        gate_o += x_val * W[dir][3 + h][i];
-                        gate_f += x_val * W[dir][3 * 2 + h][i];
-                        gate_c += x_val * W[dir][3 * 3 + h][i];
+                        float x_val = input_x[t][b][i];
+                        gate_i += x_val * input_w[dir][h][i];
+                        gate_o += x_val * input_w[dir][3 + h][i];
+                        gate_f += x_val * input_w[dir][3 * 2 + h][i];
+                        gate_c += x_val * input_w[dir][3 * 3 + h][i];
                     }
                     for (int i = 0; i < 3; ++i) {
                         float h_val = H_prev[b][i];
-                        gate_i += h_val * R[dir][h][i];
-                        gate_o += h_val * R[dir][3 + h][i];
-                        gate_f += h_val * R[dir][3 * 2 + h][i];
-                        gate_c += h_val * R[dir][3 * 3 + h][i];
+                        gate_i += h_val * input_r[dir][h][i];
+                        gate_o += h_val * input_r[dir][3 + h][i];
+                        gate_f += h_val * input_r[dir][3 * 2 + h][i];
+                        gate_c += h_val * input_r[dir][3 * 3 + h][i];
                     }
                     float i_gate = ref_scalar_f32_sigmoid(gate_i);
                     float f_gate = ref_scalar_f32_sigmoid(gate_f);
@@ -92,7 +92,7 @@ static inline void model_op0(const float X[restrict 1][1][2], const float W[rest
                     float h_new = o_gate * ref_scalar_f32_tanh(c_new);
                     C_next[h] = c_new;
                     H_next[h] = h_new;
-                    Y[step][dir][b][h] = h_new;
+                    output_y[step][dir][b][h] = h_new;
                 }
                 for (int h = 0; h < 3; ++h) {
                     C_prev[b][h] = C_next[h];
@@ -101,18 +101,18 @@ static inline void model_op0(const float X[restrict 1][1][2], const float W[rest
             }
             for (int step = seq_limit; step < 1; ++step) {
                 for (int h = 0; h < 3; ++h) {
-                    Y[step][dir][b][h] = 0.0f;
+                    output_y[step][dir][b][h] = 0.0f;
                 }
             }
         }
         for (int b = 0; b < 1; ++b) {
             for (int h = 0; h < 3; ++h) {
-                Y_h[dir][b][h] = H_prev[b][h];
+                output_y_h[dir][b][h] = H_prev[b][h];
             }
         }
         for (int b = 0; b < 1; ++b) {
             for (int h = 0; h < 3; ++h) {
-                Y_c[dir][b][h] = C_prev[b][h];
+                output_y_c[dir][b][h] = C_prev[b][h];
             }
         }
     }

--- a/tests/golden/op_matmul_matmul.c
+++ b/tests/golden/op_matmul_matmul.c
@@ -28,14 +28,14 @@
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float in0[restrict 2][3], const float in1[restrict 3][4], float out[restrict 2][4]) {
+static inline void model_op0(const float input0[restrict 2][3], const float input1[restrict 3][4], float output[restrict 2][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 4; ++i1) {
             float acc = 0.0f;
             for (size_t k = 0; k < 3; ++k) {
-                acc += in0[i0][k] * in1[k][i1];
+                acc += input0[i0][k] * input1[k][i1];
             }
-            out[i0][i1] = acc;
+            output[i0][i1] = acc;
         }
     }
 }

--- a/tests/golden/op_maxpool_maxpool.c
+++ b/tests/golden/op_maxpool_maxpool.c
@@ -33,7 +33,7 @@
  *   pads: [0, 0, 0, 0]
  *   strides: [2, 2]
  */
-static inline void model_op0(const float in0[restrict 1][1][4][4], float out[restrict 1][1][2][2]) {
+static inline void model_op0(const float input0[restrict 1][1][4][4], float output[restrict 1][1][2][2]) {
     for (size_t n = 0; n < 1; ++n) {
         for (size_t c = 0; c < 1; ++c) {
             for (size_t oh = 0; oh < 2; ++oh) {
@@ -49,13 +49,13 @@ static inline void model_op0(const float in0[restrict 1][1][4][4], float out[res
                             if (iw < 0 || iw >= 4) {
                                 continue;
                             }
-                            float val = in0[n][c][ih][iw];
+                            float val = input0[n][c][ih][iw];
                             if (val > max_value) {
                                 max_value = val;
                             }
                         }
                     }
-                    out[n][c][oh][ow] = max_value;
+                    output[n][c][oh][ow] = max_value;
                 }
             }
         }

--- a/tests/golden/op_meanvariancenormalization_mean_variance_normalization.c
+++ b/tests/golden/op_meanvariancenormalization_mean_variance_normalization.c
@@ -30,22 +30,22 @@
  * Attrs:
  *   axes: [-1]
  */
-static inline void model_op0(const float in0[restrict 2][3][4], float out[restrict 2][3][4]) {
+static inline void model_op0(const float input0[restrict 2][3][4], float output[restrict 2][3][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             float sum = 0.0f;
             for (size_t i2 = 0; i2 < 4; ++i2) {
-                sum += in0[i0][i1][i2];
+                sum += input0[i0][i1][i2];
             }
             float mean = sum / 4;
             float var = 0.0f;
             for (size_t i2 = 0; i2 < 4; ++i2) {
-                float diff = in0[i0][i1][i2] - mean;
+                float diff = input0[i0][i1][i2] - mean;
                 var += diff * diff;
             }
             float denom = sqrtf(var / 4 + 1e-09f);
             for (size_t i2 = 0; i2 < 4; ++i2) {
-                out[i0][i1][i2] = (in0[i0][i1][i2] - mean) / denom;
+                output[i0][i1][i2] = (input0[i0][i1][i2] - mean) / denom;
             }
         }
     }

--- a/tests/golden/op_multiinputbinary_sum.c
+++ b/tests/golden/op_multiinputbinary_sum.c
@@ -41,12 +41,12 @@ static inline float ref_scalar_f32_add(float a, float b) {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float in0[restrict 2][3], const float in1[restrict 2][3], const float in2[restrict 2][3], float out[restrict 2][3]) {
+static inline void model_op0(const float input0[restrict 2][3], const float input1[restrict 2][3], const float input2[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            out[i0][i1] = in0[i0][i1];
-            out[i0][i1] = ref_scalar_f32_add(out[i0][i1], in1[i0][i1]);
-            out[i0][i1] = ref_scalar_f32_add(out[i0][i1], in2[i0][i1]);
+            output[i0][i1] = input0[i0][i1];
+            output[i0][i1] = ref_scalar_f32_add(output[i0][i1], input1[i0][i1]);
+            output[i0][i1] = ref_scalar_f32_add(output[i0][i1], input2[i0][i1]);
         }
     }
 }

--- a/tests/golden/op_negativeloglikelihoodloss_negative_log_likelihood_loss.c
+++ b/tests/golden/op_negativeloglikelihoodloss_negative_log_likelihood_loss.c
@@ -30,10 +30,10 @@
  * Attrs:
  *   reduction: mean
  */
-static inline void model_op0(const float input[restrict 2][3], const int64_t target[restrict 2], float loss[restrict 1]) {
-    const float *input_flat = (const float *)input;
+static inline void model_op0(const float input0[restrict 2][3], const int64_t target[restrict 2], float output[restrict 1]) {
+    const float *input_flat = (const float *)input0;
     const int64_t *target_flat = (const int64_t *)target;
-    float *output_flat = (float *)loss;
+    float *output_flat = (float *)output;
     const size_t n = 2;
     const size_t c = 3;
     const size_t d = 1;

--- a/tests/golden/op_reduce_reduce_mean.c
+++ b/tests/golden/op_reduce_reduce_mean.c
@@ -34,15 +34,15 @@ static const int64_t axes[1] = {
  * Attrs:
  *   keepdims: 1
  */
-static inline void model_op0(const float in0[restrict 2][3][4], float out[restrict 2][1][4]) {
+static inline void model_op0(const float input0[restrict 2][3][4], float output[restrict 2][1][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 1; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
                 float acc = 0.0f;
                 for (size_t r0 = 0; r0 < 3; ++r0) {
-                    acc += in0[i0][r0][i2];
+                    acc += input0[i0][r0][i2];
                 }
-                out[i0][i1][i2] = acc / 3.0f;
+                output[i0][i1][i2] = acc / 3.0f;
             }
         }
     }

--- a/tests/golden/op_reshape_reshape.c
+++ b/tests/golden/op_reshape_reshape.c
@@ -34,8 +34,8 @@ static const int64_t shape[2] = {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float in0[restrict 2][3][4], float out[restrict 2][12]) {
-    memcpy(out, in0, sizeof(float) * 24);
+static inline void model_op0(const float input0[restrict 2][3][4], float output[restrict 2][12]) {
+    memcpy(output, input0, sizeof(float) * 24);
 }
 
 void model(const float in0[restrict 2][3][4], float out[restrict 2][12]) {

--- a/tests/golden/op_resize_resize.c
+++ b/tests/golden/op_resize_resize.c
@@ -37,7 +37,7 @@ static const int64_t sizes[4] = {
  *   mode: nearest
  *   nearest_mode: floor
  */
-static inline void model_op0(const float in0[restrict 1][1][2][2], const int64_t sizes[restrict 4], float out[restrict 1][1][4][4]) {
+static inline void model_op0(const float input0[restrict 1][1][2][2], const int64_t sizes_input[restrict 4], float output[restrict 1][1][4][4]) {
     const int64_t input_shape[4] = { 1, 1, 2, 2 };
     const int64_t output_shape[4] = { 1, 1, 4, 4 };
     double scales[4];
@@ -46,10 +46,10 @@ static inline void model_op0(const float in0[restrict 1][1][2][2], const int64_t
     for (size_t r = 0; r < 4; ++r) {
         scales[r] = 1.0;
     }
-    scales[0] = (double)sizes[0] / (double)input_shape[0];
-    scales[1] = (double)sizes[1] / (double)input_shape[1];
-    scales[2] = (double)sizes[2] / (double)input_shape[2];
-    scales[3] = (double)sizes[3] / (double)input_shape[3];
+    scales[0] = (double)sizes_input[0] / (double)input_shape[0];
+    scales[1] = (double)sizes_input[1] / (double)input_shape[1];
+    scales[2] = (double)sizes_input[2] / (double)input_shape[2];
+    scales[3] = (double)sizes_input[3] / (double)input_shape[3];
     for (size_t i0 = 0; i0 < 1; ++i0) {
         for (size_t i1 = 0; i1 < 1; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
@@ -64,7 +64,7 @@ static inline void model_op0(const float in0[restrict 1][1][2][2], const int64_t
                     double x_orig3;
                     x_orig3 = (double)i3 / scales[3];
                     if (use_extrapolation) {
-                        out[i0][i1][i2][i3] = (float)0.0;
+                        output[i0][i1][i2][i3] = (float)0.0;
                     } else {
                         const double x_val0 = x_orig0;
                         const double x_floor0 = floor(x_val0);
@@ -106,7 +106,7 @@ static inline void model_op0(const float in0[restrict 1][1][2][2], const int64_t
                         } else if (idx3 >= input_shape[3]) {
                             idx3 = (int)input_shape[3] - 1;
                         }
-                        out[i0][i1][i2][i3] = in0[idx0][idx1][idx2][idx3];
+                        output[i0][i1][i2][i3] = input0[idx0][idx1][idx2][idx3];
                     }
                 }
             }

--- a/tests/golden/op_rmsnormalization_rms_normalization.c
+++ b/tests/golden/op_rmsnormalization_rms_normalization.c
@@ -31,20 +31,20 @@
  *   axis: -1
  *   epsilon: 9.999999747378752e-06
  */
-static inline void model_op0(const float in0[restrict 2][3][4], const float in1[restrict 4], float out[restrict 2][3][4]) {
+static inline void model_op0(const float input0[restrict 2][3][4], const float scale[restrict 4], float output[restrict 2][3][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             float sum = 0.0f;
             for (size_t i2 = 0; i2 < 4; ++i2) {
-                float value = in0[i0][i1][i2];
+                float value = input0[i0][i1][i2];
                 sum += value * value;
             }
             float mean_square = sum / 4;
             float denom = sqrtf(mean_square + 9.99999975e-06f);
             for (size_t i2 = 0; i2 < 4; ++i2) {
-                float value = in0[i0][i1][i2] / denom;
-                value = value * in1[i2];
-                out[i0][i1][i2] = value;
+                float value = input0[i0][i1][i2] / denom;
+                value = value * scale[i2];
+                output[i0][i1][i2] = value;
             }
         }
     }

--- a/tests/golden/op_shape_shape.c
+++ b/tests/golden/op_shape_shape.c
@@ -29,11 +29,11 @@
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float in0[restrict 2][3][4], int64_t out[restrict 3]) {
-    (void)in0;
-    out[0] = 2LL;
-    out[1] = 3LL;
-    out[2] = 4LL;
+static inline void model_op0(const float input0[restrict 2][3][4], int64_t output[restrict 3]) {
+    (void)input0;
+    output[0] = 2LL;
+    output[1] = 3LL;
+    output[2] = 4LL;
 }
 
 void model(const float in0[restrict 2][3][4], int64_t out[restrict 3]) {

--- a/tests/golden/op_size_size.c
+++ b/tests/golden/op_size_size.c
@@ -29,9 +29,9 @@
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float in0[restrict 2][3][4], int64_t out[restrict 1]) {
-    (void)in0;
-    out[0] = 24LL;
+static inline void model_op0(const float input0[restrict 2][3][4], int64_t output[restrict 1]) {
+    (void)input0;
+    output[0] = 24LL;
 }
 
 void model(const float in0[restrict 2][3][4], int64_t out[restrict 1]) {

--- a/tests/golden/op_slice_slice.c
+++ b/tests/golden/op_slice_slice.c
@@ -45,11 +45,11 @@ static const int64_t steps[2] = {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float in0[restrict 2][3][4], float out[restrict 2][3][1]) {
+static inline void model_op0(const float input0[restrict 2][3][4], float output[restrict 2][3][1]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 1; ++i2) {
-                out[i0][i1][i2] = in0[i0][i1][1 + 2 * i2];
+                output[i0][i1][i2] = input0[i0][i1][1 + 2 * i2];
             }
         }
     }

--- a/tests/golden/op_softmax_softmax.c
+++ b/tests/golden/op_softmax_softmax.c
@@ -30,9 +30,9 @@
  * Attrs:
  *   axis: 1
  */
-static inline void model_op0(const float in0[restrict 2][3], float out[restrict 2][3]) {
-    const float *input_flat = (const float *)in0;
-    float *output_flat = (float *)out;
+static inline void model_op0(const float input0[restrict 2][3], float output[restrict 2][3]) {
+    const float *input_flat = (const float *)input0;
+    float *output_flat = (float *)output;
     const size_t outer = 2;
     const size_t axis_size = 3;
     const size_t inner = 1;

--- a/tests/golden/op_softmaxcrossentropyloss_softmax_cross_entropy_loss.c
+++ b/tests/golden/op_softmaxcrossentropyloss_softmax_cross_entropy_loss.c
@@ -31,10 +31,10 @@
  * Attrs:
  *   reduction: mean
  */
-static inline void model_op0(const float scores[restrict 2][3], const int64_t labels[restrict 2], float loss[restrict 1], float log_prob[restrict 2][3]) {
-    const float *input_flat = (const float *)scores;
-    const int64_t *target_flat = (const int64_t *)labels;
-    float *output_flat = (float *)loss;
+static inline void model_op0(const float input0[restrict 2][3], const int64_t target[restrict 2], float output[restrict 1], float log_prob[restrict 2][3]) {
+    const float *input_flat = (const float *)input0;
+    const int64_t *target_flat = (const int64_t *)target;
+    float *output_flat = (float *)output;
     float *log_prob_flat = (float *)log_prob;
     const size_t n = 2;
     const size_t c = 3;

--- a/tests/golden/op_spacetodepth_space_to_depth.c
+++ b/tests/golden/op_spacetodepth_space_to_depth.c
@@ -29,9 +29,9 @@
  * Attrs:
  *   blocksize: 2
  */
-static inline void model_op0(const float in0[restrict 1][1][4][4], float out[restrict 1][4][2][2]) {
-    const float *input_data = (const float *)in0;
-    float *output_data = (float *)out;
+static inline void model_op0(const float input0[restrict 1][1][4][4], float output[restrict 1][4][2][2]) {
+    const float *input_data = (const float *)input0;
+    float *output_data = (float *)output;
     size_t output_index = 0;
     for (size_t n = 0; n < 1; ++n) {
         for (size_t c_out = 0; c_out < 4; ++c_out) {

--- a/tests/golden/op_split_split.c
+++ b/tests/golden/op_split_split.c
@@ -35,8 +35,8 @@ static const int64_t split[3] = {
  * Attrs:
  *   axis: 1
  */
-static inline void model_op0(const float input[restrict 2][6], float output_0[restrict 2][2], float output_1[restrict 2][2], float output_2[restrict 2][2]) {
-    const float *input_data = (const float *)input;
+static inline void model_op0(const float input0[restrict 2][6], float output_0[restrict 2][2], float output_1[restrict 2][2], float output_2[restrict 2][2]) {
+    const float *input_data = (const float *)input0;
     float *output_ptrs[] = { (float *)output_0, (float *)output_1, (float *)output_2 };
     const size_t axis_sizes[] = { 2, 2, 2 };
     for (size_t outer_idx = 0; outer_idx < 2; ++outer_idx) {

--- a/tests/golden/op_tile_tile.c
+++ b/tests/golden/op_tile_tile.c
@@ -33,8 +33,8 @@ static const int64_t repeats[2] = {
  * Outputs: output
  * Attrs: n/a
  */
-static inline void model_op0(const float input[restrict 2][3], float output[restrict 4][3]) {
-    const float *input_data = (const float *)input;
+static inline void model_op0(const float input0[restrict 2][3], float output[restrict 4][3]) {
+    const float *input_data = (const float *)input0;
     float *output_data = (float *)output;
     size_t output_index = 0;
     for (size_t i0 = 0; i0 < 4; ++i0) {

--- a/tests/golden/op_transpose_transpose.c
+++ b/tests/golden/op_transpose_transpose.c
@@ -29,11 +29,11 @@
  * Attrs:
  *   perm: [2, 0, 1]
  */
-static inline void model_op0(const float in0[restrict 2][3][4], float out[restrict 4][2][3]) {
+static inline void model_op0(const float input0[restrict 2][3][4], float output[restrict 4][2][3]) {
     for (size_t i0 = 0; i0 < 4; ++i0) {
         for (size_t i1 = 0; i1 < 2; ++i1) {
             for (size_t i2 = 0; i2 < 3; ++i2) {
-                out[i0][i1][i2] = in0[i1][i2][i0];
+                output[i0][i1][i2] = input0[i1][i2][i0];
             }
         }
     }

--- a/tests/golden/op_unary_tanh.c
+++ b/tests/golden/op_unary_tanh.c
@@ -41,10 +41,10 @@ static inline float ref_scalar_f32_tanh(float a) {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float in0[restrict 2][3], float out[restrict 2][3]) {
+static inline void model_op0(const float input0[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            out[i0][i1] = ref_scalar_f32_tanh(in0[i0][i1]);
+            output[i0][i1] = ref_scalar_f32_tanh(input0[i0][i1]);
         }
     }
 }

--- a/tests/golden/op_where_where.c
+++ b/tests/golden/op_where_where.c
@@ -29,10 +29,10 @@
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const bool condition[restrict 2][3], const float x[restrict 2][3], const float y[restrict 2][3], float out[restrict 2][3]) {
+static inline void model_op0(const bool condition[restrict 2][3], const float input_x[restrict 2][3], const float input_y[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            out[i0][i1] = condition[i0][i1] ? x[i0][i1] : y[i0][i1];
+            output[i0][i1] = condition[i0][i1] ? input_x[i0][i1] : input_y[i0][i1];
         }
     }
 }

--- a/tests/golden/relu_model.c
+++ b/tests/golden/relu_model.c
@@ -41,10 +41,10 @@ static inline float ref_scalar_f32_relu(float a) {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float x[restrict 2][3], float out[restrict 2][3]) {
+static inline void model_op0(const float input0[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            out[i0][i1] = ref_scalar_f32_relu(x[i0][i1]);
+            output[i0][i1] = ref_scalar_f32_relu(input0[i0][i1]);
         }
     }
 }

--- a/tests/golden/tanh_model.c
+++ b/tests/golden/tanh_model.c
@@ -41,10 +41,10 @@ static inline float ref_scalar_f32_tanh(float a) {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float x[restrict 2][3], float out[restrict 2][3]) {
+static inline void model_op0(const float input0[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
-            out[i0][i1] = ref_scalar_f32_tanh(x[i0][i1]);
+            output[i0][i1] = ref_scalar_f32_tanh(input0[i0][i1]);
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Make generated op function signatures deterministic and independent of call-site variable names by using fixed parameter identifiers derived from parameter roles.

### Description
- Change the parameter mapping logic in `CEmitter` (`src/onnx2c/codegen/c_emitter.py`) to sanitize and base generated parameter names on the parameter `key` (role) instead of the call-site `name` by updating `_unique_param_map` and `_shared_param_map` to use `key`-derived identifiers.
- Ensure generated op signatures and bodies reference the new fixed names (e.g., `input0`, `input1`, `output`, `input_min`, `input_max`, etc.).
- Regenerate golden C outputs under `tests/golden/` so emitted C matches the new signatures.

### Testing
- Ran the full test suite with reference updates using `UPDATE_REFS=1 pytest -n auto -q` which took `40.48s` to complete.
- Test result: `233 passed, 2 skipped, 2 warnings` and golden references were updated to match the new signatures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696905a272dc83259a48f3dafb11d8bb)