### PR TITLE
cli: derive default output .c filename from model when omitted

### DIFF
--- a/src/onnx2c/cli.py
+++ b/src/onnx2c/cli.py
@@ -51,7 +51,16 @@ def _build_parser() -> argparse.ArgumentParser:
         "compile", help="Compile an ONNX model into C source"
     )
     compile_parser.add_argument("model", type=Path, help="Path to the ONNX model")
-    compile_parser.add_argument("output", type=Path, help="Output C file path")
+    compile_parser.add_argument(
+        "output",
+        type=Path,
+        nargs="?",
+        default=None,
+        help=(
+            "Output C file path (default: use model filename with .c suffix, "
+            "e.g., model.onnx -> model.c)"
+        ),
+    )
     compile_parser.add_argument(
         "--template-dir",
         type=Path,
@@ -122,7 +131,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 def _handle_compile(args: argparse.Namespace) -> int:
     model_path: Path = args.model
-    output_path: Path = args.output
+    output_path: Path = args.output or model_path.with_suffix(".c")
     model_name = args.model_name or output_path.stem
     try:
         model_checksum = _model_checksum(model_path)


### PR DESCRIPTION
### Motivation
- Make the `compile` CLI more ergonomic by allowing the `output` argument to be omitted and deriving the output C filename from the provided model (e.g., `model.onnx` -> `model.c`).

### Description
- Update `src/onnx2c/cli.py` to make the `compile` `output` positional argument optional (`nargs='?'`, `default=None`) and set `output_path = args.output or model_path.with_suffix('.c')`, and update the help text to document the default behavior.

### Testing
- Ran `UPDATE_REFS=1 pytest -n auto -q` (58.95s): `233 passed, 2 skipped, 2 warnings`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69690516130c8325a32e224613bec22d)