### PR TITLE
codegen: lowercase node function names

### DIFF
--- a/src/emx_onnx_cgen/codegen/c_emitter.py
+++ b/src/emx_onnx_cgen/codegen/c_emitter.py
@@ -1006,10 +1006,8 @@ class CEmitter:
 
     def _op_function_name(self, model: LoweredModel, index: int) -> str:
         node_info = model.node_infos[index]
-        parts = [f"node{index}", node_info.op_type]
-        if node_info.name:
-            parts.append(node_info.name)
-        base_name = "_".join(parts)
+        suffix = node_info.name or node_info.op_type
+        base_name = f"node{index}_{suffix}".lower()
         return self._sanitize_identifier(base_name)
 
     @staticmethod

--- a/tests/golden/add_initializer_model.c
+++ b/tests/golden/add_initializer_model.c
@@ -46,7 +46,7 @@ static inline float ref_scalar_f32_add(float a, float b) {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void node0_Add(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_add(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_add(input0[i0][i1], input1[i0][i1]);
@@ -55,5 +55,5 @@ static inline void node0_Add(const float input0[restrict 2][3], const float inpu
 }
 
 void model(const float in0[restrict 2][3], float out[restrict 2][3]) {
-    node0_Add(in0, weight, out);
+    node0_add(in0, weight, out);
 }

--- a/tests/golden/add_model.c
+++ b/tests/golden/add_model.c
@@ -42,7 +42,7 @@ static inline float ref_scalar_f32_add(float a, float b) {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void node0_Add(const float input0[restrict 2][3][4], const float input1[restrict 2][3][4], float output[restrict 2][3][4]) {
+static inline void node0_add(const float input0[restrict 2][3][4], const float input1[restrict 2][3][4], float output[restrict 2][3][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
@@ -53,5 +53,5 @@ static inline void node0_Add(const float input0[restrict 2][3][4], const float i
 }
 
 void model(const float a[restrict 2][3][4], const float b[restrict 2][3][4], float out[restrict 2][3][4]) {
-    node0_Add(a, b, out);
+    node0_add(a, b, out);
 }

--- a/tests/golden/add_model_no_restrict.c
+++ b/tests/golden/add_model_no_restrict.c
@@ -42,7 +42,7 @@ static inline float ref_scalar_f32_add(float a, float b) {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void node0_Add(const float input0[2][3][4], const float input1[2][3][4], float output[2][3][4]) {
+static inline void node0_add(const float input0[2][3][4], const float input1[2][3][4], float output[2][3][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
@@ -53,5 +53,5 @@ static inline void node0_Add(const float input0[2][3][4], const float input1[2][
 }
 
 void model(const float a[2][3][4], const float b[2][3][4], float out[2][3][4]) {
-    node0_Add(a, b, out);
+    node0_add(a, b, out);
 }

--- a/tests/golden/add_model_testbench.c
+++ b/tests/golden/add_model_testbench.c
@@ -44,7 +44,7 @@ static inline float ref_scalar_f32_add(float a, float b) {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void node0_Add(const float input0[restrict 2][3][4], const float input1[restrict 2][3][4], float output[restrict 2][3][4]) {
+static inline void node0_add(const float input0[restrict 2][3][4], const float input1[restrict 2][3][4], float output[restrict 2][3][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
@@ -55,7 +55,7 @@ static inline void node0_Add(const float input0[restrict 2][3][4], const float i
 }
 
 void model(const float a[restrict 2][3][4], const float b[restrict 2][3][4], float out[restrict 2][3][4]) {
-    node0_Add(a, b, out);
+    node0_add(a, b, out);
 }
 
 static uint64_t rng_state = 0x243f6a8885a308d3ull;

--- a/tests/golden/dynamic_dims_model.c
+++ b/tests/golden/dynamic_dims_model.c
@@ -42,7 +42,7 @@ static inline float ref_scalar_f32_relu(float a) {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void node0_Relu(int N, int C, const float input0[restrict N][C], float output[restrict N][C]) {
+static inline void node0_relu(int N, int C, const float input0[restrict N][C], float output[restrict N][C]) {
     for (size_t i0 = 0; i0 < N; ++i0) {
         for (size_t i1 = 0; i1 < C; ++i1) {
             output[i0][i1] = ref_scalar_f32_relu(input0[i0][i1]);
@@ -51,5 +51,5 @@ static inline void node0_Relu(int N, int C, const float input0[restrict N][C], f
 }
 
 void dynamic_dims_model(int N, int C, const float x[restrict N][C], float out[restrict N][C]) {
-    node0_Relu(N, C, x, out);
+    node0_relu(N, C, x, out);
 }

--- a/tests/golden/matmul_model.c
+++ b/tests/golden/matmul_model.c
@@ -29,7 +29,7 @@
  * Outputs: out
  * Attrs: n/a
  */
-static inline void node0_MatMul(const float input0[restrict 2][3], const float input1[restrict 3][4], float output[restrict 2][4]) {
+static inline void node0_matmul(const float input0[restrict 2][3], const float input1[restrict 3][4], float output[restrict 2][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 4; ++i1) {
             float acc = 0.0f;
@@ -42,5 +42,5 @@ static inline void node0_MatMul(const float input0[restrict 2][3], const float i
 }
 
 void model(const float a[restrict 2][3], const float b[restrict 3][4], float out[restrict 2][4]) {
-    node0_MatMul(a, b, out);
+    node0_matmul(a, b, out);
 }

--- a/tests/golden/mul_add_model.c
+++ b/tests/golden/mul_add_model.c
@@ -46,7 +46,7 @@ static inline float ref_scalar_f32_add(float a, float b) {
  * Outputs: mul_out
  * Attrs: n/a
  */
-static inline void node0_Mul(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_mul(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_mul(input0[i0][i1], input1[i0][i1]);
@@ -62,7 +62,7 @@ static inline void node0_Mul(const float input0[restrict 2][3], const float inpu
  * Outputs: out
  * Attrs: n/a
  */
-static inline void node1_Add(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
+static inline void node1_add(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_add(input0[i0][i1], input1[i0][i1]);
@@ -72,6 +72,6 @@ static inline void node1_Add(const float input0[restrict 2][3], const float inpu
 
 void model(const float a[restrict 2][3], const float b[restrict 2][3], const float c[restrict 2][3], float out[restrict 2][3]) {
     float tmp[2][3];
-    node0_Mul(a, b, tmp);
-    node1_Add(tmp, c, out);
+    node0_mul(a, b, tmp);
+    node1_add(tmp, c, out);
 }

--- a/tests/golden/mul_add_relu_model.c
+++ b/tests/golden/mul_add_relu_model.c
@@ -50,7 +50,7 @@ static inline float ref_scalar_f32_relu(float a) {
  * Outputs: mul_out
  * Attrs: n/a
  */
-static inline void node0_Mul(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_mul(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_mul(input0[i0][i1], input1[i0][i1]);
@@ -66,7 +66,7 @@ static inline void node0_Mul(const float input0[restrict 2][3], const float inpu
  * Outputs: add_out
  * Attrs: n/a
  */
-static inline void node1_Add(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
+static inline void node1_add(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_add(input0[i0][i1], input1[i0][i1]);
@@ -82,7 +82,7 @@ static inline void node1_Add(const float input0[restrict 2][3], const float inpu
  * Outputs: out
  * Attrs: n/a
  */
-static inline void node2_Relu(const float input0[restrict 2][3], float output[restrict 2][3]) {
+static inline void node2_relu(const float input0[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_relu(input0[i0][i1]);
@@ -93,7 +93,7 @@ static inline void node2_Relu(const float input0[restrict 2][3], float output[re
 void model(const float a[restrict 2][3], const float b[restrict 2][3], const float c[restrict 2][3], float out[restrict 2][3]) {
     float tmp0[2][3];
     float tmp1[2][3];
-    node0_Mul(a, b, tmp0);
-    node1_Add(tmp0, c, tmp1);
-    node2_Relu(tmp1, out);
+    node0_mul(a, b, tmp0);
+    node1_add(tmp0, c, tmp1);
+    node2_relu(tmp1, out);
 }

--- a/tests/golden/mul_model.c
+++ b/tests/golden/mul_model.c
@@ -42,7 +42,7 @@ static inline float ref_scalar_f32_mul(float a, float b) {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void node0_Mul(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_mul(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_mul(input0[i0][i1], input1[i0][i1]);
@@ -51,5 +51,5 @@ static inline void node0_Mul(const float input0[restrict 2][3], const float inpu
 }
 
 void model(const float a[restrict 2][3], const float b[restrict 2][3], float out[restrict 2][3]) {
-    node0_Mul(a, b, out);
+    node0_mul(a, b, out);
 }

--- a/tests/golden/op_argreduce_arg_max.c
+++ b/tests/golden/op_argreduce_arg_max.c
@@ -33,7 +33,7 @@
  *   keepdims: 1
  *   select_last_index: 0
  */
-static inline void node0_ArgMax(const float input0[restrict 2][3][4], int64_t output[restrict 2][1][4]) {
+static inline void node0_argmax(const float input0[restrict 2][3][4], int64_t output[restrict 2][1][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 1; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
@@ -53,5 +53,5 @@ static inline void node0_ArgMax(const float input0[restrict 2][3][4], int64_t ou
 }
 
 void model(const float input[restrict 2][3][4], int64_t output[restrict 2][1][4]) {
-    node0_ArgMax(input, output);
+    node0_argmax(input, output);
 }

--- a/tests/golden/op_attention_attention.c
+++ b/tests/golden/op_attention_attention.c
@@ -30,7 +30,7 @@
  * Outputs: out
  * Attrs: n/a
  */
-static inline void node0_Attention(const float input_q[restrict 1][2][3][4], const float input_k[restrict 1][2][5][4], const float input_v[restrict 1][2][5][4], float output[restrict 1][2][3][4]) {
+static inline void node0_attention(const float input_q[restrict 1][2][3][4], const float input_k[restrict 1][2][5][4], const float input_v[restrict 1][2][5][4], float output[restrict 1][2][3][4]) {
     const float scale = 0.5f;
     const float softcap = 0.0f;
     for (int b = 0; b < 1; ++b) {
@@ -89,5 +89,5 @@ static inline void node0_Attention(const float input_q[restrict 1][2][3][4], con
 }
 
 void model(const float in0[restrict 1][2][3][4], const float in1[restrict 1][2][5][4], const float in2[restrict 1][2][5][4], float out[restrict 1][2][3][4]) {
-    node0_Attention(in0, in1, in2, out);
+    node0_attention(in0, in1, in2, out);
 }

--- a/tests/golden/op_averagepool_average_pool.c
+++ b/tests/golden/op_averagepool_average_pool.c
@@ -31,7 +31,7 @@
  *   kernel_shape: [2, 2]
  *   strides: [2, 2]
  */
-static inline void node0_AveragePool(const float input0[restrict 1][1][4][4], float output[restrict 1][1][2][2]) {
+static inline void node0_averagepool(const float input0[restrict 1][1][4][4], float output[restrict 1][1][2][2]) {
     for (size_t n = 0; n < 1; ++n) {
         for (size_t c = 0; c < 1; ++c) {
             for (size_t oh = 0; oh < 2; ++oh) {
@@ -66,5 +66,5 @@ static inline void node0_AveragePool(const float input0[restrict 1][1][4][4], fl
 }
 
 void model(const float input[restrict 1][1][4][4], float output[restrict 1][1][2][2]) {
-    node0_AveragePool(input, output);
+    node0_averagepool(input, output);
 }

--- a/tests/golden/op_batchnorm_batch_normalization.c
+++ b/tests/golden/op_batchnorm_batch_normalization.c
@@ -47,7 +47,7 @@ static const float var[3] = {
  * Attrs:
  *   epsilon: 9.999999747378752e-06
  */
-static inline void node0_BatchNormalization(const float input0[restrict 2][3][2][2], const float scale[restrict 3], const float bias[restrict 3], const float mean[restrict 3], const float variance[restrict 3], float output[restrict 2][3][2][2]) {
+static inline void node0_batchnormalization(const float input0[restrict 2][3][2][2], const float scale[restrict 3], const float bias[restrict 3], const float mean[restrict 3], const float variance[restrict 3], float output[restrict 2][3][2][2]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 2; ++i2) {
@@ -62,5 +62,5 @@ static inline void node0_BatchNormalization(const float input0[restrict 2][3][2]
 }
 
 void model(const float in0[restrict 2][3][2][2], float out[restrict 2][3][2][2]) {
-    node0_BatchNormalization(in0, scale, bias, mean, var, out);
+    node0_batchnormalization(in0, scale, bias, mean, var, out);
 }

--- a/tests/golden/op_binary_mul.c
+++ b/tests/golden/op_binary_mul.c
@@ -42,7 +42,7 @@ static inline float ref_scalar_f32_mul(float a, float b) {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void node0_Mul(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_mul(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_mul(input0[i0][i1], input1[i0][i1]);
@@ -51,5 +51,5 @@ static inline void node0_Mul(const float input0[restrict 2][3], const float inpu
 }
 
 void model(const float in0[restrict 2][3], const float in1[restrict 2][3], float out[restrict 2][3]) {
-    node0_Mul(in0, in1, out);
+    node0_mul(in0, in1, out);
 }

--- a/tests/golden/op_cast_cast.c
+++ b/tests/golden/op_cast_cast.c
@@ -31,7 +31,7 @@
  * Attrs:
  *   to: 6
  */
-static inline void node0_Cast(const float input0[restrict 2][3], int32_t output[restrict 2][3]) {
+static inline void node0_cast(const float input0[restrict 2][3], int32_t output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = (int32_t)input0[i0][i1];
@@ -40,5 +40,5 @@ static inline void node0_Cast(const float input0[restrict 2][3], int32_t output[
 }
 
 void model(const float in0[restrict 2][3], int32_t out[restrict 2][3]) {
-    node0_Cast(in0, out);
+    node0_cast(in0, out);
 }

--- a/tests/golden/op_clip_clip.c
+++ b/tests/golden/op_clip_clip.c
@@ -37,7 +37,7 @@ static const float max[1] = {
  * Outputs: output
  * Attrs: n/a
  */
-static inline void node0_Clip(const float input0[restrict 2][3], const float input_min[restrict 1], const float input_max[restrict 1], float output[restrict 2][3]) {
+static inline void node0_clip(const float input0[restrict 2][3], const float input_min[restrict 1], const float input_max[restrict 1], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             float value = input0[i0][i1];
@@ -53,5 +53,5 @@ static inline void node0_Clip(const float input0[restrict 2][3], const float inp
 }
 
 void model(const float input[restrict 2][3], float output[restrict 2][3]) {
-    node0_Clip(input, min, max, output);
+    node0_clip(input, min, max, output);
 }

--- a/tests/golden/op_concat_concat.c
+++ b/tests/golden/op_concat_concat.c
@@ -31,7 +31,7 @@
  * Attrs:
  *   axis: 2
  */
-static inline void node0_Concat(const float input_0[restrict 1][2][3], const float input_1[restrict 1][2][1], float output[restrict 1][2][4]) {
+static inline void node0_concat(const float input_0[restrict 1][2][3], const float input_1[restrict 1][2][1], float output[restrict 1][2][4]) {
     const void *inputs[] = { input_0, input_1 };
     const size_t axis_sizes[] = { 3, 1 };
     size_t concat_axis = 0;
@@ -61,5 +61,5 @@ static inline void node0_Concat(const float input_0[restrict 1][2][3], const flo
 }
 
 void model(const float in0[restrict 1][2][3], const float in1[restrict 1][2][1], float out[restrict 1][2][4]) {
-    node0_Concat(in0, in1, out);
+    node0_concat(in0, in1, out);
 }

--- a/tests/golden/op_constantofshape_constant_of_shape.c
+++ b/tests/golden/op_constantofshape_constant_of_shape.c
@@ -39,7 +39,7 @@ float_data: 1.25
 name: "fill"
 
  */
-static inline void node0_ConstantOfShape(const int64_t input0[restrict 3], float output[restrict 2][3][4]) {
+static inline void node0_constantofshape(const int64_t input0[restrict 3], float output[restrict 2][3][4]) {
     (void)input0;
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
@@ -51,5 +51,5 @@ static inline void node0_ConstantOfShape(const int64_t input0[restrict 3], float
 }
 
 void model(float out[restrict 2][3][4]) {
-    node0_ConstantOfShape(shape, out);
+    node0_constantofshape(shape, out);
 }

--- a/tests/golden/op_conv_conv.c
+++ b/tests/golden/op_conv_conv.c
@@ -40,7 +40,7 @@ static const float bias[1] = {
  *   pads: [1, 1, 1, 1]
  *   strides: [1, 1]
  */
-static inline void node0_Conv(const float input0[restrict 1][1][4][4], const float weights[restrict 1][1][3][3], const float bias[restrict 1], float output[restrict 1][1][4][4]) {
+static inline void node0_conv(const float input0[restrict 1][1][4][4], const float weights[restrict 1][1][3][3], const float bias[restrict 1], float output[restrict 1][1][4][4]) {
     for (size_t n = 0; n < 1; ++n) {
         for (size_t g = 0; g < 1; ++g) {
             for (size_t oc = 0; oc < 1; ++oc) {
@@ -70,5 +70,5 @@ static inline void node0_Conv(const float input0[restrict 1][1][4][4], const flo
 }
 
 void model(const float in0[restrict 1][1][4][4], float out[restrict 1][1][4][4]) {
-    node0_Conv(in0, weight, bias, out);
+    node0_conv(in0, weight, bias, out);
 }

--- a/tests/golden/op_cumsum_cumsum.c
+++ b/tests/golden/op_cumsum_cumsum.c
@@ -36,7 +36,7 @@ static const int64_t axis[1] = {
  *   exclusive: 0
  *   reverse: 0
  */
-static inline void node0_CumSum(const float input0[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_cumsum(const float input0[restrict 2][3], float output[restrict 2][3]) {
     const size_t dims[2] = { 2, 3 };
     int axis = 1;
     if (axis < 0) {
@@ -68,5 +68,5 @@ static inline void node0_CumSum(const float input0[restrict 2][3], float output[
 }
 
 void model(const float input[restrict 2][3], float output[restrict 2][3]) {
-    node0_CumSum(input, output);
+    node0_cumsum(input, output);
 }

--- a/tests/golden/op_depthtospace_depth_to_space.c
+++ b/tests/golden/op_depthtospace_depth_to_space.c
@@ -31,7 +31,7 @@
  *   blocksize: 2
  *   mode: DCR
  */
-static inline void node0_DepthToSpace(const float input0[restrict 1][4][2][2], float output[restrict 1][1][4][4]) {
+static inline void node0_depthtospace(const float input0[restrict 1][4][2][2], float output[restrict 1][1][4][4]) {
     const float *input_data = (const float *)input0;
     float *output_data = (float *)output;
     size_t output_index = 0;
@@ -55,5 +55,5 @@ static inline void node0_DepthToSpace(const float input0[restrict 1][4][2][2], f
 }
 
 void model(const float in0[restrict 1][4][2][2], float out[restrict 1][1][4][4]) {
-    node0_DepthToSpace(in0, out);
+    node0_depthtospace(in0, out);
 }

--- a/tests/golden/op_expand_expand.c
+++ b/tests/golden/op_expand_expand.c
@@ -34,7 +34,7 @@ static const int64_t shape[2] = {
  * Outputs: output
  * Attrs: n/a
  */
-static inline void node0_Expand(const float input0[restrict 1][3], float output[restrict 2][3]) {
+static inline void node0_expand(const float input0[restrict 1][3], float output[restrict 2][3]) {
     const float *input_data = (const float *)input0;
     float *output_data = (float *)output;
     size_t output_index = 0;
@@ -48,5 +48,5 @@ static inline void node0_Expand(const float input0[restrict 1][3], float output[
 }
 
 void model(const float input[restrict 1][3], float output[restrict 2][3]) {
-    node0_Expand(input, output);
+    node0_expand(input, output);
 }

--- a/tests/golden/op_eyelike_eye_like.c
+++ b/tests/golden/op_eyelike_eye_like.c
@@ -30,7 +30,7 @@
  * Attrs:
  *   k: 0
  */
-static inline void node0_EyeLike(const float input0[restrict 3][3], float output[restrict 3][3]) {
+static inline void node0_eyelike(const float input0[restrict 3][3], float output[restrict 3][3]) {
     (void)input0;
     float *output_data = (float *)output;
     size_t total = (size_t)1 * 3 * 3;
@@ -59,5 +59,5 @@ static inline void node0_EyeLike(const float input0[restrict 3][3], float output
 }
 
 void model(const float input[restrict 3][3], float output[restrict 3][3]) {
-    node0_EyeLike(input, output);
+    node0_eyelike(input, output);
 }

--- a/tests/golden/op_gather_gather.c
+++ b/tests/golden/op_gather_gather.c
@@ -31,7 +31,7 @@
  * Attrs:
  *   axis: 0
  */
-static inline void node0_Gather(const float data[restrict 3][2], const int64_t indices[restrict 2], float output[restrict 2][2]) {
+static inline void node0_gather(const float data[restrict 3][2], const int64_t indices[restrict 2], float output[restrict 2][2]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 2; ++i1) {
             int64_t gather_index = (int64_t)indices[i0];
@@ -44,5 +44,5 @@ static inline void node0_Gather(const float data[restrict 3][2], const int64_t i
 }
 
 void model(const float data[restrict 3][2], const int64_t indices[restrict 2], float out[restrict 2][2]) {
-    node0_Gather(data, indices, out);
+    node0_gather(data, indices, out);
 }

--- a/tests/golden/op_gatherelements_gather_elements.c
+++ b/tests/golden/op_gatherelements_gather_elements.c
@@ -31,7 +31,7 @@
  * Attrs:
  *   axis: 0
  */
-static inline void node0_GatherElements(const float data[restrict 2][3], const int64_t indices[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_gatherelements(const float data[restrict 2][3], const int64_t indices[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             int64_t gather_index = (int64_t)indices[i0][i1];
@@ -44,5 +44,5 @@ static inline void node0_GatherElements(const float data[restrict 2][3], const i
 }
 
 void model(const float data[restrict 2][3], const int64_t indices[restrict 2][3], float out[restrict 2][3]) {
-    node0_GatherElements(data, indices, out);
+    node0_gatherelements(data, indices, out);
 }

--- a/tests/golden/op_gemm_gemm.c
+++ b/tests/golden/op_gemm_gemm.c
@@ -31,7 +31,7 @@
  *   alpha: 1.0
  *   beta: 1.0
  */
-static inline void node0_Gemm(const float input_a[restrict 2][3], const float input_b[restrict 3][4], const float input_c[restrict 2][4], float output[restrict 2][4]) {
+static inline void node0_gemm(const float input_a[restrict 2][3], const float input_b[restrict 3][4], const float input_c[restrict 2][4], float output[restrict 2][4]) {
     for (size_t i = 0; i < 2; ++i) {
         for (size_t j = 0; j < 4; ++j) {
             float acc = 0.0f;
@@ -49,5 +49,5 @@ static inline void node0_Gemm(const float input_a[restrict 2][3], const float in
 }
 
 void model(const float in0[restrict 2][3], const float in1[restrict 3][4], const float in2[restrict 2][4], float out[restrict 2][4]) {
-    node0_Gemm(in0, in1, in2, out);
+    node0_gemm(in0, in1, in2, out);
 }

--- a/tests/golden/op_gridsample_grid_sample.c
+++ b/tests/golden/op_gridsample_grid_sample.c
@@ -33,7 +33,7 @@
  *   mode: linear
  *   padding_mode: zeros
  */
-static inline double node0_GridSample_reflect(double value, double x_min, double x_max) {
+static inline double node0_gridsample_reflect(double value, double x_min, double x_max) {
     const double range = x_max - x_min;
     if (range == 0.0) {
         return x_min;
@@ -53,7 +53,7 @@ static inline double node0_GridSample_reflect(double value, double x_min, double
     return value;
 }
 
-static inline void node0_GridSample(const float x[restrict 1][1][2][2], const float grid[restrict 1][2][2][2], float y[restrict 1][1][2][2]) {
+static inline void node0_gridsample(const float x[restrict 1][1][2][2], const float grid[restrict 1][2][2][2], float y[restrict 1][1][2][2]) {
     const int input_spatial[2] = { 2, 2 };
     const double border_min[2] = { -0.5, -0.5 };
     const double border_max[2] = { 1.5, 1.5 };
@@ -155,5 +155,5 @@ static inline void node0_GridSample(const float x[restrict 1][1][2][2], const fl
 }
 
 void model(const float x[restrict 1][1][2][2], const float grid[restrict 1][2][2][2], float y[restrict 1][1][2][2]) {
-    node0_GridSample(x, grid, y);
+    node0_gridsample(x, grid, y);
 }

--- a/tests/golden/op_groupnormalization_group_normalization.c
+++ b/tests/golden/op_groupnormalization_group_normalization.c
@@ -32,7 +32,7 @@
  *   epsilon: 9.999999747378752e-06
  *   num_groups: 2
  */
-static inline void node0_GroupNormalization(const float input0[restrict 1][4][2][2], const float scale[restrict 4], const float bias[restrict 4], float output[restrict 1][4][2][2]) {
+static inline void node0_groupnormalization(const float input0[restrict 1][4][2][2], const float scale[restrict 4], const float bias[restrict 4], float output[restrict 1][4][2][2]) {
     for (size_t i0 = 0; i0 < 1; ++i0) {
         for (size_t g = 0; g < 2; ++g) {
             float sum = 0.0f;
@@ -70,5 +70,5 @@ static inline void node0_GroupNormalization(const float input0[restrict 1][4][2]
 }
 
 void model(const float in0[restrict 1][4][2][2], const float in1[restrict 4], const float in2[restrict 4], float out[restrict 1][4][2][2]) {
-    node0_GroupNormalization(in0, in1, in2, out);
+    node0_groupnormalization(in0, in1, in2, out);
 }

--- a/tests/golden/op_identity_identity.c
+++ b/tests/golden/op_identity_identity.c
@@ -30,7 +30,7 @@
  * Outputs: out
  * Attrs: n/a
  */
-static inline void node0_Identity(const float input0[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_identity(const float input0[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = input0[i0][i1];
@@ -39,5 +39,5 @@ static inline void node0_Identity(const float input0[restrict 2][3], float outpu
 }
 
 void model(const float in0[restrict 2][3], float out[restrict 2][3]) {
-    node0_Identity(in0, out);
+    node0_identity(in0, out);
 }

--- a/tests/golden/op_instancenormalization_instance_normalization.c
+++ b/tests/golden/op_instancenormalization_instance_normalization.c
@@ -31,7 +31,7 @@
  * Attrs:
  *   epsilon: 9.999999747378752e-06
  */
-static inline void node0_InstanceNormalization(const float input0[restrict 1][3][2][2], const float scale[restrict 3], const float bias[restrict 3], float output[restrict 1][3][2][2]) {
+static inline void node0_instancenormalization(const float input0[restrict 1][3][2][2], const float scale[restrict 3], const float bias[restrict 3], float output[restrict 1][3][2][2]) {
     for (size_t i0 = 0; i0 < 1; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             float sum = 0.0f;
@@ -60,5 +60,5 @@ static inline void node0_InstanceNormalization(const float input0[restrict 1][3]
 }
 
 void model(const float in0[restrict 1][3][2][2], const float in1[restrict 3], const float in2[restrict 3], float out[restrict 1][3][2][2]) {
-    node0_InstanceNormalization(in0, in1, in2, out);
+    node0_instancenormalization(in0, in1, in2, out);
 }

--- a/tests/golden/op_layernormalization_layer_normalization.c
+++ b/tests/golden/op_layernormalization_layer_normalization.c
@@ -32,7 +32,7 @@
  *   axis: 1
  *   epsilon: 9.999999747378752e-06
  */
-static inline void node0_LayerNormalization(const float input0[restrict 2][3][4], const float scale[restrict 3][4], const float bias[restrict 3][4], float output[restrict 2][3][4]) {
+static inline void node0_layernormalization(const float input0[restrict 2][3][4], const float scale[restrict 3][4], const float bias[restrict 3][4], float output[restrict 2][3][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         float sum = 0.0f;
         for (size_t i1 = 0; i1 < 3; ++i1) {
@@ -61,5 +61,5 @@ static inline void node0_LayerNormalization(const float input0[restrict 2][3][4]
 }
 
 void model(const float in0[restrict 2][3][4], const float in1[restrict 3][4], const float in2[restrict 3][4], float out[restrict 2][3][4]) {
-    node0_LayerNormalization(in0, in1, in2, out);
+    node0_layernormalization(in0, in1, in2, out);
 }

--- a/tests/golden/op_logsoftmax_logsoftmax.c
+++ b/tests/golden/op_logsoftmax_logsoftmax.c
@@ -31,7 +31,7 @@
  * Attrs:
  *   axis: 1
  */
-static inline void node0_LogSoftmax(const float input0[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_logsoftmax(const float input0[restrict 2][3], float output[restrict 2][3]) {
     const float *input_flat = (const float *)input0;
     float *output_flat = (float *)output;
     const size_t outer = 2;
@@ -62,5 +62,5 @@ static inline void node0_LogSoftmax(const float input0[restrict 2][3], float out
 }
 
 void model(const float in0[restrict 2][3], float out[restrict 2][3]) {
-    node0_LogSoftmax(in0, out);
+    node0_logsoftmax(in0, out);
 }

--- a/tests/golden/op_lpnormalization_lp_normalization.c
+++ b/tests/golden/op_lpnormalization_lp_normalization.c
@@ -32,7 +32,7 @@
  *   axis: -1
  *   p: 1
  */
-static inline void node0_LpNormalization(const float input0[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_lpnormalization(const float input0[restrict 2][3], float output[restrict 2][3]) {
     const float *input_flat = (const float *)input0;
     float *output_flat = (float *)output;
     const size_t outer = 2;
@@ -54,5 +54,5 @@ static inline void node0_LpNormalization(const float input0[restrict 2][3], floa
 }
 
 void model(const float in0[restrict 2][3], float out[restrict 2][3]) {
-    node0_LpNormalization(in0, out);
+    node0_lpnormalization(in0, out);
 }

--- a/tests/golden/op_lrn_lrn.c
+++ b/tests/golden/op_lrn_lrn.c
@@ -34,7 +34,7 @@
  *   bias: 1.0
  *   size: 3
  */
-static inline void node0_LRN(const float input0[restrict 1][3][4][4], float output[restrict 1][3][4][4]) {
+static inline void node0_lrn(const float input0[restrict 1][3][4][4], float output[restrict 1][3][4][4]) {
     for (size_t i0 = 0; i0 < 1; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
@@ -58,5 +58,5 @@ static inline void node0_LRN(const float input0[restrict 1][3][4][4], float outp
 }
 
 void model(const float in0[restrict 1][3][4][4], float out[restrict 1][3][4][4]) {
-    node0_LRN(in0, out);
+    node0_lrn(in0, out);
 }

--- a/tests/golden/op_lstm_lstm.c
+++ b/tests/golden/op_lstm_lstm.c
@@ -48,7 +48,7 @@ static inline float ref_scalar_f32_tanh(float a) {
  *   hidden_size: 3
  *   layout: 0
  */
-static inline void node0_LSTM(const float input_x[restrict 1][1][2], const float input_w[restrict 1][12][2], const float input_r[restrict 1][12][3], float output_y[restrict 1][1][1][3], float output_y_h[restrict 1][1][3], float output_y_c[restrict 1][1][3]) {
+static inline void node0_lstm(const float input_x[restrict 1][1][2], const float input_w[restrict 1][12][2], const float input_r[restrict 1][12][3], float output_y[restrict 1][1][1][3], float output_y_h[restrict 1][1][3], float output_y_c[restrict 1][1][3]) {
     {
         const int dir = 0;
         const int reverse = 0;
@@ -120,5 +120,5 @@ static inline void node0_LSTM(const float input_x[restrict 1][1][2], const float
 }
 
 void model(const float X[restrict 1][1][2], const float W[restrict 1][12][2], const float R[restrict 1][12][3], float Y[restrict 1][1][1][3], float Y_h[restrict 1][1][3], float Y_c[restrict 1][1][3]) {
-    node0_LSTM(X, W, R, Y, Y_h, Y_c);
+    node0_lstm(X, W, R, Y, Y_h, Y_c);
 }

--- a/tests/golden/op_matmul_matmul.c
+++ b/tests/golden/op_matmul_matmul.c
@@ -29,7 +29,7 @@
  * Outputs: out
  * Attrs: n/a
  */
-static inline void node0_MatMul(const float input0[restrict 2][3], const float input1[restrict 3][4], float output[restrict 2][4]) {
+static inline void node0_matmul(const float input0[restrict 2][3], const float input1[restrict 3][4], float output[restrict 2][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 4; ++i1) {
             float acc = 0.0f;
@@ -42,5 +42,5 @@ static inline void node0_MatMul(const float input0[restrict 2][3], const float i
 }
 
 void model(const float in0[restrict 2][3], const float in1[restrict 3][4], float out[restrict 2][4]) {
-    node0_MatMul(in0, in1, out);
+    node0_matmul(in0, in1, out);
 }

--- a/tests/golden/op_maxpool_maxpool.c
+++ b/tests/golden/op_maxpool_maxpool.c
@@ -34,7 +34,7 @@
  *   pads: [0, 0, 0, 0]
  *   strides: [2, 2]
  */
-static inline void node0_MaxPool(const float input0[restrict 1][1][4][4], float output[restrict 1][1][2][2]) {
+static inline void node0_maxpool(const float input0[restrict 1][1][4][4], float output[restrict 1][1][2][2]) {
     for (size_t n = 0; n < 1; ++n) {
         for (size_t c = 0; c < 1; ++c) {
             for (size_t oh = 0; oh < 2; ++oh) {
@@ -64,5 +64,5 @@ static inline void node0_MaxPool(const float input0[restrict 1][1][4][4], float 
 }
 
 void model(const float in0[restrict 1][1][4][4], float out[restrict 1][1][2][2]) {
-    node0_MaxPool(in0, out);
+    node0_maxpool(in0, out);
 }

--- a/tests/golden/op_meanvariancenormalization_mean_variance_normalization.c
+++ b/tests/golden/op_meanvariancenormalization_mean_variance_normalization.c
@@ -31,7 +31,7 @@
  * Attrs:
  *   axes: [-1]
  */
-static inline void node0_MeanVarianceNormalization(const float input0[restrict 2][3][4], float output[restrict 2][3][4]) {
+static inline void node0_meanvariancenormalization(const float input0[restrict 2][3][4], float output[restrict 2][3][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             float sum = 0.0f;
@@ -53,5 +53,5 @@ static inline void node0_MeanVarianceNormalization(const float input0[restrict 2
 }
 
 void model(const float in0[restrict 2][3][4], float out[restrict 2][3][4]) {
-    node0_MeanVarianceNormalization(in0, out);
+    node0_meanvariancenormalization(in0, out);
 }

--- a/tests/golden/op_multiinputbinary_sum.c
+++ b/tests/golden/op_multiinputbinary_sum.c
@@ -42,7 +42,7 @@ static inline float ref_scalar_f32_add(float a, float b) {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void node0_Sum(const float input0[restrict 2][3], const float input1[restrict 2][3], const float input2[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_sum(const float input0[restrict 2][3], const float input1[restrict 2][3], const float input2[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = input0[i0][i1];
@@ -53,5 +53,5 @@ static inline void node0_Sum(const float input0[restrict 2][3], const float inpu
 }
 
 void model(const float in0[restrict 2][3], const float in1[restrict 2][3], const float in2[restrict 2][3], float out[restrict 2][3]) {
-    node0_Sum(in0, in1, in2, out);
+    node0_sum(in0, in1, in2, out);
 }

--- a/tests/golden/op_negativeloglikelihoodloss_negative_log_likelihood_loss.c
+++ b/tests/golden/op_negativeloglikelihoodloss_negative_log_likelihood_loss.c
@@ -31,7 +31,7 @@
  * Attrs:
  *   reduction: mean
  */
-static inline void node0_NegativeLogLikelihoodLoss(const float input0[restrict 2][3], const int64_t target[restrict 2], float output[restrict 1]) {
+static inline void node0_negativeloglikelihoodloss(const float input0[restrict 2][3], const int64_t target[restrict 2], float output[restrict 1]) {
     const float *input_flat = (const float *)input0;
     const int64_t *target_flat = (const int64_t *)target;
     float *output_flat = (float *)output;
@@ -63,5 +63,5 @@ static inline void node0_NegativeLogLikelihoodLoss(const float input0[restrict 2
 }
 
 void model(const float input[restrict 2][3], const int64_t target[restrict 2], float loss[restrict 1]) {
-    node0_NegativeLogLikelihoodLoss(input, target, loss);
+    node0_negativeloglikelihoodloss(input, target, loss);
 }

--- a/tests/golden/op_pad_pad.c
+++ b/tests/golden/op_pad_pad.c
@@ -39,7 +39,7 @@ static const float value[1] = {
  * Attrs:
  *   mode: constant
  */
-static inline void node0_Pad(const float input[restrict 2][3], float output[restrict 2][5]) {
+static inline void node0_pad(const float input[restrict 2][3], float output[restrict 2][5]) {
     const float *input_flat = (const float *)input;
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 5; ++i1) {
@@ -79,5 +79,5 @@ static inline void node0_Pad(const float input[restrict 2][3], float output[rest
 }
 
 void model(const float input[restrict 2][3], float output[restrict 2][5]) {
-    node0_Pad(input, output);
+    node0_pad(input, output);
 }

--- a/tests/golden/op_range_range.c
+++ b/tests/golden/op_range_range.c
@@ -42,7 +42,7 @@ static const int64_t delta[1] = {
  * Outputs: output
  * Attrs: n/a
  */
-static inline void node0_Range(const int64_t start[restrict 1], const int64_t limit[restrict 1], const int64_t delta[restrict 1], int64_t output[restrict 4]) {
+static inline void node0_range(const int64_t start[restrict 1], const int64_t limit[restrict 1], const int64_t delta[restrict 1], int64_t output[restrict 4]) {
     (void)limit;
     const int64_t start_value = start[0];
     const int64_t delta_value = delta[0];
@@ -52,5 +52,5 @@ static inline void node0_Range(const int64_t start[restrict 1], const int64_t li
 }
 
 void model(int64_t output[restrict 4]) {
-    node0_Range(start, limit, delta, output);
+    node0_range(start, limit, delta, output);
 }

--- a/tests/golden/op_reduce_reduce_mean.c
+++ b/tests/golden/op_reduce_reduce_mean.c
@@ -35,7 +35,7 @@ static const int64_t axes[1] = {
  * Attrs:
  *   keepdims: 1
  */
-static inline void node0_ReduceMean(const float input0[restrict 2][3][4], float output[restrict 2][1][4]) {
+static inline void node0_reducemean(const float input0[restrict 2][3][4], float output[restrict 2][1][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 1; ++i1) {
             for (size_t i2 = 0; i2 < 4; ++i2) {
@@ -50,5 +50,5 @@ static inline void node0_ReduceMean(const float input0[restrict 2][3][4], float 
 }
 
 void model(const float in0[restrict 2][3][4], float out[restrict 2][1][4]) {
-    node0_ReduceMean(in0, out);
+    node0_reducemean(in0, out);
 }

--- a/tests/golden/op_reshape_reshape.c
+++ b/tests/golden/op_reshape_reshape.c
@@ -35,10 +35,10 @@ static const int64_t shape[2] = {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void node0_Reshape(const float input0[restrict 2][3][4], float output[restrict 2][12]) {
+static inline void node0_reshape(const float input0[restrict 2][3][4], float output[restrict 2][12]) {
     memcpy(output, input0, sizeof(float) * 24);
 }
 
 void model(const float in0[restrict 2][3][4], float out[restrict 2][12]) {
-    node0_Reshape(in0, out);
+    node0_reshape(in0, out);
 }

--- a/tests/golden/op_resize_resize.c
+++ b/tests/golden/op_resize_resize.c
@@ -38,7 +38,7 @@ static const int64_t sizes[4] = {
  *   mode: nearest
  *   nearest_mode: floor
  */
-static inline void node0_Resize(const float input0[restrict 1][1][2][2], const int64_t sizes_input[restrict 4], float output[restrict 1][1][4][4]) {
+static inline void node0_resize(const float input0[restrict 1][1][2][2], const int64_t sizes_input[restrict 4], float output[restrict 1][1][4][4]) {
     const int64_t input_shape[4] = { 1, 1, 2, 2 };
     const int64_t output_shape[4] = { 1, 1, 4, 4 };
     double scales[4];
@@ -116,5 +116,5 @@ static inline void node0_Resize(const float input0[restrict 1][1][2][2], const i
 }
 
 void model(const float in0[restrict 1][1][2][2], float out[restrict 1][1][4][4]) {
-    node0_Resize(in0, sizes, out);
+    node0_resize(in0, sizes, out);
 }

--- a/tests/golden/op_rmsnormalization_rms_normalization.c
+++ b/tests/golden/op_rmsnormalization_rms_normalization.c
@@ -32,7 +32,7 @@
  *   axis: -1
  *   epsilon: 9.999999747378752e-06
  */
-static inline void node0_RMSNormalization(const float input0[restrict 2][3][4], const float scale[restrict 4], float output[restrict 2][3][4]) {
+static inline void node0_rmsnormalization(const float input0[restrict 2][3][4], const float scale[restrict 4], float output[restrict 2][3][4]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             float sum = 0.0f;
@@ -52,5 +52,5 @@ static inline void node0_RMSNormalization(const float input0[restrict 2][3][4], 
 }
 
 void model(const float in0[restrict 2][3][4], const float in1[restrict 4], float out[restrict 2][3][4]) {
-    node0_RMSNormalization(in0, in1, out);
+    node0_rmsnormalization(in0, in1, out);
 }

--- a/tests/golden/op_shape_shape.c
+++ b/tests/golden/op_shape_shape.c
@@ -30,7 +30,7 @@
  * Outputs: out
  * Attrs: n/a
  */
-static inline void node0_Shape(const float input0[restrict 2][3][4], int64_t output[restrict 3]) {
+static inline void node0_shape(const float input0[restrict 2][3][4], int64_t output[restrict 3]) {
     (void)input0;
     output[0] = 2LL;
     output[1] = 3LL;
@@ -38,5 +38,5 @@ static inline void node0_Shape(const float input0[restrict 2][3][4], int64_t out
 }
 
 void model(const float in0[restrict 2][3][4], int64_t out[restrict 3]) {
-    node0_Shape(in0, out);
+    node0_shape(in0, out);
 }

--- a/tests/golden/op_size_size.c
+++ b/tests/golden/op_size_size.c
@@ -30,11 +30,11 @@
  * Outputs: out
  * Attrs: n/a
  */
-static inline void node0_Size(const float input0[restrict 2][3][4], int64_t output[restrict 1]) {
+static inline void node0_size(const float input0[restrict 2][3][4], int64_t output[restrict 1]) {
     (void)input0;
     output[0] = 24LL;
 }
 
 void model(const float in0[restrict 2][3][4], int64_t out[restrict 1]) {
-    node0_Size(in0, out);
+    node0_size(in0, out);
 }

--- a/tests/golden/op_slice_slice.c
+++ b/tests/golden/op_slice_slice.c
@@ -46,7 +46,7 @@ static const int64_t steps[2] = {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void node0_Slice(const float input0[restrict 2][3][4], float output[restrict 2][3][1]) {
+static inline void node0_slice(const float input0[restrict 2][3][4], float output[restrict 2][3][1]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             for (size_t i2 = 0; i2 < 1; ++i2) {
@@ -57,5 +57,5 @@ static inline void node0_Slice(const float input0[restrict 2][3][4], float outpu
 }
 
 void model(const float in0[restrict 2][3][4], float out[restrict 2][3][1]) {
-    node0_Slice(in0, out);
+    node0_slice(in0, out);
 }

--- a/tests/golden/op_softmax_softmax.c
+++ b/tests/golden/op_softmax_softmax.c
@@ -31,7 +31,7 @@
  * Attrs:
  *   axis: 1
  */
-static inline void node0_Softmax(const float input0[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_softmax(const float input0[restrict 2][3], float output[restrict 2][3]) {
     const float *input_flat = (const float *)input0;
     float *output_flat = (float *)output;
     const size_t outer = 2;
@@ -61,5 +61,5 @@ static inline void node0_Softmax(const float input0[restrict 2][3], float output
 }
 
 void model(const float in0[restrict 2][3], float out[restrict 2][3]) {
-    node0_Softmax(in0, out);
+    node0_softmax(in0, out);
 }

--- a/tests/golden/op_softmaxcrossentropyloss_softmax_cross_entropy_loss.c
+++ b/tests/golden/op_softmaxcrossentropyloss_softmax_cross_entropy_loss.c
@@ -32,7 +32,7 @@
  * Attrs:
  *   reduction: mean
  */
-static inline void node0_SoftmaxCrossEntropyLoss(const float input0[restrict 2][3], const int64_t target[restrict 2], float output[restrict 1], float log_prob[restrict 2][3]) {
+static inline void node0_softmaxcrossentropyloss(const float input0[restrict 2][3], const int64_t target[restrict 2], float output[restrict 1], float log_prob[restrict 2][3]) {
     const float *input_flat = (const float *)input0;
     const int64_t *target_flat = (const int64_t *)target;
     float *output_flat = (float *)output;
@@ -77,5 +77,5 @@ static inline void node0_SoftmaxCrossEntropyLoss(const float input0[restrict 2][
 }
 
 void model(const float scores[restrict 2][3], const int64_t labels[restrict 2], float loss[restrict 1], float log_prob[restrict 2][3]) {
-    node0_SoftmaxCrossEntropyLoss(scores, labels, loss, log_prob);
+    node0_softmaxcrossentropyloss(scores, labels, loss, log_prob);
 }

--- a/tests/golden/op_spacetodepth_space_to_depth.c
+++ b/tests/golden/op_spacetodepth_space_to_depth.c
@@ -30,7 +30,7 @@
  * Attrs:
  *   blocksize: 2
  */
-static inline void node0_SpaceToDepth(const float input0[restrict 1][1][4][4], float output[restrict 1][4][2][2]) {
+static inline void node0_spacetodepth(const float input0[restrict 1][1][4][4], float output[restrict 1][4][2][2]) {
     const float *input_data = (const float *)input0;
     float *output_data = (float *)output;
     size_t output_index = 0;
@@ -54,5 +54,5 @@ static inline void node0_SpaceToDepth(const float input0[restrict 1][1][4][4], f
 }
 
 void model(const float in0[restrict 1][1][4][4], float out[restrict 1][4][2][2]) {
-    node0_SpaceToDepth(in0, out);
+    node0_spacetodepth(in0, out);
 }

--- a/tests/golden/op_split_split.c
+++ b/tests/golden/op_split_split.c
@@ -36,7 +36,7 @@ static const int64_t split[3] = {
  * Attrs:
  *   axis: 1
  */
-static inline void node0_Split(const float input0[restrict 2][6], float output_0[restrict 2][2], float output_1[restrict 2][2], float output_2[restrict 2][2]) {
+static inline void node0_split(const float input0[restrict 2][6], float output_0[restrict 2][2], float output_1[restrict 2][2], float output_2[restrict 2][2]) {
     const float *input_data = (const float *)input0;
     float *output_ptrs[] = { (float *)output_0, (float *)output_1, (float *)output_2 };
     const size_t axis_sizes[] = { 2, 2, 2 };
@@ -56,5 +56,5 @@ static inline void node0_Split(const float input0[restrict 2][6], float output_0
 }
 
 void model(const float input[restrict 2][6], float output_0[restrict 2][2], float output_1[restrict 2][2], float output_2[restrict 2][2]) {
-    node0_Split(input, output_0, output_1, output_2);
+    node0_split(input, output_0, output_1, output_2);
 }

--- a/tests/golden/op_tile_tile.c
+++ b/tests/golden/op_tile_tile.c
@@ -34,7 +34,7 @@ static const int64_t repeats[2] = {
  * Outputs: output
  * Attrs: n/a
  */
-static inline void node0_Tile(const float input0[restrict 2][3], float output[restrict 4][3]) {
+static inline void node0_tile(const float input0[restrict 2][3], float output[restrict 4][3]) {
     const float *input_data = (const float *)input0;
     float *output_data = (float *)output;
     size_t output_index = 0;
@@ -48,5 +48,5 @@ static inline void node0_Tile(const float input0[restrict 2][3], float output[re
 }
 
 void model(const float input[restrict 2][3], float output[restrict 4][3]) {
-    node0_Tile(input, output);
+    node0_tile(input, output);
 }

--- a/tests/golden/op_transpose_transpose.c
+++ b/tests/golden/op_transpose_transpose.c
@@ -30,7 +30,7 @@
  * Attrs:
  *   perm: [2, 0, 1]
  */
-static inline void node0_Transpose(const float input0[restrict 2][3][4], float output[restrict 4][2][3]) {
+static inline void node0_transpose(const float input0[restrict 2][3][4], float output[restrict 4][2][3]) {
     for (size_t i0 = 0; i0 < 4; ++i0) {
         for (size_t i1 = 0; i1 < 2; ++i1) {
             for (size_t i2 = 0; i2 < 3; ++i2) {
@@ -41,5 +41,5 @@ static inline void node0_Transpose(const float input0[restrict 2][3][4], float o
 }
 
 void model(const float in0[restrict 2][3][4], float out[restrict 4][2][3]) {
-    node0_Transpose(in0, out);
+    node0_transpose(in0, out);
 }

--- a/tests/golden/op_unary_tanh.c
+++ b/tests/golden/op_unary_tanh.c
@@ -42,7 +42,7 @@ static inline float ref_scalar_f32_tanh(float a) {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void node0_Tanh(const float input0[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_tanh(const float input0[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_tanh(input0[i0][i1]);
@@ -51,5 +51,5 @@ static inline void node0_Tanh(const float input0[restrict 2][3], float output[re
 }
 
 void model(const float in0[restrict 2][3], float out[restrict 2][3]) {
-    node0_Tanh(in0, out);
+    node0_tanh(in0, out);
 }

--- a/tests/golden/op_where_where.c
+++ b/tests/golden/op_where_where.c
@@ -30,7 +30,7 @@
  * Outputs: out
  * Attrs: n/a
  */
-static inline void node0_Where(const bool condition[restrict 2][3], const float input_x[restrict 2][3], const float input_y[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_where(const bool condition[restrict 2][3], const float input_x[restrict 2][3], const float input_y[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = condition[i0][i1] ? input_x[i0][i1] : input_y[i0][i1];
@@ -39,5 +39,5 @@ static inline void node0_Where(const bool condition[restrict 2][3], const float 
 }
 
 void model(const bool condition[restrict 2][3], const float x[restrict 2][3], const float y[restrict 2][3], float out[restrict 2][3]) {
-    node0_Where(condition, x, y, out);
+    node0_where(condition, x, y, out);
 }

--- a/tests/golden/relu_model.c
+++ b/tests/golden/relu_model.c
@@ -42,7 +42,7 @@ static inline float ref_scalar_f32_relu(float a) {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void node0_Relu(const float input0[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_relu(const float input0[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_relu(input0[i0][i1]);
@@ -51,5 +51,5 @@ static inline void node0_Relu(const float input0[restrict 2][3], float output[re
 }
 
 void model(const float x[restrict 2][3], float out[restrict 2][3]) {
-    node0_Relu(x, out);
+    node0_relu(x, out);
 }

--- a/tests/golden/tanh_model.c
+++ b/tests/golden/tanh_model.c
@@ -42,7 +42,7 @@ static inline float ref_scalar_f32_tanh(float a) {
  * Outputs: out
  * Attrs: n/a
  */
-static inline void node0_Tanh(const float input0[restrict 2][3], float output[restrict 2][3]) {
+static inline void node0_tanh(const float input0[restrict 2][3], float output[restrict 2][3]) {
     for (size_t i0 = 0; i0 < 2; ++i0) {
         for (size_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_tanh(input0[i0][i1]);
@@ -51,5 +51,5 @@ static inline void node0_Tanh(const float input0[restrict 2][3], float output[re
 }
 
 void model(const float x[restrict 2][3], float out[restrict 2][3]) {
-    node0_Tanh(x, out);
+    node0_tanh(x, out);
 }


### PR DESCRIPTION
### Motivation
- Ensure generated node function names follow the new stable naming convention `node<index>_<name|optype>` and are normalized to lowercase for determinism and consistency.

### Description
- Update `_op_function_name` in `src/emx_onnx_cgen/codegen/c_emitter.py` to use `suffix = node_info.name or node_info.op_type` and `base_name = f"node{index}_{suffix}".lower()` before sanitization.
- Keep identifier sanitation via `CEmitter._sanitize_identifier` so generated names remain valid C identifiers.
- Regenerate affected golden C outputs under `tests/golden/` to reflect the new lowercase naming scheme.

### Testing
- Ran the test suite with reference updates using `UPDATE_REFS=1 pytest -n auto -q` which completed in `54.96s` and produced `233 passed, 2 skipped, 2 warnings`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69696afaa30883259391a60495dd2581)