### PR TITLE
codegen: standardize weight constant naming

### DIFF
--- a/tests/golden/add_initializer_model.c
+++ b/tests/golden/add_initializer_model.c
@@ -25,12 +25,12 @@
 
 /*
  * Weight 1:
- * Name: weight
+ * Name: weight1_weight
  * Shape: (2, 3)
  * Elements: 6
  * Dtype: float
  */
-static const float weight[2][3] = {
+static const float weight1_weight[2][3] = {
     0.100000001f, 0.200000003f, 0.300000012f, 0.400000006f, 0.5f, 0.600000024f
 };
 
@@ -55,5 +55,5 @@ static inline void node0_add(const float input0[restrict 2][3], const float inpu
 }
 
 void model(const float in0[restrict 2][3], float out[restrict 2][3]) {
-    node0_add(in0, weight, out);
+    node0_add(in0, weight1_weight, out);
 }

--- a/tests/golden/op_batchnorm_batch_normalization.c
+++ b/tests/golden/op_batchnorm_batch_normalization.c
@@ -24,45 +24,45 @@
 
 /*
  * Weight 1:
- * Name: scale
+ * Name: weight1_scale
  * Shape: (3,)
  * Elements: 3
  * Dtype: float
  */
-static const float scale[3] = {
+static const float weight1_scale[3] = {
     1.0f, 1.5f, -0.5f
 };
 
 /*
  * Weight 2:
- * Name: bias
+ * Name: weight2_bias
  * Shape: (3,)
  * Elements: 3
  * Dtype: float
  */
-static const float bias[3] = {
+static const float weight2_bias[3] = {
     0.0f, 0.100000001f, -0.200000003f
 };
 
 /*
  * Weight 3:
- * Name: mean
+ * Name: weight3_mean
  * Shape: (3,)
  * Elements: 3
  * Dtype: float
  */
-static const float mean[3] = {
+static const float weight3_mean[3] = {
     0.5f, -0.5f, 1.0f
 };
 
 /*
  * Weight 4:
- * Name: var
+ * Name: weight4_var
  * Shape: (3,)
  * Elements: 3
  * Dtype: float
  */
-static const float var[3] = {
+static const float weight4_var[3] = {
     0.25f, 0.5f, 1.5f
 };
 
@@ -90,5 +90,5 @@ static inline void node0_batchnormalization(const float input0[restrict 2][3][2]
 }
 
 void model(const float in0[restrict 2][3][2][2], float out[restrict 2][3][2][2]) {
-    node0_batchnormalization(in0, scale, bias, mean, var, out);
+    node0_batchnormalization(in0, weight1_scale, weight2_bias, weight3_mean, weight4_var, out);
 }

--- a/tests/golden/op_clip_clip.c
+++ b/tests/golden/op_clip_clip.c
@@ -23,23 +23,23 @@
 
 /*
  * Weight 1:
- * Name: min
+ * Name: weight1_min
  * Shape: []
  * Elements: 1
  * Dtype: float
  */
-static const float min[1] = {
+static const float weight1_min[1] = {
     0.0f
 };
 
 /*
  * Weight 2:
- * Name: max
+ * Name: weight2_max
  * Shape: []
  * Elements: 1
  * Dtype: float
  */
-static const float max[1] = {
+static const float weight2_max[1] = {
     6.0f
 };
 
@@ -67,5 +67,5 @@ static inline void node0_clip(const float input0[restrict 2][3], const float inp
 }
 
 void model(const float input[restrict 2][3], float output[restrict 2][3]) {
-    node0_clip(input, min, max, output);
+    node0_clip(input, weight1_min, weight2_max, output);
 }

--- a/tests/golden/op_constantofshape_constant_of_shape.c
+++ b/tests/golden/op_constantofshape_constant_of_shape.c
@@ -24,12 +24,12 @@
 
 /*
  * Weight 1:
- * Name: shape
+ * Name: weight1_shape
  * Shape: (3,)
  * Elements: 3
  * Dtype: int64
  */
-static const int64_t shape[3] = {
+static const int64_t weight1_shape[3] = {
     2LL, 3LL, 4LL
 };
 
@@ -58,5 +58,5 @@ static inline void node0_constantofshape(const int64_t input0[restrict 3], float
 }
 
 void model(float out[restrict 2][3][4]) {
-    node0_constantofshape(shape, out);
+    node0_constantofshape(weight1_shape, out);
 }

--- a/tests/golden/op_conv_conv.c
+++ b/tests/golden/op_conv_conv.c
@@ -23,24 +23,24 @@
 
 /*
  * Weight 1:
- * Name: weight
+ * Name: weight1_weight
  * Shape: (1, 1, 3, 3)
  * Elements: 9
  * Dtype: float
  */
-static const float weight[1][1][3][3] = {
+static const float weight1_weight[1][1][3][3] = {
     0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f,
     8.0f
 };
 
 /*
  * Weight 2:
- * Name: bias
+ * Name: weight2_bias
  * Shape: (1,)
  * Elements: 1
  * Dtype: float
  */
-static const float bias[1] = {
+static const float weight2_bias[1] = {
     0.25f
 };
 
@@ -84,5 +84,5 @@ static inline void node0_conv(const float input0[restrict 1][1][4][4], const flo
 }
 
 void model(const float in0[restrict 1][1][4][4], float out[restrict 1][1][4][4]) {
-    node0_conv(in0, weight, bias, out);
+    node0_conv(in0, weight1_weight, weight2_bias, out);
 }

--- a/tests/golden/op_cumsum_cumsum.c
+++ b/tests/golden/op_cumsum_cumsum.c
@@ -24,12 +24,12 @@
 
 /*
  * Weight 1:
- * Name: axis
+ * Name: weight1_axis
  * Shape: []
  * Elements: 1
  * Dtype: int64
  */
-static const int64_t axis[1] = {
+static const int64_t weight1_axis[1] = {
     1LL
 };
 

--- a/tests/golden/op_expand_expand.c
+++ b/tests/golden/op_expand_expand.c
@@ -24,12 +24,12 @@
 
 /*
  * Weight 1:
- * Name: shape
+ * Name: weight1_shape
  * Shape: (2,)
  * Elements: 2
  * Dtype: int64
  */
-static const int64_t shape[2] = {
+static const int64_t weight1_shape[2] = {
     2LL, 3LL
 };
 

--- a/tests/golden/op_pad_pad.c
+++ b/tests/golden/op_pad_pad.c
@@ -24,23 +24,23 @@
 
 /*
  * Weight 1:
- * Name: pads
+ * Name: weight1_pads
  * Shape: (4,)
  * Elements: 4
  * Dtype: int64
  */
-static const int64_t pads[4] = {
+static const int64_t weight1_pads[4] = {
     0LL, 1LL, 0LL, 1LL
 };
 
 /*
  * Weight 2:
- * Name: value
+ * Name: weight2_value
  * Shape: []
  * Elements: 1
  * Dtype: float
  */
-static const float value[1] = {
+static const float weight2_value[1] = {
     0.0f
 };
 

--- a/tests/golden/op_range_range.c
+++ b/tests/golden/op_range_range.c
@@ -24,34 +24,34 @@
 
 /*
  * Weight 1:
- * Name: start
+ * Name: weight1_start
  * Shape: []
  * Elements: 1
  * Dtype: int64
  */
-static const int64_t start[1] = {
+static const int64_t weight1_start[1] = {
     0LL
 };
 
 /*
  * Weight 2:
- * Name: limit
+ * Name: weight2_limit
  * Shape: []
  * Elements: 1
  * Dtype: int64
  */
-static const int64_t limit[1] = {
+static const int64_t weight2_limit[1] = {
     4LL
 };
 
 /*
  * Weight 3:
- * Name: delta
+ * Name: weight3_delta
  * Shape: []
  * Elements: 1
  * Dtype: int64
  */
-static const int64_t delta[1] = {
+static const int64_t weight3_delta[1] = {
     1LL
 };
 
@@ -73,5 +73,5 @@ static inline void node0_range(const int64_t start[restrict 1], const int64_t li
 }
 
 void model(int64_t output[restrict 4]) {
-    node0_range(start, limit, delta, output);
+    node0_range(weight1_start, weight2_limit, weight3_delta, output);
 }

--- a/tests/golden/op_reduce_reduce_mean.c
+++ b/tests/golden/op_reduce_reduce_mean.c
@@ -24,12 +24,12 @@
 
 /*
  * Weight 1:
- * Name: axes
+ * Name: weight1_axes
  * Shape: (1,)
  * Elements: 1
  * Dtype: int64
  */
-static const int64_t axes[1] = {
+static const int64_t weight1_axes[1] = {
     1LL
 };
 

--- a/tests/golden/op_reshape_reshape.c
+++ b/tests/golden/op_reshape_reshape.c
@@ -25,12 +25,12 @@
 
 /*
  * Weight 1:
- * Name: shape
+ * Name: weight1_shape
  * Shape: (2,)
  * Elements: 2
  * Dtype: int64
  */
-static const int64_t shape[2] = {
+static const int64_t weight1_shape[2] = {
     0LL, -1LL
 };
 

--- a/tests/golden/op_resize_resize.c
+++ b/tests/golden/op_resize_resize.c
@@ -25,12 +25,12 @@
 
 /*
  * Weight 1:
- * Name: sizes
+ * Name: weight1_sizes
  * Shape: (4,)
  * Elements: 4
  * Dtype: int64
  */
-static const int64_t sizes[4] = {
+static const int64_t weight1_sizes[4] = {
     1LL, 1LL, 4LL, 4LL
 };
 
@@ -123,5 +123,5 @@ static inline void node0_resize(const float input0[restrict 1][1][2][2], const i
 }
 
 void model(const float in0[restrict 1][1][2][2], float out[restrict 1][1][4][4]) {
-    node0_resize(in0, sizes, out);
+    node0_resize(in0, weight1_sizes, out);
 }

--- a/tests/golden/op_slice_slice.c
+++ b/tests/golden/op_slice_slice.c
@@ -24,45 +24,45 @@
 
 /*
  * Weight 1:
- * Name: starts
+ * Name: weight1_starts
  * Shape: (2,)
  * Elements: 2
  * Dtype: int64
  */
-static const int64_t starts[2] = {
+static const int64_t weight1_starts[2] = {
     0LL, 1LL
 };
 
 /*
  * Weight 2:
- * Name: ends
+ * Name: weight2_ends
  * Shape: (2,)
  * Elements: 2
  * Dtype: int64
  */
-static const int64_t ends[2] = {
+static const int64_t weight2_ends[2] = {
     2LL, 3LL
 };
 
 /*
  * Weight 3:
- * Name: axes
+ * Name: weight3_axes
  * Shape: (2,)
  * Elements: 2
  * Dtype: int64
  */
-static const int64_t axes[2] = {
+static const int64_t weight3_axes[2] = {
     0LL, 2LL
 };
 
 /*
  * Weight 4:
- * Name: steps
+ * Name: weight4_steps
  * Shape: (2,)
  * Elements: 2
  * Dtype: int64
  */
-static const int64_t steps[2] = {
+static const int64_t weight4_steps[2] = {
     1LL, 2LL
 };
 

--- a/tests/golden/op_split_split.c
+++ b/tests/golden/op_split_split.c
@@ -25,12 +25,12 @@
 
 /*
  * Weight 1:
- * Name: split
+ * Name: weight1_split
  * Shape: (3,)
  * Elements: 3
  * Dtype: int64
  */
-static const int64_t split[3] = {
+static const int64_t weight1_split[3] = {
     2LL, 2LL, 2LL
 };
 

--- a/tests/golden/op_tile_tile.c
+++ b/tests/golden/op_tile_tile.c
@@ -24,12 +24,12 @@
 
 /*
  * Weight 1:
- * Name: repeats
+ * Name: weight1_repeats
  * Shape: (2,)
  * Elements: 2
  * Dtype: int64
  */
-static const int64_t repeats[2] = {
+static const int64_t weight1_repeats[2] = {
     2LL, 1LL
 };
 

--- a/tests/test_codegen_data_file.py
+++ b/tests/test_codegen_data_file.py
@@ -38,6 +38,6 @@ def test_compile_with_data_file_emits_externs() -> None:
     )
     main_source, data_source = compiler.compile_with_data_file(model)
 
-    assert "extern const float weights[2][2];" in main_source
+    assert "extern const float weight1_weights[2][2];" in main_source
     assert "static const float" not in main_source
-    assert "const float weights[2][2]" in data_source
+    assert "const float weight1_weights[2][2]" in data_source


### PR DESCRIPTION
### Motivation
- Ensure initializer/weight symbols in generated C follow a deterministic, repository-wide convention of `weight<no>_<name>` in lowercase to avoid name collisions and improve readability.
- Prevent operator-level name mapping from accidentally reusing constant names and guarantee stable, unique C identifiers for constants.
- Keep codegen deterministic and compatible with golden reference tests that assert on emitted names.

### Description
- Change `_build_name_map` in `src/emx_onnx_cgen/codegen/c_emitter.py` to exclude constant names when collecting op-related names and to assign constants a deterministic identifier `weight{index}_{sanitized_name}` (lowercased and sanitized) while preserving uniqueness via `_ensure_unique_identifier`.
- Update the data-file codegen test `tests/test_codegen_data_file.py` to expect the new `weight1_weights` identifier instead of `weights` and refresh golden C outputs under `tests/golden/` to reflect the new `weight<no>_<name>` naming.
- Keep existing sanitization and uniqueness logic so names remain valid C identifiers and stable across runs.

### Testing
- Ran the full test suite with references refreshed using `UPDATE_REFS=1 pytest -n auto -q`, which completed successfully with `233 passed, 2 skipped, 2 warnings` in `57.74s`.
- Verified the updated golden files under `tests/golden/` matched the regenerated outputs after the naming change.
- Confirmed the data-file codegen test `test_compile_with_data_file_emits_externs` now passes against the new `weight1_weights` identifier.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69696e6c15c08325b63551d03029605a)