### PR TITLE
build: include build backend in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include build_backend.py


### PR DESCRIPTION
### Motivation
- Ensure the custom PEP 517 build backend `build_backend.py` is packaged into source distributions so wheel builds from an sdist can locate and import the backend.

### Description
- Add `MANIFEST.in` containing `include build_backend.py` to include the backend file in generated sdists.

### Testing
- Ran `UPDATE_REFS=1 pytest -n auto -q`, which completed successfully with `233 passed, 2 skipped, 2 warnings` in `61.520 seconds`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69696637c6c48325bd71f778297fb0ac)