### PR TITLE
codegen: format weights as hex-floats with multi-dim layout and truncation option

### DIFF
--- a/src/emx_onnx_cgen/cli.py
+++ b/src/emx_onnx_cgen/cli.py
@@ -86,6 +86,15 @@ def _build_parser() -> argparse.ArgumentParser:
             "named like the output with a _data suffix"
         ),
     )
+    compile_parser.add_argument(
+        "--truncate-weights-after",
+        type=int,
+        default=None,
+        help=(
+            "Truncate inline weight initializers after N values and insert "
+            "\"...\" placeholders (default: no truncation)"
+        ),
+    )
     add_restrict_flags(compile_parser)
 
     verify_parser = subparsers.add_parser(
@@ -110,6 +119,15 @@ def _build_parser() -> argparse.ArgumentParser:
         type=str,
         default=None,
         help="C compiler command to build the testbench binary",
+    )
+    verify_parser.add_argument(
+        "--truncate-weights-after",
+        type=int,
+        default=None,
+        help=(
+            "Truncate inline weight initializers after N values and insert "
+            "\"...\" placeholders (default: no truncation)"
+        ),
     )
     add_restrict_flags(verify_parser)
     return parser
@@ -143,6 +161,7 @@ def _handle_compile(args: argparse.Namespace) -> int:
             command_line=args.command_line,
             model_checksum=model_checksum,
             restrict_arrays=args.restrict_arrays,
+            truncate_weights_after=args.truncate_weights_after,
         )
         compiler = Compiler(options)
         if args.emit_data_file:
@@ -217,6 +236,7 @@ def _handle_verify(args: argparse.Namespace) -> int:
             command_line=args.command_line,
             model_checksum=model_checksum,
             restrict_arrays=args.restrict_arrays,
+            truncate_weights_after=args.truncate_weights_after,
         )
         compiler = Compiler(options)
         generated = compiler.compile(model)

--- a/src/emx_onnx_cgen/compiler.py
+++ b/src/emx_onnx_cgen/compiler.py
@@ -157,6 +157,7 @@ class CompilerOptions:
     model_checksum: str | None = None
     restrict_arrays: bool = True
     testbench_inputs: Mapping[str, np.ndarray] | None = None
+    truncate_weights_after: int | None = None
 
 
 class Compiler:
@@ -165,7 +166,9 @@ class Compiler:
             options = CompilerOptions(template_dir=Path("templates"))
         self._options = options
         self._emitter = CEmitter(
-            options.template_dir, restrict_arrays=options.restrict_arrays
+            options.template_dir,
+            restrict_arrays=options.restrict_arrays,
+            truncate_weights_after=options.truncate_weights_after,
         )
 
     def compile(self, model: onnx.ModelProto) -> str:

--- a/tests/golden/add_initializer_model.c
+++ b/tests/golden/add_initializer_model.c
@@ -31,7 +31,12 @@
  * Dtype: float
  */
 static const float weight1_weight[2][3] = {
-    0.100000001f, 0.200000003f, 0.300000012f, 0.400000006f, 0.5f, 0.600000024f
+    {
+        0x1.99999ap-4f, 0x1.99999ap-3f, 0x1.333334p-2f
+    },
+    {
+        0x1.99999ap-2f, 0x1.000000p-1f, 0x1.333334p-1f
+    }
 };
 
 static inline float ref_scalar_f32_add(float a, float b) {

--- a/tests/golden/op_batchnorm_batch_normalization.c
+++ b/tests/golden/op_batchnorm_batch_normalization.c
@@ -30,7 +30,7 @@
  * Dtype: float
  */
 static const float weight1_scale[3] = {
-    1.0f, 1.5f, -0.5f
+    0x1.000000p+0f, 0x1.800000p+0f, -0x1.000000p-1f
 };
 
 /*
@@ -41,7 +41,7 @@ static const float weight1_scale[3] = {
  * Dtype: float
  */
 static const float weight2_bias[3] = {
-    0.0f, 0.100000001f, -0.200000003f
+    0x0.0p+0f, 0x1.99999ap-4f, -0x1.99999ap-3f
 };
 
 /*
@@ -52,7 +52,7 @@ static const float weight2_bias[3] = {
  * Dtype: float
  */
 static const float weight3_mean[3] = {
-    0.5f, -0.5f, 1.0f
+    0x1.000000p-1f, -0x1.000000p-1f, 0x1.000000p+0f
 };
 
 /*
@@ -63,7 +63,7 @@ static const float weight3_mean[3] = {
  * Dtype: float
  */
 static const float weight4_var[3] = {
-    0.25f, 0.5f, 1.5f
+    0x1.000000p-2f, 0x1.000000p-1f, 0x1.800000p+0f
 };
 
 /*

--- a/tests/golden/op_clip_clip.c
+++ b/tests/golden/op_clip_clip.c
@@ -29,7 +29,7 @@
  * Dtype: float
  */
 static const float weight1_min[1] = {
-    0.0f
+    0x0.0p+0f
 };
 
 /*
@@ -40,7 +40,7 @@ static const float weight1_min[1] = {
  * Dtype: float
  */
 static const float weight2_max[1] = {
-    6.0f
+    0x1.800000p+2f
 };
 
 /*

--- a/tests/golden/op_conv_conv.c
+++ b/tests/golden/op_conv_conv.c
@@ -29,8 +29,19 @@
  * Dtype: float
  */
 static const float weight1_weight[1][1][3][3] = {
-    0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f,
-    8.0f
+    {
+        {
+            {
+                0x0.0p+0f, 0x1.000000p+0f, 0x1.000000p+1f
+            },
+            {
+                0x1.800000p+1f, 0x1.000000p+2f, 0x1.400000p+2f
+            },
+            {
+                0x1.800000p+2f, 0x1.c00000p+2f, 0x1.000000p+3f
+            }
+        }
+    }
 };
 
 /*
@@ -41,7 +52,7 @@ static const float weight1_weight[1][1][3][3] = {
  * Dtype: float
  */
 static const float weight2_bias[1] = {
-    0.25f
+    0x1.000000p-2f
 };
 
 /*

--- a/tests/golden/op_pad_pad.c
+++ b/tests/golden/op_pad_pad.c
@@ -41,7 +41,7 @@ static const int64_t weight1_pads[4] = {
  * Dtype: float
  */
 static const float weight2_value[1] = {
-    0.0f
+    0x0.0p+0f
 };
 
 /*


### PR DESCRIPTION
### Motivation
- Ensure weight initializers are emitted in the same readable, deterministic style used by emx-pytorch2c: hex-float literals, nested multi-dimensional C initializer layout, and optional truncation with "..." placeholders.  
- Provide a CLI flag to control truncation so large weight arrays can be abbreviated for humans while keeping an option to emit full data.  

### Description
- Emit weights using hex-floating formatting by adding `_format_float32_hex`/`_format_float64_hex` and a `_format_weight_value` path in `CEmitter` and switch constant emission to use these formatting helpers.  
- Produce multi-dimensional initializer layout with `_emit_initializer_lines` and support truncated emission with `_emit_initializer_lines_truncated`, and wire truncation control into `CEmitter` via a `truncate_weights_after` parameter.  
- Add a `--truncate-weights-after` CLI option and a `truncate_weights_after` field on `CompilerOptions`, and propagate the option from `cli.py` through `Compiler` into `CEmitter`.  
- Updated golden C outputs to the new weight format to keep reference snapshots in sync.  

### Testing
- Ran the full test suite with updated references using `UPDATE_REFS=1 pytest -n auto -q`, which completed in 58.07s and succeeded with `233 passed, 2 skipped` (no failing automated tests remain).  
- Verified that emitted testbench C includes the new `static const` hex-float weight initializers and that testbench runs/builds during the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696970f8d59c8325bcf8430ca83ab078)