### PR TITLE
codegen: rename op functions by node

### DIFF
--- a/src/onnx2c/compiler.py
+++ b/src/onnx2c/compiler.py
@@ -426,6 +426,7 @@ class Compiler:
             node_infos.append(
                 NodeInfo(
                     op_type=node.op_type,
+                    name=node.name,
                     inputs=tuple(node.inputs),
                     outputs=tuple(node.outputs),
                     attrs=dict(node.attrs),

--- a/src/onnx2c/ir/model.py
+++ b/src/onnx2c/ir/model.py
@@ -24,6 +24,7 @@ class Value:
 @dataclass(frozen=True)
 class Node:
     op_type: str
+    name: str | None
     inputs: tuple[str, ...]
     outputs: tuple[str, ...]
     attrs: Mapping[str, object]

--- a/src/onnx2c/onnx_import.py
+++ b/src/onnx2c/onnx_import.py
@@ -229,6 +229,7 @@ def import_onnx(model: onnx.ModelProto) -> Graph:
         nodes.append(
             Node(
                 op_type=node.op_type,
+                name=node.name or None,
                 inputs=tuple(node.input),
                 outputs=tuple(node.output),
                 attrs=_node_attrs(node),

--- a/tests/golden/add_initializer_model.c
+++ b/tests/golden/add_initializer_model.c
@@ -41,11 +41,12 @@ static inline float ref_scalar_f32_add(float a, float b) {
 /*
  * Node 0:
  * OpType: Add
+ * Name: n/a
  * Inputs: in0, weight
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_Add(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_add(input0[i0][i1], input1[i0][i1]);
@@ -54,5 +55,5 @@ static inline void model_op0(const float input0[restrict 2][3], const float inpu
 }
 
 void model(const float in0[restrict 2][3], float out[restrict 2][3]) {
-    model_op0(in0, weight, out);
+    node0_Add(in0, weight, out);
 }

--- a/tests/golden/add_model.c
+++ b/tests/golden/add_model.c
@@ -37,11 +37,12 @@ static inline float ref_scalar_f32_add(float a, float b) {
 /*
  * Node 0:
  * OpType: Add
+ * Name: n/a
  * Inputs: a, b
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float input0[restrict 2][3][4], const float input1[restrict 2][3][4], float output[restrict 2][3][4]) {
+static inline void node0_Add(const float input0[restrict 2][3][4], const float input1[restrict 2][3][4], float output[restrict 2][3][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
@@ -52,5 +53,5 @@ static inline void model_op0(const float input0[restrict 2][3][4], const float i
 }
 
 void model(const float a[restrict 2][3][4], const float b[restrict 2][3][4], float out[restrict 2][3][4]) {
-    model_op0(a, b, out);
+    node0_Add(a, b, out);
 }

--- a/tests/golden/add_model_no_restrict.c
+++ b/tests/golden/add_model_no_restrict.c
@@ -37,11 +37,12 @@ static inline float ref_scalar_f32_add(float a, float b) {
 /*
  * Node 0:
  * OpType: Add
+ * Name: n/a
  * Inputs: a, b
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float input0[2][3][4], const float input1[2][3][4], float output[2][3][4]) {
+static inline void node0_Add(const float input0[2][3][4], const float input1[2][3][4], float output[2][3][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
@@ -52,5 +53,5 @@ static inline void model_op0(const float input0[2][3][4], const float input1[2][
 }
 
 void model(const float a[2][3][4], const float b[2][3][4], float out[2][3][4]) {
-    model_op0(a, b, out);
+    node0_Add(a, b, out);
 }

--- a/tests/golden/add_model_testbench.c
+++ b/tests/golden/add_model_testbench.c
@@ -39,11 +39,12 @@ static inline float ref_scalar_f32_add(float a, float b) {
 /*
  * Node 0:
  * OpType: Add
+ * Name: n/a
  * Inputs: a, b
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float input0[restrict 2][3][4], const float input1[restrict 2][3][4], float output[restrict 2][3][4]) {
+static inline void node0_Add(const float input0[restrict 2][3][4], const float input1[restrict 2][3][4], float output[restrict 2][3][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
@@ -54,7 +55,7 @@ static inline void model_op0(const float input0[restrict 2][3][4], const float i
 }
 
 void model(const float a[restrict 2][3][4], const float b[restrict 2][3][4], float out[restrict 2][3][4]) {
-    model_op0(a, b, out);
+    node0_Add(a, b, out);
 }
 
 static uint64_t rng_state = 0x243f6a8885a308d3ull;

--- a/tests/golden/dynamic_dims_model.c
+++ b/tests/golden/dynamic_dims_model.c
@@ -37,11 +37,12 @@ static inline float ref_scalar_f32_relu(float a) {
 /*
  * Node 0:
  * OpType: Relu
+ * Name: n/a
  * Inputs: x
  * Outputs: out
  * Attrs: n/a
  */
-static inline void dynamic_dims_model_op0(int N, int C, const float input0[restrict N][C], float output[restrict N][C]) {
+static inline void node0_Relu(int N, int C, const float input0[restrict N][C], float output[restrict N][C]) {
     for (size_t i0 = 0; i0 < N; ++i0) {
         for (size_t i1 = 0; i1 < C; ++i1) {
             output[i0][i1] = ref_scalar_f32_relu(input0[i0][i1]);
@@ -50,5 +51,5 @@ static inline void dynamic_dims_model_op0(int N, int C, const float input0[restr
 }
 
 void dynamic_dims_model(int N, int C, const float x[restrict N][C], float out[restrict N][C]) {
-    dynamic_dims_model_op0(N, C, x, out);
+    node0_Relu(N, C, x, out);
 }

--- a/tests/golden/matmul_model.c
+++ b/tests/golden/matmul_model.c
@@ -24,11 +24,12 @@
 /*
  * Node 0:
  * OpType: MatMul
+ * Name: n/a
  * Inputs: a, b
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float input0[restrict 2][3], const float input1[restrict 3][4], float output[restrict 2][4]) {
+static inline void node0_MatMul(const float input0[restrict 2][3], const float input1[restrict 3][4], float output[restrict 2][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 4; ++i1) {
             float acc = 0.0f;
@@ -41,5 +42,5 @@ static inline void model_op0(const float input0[restrict 2][3], const float inpu
 }
 
 void model(const float a[restrict 2][3], const float b[restrict 3][4], float out[restrict 2][4]) {
-    model_op0(a, b, out);
+    node0_MatMul(a, b, out);
 }

--- a/tests/golden/mul_add_model.c
+++ b/tests/golden/mul_add_model.c
@@ -41,11 +41,12 @@ static inline float ref_scalar_f32_add(float a, float b) {
 /*
  * Node 0:
  * OpType: Mul
+ * Name: n/a
  * Inputs: a, b
  * Outputs: mul_out
  * Attrs: n/a
  */
-static inline void model_op0(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_Mul(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_mul(input0[i0][i1], input1[i0][i1]);
@@ -56,11 +57,12 @@ static inline void model_op0(const float input0[restrict 2][3], const float inpu
 /*
  * Node 1:
  * OpType: Add
+ * Name: n/a
  * Inputs: mul_out, c
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op1(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
+static inline void node1_Add(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_add(input0[i0][i1], input1[i0][i1]);
@@ -70,6 +72,6 @@ static inline void model_op1(const float input0[restrict 2][3], const float inpu
 
 void model(const float a[restrict 2][3], const float b[restrict 2][3], const float c[restrict 2][3], float out[restrict 2][3]) {
     float tmp[2][3];
-    model_op0(a, b, tmp);
-    model_op1(tmp, c, out);
+    node0_Mul(a, b, tmp);
+    node1_Add(tmp, c, out);
 }

--- a/tests/golden/mul_add_relu_model.c
+++ b/tests/golden/mul_add_relu_model.c
@@ -45,11 +45,12 @@ static inline float ref_scalar_f32_relu(float a) {
 /*
  * Node 0:
  * OpType: Mul
+ * Name: n/a
  * Inputs: a, b
  * Outputs: mul_out
  * Attrs: n/a
  */
-static inline void model_op0(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_Mul(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_mul(input0[i0][i1], input1[i0][i1]);
@@ -60,11 +61,12 @@ static inline void model_op0(const float input0[restrict 2][3], const float inpu
 /*
  * Node 1:
  * OpType: Add
+ * Name: n/a
  * Inputs: mul_out, c
  * Outputs: add_out
  * Attrs: n/a
  */
-static inline void model_op1(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
+static inline void node1_Add(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_add(input0[i0][i1], input1[i0][i1]);
@@ -75,11 +77,12 @@ static inline void model_op1(const float input0[restrict 2][3], const float inpu
 /*
  * Node 2:
  * OpType: Relu
+ * Name: n/a
  * Inputs: add_out
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op2(const float input0[restrict 2][3], float output[restrict 2][3]) {
+static inline void node2_Relu(const float input0[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_relu(input0[i0][i1]);
@@ -90,7 +93,7 @@ static inline void model_op2(const float input0[restrict 2][3], float output[res
 void model(const float a[restrict 2][3], const float b[restrict 2][3], const float c[restrict 2][3], float out[restrict 2][3]) {
     float tmp0[2][3];
     float tmp1[2][3];
-    model_op0(a, b, tmp0);
-    model_op1(tmp0, c, tmp1);
-    model_op2(tmp1, out);
+    node0_Mul(a, b, tmp0);
+    node1_Add(tmp0, c, tmp1);
+    node2_Relu(tmp1, out);
 }

--- a/tests/golden/mul_model.c
+++ b/tests/golden/mul_model.c
@@ -37,11 +37,12 @@ static inline float ref_scalar_f32_mul(float a, float b) {
 /*
  * Node 0:
  * OpType: Mul
+ * Name: n/a
  * Inputs: a, b
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_Mul(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_mul(input0[i0][i1], input1[i0][i1]);
@@ -50,5 +51,5 @@ static inline void model_op0(const float input0[restrict 2][3], const float inpu
 }
 
 void model(const float a[restrict 2][3], const float b[restrict 2][3], float out[restrict 2][3]) {
-    model_op0(a, b, out);
+    node0_Mul(a, b, out);
 }

--- a/tests/golden/op_argreduce_arg_max.c
+++ b/tests/golden/op_argreduce_arg_max.c
@@ -25,6 +25,7 @@
 /*
  * Node 0:
  * OpType: ArgMax
+ * Name: n/a
  * Inputs: input
  * Outputs: output
  * Attrs:
@@ -32,7 +33,7 @@
  *   keepdims: 1
  *   select_last_index: 0
  */
-static inline void model_op0(const float input0[restrict 2][3][4], int64_t output[restrict 2][1][4]) {
+static inline void node0_ArgMax(const float input0[restrict 2][3][4], int64_t output[restrict 2][1][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 1; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
@@ -52,5 +53,5 @@ static inline void model_op0(const float input0[restrict 2][3][4], int64_t outpu
 }
 
 void model(const float input[restrict 2][3][4], int64_t output[restrict 2][1][4]) {
-    model_op0(input, output);
+    node0_ArgMax(input, output);
 }

--- a/tests/golden/op_attention_attention.c
+++ b/tests/golden/op_attention_attention.c
@@ -25,11 +25,12 @@
 /*
  * Node 0:
  * OpType: Attention
+ * Name: n/a
  * Inputs: in0, in1, in2
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float input_q[restrict 1][2][3][4], const float input_k[restrict 1][2][5][4], const float input_v[restrict 1][2][5][4], float output[restrict 1][2][3][4]) {
+static inline void node0_Attention(const float input_q[restrict 1][2][3][4], const float input_k[restrict 1][2][5][4], const float input_v[restrict 1][2][5][4], float output[restrict 1][2][3][4]) {
     const float scale = 0.5f;
     const float softcap = 0.0f;
     for (int b = 0; b < 1; ++b) {
@@ -88,5 +89,5 @@ static inline void model_op0(const float input_q[restrict 1][2][3][4], const flo
 }
 
 void model(const float in0[restrict 1][2][3][4], const float in1[restrict 1][2][5][4], const float in2[restrict 1][2][5][4], float out[restrict 1][2][3][4]) {
-    model_op0(in0, in1, in2, out);
+    node0_Attention(in0, in1, in2, out);
 }

--- a/tests/golden/op_averagepool_average_pool.c
+++ b/tests/golden/op_averagepool_average_pool.c
@@ -24,13 +24,14 @@
 /*
  * Node 0:
  * OpType: AveragePool
+ * Name: n/a
  * Inputs: input
  * Outputs: output
  * Attrs:
  *   kernel_shape: [2, 2]
  *   strides: [2, 2]
  */
-static inline void model_op0(const float input0[restrict 1][1][4][4], float output[restrict 1][1][2][2]) {
+static inline void node0_AveragePool(const float input0[restrict 1][1][4][4], float output[restrict 1][1][2][2]) {
     for (size_t n = 0; n < 1; ++n) {
         for (size_t c = 0; c < 1; ++c) {
             for (size_t oh = 0; oh < 2; ++oh) {
@@ -65,5 +66,5 @@ static inline void model_op0(const float input0[restrict 1][1][4][4], float outp
 }
 
 void model(const float input[restrict 1][1][4][4], float output[restrict 1][1][2][2]) {
-    model_op0(input, output);
+    node0_AveragePool(input, output);
 }

--- a/tests/golden/op_batchnorm_batch_normalization.c
+++ b/tests/golden/op_batchnorm_batch_normalization.c
@@ -41,12 +41,13 @@ static const float var[3] = {
 /*
  * Node 0:
  * OpType: BatchNormalization
+ * Name: n/a
  * Inputs: in0, scale, bias, mean, var
  * Outputs: out
  * Attrs:
  *   epsilon: 9.999999747378752e-06
  */
-static inline void model_op0(const float input0[restrict 2][3][2][2], const float scale[restrict 3], const float bias[restrict 3], const float mean[restrict 3], const float variance[restrict 3], float output[restrict 2][3][2][2]) {
+static inline void node0_BatchNormalization(const float input0[restrict 2][3][2][2], const float scale[restrict 3], const float bias[restrict 3], const float mean[restrict 3], const float variance[restrict 3], float output[restrict 2][3][2][2]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 2; ++i2) {
@@ -61,5 +62,5 @@ static inline void model_op0(const float input0[restrict 2][3][2][2], const floa
 }
 
 void model(const float in0[restrict 2][3][2][2], float out[restrict 2][3][2][2]) {
-    model_op0(in0, scale, bias, mean, var, out);
+    node0_BatchNormalization(in0, scale, bias, mean, var, out);
 }

--- a/tests/golden/op_binary_mul.c
+++ b/tests/golden/op_binary_mul.c
@@ -37,11 +37,12 @@ static inline float ref_scalar_f32_mul(float a, float b) {
 /*
  * Node 0:
  * OpType: Mul
+ * Name: n/a
  * Inputs: in0, in1
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_Mul(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_mul(input0[i0][i1], input1[i0][i1]);
@@ -50,5 +51,5 @@ static inline void model_op0(const float input0[restrict 2][3], const float inpu
 }
 
 void model(const float in0[restrict 2][3], const float in1[restrict 2][3], float out[restrict 2][3]) {
-    model_op0(in0, in1, out);
+    node0_Mul(in0, in1, out);
 }

--- a/tests/golden/op_cast_cast.c
+++ b/tests/golden/op_cast_cast.c
@@ -25,12 +25,13 @@
 /*
  * Node 0:
  * OpType: Cast
+ * Name: n/a
  * Inputs: in0
  * Outputs: out
  * Attrs:
  *   to: 6
  */
-static inline void model_op0(const float input0[restrict 2][3], int32_t output[restrict 2][3]) {
+static inline void node0_Cast(const float input0[restrict 2][3], int32_t output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = (int32_t)input0[i0][i1];
@@ -39,5 +40,5 @@ static inline void model_op0(const float input0[restrict 2][3], int32_t output[r
 }
 
 void model(const float in0[restrict 2][3], int32_t out[restrict 2][3]) {
-    model_op0(in0, out);
+    node0_Cast(in0, out);
 }

--- a/tests/golden/op_clip_clip.c
+++ b/tests/golden/op_clip_clip.c
@@ -32,11 +32,12 @@ static const float max[1] = {
 /*
  * Node 0:
  * OpType: Clip
+ * Name: n/a
  * Inputs: input, min, max
  * Outputs: output
  * Attrs: n/a
  */
-static inline void model_op0(const float input0[restrict 2][3], const float input_min[restrict 1], const float input_max[restrict 1], float output[restrict 2][3]) {
+static inline void node0_Clip(const float input0[restrict 2][3], const float input_min[restrict 1], const float input_max[restrict 1], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             float value = input0[i0][i1];
@@ -52,5 +53,5 @@ static inline void model_op0(const float input0[restrict 2][3], const float inpu
 }
 
 void model(const float input[restrict 2][3], float output[restrict 2][3]) {
-    model_op0(input, min, max, output);
+    node0_Clip(input, min, max, output);
 }

--- a/tests/golden/op_concat_concat.c
+++ b/tests/golden/op_concat_concat.c
@@ -25,12 +25,13 @@
 /*
  * Node 0:
  * OpType: Concat
+ * Name: n/a
  * Inputs: in0, in1
  * Outputs: out
  * Attrs:
  *   axis: 2
  */
-static inline void model_op0(const float input_0[restrict 1][2][3], const float input_1[restrict 1][2][1], float output[restrict 1][2][4]) {
+static inline void node0_Concat(const float input_0[restrict 1][2][3], const float input_1[restrict 1][2][1], float output[restrict 1][2][4]) {
     const void *inputs[] = { input_0, input_1 };
     const size_t axis_sizes[] = { 3, 1 };
     size_t concat_axis = 0;
@@ -60,5 +61,5 @@ static inline void model_op0(const float input_0[restrict 1][2][3], const float 
 }
 
 void model(const float in0[restrict 1][2][3], const float in1[restrict 1][2][1], float out[restrict 1][2][4]) {
-    model_op0(in0, in1, out);
+    node0_Concat(in0, in1, out);
 }

--- a/tests/golden/op_constantofshape_constant_of_shape.c
+++ b/tests/golden/op_constantofshape_constant_of_shape.c
@@ -29,6 +29,7 @@ static const int64_t shape[3] = {
 /*
  * Node 0:
  * OpType: ConstantOfShape
+ * Name: n/a
  * Inputs: shape
  * Outputs: out
  * Attrs:
@@ -38,7 +39,7 @@ float_data: 1.25
 name: "fill"
 
  */
-static inline void model_op0(const int64_t input0[restrict 3], float output[restrict 2][3][4]) {
+static inline void node0_ConstantOfShape(const int64_t input0[restrict 3], float output[restrict 2][3][4]) {
     (void)input0;
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
@@ -50,5 +51,5 @@ static inline void model_op0(const int64_t input0[restrict 3], float output[rest
 }
 
 void model(float out[restrict 2][3][4]) {
-    model_op0(shape, out);
+    node0_ConstantOfShape(shape, out);
 }

--- a/tests/golden/op_conv_conv.c
+++ b/tests/golden/op_conv_conv.c
@@ -33,13 +33,14 @@ static const float bias[1] = {
 /*
  * Node 0:
  * OpType: Conv
+ * Name: n/a
  * Inputs: in0, weight, bias
  * Outputs: out
  * Attrs:
  *   pads: [1, 1, 1, 1]
  *   strides: [1, 1]
  */
-static inline void model_op0(const float input0[restrict 1][1][4][4], const float weights[restrict 1][1][3][3], const float bias[restrict 1], float output[restrict 1][1][4][4]) {
+static inline void node0_Conv(const float input0[restrict 1][1][4][4], const float weights[restrict 1][1][3][3], const float bias[restrict 1], float output[restrict 1][1][4][4]) {
     for (size_t n = 0; n < 1; ++n) {
         for (size_t g = 0; g < 1; ++g) {
             for (size_t oc = 0; oc < 1; ++oc) {
@@ -69,5 +70,5 @@ static inline void model_op0(const float input0[restrict 1][1][4][4], const floa
 }
 
 void model(const float in0[restrict 1][1][4][4], float out[restrict 1][1][4][4]) {
-    model_op0(in0, weight, bias, out);
+    node0_Conv(in0, weight, bias, out);
 }

--- a/tests/golden/op_cumsum_cumsum.c
+++ b/tests/golden/op_cumsum_cumsum.c
@@ -29,13 +29,14 @@ static const int64_t axis[1] = {
 /*
  * Node 0:
  * OpType: CumSum
+ * Name: n/a
  * Inputs: input, axis
  * Outputs: output
  * Attrs:
  *   exclusive: 0
  *   reverse: 0
  */
-static inline void model_op0(const float input0[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_CumSum(const float input0[restrict 2][3], float output[restrict 2][3]) {
     const size_t dims[2] = { 2, 3 };
     int axis = 1;
     if (axis < 0) {
@@ -67,5 +68,5 @@ static inline void model_op0(const float input0[restrict 2][3], float output[res
 }
 
 void model(const float input[restrict 2][3], float output[restrict 2][3]) {
-    model_op0(input, output);
+    node0_CumSum(input, output);
 }

--- a/tests/golden/op_depthtospace_depth_to_space.c
+++ b/tests/golden/op_depthtospace_depth_to_space.c
@@ -24,13 +24,14 @@
 /*
  * Node 0:
  * OpType: DepthToSpace
+ * Name: n/a
  * Inputs: in0
  * Outputs: out
  * Attrs:
  *   blocksize: 2
  *   mode: DCR
  */
-static inline void model_op0(const float input0[restrict 1][4][2][2], float output[restrict 1][1][4][4]) {
+static inline void node0_DepthToSpace(const float input0[restrict 1][4][2][2], float output[restrict 1][1][4][4]) {
     const float *input_data = (const float *)input0;
     float *output_data = (float *)output;
     size_t output_index = 0;
@@ -54,5 +55,5 @@ static inline void model_op0(const float input0[restrict 1][4][2][2], float outp
 }
 
 void model(const float in0[restrict 1][4][2][2], float out[restrict 1][1][4][4]) {
-    model_op0(in0, out);
+    node0_DepthToSpace(in0, out);
 }

--- a/tests/golden/op_expand_expand.c
+++ b/tests/golden/op_expand_expand.c
@@ -29,11 +29,12 @@ static const int64_t shape[2] = {
 /*
  * Node 0:
  * OpType: Expand
+ * Name: n/a
  * Inputs: input, shape
  * Outputs: output
  * Attrs: n/a
  */
-static inline void model_op0(const float input0[restrict 1][3], float output[restrict 2][3]) {
+static inline void node0_Expand(const float input0[restrict 1][3], float output[restrict 2][3]) {
     const float *input_data = (const float *)input0;
     float *output_data = (float *)output;
     size_t output_index = 0;
@@ -47,5 +48,5 @@ static inline void model_op0(const float input0[restrict 1][3], float output[res
 }
 
 void model(const float input[restrict 1][3], float output[restrict 2][3]) {
-    model_op0(input, output);
+    node0_Expand(input, output);
 }

--- a/tests/golden/op_eyelike_eye_like.c
+++ b/tests/golden/op_eyelike_eye_like.c
@@ -24,12 +24,13 @@
 /*
  * Node 0:
  * OpType: EyeLike
+ * Name: n/a
  * Inputs: input
  * Outputs: output
  * Attrs:
  *   k: 0
  */
-static inline void model_op0(const float input0[restrict 3][3], float output[restrict 3][3]) {
+static inline void node0_EyeLike(const float input0[restrict 3][3], float output[restrict 3][3]) {
     (void)input0;
     float *output_data = (float *)output;
     size_t total = (size_t)1 * 3 * 3;
@@ -58,5 +59,5 @@ static inline void model_op0(const float input0[restrict 3][3], float output[res
 }
 
 void model(const float input[restrict 3][3], float output[restrict 3][3]) {
-    model_op0(input, output);
+    node0_EyeLike(input, output);
 }

--- a/tests/golden/op_gather_gather.c
+++ b/tests/golden/op_gather_gather.c
@@ -25,12 +25,13 @@
 /*
  * Node 0:
  * OpType: Gather
+ * Name: n/a
  * Inputs: data, indices
  * Outputs: out
  * Attrs:
  *   axis: 0
  */
-static inline void model_op0(const float data[restrict 3][2], const int64_t indices[restrict 2], float output[restrict 2][2]) {
+static inline void node0_Gather(const float data[restrict 3][2], const int64_t indices[restrict 2], float output[restrict 2][2]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 2; ++i1) {
             int64_t gather_index = (int64_t)indices[i0];
@@ -43,5 +44,5 @@ static inline void model_op0(const float data[restrict 3][2], const int64_t indi
 }
 
 void model(const float data[restrict 3][2], const int64_t indices[restrict 2], float out[restrict 2][2]) {
-    model_op0(data, indices, out);
+    node0_Gather(data, indices, out);
 }

--- a/tests/golden/op_gatherelements_gather_elements.c
+++ b/tests/golden/op_gatherelements_gather_elements.c
@@ -25,12 +25,13 @@
 /*
  * Node 0:
  * OpType: GatherElements
+ * Name: n/a
  * Inputs: data, indices
  * Outputs: out
  * Attrs:
  *   axis: 0
  */
-static inline void model_op0(const float data[restrict 2][3], const int64_t indices[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_GatherElements(const float data[restrict 2][3], const int64_t indices[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             int64_t gather_index = (int64_t)indices[i0][i1];
@@ -43,5 +44,5 @@ static inline void model_op0(const float data[restrict 2][3], const int64_t indi
 }
 
 void model(const float data[restrict 2][3], const int64_t indices[restrict 2][3], float out[restrict 2][3]) {
-    model_op0(data, indices, out);
+    node0_GatherElements(data, indices, out);
 }

--- a/tests/golden/op_gemm_gemm.c
+++ b/tests/golden/op_gemm_gemm.c
@@ -24,13 +24,14 @@
 /*
  * Node 0:
  * OpType: Gemm
+ * Name: n/a
  * Inputs: in0, in1, in2
  * Outputs: out
  * Attrs:
  *   alpha: 1.0
  *   beta: 1.0
  */
-static inline void model_op0(const float input_a[restrict 2][3], const float input_b[restrict 3][4], const float input_c[restrict 2][4], float output[restrict 2][4]) {
+static inline void node0_Gemm(const float input_a[restrict 2][3], const float input_b[restrict 3][4], const float input_c[restrict 2][4], float output[restrict 2][4]) {
     for (size_t i = 0; i < 2; ++i) {
         for (size_t j = 0; j < 4; ++j) {
             float acc = 0.0f;
@@ -48,5 +49,5 @@ static inline void model_op0(const float input_a[restrict 2][3], const float inp
 }
 
 void model(const float in0[restrict 2][3], const float in1[restrict 3][4], const float in2[restrict 2][4], float out[restrict 2][4]) {
-    model_op0(in0, in1, in2, out);
+    node0_Gemm(in0, in1, in2, out);
 }

--- a/tests/golden/op_gridsample_grid_sample.c
+++ b/tests/golden/op_gridsample_grid_sample.c
@@ -25,6 +25,7 @@
 /*
  * Node 0:
  * OpType: GridSample
+ * Name: n/a
  * Inputs: x, grid
  * Outputs: y
  * Attrs:
@@ -32,7 +33,7 @@
  *   mode: linear
  *   padding_mode: zeros
  */
-static inline double model_op0_reflect(double value, double x_min, double x_max) {
+static inline double node0_GridSample_reflect(double value, double x_min, double x_max) {
     const double range = x_max - x_min;
     if (range == 0.0) {
         return x_min;
@@ -52,7 +53,7 @@ static inline double model_op0_reflect(double value, double x_min, double x_max)
     return value;
 }
 
-static inline void model_op0(const float x[restrict 1][1][2][2], const float grid[restrict 1][2][2][2], float y[restrict 1][1][2][2]) {
+static inline void node0_GridSample(const float x[restrict 1][1][2][2], const float grid[restrict 1][2][2][2], float y[restrict 1][1][2][2]) {
     const int input_spatial[2] = { 2, 2 };
     const double border_min[2] = { -0.5, -0.5 };
     const double border_max[2] = { 1.5, 1.5 };
@@ -154,5 +155,5 @@ static inline void model_op0(const float x[restrict 1][1][2][2], const float gri
 }
 
 void model(const float x[restrict 1][1][2][2], const float grid[restrict 1][2][2][2], float y[restrict 1][1][2][2]) {
-    model_op0(x, grid, y);
+    node0_GridSample(x, grid, y);
 }

--- a/tests/golden/op_groupnormalization_group_normalization.c
+++ b/tests/golden/op_groupnormalization_group_normalization.c
@@ -25,13 +25,14 @@
 /*
  * Node 0:
  * OpType: GroupNormalization
+ * Name: n/a
  * Inputs: in0, in1, in2
  * Outputs: out
  * Attrs:
  *   epsilon: 9.999999747378752e-06
  *   num_groups: 2
  */
-static inline void model_op0(const float input0[restrict 1][4][2][2], const float scale[restrict 4], const float bias[restrict 4], float output[restrict 1][4][2][2]) {
+static inline void node0_GroupNormalization(const float input0[restrict 1][4][2][2], const float scale[restrict 4], const float bias[restrict 4], float output[restrict 1][4][2][2]) {
     for (size_t i0 = 0; i0 < 1; ++i0) {
         for (size_t g = 0; g < 2; ++g) {
             float sum = 0.0f;
@@ -69,5 +70,5 @@ static inline void model_op0(const float input0[restrict 1][4][2][2], const floa
 }
 
 void model(const float in0[restrict 1][4][2][2], const float in1[restrict 4], const float in2[restrict 4], float out[restrict 1][4][2][2]) {
-    model_op0(in0, in1, in2, out);
+    node0_GroupNormalization(in0, in1, in2, out);
 }

--- a/tests/golden/op_identity_identity.c
+++ b/tests/golden/op_identity_identity.c
@@ -25,11 +25,12 @@
 /*
  * Node 0:
  * OpType: Identity
+ * Name: n/a
  * Inputs: in0
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float input0[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_Identity(const float input0[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = input0[i0][i1];
@@ -38,5 +39,5 @@ static inline void model_op0(const float input0[restrict 2][3], float output[res
 }
 
 void model(const float in0[restrict 2][3], float out[restrict 2][3]) {
-    model_op0(in0, out);
+    node0_Identity(in0, out);
 }

--- a/tests/golden/op_instancenormalization_instance_normalization.c
+++ b/tests/golden/op_instancenormalization_instance_normalization.c
@@ -25,12 +25,13 @@
 /*
  * Node 0:
  * OpType: InstanceNormalization
+ * Name: n/a
  * Inputs: in0, in1, in2
  * Outputs: out
  * Attrs:
  *   epsilon: 9.999999747378752e-06
  */
-static inline void model_op0(const float input0[restrict 1][3][2][2], const float scale[restrict 3], const float bias[restrict 3], float output[restrict 1][3][2][2]) {
+static inline void node0_InstanceNormalization(const float input0[restrict 1][3][2][2], const float scale[restrict 3], const float bias[restrict 3], float output[restrict 1][3][2][2]) {
     for (size_t i0 = 0; i0 < 1; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             float sum = 0.0f;
@@ -59,5 +60,5 @@ static inline void model_op0(const float input0[restrict 1][3][2][2], const floa
 }
 
 void model(const float in0[restrict 1][3][2][2], const float in1[restrict 3], const float in2[restrict 3], float out[restrict 1][3][2][2]) {
-    model_op0(in0, in1, in2, out);
+    node0_InstanceNormalization(in0, in1, in2, out);
 }

--- a/tests/golden/op_layernormalization_layer_normalization.c
+++ b/tests/golden/op_layernormalization_layer_normalization.c
@@ -25,13 +25,14 @@
 /*
  * Node 0:
  * OpType: LayerNormalization
+ * Name: n/a
  * Inputs: in0, in1, in2
  * Outputs: out
  * Attrs:
  *   axis: 1
  *   epsilon: 9.999999747378752e-06
  */
-static inline void model_op0(const float input0[restrict 2][3][4], const float scale[restrict 3][4], const float bias[restrict 3][4], float output[restrict 2][3][4]) {
+static inline void node0_LayerNormalization(const float input0[restrict 2][3][4], const float scale[restrict 3][4], const float bias[restrict 3][4], float output[restrict 2][3][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         float sum = 0.0f;
         for (size_t i1 = 0; i1 < 3; ++i1) {
@@ -60,5 +61,5 @@ static inline void model_op0(const float input0[restrict 2][3][4], const float s
 }
 
 void model(const float in0[restrict 2][3][4], const float in1[restrict 3][4], const float in2[restrict 3][4], float out[restrict 2][3][4]) {
-    model_op0(in0, in1, in2, out);
+    node0_LayerNormalization(in0, in1, in2, out);
 }

--- a/tests/golden/op_logsoftmax_logsoftmax.c
+++ b/tests/golden/op_logsoftmax_logsoftmax.c
@@ -25,12 +25,13 @@
 /*
  * Node 0:
  * OpType: LogSoftmax
+ * Name: n/a
  * Inputs: in0
  * Outputs: out
  * Attrs:
  *   axis: 1
  */
-static inline void model_op0(const float input0[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_LogSoftmax(const float input0[restrict 2][3], float output[restrict 2][3]) {
     const float *input_flat = (const float *)input0;
     float *output_flat = (float *)output;
     const size_t outer = 2;
@@ -61,5 +62,5 @@ static inline void model_op0(const float input0[restrict 2][3], float output[res
 }
 
 void model(const float in0[restrict 2][3], float out[restrict 2][3]) {
-    model_op0(in0, out);
+    node0_LogSoftmax(in0, out);
 }

--- a/tests/golden/op_lpnormalization_lp_normalization.c
+++ b/tests/golden/op_lpnormalization_lp_normalization.c
@@ -25,13 +25,14 @@
 /*
  * Node 0:
  * OpType: LpNormalization
+ * Name: n/a
  * Inputs: in0
  * Outputs: out
  * Attrs:
  *   axis: -1
  *   p: 1
  */
-static inline void model_op0(const float input0[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_LpNormalization(const float input0[restrict 2][3], float output[restrict 2][3]) {
     const float *input_flat = (const float *)input0;
     float *output_flat = (float *)output;
     const size_t outer = 2;
@@ -53,5 +54,5 @@ static inline void model_op0(const float input0[restrict 2][3], float output[res
 }
 
 void model(const float in0[restrict 2][3], float out[restrict 2][3]) {
-    model_op0(in0, out);
+    node0_LpNormalization(in0, out);
 }

--- a/tests/golden/op_lrn_lrn.c
+++ b/tests/golden/op_lrn_lrn.c
@@ -25,6 +25,7 @@
 /*
  * Node 0:
  * OpType: LRN
+ * Name: n/a
  * Inputs: in0
  * Outputs: out
  * Attrs:
@@ -33,7 +34,7 @@
  *   bias: 1.0
  *   size: 3
  */
-static inline void model_op0(const float input0[restrict 1][3][4][4], float output[restrict 1][3][4][4]) {
+static inline void node0_LRN(const float input0[restrict 1][3][4][4], float output[restrict 1][3][4][4]) {
     for (size_t i0 = 0; i0 < 1; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
@@ -57,5 +58,5 @@ static inline void model_op0(const float input0[restrict 1][3][4][4], float outp
 }
 
 void model(const float in0[restrict 1][3][4][4], float out[restrict 1][3][4][4]) {
-    model_op0(in0, out);
+    node0_LRN(in0, out);
 }

--- a/tests/golden/op_lstm_lstm.c
+++ b/tests/golden/op_lstm_lstm.c
@@ -41,13 +41,14 @@ static inline float ref_scalar_f32_tanh(float a) {
 /*
  * Node 0:
  * OpType: LSTM
+ * Name: n/a
  * Inputs: X, W, R
  * Outputs: Y, Y_h, Y_c
  * Attrs:
  *   hidden_size: 3
  *   layout: 0
  */
-static inline void model_op0(const float input_x[restrict 1][1][2], const float input_w[restrict 1][12][2], const float input_r[restrict 1][12][3], float output_y[restrict 1][1][1][3], float output_y_h[restrict 1][1][3], float output_y_c[restrict 1][1][3]) {
+static inline void node0_LSTM(const float input_x[restrict 1][1][2], const float input_w[restrict 1][12][2], const float input_r[restrict 1][12][3], float output_y[restrict 1][1][1][3], float output_y_h[restrict 1][1][3], float output_y_c[restrict 1][1][3]) {
     {
         const int dir = 0;
         const int reverse = 0;
@@ -119,5 +120,5 @@ static inline void model_op0(const float input_x[restrict 1][1][2], const float 
 }
 
 void model(const float X[restrict 1][1][2], const float W[restrict 1][12][2], const float R[restrict 1][12][3], float Y[restrict 1][1][1][3], float Y_h[restrict 1][1][3], float Y_c[restrict 1][1][3]) {
-    model_op0(X, W, R, Y, Y_h, Y_c);
+    node0_LSTM(X, W, R, Y, Y_h, Y_c);
 }

--- a/tests/golden/op_matmul_matmul.c
+++ b/tests/golden/op_matmul_matmul.c
@@ -24,11 +24,12 @@
 /*
  * Node 0:
  * OpType: MatMul
+ * Name: n/a
  * Inputs: in0, in1
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float input0[restrict 2][3], const float input1[restrict 3][4], float output[restrict 2][4]) {
+static inline void node0_MatMul(const float input0[restrict 2][3], const float input1[restrict 3][4], float output[restrict 2][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 4; ++i1) {
             float acc = 0.0f;
@@ -41,5 +42,5 @@ static inline void model_op0(const float input0[restrict 2][3], const float inpu
 }
 
 void model(const float in0[restrict 2][3], const float in1[restrict 3][4], float out[restrict 2][4]) {
-    model_op0(in0, in1, out);
+    node0_MatMul(in0, in1, out);
 }

--- a/tests/golden/op_maxpool_maxpool.c
+++ b/tests/golden/op_maxpool_maxpool.c
@@ -25,6 +25,7 @@
 /*
  * Node 0:
  * OpType: MaxPool
+ * Name: n/a
  * Inputs: in0
  * Outputs: out
  * Attrs:
@@ -33,7 +34,7 @@
  *   pads: [0, 0, 0, 0]
  *   strides: [2, 2]
  */
-static inline void model_op0(const float input0[restrict 1][1][4][4], float output[restrict 1][1][2][2]) {
+static inline void node0_MaxPool(const float input0[restrict 1][1][4][4], float output[restrict 1][1][2][2]) {
     for (size_t n = 0; n < 1; ++n) {
         for (size_t c = 0; c < 1; ++c) {
             for (size_t oh = 0; oh < 2; ++oh) {
@@ -63,5 +64,5 @@ static inline void model_op0(const float input0[restrict 1][1][4][4], float outp
 }
 
 void model(const float in0[restrict 1][1][4][4], float out[restrict 1][1][2][2]) {
-    model_op0(in0, out);
+    node0_MaxPool(in0, out);
 }

--- a/tests/golden/op_meanvariancenormalization_mean_variance_normalization.c
+++ b/tests/golden/op_meanvariancenormalization_mean_variance_normalization.c
@@ -25,12 +25,13 @@
 /*
  * Node 0:
  * OpType: MeanVarianceNormalization
+ * Name: n/a
  * Inputs: in0
  * Outputs: out
  * Attrs:
  *   axes: [-1]
  */
-static inline void model_op0(const float input0[restrict 2][3][4], float output[restrict 2][3][4]) {
+static inline void node0_MeanVarianceNormalization(const float input0[restrict 2][3][4], float output[restrict 2][3][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             float sum = 0.0f;
@@ -52,5 +53,5 @@ static inline void model_op0(const float input0[restrict 2][3][4], float output[
 }
 
 void model(const float in0[restrict 2][3][4], float out[restrict 2][3][4]) {
-    model_op0(in0, out);
+    node0_MeanVarianceNormalization(in0, out);
 }

--- a/tests/golden/op_multiinputbinary_sum.c
+++ b/tests/golden/op_multiinputbinary_sum.c
@@ -37,11 +37,12 @@ static inline float ref_scalar_f32_add(float a, float b) {
 /*
  * Node 0:
  * OpType: Sum
+ * Name: n/a
  * Inputs: in0, in1, in2
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float input0[restrict 2][3], const float input1[restrict 2][3], const float input2[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_Sum(const float input0[restrict 2][3], const float input1[restrict 2][3], const float input2[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = input0[i0][i1];
@@ -52,5 +53,5 @@ static inline void model_op0(const float input0[restrict 2][3], const float inpu
 }
 
 void model(const float in0[restrict 2][3], const float in1[restrict 2][3], const float in2[restrict 2][3], float out[restrict 2][3]) {
-    model_op0(in0, in1, in2, out);
+    node0_Sum(in0, in1, in2, out);
 }

--- a/tests/golden/op_negativeloglikelihoodloss_negative_log_likelihood_loss.c
+++ b/tests/golden/op_negativeloglikelihoodloss_negative_log_likelihood_loss.c
@@ -25,12 +25,13 @@
 /*
  * Node 0:
  * OpType: NegativeLogLikelihoodLoss
+ * Name: n/a
  * Inputs: input, target
  * Outputs: loss
  * Attrs:
  *   reduction: mean
  */
-static inline void model_op0(const float input0[restrict 2][3], const int64_t target[restrict 2], float output[restrict 1]) {
+static inline void node0_NegativeLogLikelihoodLoss(const float input0[restrict 2][3], const int64_t target[restrict 2], float output[restrict 1]) {
     const float *input_flat = (const float *)input0;
     const int64_t *target_flat = (const int64_t *)target;
     float *output_flat = (float *)output;
@@ -62,5 +63,5 @@ static inline void model_op0(const float input0[restrict 2][3], const int64_t ta
 }
 
 void model(const float input[restrict 2][3], const int64_t target[restrict 2], float loss[restrict 1]) {
-    model_op0(input, target, loss);
+    node0_NegativeLogLikelihoodLoss(input, target, loss);
 }

--- a/tests/golden/op_pad_pad.c
+++ b/tests/golden/op_pad_pad.c
@@ -33,12 +33,13 @@ static const float value[1] = {
 /*
  * Node 0:
  * OpType: Pad
+ * Name: n/a
  * Inputs: input, pads, value
  * Outputs: output
  * Attrs:
  *   mode: constant
  */
-static inline void model_op0(const float input[restrict 2][3], float output[restrict 2][5]) {
+static inline void node0_Pad(const float input[restrict 2][3], float output[restrict 2][5]) {
     const float *input_flat = (const float *)input;
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 5; ++i1) {
@@ -78,5 +79,5 @@ static inline void model_op0(const float input[restrict 2][3], float output[rest
 }
 
 void model(const float input[restrict 2][3], float output[restrict 2][5]) {
-    model_op0(input, output);
+    node0_Pad(input, output);
 }

--- a/tests/golden/op_range_range.c
+++ b/tests/golden/op_range_range.c
@@ -37,11 +37,12 @@ static const int64_t delta[1] = {
 /*
  * Node 0:
  * OpType: Range
+ * Name: n/a
  * Inputs: start, limit, delta
  * Outputs: output
  * Attrs: n/a
  */
-static inline void model_op0(const int64_t start[restrict 1], const int64_t limit[restrict 1], const int64_t delta[restrict 1], int64_t output[restrict 4]) {
+static inline void node0_Range(const int64_t start[restrict 1], const int64_t limit[restrict 1], const int64_t delta[restrict 1], int64_t output[restrict 4]) {
     (void)limit;
     const int64_t start_value = start[0];
     const int64_t delta_value = delta[0];
@@ -51,5 +52,5 @@ static inline void model_op0(const int64_t start[restrict 1], const int64_t limi
 }
 
 void model(int64_t output[restrict 4]) {
-    model_op0(start, limit, delta, output);
+    node0_Range(start, limit, delta, output);
 }

--- a/tests/golden/op_reduce_reduce_mean.c
+++ b/tests/golden/op_reduce_reduce_mean.c
@@ -29,12 +29,13 @@ static const int64_t axes[1] = {
 /*
  * Node 0:
  * OpType: ReduceMean
+ * Name: n/a
  * Inputs: in0, axes
  * Outputs: out
  * Attrs:
  *   keepdims: 1
  */
-static inline void model_op0(const float input0[restrict 2][3][4], float output[restrict 2][1][4]) {
+static inline void node0_ReduceMean(const float input0[restrict 2][3][4], float output[restrict 2][1][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 1; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
@@ -49,5 +50,5 @@ static inline void model_op0(const float input0[restrict 2][3][4], float output[
 }
 
 void model(const float in0[restrict 2][3][4], float out[restrict 2][1][4]) {
-    model_op0(in0, out);
+    node0_ReduceMean(in0, out);
 }

--- a/tests/golden/op_reshape_reshape.c
+++ b/tests/golden/op_reshape_reshape.c
@@ -30,14 +30,15 @@ static const int64_t shape[2] = {
 /*
  * Node 0:
  * OpType: Reshape
+ * Name: n/a
  * Inputs: in0, shape
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float input0[restrict 2][3][4], float output[restrict 2][12]) {
+static inline void node0_Reshape(const float input0[restrict 2][3][4], float output[restrict 2][12]) {
     memcpy(output, input0, sizeof(float) * 24);
 }
 
 void model(const float in0[restrict 2][3][4], float out[restrict 2][12]) {
-    model_op0(in0, out);
+    node0_Reshape(in0, out);
 }

--- a/tests/golden/op_resize_resize.c
+++ b/tests/golden/op_resize_resize.c
@@ -30,6 +30,7 @@ static const int64_t sizes[4] = {
 /*
  * Node 0:
  * OpType: Resize
+ * Name: n/a
  * Inputs: in0, , , sizes
  * Outputs: out
  * Attrs:
@@ -37,7 +38,7 @@ static const int64_t sizes[4] = {
  *   mode: nearest
  *   nearest_mode: floor
  */
-static inline void model_op0(const float input0[restrict 1][1][2][2], const int64_t sizes_input[restrict 4], float output[restrict 1][1][4][4]) {
+static inline void node0_Resize(const float input0[restrict 1][1][2][2], const int64_t sizes_input[restrict 4], float output[restrict 1][1][4][4]) {
     const int64_t input_shape[4] = { 1, 1, 2, 2 };
     const int64_t output_shape[4] = { 1, 1, 4, 4 };
     double scales[4];
@@ -115,5 +116,5 @@ static inline void model_op0(const float input0[restrict 1][1][2][2], const int6
 }
 
 void model(const float in0[restrict 1][1][2][2], float out[restrict 1][1][4][4]) {
-    model_op0(in0, sizes, out);
+    node0_Resize(in0, sizes, out);
 }

--- a/tests/golden/op_rmsnormalization_rms_normalization.c
+++ b/tests/golden/op_rmsnormalization_rms_normalization.c
@@ -25,13 +25,14 @@
 /*
  * Node 0:
  * OpType: RMSNormalization
+ * Name: n/a
  * Inputs: in0, in1
  * Outputs: out
  * Attrs:
  *   axis: -1
  *   epsilon: 9.999999747378752e-06
  */
-static inline void model_op0(const float input0[restrict 2][3][4], const float scale[restrict 4], float output[restrict 2][3][4]) {
+static inline void node0_RMSNormalization(const float input0[restrict 2][3][4], const float scale[restrict 4], float output[restrict 2][3][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             float sum = 0.0f;
@@ -51,5 +52,5 @@ static inline void model_op0(const float input0[restrict 2][3][4], const float s
 }
 
 void model(const float in0[restrict 2][3][4], const float in1[restrict 4], float out[restrict 2][3][4]) {
-    model_op0(in0, in1, out);
+    node0_RMSNormalization(in0, in1, out);
 }

--- a/tests/golden/op_shape_shape.c
+++ b/tests/golden/op_shape_shape.c
@@ -25,11 +25,12 @@
 /*
  * Node 0:
  * OpType: Shape
+ * Name: n/a
  * Inputs: in0
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float input0[restrict 2][3][4], int64_t output[restrict 3]) {
+static inline void node0_Shape(const float input0[restrict 2][3][4], int64_t output[restrict 3]) {
     (void)input0;
     output[0] = 2LL;
     output[1] = 3LL;
@@ -37,5 +38,5 @@ static inline void model_op0(const float input0[restrict 2][3][4], int64_t outpu
 }
 
 void model(const float in0[restrict 2][3][4], int64_t out[restrict 3]) {
-    model_op0(in0, out);
+    node0_Shape(in0, out);
 }

--- a/tests/golden/op_size_size.c
+++ b/tests/golden/op_size_size.c
@@ -25,15 +25,16 @@
 /*
  * Node 0:
  * OpType: Size
+ * Name: n/a
  * Inputs: in0
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float input0[restrict 2][3][4], int64_t output[restrict 1]) {
+static inline void node0_Size(const float input0[restrict 2][3][4], int64_t output[restrict 1]) {
     (void)input0;
     output[0] = 24LL;
 }
 
 void model(const float in0[restrict 2][3][4], int64_t out[restrict 1]) {
-    model_op0(in0, out);
+    node0_Size(in0, out);
 }

--- a/tests/golden/op_slice_slice.c
+++ b/tests/golden/op_slice_slice.c
@@ -41,11 +41,12 @@ static const int64_t steps[2] = {
 /*
  * Node 0:
  * OpType: Slice
+ * Name: n/a
  * Inputs: in0, starts, ends, axes, steps
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float input0[restrict 2][3][4], float output[restrict 2][3][1]) {
+static inline void node0_Slice(const float input0[restrict 2][3][4], float output[restrict 2][3][1]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 1; ++i2) {
@@ -56,5 +57,5 @@ static inline void model_op0(const float input0[restrict 2][3][4], float output[
 }
 
 void model(const float in0[restrict 2][3][4], float out[restrict 2][3][1]) {
-    model_op0(in0, out);
+    node0_Slice(in0, out);
 }

--- a/tests/golden/op_softmax_softmax.c
+++ b/tests/golden/op_softmax_softmax.c
@@ -25,12 +25,13 @@
 /*
  * Node 0:
  * OpType: Softmax
+ * Name: n/a
  * Inputs: in0
  * Outputs: out
  * Attrs:
  *   axis: 1
  */
-static inline void model_op0(const float input0[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_Softmax(const float input0[restrict 2][3], float output[restrict 2][3]) {
     const float *input_flat = (const float *)input0;
     float *output_flat = (float *)output;
     const size_t outer = 2;
@@ -60,5 +61,5 @@ static inline void model_op0(const float input0[restrict 2][3], float output[res
 }
 
 void model(const float in0[restrict 2][3], float out[restrict 2][3]) {
-    model_op0(in0, out);
+    node0_Softmax(in0, out);
 }

--- a/tests/golden/op_softmaxcrossentropyloss_softmax_cross_entropy_loss.c
+++ b/tests/golden/op_softmaxcrossentropyloss_softmax_cross_entropy_loss.c
@@ -26,12 +26,13 @@
 /*
  * Node 0:
  * OpType: SoftmaxCrossEntropyLoss
+ * Name: n/a
  * Inputs: scores, labels
  * Outputs: loss, log_prob
  * Attrs:
  *   reduction: mean
  */
-static inline void model_op0(const float input0[restrict 2][3], const int64_t target[restrict 2], float output[restrict 1], float log_prob[restrict 2][3]) {
+static inline void node0_SoftmaxCrossEntropyLoss(const float input0[restrict 2][3], const int64_t target[restrict 2], float output[restrict 1], float log_prob[restrict 2][3]) {
     const float *input_flat = (const float *)input0;
     const int64_t *target_flat = (const int64_t *)target;
     float *output_flat = (float *)output;
@@ -76,5 +77,5 @@ static inline void model_op0(const float input0[restrict 2][3], const int64_t ta
 }
 
 void model(const float scores[restrict 2][3], const int64_t labels[restrict 2], float loss[restrict 1], float log_prob[restrict 2][3]) {
-    model_op0(scores, labels, loss, log_prob);
+    node0_SoftmaxCrossEntropyLoss(scores, labels, loss, log_prob);
 }

--- a/tests/golden/op_spacetodepth_space_to_depth.c
+++ b/tests/golden/op_spacetodepth_space_to_depth.c
@@ -24,12 +24,13 @@
 /*
  * Node 0:
  * OpType: SpaceToDepth
+ * Name: n/a
  * Inputs: in0
  * Outputs: out
  * Attrs:
  *   blocksize: 2
  */
-static inline void model_op0(const float input0[restrict 1][1][4][4], float output[restrict 1][4][2][2]) {
+static inline void node0_SpaceToDepth(const float input0[restrict 1][1][4][4], float output[restrict 1][4][2][2]) {
     const float *input_data = (const float *)input0;
     float *output_data = (float *)output;
     size_t output_index = 0;
@@ -53,5 +54,5 @@ static inline void model_op0(const float input0[restrict 1][1][4][4], float outp
 }
 
 void model(const float in0[restrict 1][1][4][4], float out[restrict 1][4][2][2]) {
-    model_op0(in0, out);
+    node0_SpaceToDepth(in0, out);
 }

--- a/tests/golden/op_split_split.c
+++ b/tests/golden/op_split_split.c
@@ -30,12 +30,13 @@ static const int64_t split[3] = {
 /*
  * Node 0:
  * OpType: Split
+ * Name: n/a
  * Inputs: input, split
  * Outputs: output_0, output_1, output_2
  * Attrs:
  *   axis: 1
  */
-static inline void model_op0(const float input0[restrict 2][6], float output_0[restrict 2][2], float output_1[restrict 2][2], float output_2[restrict 2][2]) {
+static inline void node0_Split(const float input0[restrict 2][6], float output_0[restrict 2][2], float output_1[restrict 2][2], float output_2[restrict 2][2]) {
     const float *input_data = (const float *)input0;
     float *output_ptrs[] = { (float *)output_0, (float *)output_1, (float *)output_2 };
     const size_t axis_sizes[] = { 2, 2, 2 };
@@ -55,5 +56,5 @@ static inline void model_op0(const float input0[restrict 2][6], float output_0[r
 }
 
 void model(const float input[restrict 2][6], float output_0[restrict 2][2], float output_1[restrict 2][2], float output_2[restrict 2][2]) {
-    model_op0(input, output_0, output_1, output_2);
+    node0_Split(input, output_0, output_1, output_2);
 }

--- a/tests/golden/op_tile_tile.c
+++ b/tests/golden/op_tile_tile.c
@@ -29,11 +29,12 @@ static const int64_t repeats[2] = {
 /*
  * Node 0:
  * OpType: Tile
+ * Name: n/a
  * Inputs: input, repeats
  * Outputs: output
  * Attrs: n/a
  */
-static inline void model_op0(const float input0[restrict 2][3], float output[restrict 4][3]) {
+static inline void node0_Tile(const float input0[restrict 2][3], float output[restrict 4][3]) {
     const float *input_data = (const float *)input0;
     float *output_data = (float *)output;
     size_t output_index = 0;
@@ -47,5 +48,5 @@ static inline void model_op0(const float input0[restrict 2][3], float output[res
 }
 
 void model(const float input[restrict 2][3], float output[restrict 4][3]) {
-    model_op0(input, output);
+    node0_Tile(input, output);
 }

--- a/tests/golden/op_transpose_transpose.c
+++ b/tests/golden/op_transpose_transpose.c
@@ -24,12 +24,13 @@
 /*
  * Node 0:
  * OpType: Transpose
+ * Name: n/a
  * Inputs: in0
  * Outputs: out
  * Attrs:
  *   perm: [2, 0, 1]
  */
-static inline void model_op0(const float input0[restrict 2][3][4], float output[restrict 4][2][3]) {
+static inline void node0_Transpose(const float input0[restrict 2][3][4], float output[restrict 4][2][3]) {
     for (size_t i0 = 0; i0 < 4; ++i0) {
         for (size_t i1 = 0; i1 < 2; ++i1) {
             for (size_t i2 = 0; i2 < 3; ++i2) {
@@ -40,5 +41,5 @@ static inline void model_op0(const float input0[restrict 2][3][4], float output[
 }
 
 void model(const float in0[restrict 2][3][4], float out[restrict 4][2][3]) {
-    model_op0(in0, out);
+    node0_Transpose(in0, out);
 }

--- a/tests/golden/op_unary_tanh.c
+++ b/tests/golden/op_unary_tanh.c
@@ -37,11 +37,12 @@ static inline float ref_scalar_f32_tanh(float a) {
 /*
  * Node 0:
  * OpType: Tanh
+ * Name: n/a
  * Inputs: in0
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float input0[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_Tanh(const float input0[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_tanh(input0[i0][i1]);
@@ -50,5 +51,5 @@ static inline void model_op0(const float input0[restrict 2][3], float output[res
 }
 
 void model(const float in0[restrict 2][3], float out[restrict 2][3]) {
-    model_op0(in0, out);
+    node0_Tanh(in0, out);
 }

--- a/tests/golden/op_where_where.c
+++ b/tests/golden/op_where_where.c
@@ -25,11 +25,12 @@
 /*
  * Node 0:
  * OpType: Where
+ * Name: n/a
  * Inputs: condition, x, y
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const bool condition[restrict 2][3], const float input_x[restrict 2][3], const float input_y[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_Where(const bool condition[restrict 2][3], const float input_x[restrict 2][3], const float input_y[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = condition[i0][i1] ? input_x[i0][i1] : input_y[i0][i1];
@@ -38,5 +39,5 @@ static inline void model_op0(const bool condition[restrict 2][3], const float in
 }
 
 void model(const bool condition[restrict 2][3], const float x[restrict 2][3], const float y[restrict 2][3], float out[restrict 2][3]) {
-    model_op0(condition, x, y, out);
+    node0_Where(condition, x, y, out);
 }

--- a/tests/golden/relu_model.c
+++ b/tests/golden/relu_model.c
@@ -37,11 +37,12 @@ static inline float ref_scalar_f32_relu(float a) {
 /*
  * Node 0:
  * OpType: Relu
+ * Name: n/a
  * Inputs: x
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float input0[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_Relu(const float input0[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_relu(input0[i0][i1]);
@@ -50,5 +51,5 @@ static inline void model_op0(const float input0[restrict 2][3], float output[res
 }
 
 void model(const float x[restrict 2][3], float out[restrict 2][3]) {
-    model_op0(x, out);
+    node0_Relu(x, out);
 }

--- a/tests/golden/tanh_model.c
+++ b/tests/golden/tanh_model.c
@@ -37,11 +37,12 @@ static inline float ref_scalar_f32_tanh(float a) {
 /*
  * Node 0:
  * OpType: Tanh
+ * Name: n/a
  * Inputs: x
  * Outputs: out
  * Attrs: n/a
  */
-static inline void model_op0(const float input0[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_Tanh(const float input0[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_tanh(input0[i0][i1]);
@@ -50,5 +51,5 @@ static inline void model_op0(const float input0[restrict 2][3], float output[res
 }
 
 void model(const float x[restrict 2][3], float out[restrict 2][3]) {
-    model_op0(x, out);
+    node0_Tanh(x, out);
 }


### PR DESCRIPTION
### Motivation
- Make generated C operator function names more informative and stable by using the ONNX node index/optype and optional node name instead of the previous `<model>_op<no>` scheme.
- Surface the original ONNX node name in generated code comments so readers can correlate emitted functions with the source model.

### Description
- Add `name: str | None` to the IR `Node` and propagate it through `import_onnx()` into `Graph` nodes and into `NodeInfo` used by codegen.
- Implement `_op_function_name()` in `CEmitter` to produce sanitized function names of the form `node<index>_<OpType>[_<NodeName>]` and wire that name into all emitted call sites and templates (replacing `f"{model.name}_op{index}"`).
- Update `_emit_node_comment()` to include the node `Name` field when present.
- Refresh many golden C snapshots under `tests/golden/` so expected outputs match the new naming convention.

### Testing
- Ran the full pytest suite with references updated via `UPDATE_REFS=1 pytest -n auto -q`, which completed successfully: `233 passed, 2 skipped, 2 warnings in 60.93s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6969085754388325a884f94e2b8aec87)