### PR TITLE
codegen: add weight comment blocks for generated constants

### DIFF
--- a/src/emx_onnx_cgen/codegen/c_emitter.py
+++ b/src/emx_onnx_cgen/codegen/c_emitter.py
@@ -2857,6 +2857,23 @@ class CEmitter:
         return "\n".join(comment_lines)
 
     @staticmethod
+    def _emit_constant_comment(constant: ConstTensor, index: int) -> str:
+        shape = constant.shape
+        lines = [
+            f"Weight {index}:",
+            f"Name: {constant.name}",
+            f"Shape: {shape if shape else '[]'}",
+            f"Elements: {CEmitter._element_count(shape)}",
+            f"Dtype: {constant.dtype.onnx_name}",
+        ]
+        comment_lines = ["/*"]
+        comment_lines.extend(
+            f" * {line}" if line else " *" for line in lines
+        )
+        comment_lines.append(" */")
+        return "\n".join(comment_lines)
+
+    @staticmethod
     def _collect_constant_includes(constants: tuple[ConstTensor, ...]) -> list[str]:
         if not constants:
             return []
@@ -8834,7 +8851,8 @@ class CEmitter:
         if not constants:
             return ""
         lines: list[str] = []
-        for const in constants:
+        for index, const in enumerate(constants, start=1):
+            lines.append(self._emit_constant_comment(const, index))
             c_type = const.dtype.c_type
             array_suffix = self._array_suffix(const.shape)
             values = [
@@ -8866,7 +8884,8 @@ class CEmitter:
         if not constants:
             return ""
         lines = []
-        for const in constants:
+        for index, const in enumerate(constants, start=1):
+            lines.append(self._emit_constant_comment(const, index))
             c_type = const.dtype.c_type
             array_suffix = self._array_suffix(const.shape)
             lines.append(f"extern const {c_type} {const.name}{array_suffix};")

--- a/tests/golden/add_initializer_model.c
+++ b/tests/golden/add_initializer_model.c
@@ -30,6 +30,13 @@
 #define REF_PI_D 3.14159265358979323846
 #endif
 
+/*
+ * Weight 1:
+ * Name: weight
+ * Shape: (2, 3)
+ * Elements: 6
+ * Dtype: float
+ */
 static const float weight[2][3] = {
     0.100000001f, 0.200000003f, 0.300000012f, 0.400000006f, 0.5f, 0.600000024f
 };

--- a/tests/golden/op_batchnorm_batch_normalization.c
+++ b/tests/golden/op_batchnorm_batch_normalization.c
@@ -22,18 +22,46 @@
 #include <stddef.h>
 #include <math.h>
 
+/*
+ * Weight 1:
+ * Name: scale
+ * Shape: (3,)
+ * Elements: 3
+ * Dtype: float
+ */
 static const float scale[3] = {
     1.0f, 1.5f, -0.5f
 };
 
+/*
+ * Weight 2:
+ * Name: bias
+ * Shape: (3,)
+ * Elements: 3
+ * Dtype: float
+ */
 static const float bias[3] = {
     0.0f, 0.100000001f, -0.200000003f
 };
 
+/*
+ * Weight 3:
+ * Name: mean
+ * Shape: (3,)
+ * Elements: 3
+ * Dtype: float
+ */
 static const float mean[3] = {
     0.5f, -0.5f, 1.0f
 };
 
+/*
+ * Weight 4:
+ * Name: var
+ * Shape: (3,)
+ * Elements: 3
+ * Dtype: float
+ */
 static const float var[3] = {
     0.25f, 0.5f, 1.5f
 };

--- a/tests/golden/op_clip_clip.c
+++ b/tests/golden/op_clip_clip.c
@@ -21,10 +21,24 @@
 
 #include <stddef.h>
 
+/*
+ * Weight 1:
+ * Name: min
+ * Shape: []
+ * Elements: 1
+ * Dtype: float
+ */
 static const float min[1] = {
     0.0f
 };
 
+/*
+ * Weight 2:
+ * Name: max
+ * Shape: []
+ * Elements: 1
+ * Dtype: float
+ */
 static const float max[1] = {
     6.0f
 };

--- a/tests/golden/op_constantofshape_constant_of_shape.c
+++ b/tests/golden/op_constantofshape_constant_of_shape.c
@@ -22,6 +22,13 @@
 #include <stddef.h>
 #include <stdint.h>
 
+/*
+ * Weight 1:
+ * Name: shape
+ * Shape: (3,)
+ * Elements: 3
+ * Dtype: int64
+ */
 static const int64_t shape[3] = {
     2LL, 3LL, 4LL
 };

--- a/tests/golden/op_conv_conv.c
+++ b/tests/golden/op_conv_conv.c
@@ -21,11 +21,25 @@
 
 #include <stddef.h>
 
+/*
+ * Weight 1:
+ * Name: weight
+ * Shape: (1, 1, 3, 3)
+ * Elements: 9
+ * Dtype: float
+ */
 static const float weight[1][1][3][3] = {
     0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f,
     8.0f
 };
 
+/*
+ * Weight 2:
+ * Name: bias
+ * Shape: (1,)
+ * Elements: 1
+ * Dtype: float
+ */
 static const float bias[1] = {
     0.25f
 };

--- a/tests/golden/op_cumsum_cumsum.c
+++ b/tests/golden/op_cumsum_cumsum.c
@@ -22,6 +22,13 @@
 #include <stddef.h>
 #include <stdint.h>
 
+/*
+ * Weight 1:
+ * Name: axis
+ * Shape: []
+ * Elements: 1
+ * Dtype: int64
+ */
 static const int64_t axis[1] = {
     1LL
 };

--- a/tests/golden/op_expand_expand.c
+++ b/tests/golden/op_expand_expand.c
@@ -22,6 +22,13 @@
 #include <stddef.h>
 #include <stdint.h>
 
+/*
+ * Weight 1:
+ * Name: shape
+ * Shape: (2,)
+ * Elements: 2
+ * Dtype: int64
+ */
 static const int64_t shape[2] = {
     2LL, 3LL
 };

--- a/tests/golden/op_pad_pad.c
+++ b/tests/golden/op_pad_pad.c
@@ -22,10 +22,24 @@
 #include <stddef.h>
 #include <stdint.h>
 
+/*
+ * Weight 1:
+ * Name: pads
+ * Shape: (4,)
+ * Elements: 4
+ * Dtype: int64
+ */
 static const int64_t pads[4] = {
     0LL, 1LL, 0LL, 1LL
 };
 
+/*
+ * Weight 2:
+ * Name: value
+ * Shape: []
+ * Elements: 1
+ * Dtype: float
+ */
 static const float value[1] = {
     0.0f
 };

--- a/tests/golden/op_range_range.c
+++ b/tests/golden/op_range_range.c
@@ -22,14 +22,35 @@
 #include <stddef.h>
 #include <stdint.h>
 
+/*
+ * Weight 1:
+ * Name: start
+ * Shape: []
+ * Elements: 1
+ * Dtype: int64
+ */
 static const int64_t start[1] = {
     0LL
 };
 
+/*
+ * Weight 2:
+ * Name: limit
+ * Shape: []
+ * Elements: 1
+ * Dtype: int64
+ */
 static const int64_t limit[1] = {
     4LL
 };
 
+/*
+ * Weight 3:
+ * Name: delta
+ * Shape: []
+ * Elements: 1
+ * Dtype: int64
+ */
 static const int64_t delta[1] = {
     1LL
 };

--- a/tests/golden/op_reduce_reduce_mean.c
+++ b/tests/golden/op_reduce_reduce_mean.c
@@ -22,6 +22,13 @@
 #include <stddef.h>
 #include <stdint.h>
 
+/*
+ * Weight 1:
+ * Name: axes
+ * Shape: (1,)
+ * Elements: 1
+ * Dtype: int64
+ */
 static const int64_t axes[1] = {
     1LL
 };

--- a/tests/golden/op_reshape_reshape.c
+++ b/tests/golden/op_reshape_reshape.c
@@ -23,6 +23,13 @@
 #include <stdint.h>
 #include <string.h>
 
+/*
+ * Weight 1:
+ * Name: shape
+ * Shape: (2,)
+ * Elements: 2
+ * Dtype: int64
+ */
 static const int64_t shape[2] = {
     0LL, -1LL
 };

--- a/tests/golden/op_resize_resize.c
+++ b/tests/golden/op_resize_resize.c
@@ -23,6 +23,13 @@
 #include <stdint.h>
 #include <math.h>
 
+/*
+ * Weight 1:
+ * Name: sizes
+ * Shape: (4,)
+ * Elements: 4
+ * Dtype: int64
+ */
 static const int64_t sizes[4] = {
     1LL, 1LL, 4LL, 4LL
 };

--- a/tests/golden/op_slice_slice.c
+++ b/tests/golden/op_slice_slice.c
@@ -22,18 +22,46 @@
 #include <stddef.h>
 #include <stdint.h>
 
+/*
+ * Weight 1:
+ * Name: starts
+ * Shape: (2,)
+ * Elements: 2
+ * Dtype: int64
+ */
 static const int64_t starts[2] = {
     0LL, 1LL
 };
 
+/*
+ * Weight 2:
+ * Name: ends
+ * Shape: (2,)
+ * Elements: 2
+ * Dtype: int64
+ */
 static const int64_t ends[2] = {
     2LL, 3LL
 };
 
+/*
+ * Weight 3:
+ * Name: axes
+ * Shape: (2,)
+ * Elements: 2
+ * Dtype: int64
+ */
 static const int64_t axes[2] = {
     0LL, 2LL
 };
 
+/*
+ * Weight 4:
+ * Name: steps
+ * Shape: (2,)
+ * Elements: 2
+ * Dtype: int64
+ */
 static const int64_t steps[2] = {
     1LL, 2LL
 };

--- a/tests/golden/op_split_split.c
+++ b/tests/golden/op_split_split.c
@@ -23,6 +23,13 @@
 #include <stdint.h>
 #include <string.h>
 
+/*
+ * Weight 1:
+ * Name: split
+ * Shape: (3,)
+ * Elements: 3
+ * Dtype: int64
+ */
 static const int64_t split[3] = {
     2LL, 2LL, 2LL
 };

--- a/tests/golden/op_tile_tile.c
+++ b/tests/golden/op_tile_tile.c
@@ -22,6 +22,13 @@
 #include <stddef.h>
 #include <stdint.h>
 
+/*
+ * Weight 1:
+ * Name: repeats
+ * Shape: (2,)
+ * Elements: 2
+ * Dtype: int64
+ */
 static const int64_t repeats[2] = {
     2LL, 1LL
 };


### PR DESCRIPTION
### Motivation
- Improve readability of generated C by adding a comment block for constant weight/initializer arrays analogous to existing node comment blocks.

### Description
- Add a static helper `CEmitter._emit_constant_comment` that renders weight metadata (index, name, shape, element count, dtype).
- Prepend the weight comment to constant declarations and definitions in `_emit_constant_declarations` and `_emit_constant_definitions` respectively.
- Update golden C outputs under `tests/golden/` to include the new weight comment blocks.
- Primary code change is in `src/emx_onnx_cgen/codegen/c_emitter.py` and multiple golden snapshots were refreshed.

### Testing
- Ran `UPDATE_REFS=1 pytest -n auto -q` to refresh references and exercise the emitter, which completed in 60.14s and succeeded with `233 passed, 2 skipped, 2 warnings`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69696b34c6c8832583f743830da76b3c)