### PR TITLE
codegen: name temp buffers with tmp<index>_<output> convention

### DIFF
--- a/src/emx_onnx_cgen/codegen/c_emitter.py
+++ b/src/emx_onnx_cgen/codegen/c_emitter.py
@@ -3817,11 +3817,11 @@ class CEmitter:
             return {}
         if len(intermediates) == 1:
             name, shape, dtype = intermediates[0]
-            temp_name = allocate_temp_name("tmp")
+            temp_name = allocate_temp_name(f"tmp0_{name}")
             return {name: TempBuffer(name=temp_name, shape=shape, dtype=dtype)}
         return {
             name: TempBuffer(
-                name=allocate_temp_name(f"tmp{index}"),
+                name=allocate_temp_name(f"tmp{index}_{name}"),
                 shape=shape,
                 dtype=dtype,
             )

--- a/tests/golden/mul_add_model.c
+++ b/tests/golden/mul_add_model.c
@@ -64,7 +64,7 @@ static inline void node1_add(const float input0[restrict 2][3], const float inpu
 }
 
 void model(const float a[restrict 2][3], const float b[restrict 2][3], const float c[restrict 2][3], float out[restrict 2][3]) {
-    float tmp[2][3];
-    node0_mul(a, b, tmp);
-    node1_add(tmp, c, out);
+    float tmp0_mul_out[2][3];
+    node0_mul(a, b, tmp0_mul_out);
+    node1_add(tmp0_mul_out, c, out);
 }

--- a/tests/golden/mul_add_relu_model.c
+++ b/tests/golden/mul_add_relu_model.c
@@ -84,9 +84,9 @@ static inline void node2_relu(const float input0[restrict 2][3], float output[re
 }
 
 void model(const float a[restrict 2][3], const float b[restrict 2][3], const float c[restrict 2][3], float out[restrict 2][3]) {
-    float tmp0[2][3];
-    float tmp1[2][3];
-    node0_mul(a, b, tmp0);
-    node1_add(tmp0, c, tmp1);
-    node2_relu(tmp1, out);
+    float tmp0_mul_out[2][3];
+    float tmp1_add_out[2][3];
+    node0_mul(a, b, tmp0_mul_out);
+    node1_add(tmp0_mul_out, c, tmp1_add_out);
+    node2_relu(tmp1_add_out, out);
 }


### PR DESCRIPTION
### Motivation
- Make generated C temporary buffer names more informative and stable by including the op output name (reduce ambiguity and improve readability of emitted code). 

### Description
- Update `CEmitter._temp_buffers` to allocate temp names using `tmp0_<name>` for a single intermediate and `tmp<index>_<name>` for multiple intermediates, and refresh golden C outputs to match the new naming.

### Testing
- Ran `UPDATE_REFS=1 pytest -n auto -q`, which passed (`233 passed, 2 skipped, 2 warnings`) in 63.54s.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69697083dce48325a15648aab515bfce)