### PR TITLE
codegen: switch generated index type to idx_t (int32_t)

### DIFF
--- a/templates/arg_reduce_op.c.j2
+++ b/templates/arg_reduce_op.c.j2
@@ -1,10 +1,10 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% for dim in output_shape %}
-for (size_t {{ output_loop_vars[loop.index0] }} = 0; {{ output_loop_vars[loop.index0] }} < {{ dim }}; ++{{ output_loop_vars[loop.index0] }}) {
+for (idx_t {{ output_loop_vars[loop.index0] }} = 0; {{ output_loop_vars[loop.index0] }} < {{ dim }}; ++{{ output_loop_vars[loop.index0] }}) {
 {% endfor %}
 {{ input_c_type }} best = {{ input0 }}{{ init_index_expr }};
 {{ output_c_type }} best_index = 0;
-for (size_t {{ reduce_var }} = 1; {{ reduce_var }} < {{ reduce_dim }}; ++{{ reduce_var }}) {
+for (idx_t {{ reduce_var }} = 1; {{ reduce_var }} < {{ reduce_dim }}; ++{{ reduce_var }}) {
     {{ input_c_type }} candidate = {{ input0 }}{{ input_index_expr }};
     if (candidate {{ compare_op }} best) {
         best = candidate;

--- a/templates/average_pool_op.c.j2
+++ b/templates/average_pool_op.c.j2
@@ -1,11 +1,11 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
-    for (size_t n = 0; n < {{ batch }}; ++n) {
-        for (size_t c = 0; c < {{ channels }}; ++c) {
-            for (size_t oh = 0; oh < {{ out_h }}; ++oh) {
-                for (size_t ow = 0; ow < {{ out_w }}; ++ow) {
+    for (idx_t n = 0; n < {{ batch }}; ++n) {
+        for (idx_t c = 0; c < {{ channels }}; ++c) {
+            for (idx_t oh = 0; oh < {{ out_h }}; ++oh) {
+                for (idx_t ow = 0; ow < {{ out_w }}; ++ow) {
                     {{ c_type }} acc = {{ zero_literal }};
-                    size_t count = 0;
-                    for (size_t kh = 0; kh < {{ kernel_h }}; ++kh) {
+                    idx_t count = 0;
+                    for (idx_t kh = 0; kh < {{ kernel_h }}; ++kh) {
                         const int ih = (int)(oh * {{ stride_h }} + kh) - {{ pad_top }};
                         if (ih < 0 || ih >= {{ in_h }}) {
                             if ({{ count_include_pad }}) {
@@ -13,7 +13,7 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
                             }
                             continue;
                         }
-                        for (size_t kw = 0; kw < {{ kernel_w }}; ++kw) {
+                        for (idx_t kw = 0; kw < {{ kernel_w }}; ++kw) {
                             const int iw = (int)(ow * {{ stride_w }} + kw) - {{ pad_left }};
                             if (iw < 0 || iw >= {{ in_w }}) {
                                 if ({{ count_include_pad }}) {

--- a/templates/batch_norm_op.c.j2
+++ b/templates/batch_norm_op.c.j2
@@ -1,8 +1,8 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% for dim in shape %}
-for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
-size_t c = {{ loop_vars[1] }};
+idx_t c = {{ loop_vars[1] }};
 {{ c_type }} denom = {{ sqrt_fn }}({{ variance }}[c] + {{ epsilon_literal }});
 {{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = ({{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %} - {{ mean }}[c]) / denom * {{ scale }}[c] + {{ bias }}[c];
 {% for _ in shape %}

--- a/templates/binary_op.c.j2
+++ b/templates/binary_op.c.j2
@@ -1,6 +1,6 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% for dim in shape %}
-for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
 {{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = {% if operator_kind == "func" %}{{ operator }}({{ left_expr }}, {{ right_expr }}){% elif operator_kind == "expr" %}{{ operator_expr }}{% else %}{{ left_expr }} {{ operator }} {{ right_expr }}{% endif %};
 {% for _ in shape %}

--- a/templates/cast_op.c.j2
+++ b/templates/cast_op.c.j2
@@ -1,6 +1,6 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% for dim in shape %}
-for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
 {{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = ({{ output_c_type }}){{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %};
 {% for _ in shape %}

--- a/templates/clip_op.c.j2
+++ b/templates/clip_op.c.j2
@@ -1,6 +1,6 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% for dim in shape %}
-for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
 {{ output_c_type }} value = {{ input_expr }};
 if (value < {{ min_expr }}) {

--- a/templates/concat_op.c.j2
+++ b/templates/concat_op.c.j2
@@ -1,22 +1,22 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
     const void *inputs[] = { {% for input in inputs %}{{ input }}{% if not loop.last %}, {% endif %}{% endfor %} };
-    const size_t axis_sizes[] = { {% for axis in axis_sizes %}{{ axis }}{% if not loop.last %}, {% endif %}{% endfor %} };
-    size_t concat_axis = 0;
-    for (size_t idx = 0; idx < {{ input_count }}; ++idx) {
+    const idx_t axis_sizes[] = { {% for axis in axis_sizes %}{{ axis }}{% if not loop.last %}, {% endif %}{% endfor %} };
+    idx_t concat_axis = 0;
+    for (idx_t idx = 0; idx < {{ input_count }}; ++idx) {
         concat_axis += axis_sizes[idx];
     }
     if (concat_axis == 0) {
         return;
     }
-    for (size_t outer_idx = 0; outer_idx < {{ outer }}; ++outer_idx) {
-        size_t output_offset = outer_idx * concat_axis * {{ inner }};
-        size_t axis_offset = 0;
-        for (size_t input_idx = 0; input_idx < {{ input_count }}; ++input_idx) {
-            size_t axis = axis_sizes[input_idx];
-            size_t copy_elems = axis * {{ inner }};
+    for (idx_t outer_idx = 0; outer_idx < {{ outer }}; ++outer_idx) {
+        idx_t output_offset = outer_idx * concat_axis * {{ inner }};
+        idx_t axis_offset = 0;
+        for (idx_t input_idx = 0; input_idx < {{ input_count }}; ++input_idx) {
+            idx_t axis = axis_sizes[input_idx];
+            idx_t copy_elems = axis * {{ inner }};
             const unsigned char *input_bytes =
                 (const unsigned char *)inputs[input_idx];
-            size_t input_offset = outer_idx * copy_elems;
+            idx_t input_offset = outer_idx * copy_elems;
             memcpy(
                 ((unsigned char *){{ output }}) + (output_offset + axis_offset) * sizeof({{ c_type }}),
                 input_bytes + input_offset * sizeof({{ c_type }}),

--- a/templates/constant_of_shape_op.c.j2
+++ b/templates/constant_of_shape_op.c.j2
@@ -1,7 +1,7 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
     (void){{ input0 }};
 {% for dim in shape %}
-for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
 {{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = {{ value_literal }};
 {% for _ in shape %}

--- a/templates/conv_op.c.j2
+++ b/templates/conv_op.c.j2
@@ -1,16 +1,16 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
-    for (size_t n = 0; n < {{ batch }}; ++n) {
-        for (size_t g = 0; g < {{ group }}; ++g) {
-            for (size_t oc = 0; oc < {{ group_out_channels }}; ++oc) {
-                const size_t oc_global = g * {{ group_out_channels }} + oc;
+    for (idx_t n = 0; n < {{ batch }}; ++n) {
+        for (idx_t g = 0; g < {{ group }}; ++g) {
+            for (idx_t oc = 0; oc < {{ group_out_channels }}; ++oc) {
+                const idx_t oc_global = g * {{ group_out_channels }} + oc;
                 {% for dim in range(spatial_rank) %}
-                for (size_t {{ out_indices[dim] }} = 0; {{ out_indices[dim] }} < {{ out_spatial[dim] }}; ++{{ out_indices[dim] }}) {
+                for (idx_t {{ out_indices[dim] }} = 0; {{ out_indices[dim] }} < {{ out_spatial[dim] }}; ++{{ out_indices[dim] }}) {
                 {% endfor %}
                     {{ c_type }} acc = {% if bias %}{{ bias }}[oc_global]{% else %}{{ zero_literal }}{% endif %};
-                    for (size_t ic = 0; ic < {{ group_in_channels }}; ++ic) {
-                        const size_t ic_global = g * {{ group_in_channels }} + ic;
+                    for (idx_t ic = 0; ic < {{ group_in_channels }}; ++ic) {
+                        const idx_t ic_global = g * {{ group_in_channels }} + ic;
                         {% for dim in range(spatial_rank) %}
-                        for (size_t {{ kernel_indices[dim] }} = 0; {{ kernel_indices[dim] }} < {{ kernel_shape[dim] }}; ++{{ kernel_indices[dim] }}) {
+                        for (idx_t {{ kernel_indices[dim] }} = 0; {{ kernel_indices[dim] }} < {{ kernel_shape[dim] }}; ++{{ kernel_indices[dim] }}) {
                         {% endfor %}
                             {% for dim in range(spatial_rank) %}
                             const int {{ in_indices[dim] }} = (int)({{ out_indices[dim] }} * {{ strides[dim] }} + {{ kernel_indices[dim] }} * {{ dilations[dim] }}) - {{ pads_begin[dim] }};

--- a/templates/cumsum_op.c.j2
+++ b/templates/cumsum_op.c.j2
@@ -1,5 +1,5 @@
 static inline void {{ op_name }}({{ dim_args }}const {{ c_type }} {{ input0 }}{{ input_suffix }}{% if axis_input %}, const {{ axis_c_type }} {{ axis_input }}{{ axis_suffix }}{% endif %}, {{ c_type }} {{ output }}{{ output_suffix }}) {
-    const size_t dims[{{ rank }}] = { {% for dim in input_shape %}{{ dim }}{% if not loop.last %}, {% endif %}{% endfor %} };
+    const idx_t dims[{{ rank }}] = { {% for dim in input_shape %}{{ dim }}{% if not loop.last %}, {% endif %}{% endfor %} };
     int axis = {% if axis_literal is not none %}{{ axis_literal }}{% else %}(int){{ axis_input }}[0]{% endif %};
     if (axis < 0) {
         axis += {{ rank }};
@@ -7,23 +7,23 @@ static inline void {{ op_name }}({{ dim_args }}const {{ c_type }} {{ input0 }}{{
     if (axis < 0 || axis >= {{ rank }}) {
         return;
     }
-    size_t outer = 1;
+    idx_t outer = 1;
     for (int i = 0; i < axis; ++i) {
         outer *= dims[i];
     }
-    size_t inner = 1;
+    idx_t inner = 1;
     for (int i = axis + 1; i < {{ rank }}; ++i) {
         inner *= dims[i];
     }
-    size_t axis_dim = dims[axis];
-    for (size_t outer_index = 0; outer_index < outer; ++outer_index) {
-        for (size_t inner_index = 0; inner_index < inner; ++inner_index) {
+    idx_t axis_dim = dims[axis];
+    for (idx_t outer_index = 0; outer_index < outer; ++outer_index) {
+        for (idx_t inner_index = 0; inner_index < inner; ++inner_index) {
             {{ c_type }} acc = ({{ c_type }})0;
-            size_t base = (outer_index * axis_dim * inner) + inner_index;
+            idx_t base = (outer_index * axis_dim * inner) + inner_index;
 {% if reverse %}
-            for (size_t axis_offset = 0; axis_offset < axis_dim; ++axis_offset) {
-                size_t axis_index = axis_dim - 1 - axis_offset;
-                size_t offset = base + axis_index * inner;
+            for (idx_t axis_offset = 0; axis_offset < axis_dim; ++axis_offset) {
+                idx_t axis_index = axis_dim - 1 - axis_offset;
+                idx_t offset = base + axis_index * inner;
 {% if exclusive %}
                 {{ output }}[offset] = acc;
                 acc += {{ input0 }}[offset];
@@ -33,8 +33,8 @@ static inline void {{ op_name }}({{ dim_args }}const {{ c_type }} {{ input0 }}{{
 {% endif %}
             }
 {% else %}
-            for (size_t axis_index = 0; axis_index < axis_dim; ++axis_index) {
-                size_t offset = base + axis_index * inner;
+            for (idx_t axis_index = 0; axis_index < axis_dim; ++axis_index) {
+                idx_t offset = base + axis_index * inner;
 {% if exclusive %}
                 {{ output }}[offset] = acc;
                 acc += {{ input0 }}[offset];

--- a/templates/depth_to_space_op.c.j2
+++ b/templates/depth_to_space_op.c.j2
@@ -1,22 +1,22 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
     const {{ c_type }} *input_data = (const {{ c_type }} *){{ input0 }};
     {{ c_type }} *output_data = ({{ c_type }} *){{ output }};
-    size_t output_index = 0;
-    for (size_t n = 0; n < {{ batch }}; ++n) {
-        for (size_t c_out = 0; c_out < {{ out_channels }}; ++c_out) {
-            for (size_t h_out = 0; h_out < {{ out_h }}; ++h_out) {
-                size_t h_in = h_out / {{ blocksize }};
-                size_t offset_h = h_out % {{ blocksize }};
-                for (size_t w_out = 0; w_out < {{ out_w }}; ++w_out) {
-                    size_t w_in = w_out / {{ blocksize }};
-                    size_t offset_w = w_out % {{ blocksize }};
-                    size_t c_in;
+    idx_t output_index = 0;
+    for (idx_t n = 0; n < {{ batch }}; ++n) {
+        for (idx_t c_out = 0; c_out < {{ out_channels }}; ++c_out) {
+            for (idx_t h_out = 0; h_out < {{ out_h }}; ++h_out) {
+                idx_t h_in = h_out / {{ blocksize }};
+                idx_t offset_h = h_out % {{ blocksize }};
+                for (idx_t w_out = 0; w_out < {{ out_w }}; ++w_out) {
+                    idx_t w_in = w_out / {{ blocksize }};
+                    idx_t offset_w = w_out % {{ blocksize }};
+                    idx_t c_in;
 {% if mode == "DCR" %}
                     c_in = (offset_h * {{ blocksize }} + offset_w) * {{ out_channels }} + c_out;
 {% else %}
                     c_in = (c_out * {{ blocksize }} + offset_h) * {{ blocksize }} + offset_w;
 {% endif %}
-                    size_t input_index = ((n * {{ in_channels }} + c_in) * {{ in_h }} + h_in) * {{ in_w }} + w_in;
+                    idx_t input_index = ((n * {{ in_channels }} + c_in) * {{ in_h }} + h_in) * {{ in_w }} + w_in;
                     output_data[output_index] = input_data[input_index];
                     output_index++;
                 }

--- a/templates/expand_op.c.j2
+++ b/templates/expand_op.c.j2
@@ -1,11 +1,11 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
     const {{ c_type }} *input_data = (const {{ c_type }} *){{ input0 }};
     {{ c_type }} *output_data = ({{ c_type }} *){{ output }};
-    size_t output_index = 0;
+    idx_t output_index = 0;
 {% for dim in output_shape %}
-    for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+    for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
-        size_t input_index = {{ input_index_expr }};
+        idx_t input_index = {{ input_index_expr }};
         output_data[output_index] = input_data[input_index];
         output_index++;
 {% for _ in output_shape %}

--- a/templates/eye_like_op.c.j2
+++ b/templates/eye_like_op.c.j2
@@ -1,26 +1,26 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
     (void){{ input0 }};
     {{ c_type }} *output_data = ({{ c_type }} *){{ output }};
-    size_t total = (size_t){{ batch_size }} * {{ rows }} * {{ cols }};
-    for (size_t index = 0; index < total; ++index) {
+    idx_t total = (idx_t){{ batch_size }} * {{ rows }} * {{ cols }};
+    for (idx_t index = 0; index < total; ++index) {
         output_data[index] = {{ zero_literal }};
     }
     int k = {{ k }};
-    size_t rows = {{ rows }};
-    size_t cols = {{ cols }};
-    size_t row_start = k >= 0 ? 0 : (size_t)(-k);
-    size_t col_start = k >= 0 ? (size_t)k : 0;
+    idx_t rows = {{ rows }};
+    idx_t cols = {{ cols }};
+    idx_t row_start = k >= 0 ? 0 : (idx_t)(-k);
+    idx_t col_start = k >= 0 ? (idx_t)k : 0;
     if (row_start >= rows || col_start >= cols) {
         return;
     }
-    size_t max_rows = rows - row_start;
-    size_t max_cols = cols - col_start;
-    size_t diag_len = max_rows < max_cols ? max_rows : max_cols;
-    for (size_t batch = 0; batch < {{ batch_size }}; ++batch) {
-        size_t base = batch * rows * cols;
-        for (size_t diag = 0; diag < diag_len; ++diag) {
-            size_t row = row_start + diag;
-            size_t col = col_start + diag;
+    idx_t max_rows = rows - row_start;
+    idx_t max_cols = cols - col_start;
+    idx_t diag_len = max_rows < max_cols ? max_rows : max_cols;
+    for (idx_t batch = 0; batch < {{ batch_size }}; ++batch) {
+        idx_t base = batch * rows * cols;
+        for (idx_t diag = 0; diag < diag_len; ++diag) {
+            idx_t row = row_start + diag;
+            idx_t col = col_start + diag;
             output_data[base + row * cols + col] = {{ one_literal }};
         }
     }

--- a/templates/gather_elements_op.c.j2
+++ b/templates/gather_elements_op.c.j2
@@ -1,6 +1,6 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% for dim in output_shape %}
-for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
 int64_t gather_index = (int64_t){{ indices }}{% for var in loop_vars %}[{{ var }}]{% endfor %};
 if (gather_index < 0) {

--- a/templates/gather_op.c.j2
+++ b/templates/gather_op.c.j2
@@ -1,6 +1,6 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% for dim in output_shape %}
-for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
 int64_t gather_index = (int64_t){{ indices }}{% for var in indices_indices %}[{{ var }}]{% endfor %};
 if (gather_index < 0) {

--- a/templates/gemm_op.c.j2
+++ b/templates/gemm_op.c.j2
@@ -1,8 +1,8 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
-    for (size_t i = 0; i < {{ m }}; ++i) {
-        for (size_t j = 0; j < {{ n }}; ++j) {
+    for (idx_t i = 0; i < {{ m }}; ++i) {
+        for (idx_t j = 0; j < {{ n }}; ++j) {
             {{ acc_type }} acc = {{ zero_literal }};
-            for (size_t k = 0; k < {{ k }}; ++k) {
+            for (idx_t k = 0; k < {{ k }}; ++k) {
                 {% if trans_a %}
                 const {{ c_type }} a_val = {{ input_a }}[k][i];
                 {% else %}
@@ -17,11 +17,11 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
             }
             {% if input_c %}
             {% if c_rank == 2 %}
-            size_t c_i = {% if c_dim0 == 1 %}0{% else %}i{% endif %};
-            size_t c_j = {% if c_dim1 == 1 %}0{% else %}j{% endif %};
+            idx_t c_i = {% if c_dim0 == 1 %}0{% else %}i{% endif %};
+            idx_t c_j = {% if c_dim1 == 1 %}0{% else %}j{% endif %};
             const {{ c_type }} bias = {{ input_c }}[c_i][c_j];
             {% elif c_rank == 1 %}
-            size_t c_j = {% if c_dim1 == 1 %}0{% else %}j{% endif %};
+            idx_t c_j = {% if c_dim1 == 1 %}0{% else %}j{% endif %};
             const {{ c_type }} bias = {{ input_c }}[c_j];
             {% else %}
             const {{ c_type }} bias = {{ input_c }}[0];

--- a/templates/grid_sample_op.c.j2
+++ b/templates/grid_sample_op.c.j2
@@ -38,10 +38,10 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% set n_var = output_loop_vars[0] %}
 {% set c_var = output_loop_vars[1] %}
 {% set spatial_vars = output_loop_vars[2:] %}
-    for (size_t {{ n_var }} = 0; {{ n_var }} < {{ output_shape[0] }}; ++{{ n_var }}) {
-        for (size_t {{ c_var }} = 0; {{ c_var }} < {{ output_shape[1] }}; ++{{ c_var }}) {
+    for (idx_t {{ n_var }} = 0; {{ n_var }} < {{ output_shape[0] }}; ++{{ n_var }}) {
+        for (idx_t {{ c_var }} = 0; {{ c_var }} < {{ output_shape[1] }}; ++{{ c_var }}) {
 {% for index in range(spatial_rank) %}
-            for (size_t {{ spatial_vars[index] }} = 0; {{ spatial_vars[index] }} < {{ output_spatial[index] }}; ++{{ spatial_vars[index] }}) {
+            for (idx_t {{ spatial_vars[index] }} = 0; {{ spatial_vars[index] }} < {{ output_spatial[index] }}; ++{{ spatial_vars[index] }}) {
 {% endfor %}
                 double coords[{{ spatial_rank }}];
 {% for dim in range(spatial_rank) %}

--- a/templates/group_normalization_op.c.j2
+++ b/templates/group_normalization_op.c.j2
@@ -1,13 +1,13 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% for dim in shape[:1] %}
-for (size_t {{ loop_vars[0] }} = 0; {{ loop_vars[0] }} < {{ dim }}; ++{{ loop_vars[0] }}) {
+for (idx_t {{ loop_vars[0] }} = 0; {{ loop_vars[0] }} < {{ dim }}; ++{{ loop_vars[0] }}) {
 {% endfor %}
-    for (size_t g = 0; g < {{ num_groups }}; ++g) {
+    for (idx_t g = 0; g < {{ num_groups }}; ++g) {
         {{ c_type }} sum = {{ zero_literal }};
-        for (size_t c_in_group = 0; c_in_group < {{ group_size }}; ++c_in_group) {
-            size_t c = g * {{ group_size }} + c_in_group;
+        for (idx_t c_in_group = 0; c_in_group < {{ group_size }}; ++c_in_group) {
+            idx_t c = g * {{ group_size }} + c_in_group;
 {% for dim in shape[2:] %}
-            for (size_t {{ loop_vars[loop.index0 + 2] }} = 0; {{ loop_vars[loop.index0 + 2] }} < {{ dim }}; ++{{ loop_vars[loop.index0 + 2] }}) {
+            for (idx_t {{ loop_vars[loop.index0 + 2] }} = 0; {{ loop_vars[loop.index0 + 2] }} < {{ dim }}; ++{{ loop_vars[loop.index0 + 2] }}) {
 {% endfor %}
                 sum += {{ input0 }}[{{ loop_vars[0] }}][c]{% for var in loop_vars[2:] %}[{{ var }}]{% endfor %};
 {% for _ in shape[2:] %}
@@ -16,10 +16,10 @@ for (size_t {{ loop_vars[0] }} = 0; {{ loop_vars[0] }} < {{ dim }}; ++{{ loop_va
         }
         {{ c_type }} mean = sum / ({{ group_size }} * {{ spatial_size }});
         {{ c_type }} var = {{ zero_literal }};
-        for (size_t c_in_group = 0; c_in_group < {{ group_size }}; ++c_in_group) {
-            size_t c = g * {{ group_size }} + c_in_group;
+        for (idx_t c_in_group = 0; c_in_group < {{ group_size }}; ++c_in_group) {
+            idx_t c = g * {{ group_size }} + c_in_group;
 {% for dim in shape[2:] %}
-            for (size_t {{ loop_vars[loop.index0 + 2] }} = 0; {{ loop_vars[loop.index0 + 2] }} < {{ dim }}; ++{{ loop_vars[loop.index0 + 2] }}) {
+            for (idx_t {{ loop_vars[loop.index0 + 2] }} = 0; {{ loop_vars[loop.index0 + 2] }} < {{ dim }}; ++{{ loop_vars[loop.index0 + 2] }}) {
 {% endfor %}
                 {{ c_type }} diff = {{ input0 }}[{{ loop_vars[0] }}][c]{% for var in loop_vars[2:] %}[{{ var }}]{% endfor %} - mean;
                 var += diff * diff;
@@ -28,10 +28,10 @@ for (size_t {{ loop_vars[0] }} = 0; {{ loop_vars[0] }} < {{ dim }}; ++{{ loop_va
 {% endfor %}
         }
         {{ c_type }} denom = {{ sqrt_fn }}(var / ({{ group_size }} * {{ spatial_size }}) + {{ epsilon_literal }});
-        for (size_t c_in_group = 0; c_in_group < {{ group_size }}; ++c_in_group) {
-            size_t c = g * {{ group_size }} + c_in_group;
+        for (idx_t c_in_group = 0; c_in_group < {{ group_size }}; ++c_in_group) {
+            idx_t c = g * {{ group_size }} + c_in_group;
 {% for dim in shape[2:] %}
-            for (size_t {{ loop_vars[loop.index0 + 2] }} = 0; {{ loop_vars[loop.index0 + 2] }} < {{ dim }}; ++{{ loop_vars[loop.index0 + 2] }}) {
+            for (idx_t {{ loop_vars[loop.index0 + 2] }} = 0; {{ loop_vars[loop.index0 + 2] }} < {{ dim }}; ++{{ loop_vars[loop.index0 + 2] }}) {
 {% endfor %}
                 {{ output }}[{{ loop_vars[0] }}][c]{% for var in loop_vars[2:] %}[{{ var }}]{% endfor %} =
                     ({{ input0 }}[{{ loop_vars[0] }}][c]{% for var in loop_vars[2:] %}[{{ var }}]{% endfor %} - mean) / denom * {{ scale }}[c] + {{ bias }}[c];

--- a/templates/identity_op.c.j2
+++ b/templates/identity_op.c.j2
@@ -1,6 +1,6 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% for dim in shape %}
-    for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+    for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
     {{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = {{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %};
 {% for _ in shape %}

--- a/templates/instance_normalization_op.c.j2
+++ b/templates/instance_normalization_op.c.j2
@@ -1,10 +1,10 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% for dim in shape[:2] %}
-for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
     {{ c_type }} sum = {{ zero_literal }};
 {% for dim in shape[2:] %}
-    for (size_t {{ loop_vars[loop.index0 + 2] }} = 0; {{ loop_vars[loop.index0 + 2] }} < {{ dim }}; ++{{ loop_vars[loop.index0 + 2] }}) {
+    for (idx_t {{ loop_vars[loop.index0 + 2] }} = 0; {{ loop_vars[loop.index0 + 2] }} < {{ dim }}; ++{{ loop_vars[loop.index0 + 2] }}) {
 {% endfor %}
         sum += {{ input0 }}[{{ loop_vars[0] }}][{{ loop_vars[1] }}]{% for var in loop_vars[2:] %}[{{ var }}]{% endfor %};
 {% for _ in shape[2:] %}
@@ -13,7 +13,7 @@ for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ 
     {{ c_type }} mean = sum / {{ spatial_size }};
     {{ c_type }} var = {{ zero_literal }};
 {% for dim in shape[2:] %}
-    for (size_t {{ loop_vars[loop.index0 + 2] }} = 0; {{ loop_vars[loop.index0 + 2] }} < {{ dim }}; ++{{ loop_vars[loop.index0 + 2] }}) {
+    for (idx_t {{ loop_vars[loop.index0 + 2] }} = 0; {{ loop_vars[loop.index0 + 2] }} < {{ dim }}; ++{{ loop_vars[loop.index0 + 2] }}) {
 {% endfor %}
         {{ c_type }} diff = {{ input0 }}[{{ loop_vars[0] }}][{{ loop_vars[1] }}]{% for var in loop_vars[2:] %}[{{ var }}]{% endfor %} - mean;
         var += diff * diff;
@@ -22,7 +22,7 @@ for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ 
 {% endfor %}
     {{ c_type }} denom = {{ sqrt_fn }}(var / {{ spatial_size }} + {{ epsilon_literal }});
 {% for dim in shape[2:] %}
-    for (size_t {{ loop_vars[loop.index0 + 2] }} = 0; {{ loop_vars[loop.index0 + 2] }} < {{ dim }}; ++{{ loop_vars[loop.index0 + 2] }}) {
+    for (idx_t {{ loop_vars[loop.index0 + 2] }} = 0; {{ loop_vars[loop.index0 + 2] }} < {{ dim }}; ++{{ loop_vars[loop.index0 + 2] }}) {
 {% endfor %}
         {{ output }}[{{ loop_vars[0] }}][{{ loop_vars[1] }}]{% for var in loop_vars[2:] %}[{{ var }}]{% endfor %} =
             ({{ input0 }}[{{ loop_vars[0] }}][{{ loop_vars[1] }}]{% for var in loop_vars[2:] %}[{{ var }}]{% endfor %} - mean) / denom * {{ scale }}[{{ loop_vars[1] }}] + {{ bias }}[{{ loop_vars[1] }}];

--- a/templates/layer_normalization_op.c.j2
+++ b/templates/layer_normalization_op.c.j2
@@ -1,10 +1,10 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% for dim in prefix_shape %}
-for (size_t {{ prefix_loop_vars[loop.index0] }} = 0; {{ prefix_loop_vars[loop.index0] }} < {{ dim }}; ++{{ prefix_loop_vars[loop.index0] }}) {
+for (idx_t {{ prefix_loop_vars[loop.index0] }} = 0; {{ prefix_loop_vars[loop.index0] }} < {{ dim }}; ++{{ prefix_loop_vars[loop.index0] }}) {
 {% endfor %}
     {{ c_type }} sum = {{ zero_literal }};
 {% for dim in norm_shape %}
-    for (size_t {{ norm_loop_vars[loop.index0] }} = 0; {{ norm_loop_vars[loop.index0] }} < {{ dim }}; ++{{ norm_loop_vars[loop.index0] }}) {
+    for (idx_t {{ norm_loop_vars[loop.index0] }} = 0; {{ norm_loop_vars[loop.index0] }} < {{ dim }}; ++{{ norm_loop_vars[loop.index0] }}) {
 {% endfor %}
         sum += {{ input0 }}{% for var in prefix_loop_vars %}[{{ var }}]{% endfor %}{% for var in norm_loop_vars %}[{{ var }}]{% endfor %};
 {% for _ in norm_shape %}
@@ -13,7 +13,7 @@ for (size_t {{ prefix_loop_vars[loop.index0] }} = 0; {{ prefix_loop_vars[loop.in
     {{ c_type }} mean = sum / {{ inner }};
     {{ c_type }} var = {{ zero_literal }};
 {% for dim in norm_shape %}
-    for (size_t {{ norm_loop_vars[loop.index0] }} = 0; {{ norm_loop_vars[loop.index0] }} < {{ dim }}; ++{{ norm_loop_vars[loop.index0] }}) {
+    for (idx_t {{ norm_loop_vars[loop.index0] }} = 0; {{ norm_loop_vars[loop.index0] }} < {{ dim }}; ++{{ norm_loop_vars[loop.index0] }}) {
 {% endfor %}
         {{ c_type }} diff = {{ input0 }}{% for var in prefix_loop_vars %}[{{ var }}]{% endfor %}{% for var in norm_loop_vars %}[{{ var }}]{% endfor %} - mean;
         var += diff * diff;
@@ -29,7 +29,7 @@ for (size_t {{ prefix_loop_vars[loop.index0] }} = 0; {{ prefix_loop_vars[loop.in
     {{ invstd_output }}{% for var in mean_index_vars %}[{{ var }}]{% endfor %} = inv_std;
 {% endif %}
 {% for dim in norm_shape %}
-    for (size_t {{ norm_loop_vars[loop.index0] }} = 0; {{ norm_loop_vars[loop.index0] }} < {{ dim }}; ++{{ norm_loop_vars[loop.index0] }}) {
+    for (idx_t {{ norm_loop_vars[loop.index0] }} = 0; {{ norm_loop_vars[loop.index0] }} < {{ dim }}; ++{{ norm_loop_vars[loop.index0] }}) {
 {% endfor %}
         {{ c_type }} value = ({{ input0 }}{% for var in prefix_loop_vars %}[{{ var }}]{% endfor %}{% for var in norm_loop_vars %}[{{ var }}]{% endfor %} - mean) * inv_std;
         value = value * {{ scale }}{% for var in scale_index_vars %}[{{ var }}]{% endfor %}{% if bias %} + {{ bias }}{% for var in bias_index_vars %}[{{ var }}]{% endfor %}{% endif %};

--- a/templates/logsoftmax_op.c.j2
+++ b/templates/logsoftmax_op.c.j2
@@ -1,26 +1,26 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
     const {{ c_type }} *input_flat = (const {{ c_type }} *){{ input0 }};
     {{ c_type }} *output_flat = ({{ c_type }} *){{ output }};
-    const size_t outer = {{ outer }};
-    const size_t axis_size = {{ axis_size }};
-    const size_t inner = {{ inner }};
-    for (size_t outer_idx = 0; outer_idx < outer; ++outer_idx) {
-        for (size_t inner_idx = 0; inner_idx < inner; ++inner_idx) {
-            size_t base = (outer_idx * axis_size * inner) + inner_idx;
+    const idx_t outer = {{ outer }};
+    const idx_t axis_size = {{ axis_size }};
+    const idx_t inner = {{ inner }};
+    for (idx_t outer_idx = 0; outer_idx < outer; ++outer_idx) {
+        for (idx_t inner_idx = 0; inner_idx < inner; ++inner_idx) {
+            idx_t base = (outer_idx * axis_size * inner) + inner_idx;
             {{ c_type }} max_value = input_flat[base];
-            for (size_t axis_idx = 1; axis_idx < axis_size; ++axis_idx) {
+            for (idx_t axis_idx = 1; axis_idx < axis_size; ++axis_idx) {
                 {{ c_type }} value = input_flat[base + axis_idx * inner];
                 if (value > max_value) {
                     max_value = value;
                 }
             }
             {{ c_type }} sum = 0;
-            for (size_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
+            for (idx_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
                 {{ c_type }} value = {{ exp_fn }}(input_flat[base + axis_idx * inner] - max_value);
                 sum += value;
             }
             {{ c_type }} logsum = {{ log_fn }}(sum);
-            for (size_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
+            for (idx_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
                 {{ c_type }} value = input_flat[base + axis_idx * inner] - max_value;
                 output_flat[base + axis_idx * inner] = value - logsum;
             }

--- a/templates/lp_normalization_op.c.j2
+++ b/templates/lp_normalization_op.c.j2
@@ -1,14 +1,14 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
     const {{ c_type }} *input_flat = (const {{ c_type }} *){{ input0 }};
     {{ c_type }} *output_flat = ({{ c_type }} *){{ output }};
-    const size_t outer = {{ outer }};
-    const size_t axis_size = {{ axis_size }};
-    const size_t inner = {{ inner }};
-    for (size_t outer_idx = 0; outer_idx < outer; ++outer_idx) {
-        for (size_t inner_idx = 0; inner_idx < inner; ++inner_idx) {
-            size_t base = (outer_idx * axis_size * inner) + inner_idx;
+    const idx_t outer = {{ outer }};
+    const idx_t axis_size = {{ axis_size }};
+    const idx_t inner = {{ inner }};
+    for (idx_t outer_idx = 0; outer_idx < outer; ++outer_idx) {
+        for (idx_t inner_idx = 0; inner_idx < inner; ++inner_idx) {
+            idx_t base = (outer_idx * axis_size * inner) + inner_idx;
             {{ c_type }} acc = {{ zero_literal }};
-            for (size_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
+            for (idx_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
                 {{ c_type }} value = input_flat[base + axis_idx * inner];
 {% if p == 1 %}
                 acc += {{ abs_fn }}(value);
@@ -19,7 +19,7 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% if p == 2 %}
             acc = {{ sqrt_fn }}(acc);
 {% endif %}
-            for (size_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
+            for (idx_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
                 output_flat[base + axis_idx * inner] = input_flat[base + axis_idx * inner] / acc;
             }
         }

--- a/templates/lrn_op.c.j2
+++ b/templates/lrn_op.c.j2
@@ -1,14 +1,14 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% for dim in shape %}
-for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
-size_t channel_start = {{ loop_vars[1] }} > {{ half }} ? {{ loop_vars[1] }} - {{ half }} : 0;
-size_t channel_end = {{ loop_vars[1] }} + {{ half }};
+idx_t channel_start = {{ loop_vars[1] }} > {{ half }} ? {{ loop_vars[1] }} - {{ half }} : 0;
+idx_t channel_end = {{ loop_vars[1] }} + {{ half }};
 if (channel_end >= {{ channels }}) {
     channel_end = {{ channels }} - 1;
 }
 {{ c_type }} sum = {{ zero_literal }};
-for (size_t c = channel_start; c <= channel_end; ++c) {
+for (idx_t c = channel_start; c <= channel_end; ++c) {
     {{ c_type }} val = {{ input0 }}[{{ loop_vars[0] }}][c]{% for var in loop_vars[2:] %}[{{ var }}]{% endfor %};
     sum += val * val;
 }

--- a/templates/matmul_op.c.j2
+++ b/templates/matmul_op.c.j2
@@ -1,9 +1,9 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% for idx in range(output_loop_vars | length) %}
-    {% for indent in range(loop.index0) %}    {% endfor %}for (size_t {{ output_loop_vars[idx] }} = 0; {{ output_loop_vars[idx] }} < {{ output_loop_bounds[idx] }}; ++{{ output_loop_vars[idx] }}) {
+    {% for indent in range(loop.index0) %}    {% endfor %}for (idx_t {{ output_loop_vars[idx] }} = 0; {{ output_loop_vars[idx] }} < {{ output_loop_bounds[idx] }}; ++{{ output_loop_vars[idx] }}) {
 {% endfor %}
         {% for indent in range(output_loop_vars | length) %}    {% endfor %}{{ acc_type }} acc = {{ zero_literal }};
-        {% for indent in range(output_loop_vars | length) %}    {% endfor %}for (size_t k = 0; k < {{ k }}; ++k) {
+        {% for indent in range(output_loop_vars | length) %}    {% endfor %}for (idx_t k = 0; k < {{ k }}; ++k) {
             {% for indent in range(output_loop_vars | length + 1) %}    {% endfor %}acc += {{ input0_index_expr }} * {{ input1_index_expr }};
         {% for indent in range(output_loop_vars | length) %}    {% endfor %}}
         {% for indent in range(output_loop_vars | length) %}    {% endfor %}{{ output_index_expr }} = acc;

--- a/templates/maxpool_op.c.j2
+++ b/templates/maxpool_op.c.j2
@@ -1,13 +1,13 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
-    for (size_t n = 0; n < {{ batch }}; ++n) {
-        for (size_t c = 0; c < {{ channels }}; ++c) {
+    for (idx_t n = 0; n < {{ batch }}; ++n) {
+        for (idx_t c = 0; c < {{ channels }}; ++c) {
 {% if spatial_rank == 1 %}
-            for (size_t ox = 0; ox < {{ out_spatial[0] }}; ++ox) {
+            for (idx_t ox = 0; ox < {{ out_spatial[0] }}; ++ox) {
                 {{ c_type }} max_value = {{ min_literal }};
 {% if indices %}
                 {{ indices_c_type }} max_index = 0;
 {% endif %}
-                for (size_t kx = 0; kx < {{ kernel_shape[0] }}; ++kx) {
+                for (idx_t kx = 0; kx < {{ kernel_shape[0] }}; ++kx) {
                     const int ix = (int)(ox * {{ strides[0] }} + kx * {{ dilations[0] }}) - {{ pads[0] }};
                     if (ix < 0 || ix >= {{ in_spatial[0] }}) {
                         continue;
@@ -30,18 +30,18 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% endif %}
             }
 {% elif spatial_rank == 2 %}
-            for (size_t oh = 0; oh < {{ out_spatial[0] }}; ++oh) {
-                for (size_t ow = 0; ow < {{ out_spatial[1] }}; ++ow) {
+            for (idx_t oh = 0; oh < {{ out_spatial[0] }}; ++oh) {
+                for (idx_t ow = 0; ow < {{ out_spatial[1] }}; ++ow) {
                     {{ c_type }} max_value = {{ min_literal }};
 {% if indices %}
                     {{ indices_c_type }} max_index = 0;
 {% endif %}
-                    for (size_t kh = 0; kh < {{ kernel_shape[0] }}; ++kh) {
+                    for (idx_t kh = 0; kh < {{ kernel_shape[0] }}; ++kh) {
                         const int ih = (int)(oh * {{ strides[0] }} + kh * {{ dilations[0] }}) - {{ pads[0] }};
                         if (ih < 0 || ih >= {{ in_spatial[0] }}) {
                             continue;
                         }
-                        for (size_t kw = 0; kw < {{ kernel_shape[1] }}; ++kw) {
+                        for (idx_t kw = 0; kw < {{ kernel_shape[1] }}; ++kw) {
                             const int iw = (int)(ow * {{ strides[1] }} + kw * {{ dilations[1] }}) - {{ pads[1] }};
                             if (iw < 0 || iw >= {{ in_spatial[1] }}) {
                                 continue;
@@ -66,24 +66,24 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
                 }
             }
 {% elif spatial_rank == 3 %}
-            for (size_t od = 0; od < {{ out_spatial[0] }}; ++od) {
-                for (size_t oh = 0; oh < {{ out_spatial[1] }}; ++oh) {
-                    for (size_t ow = 0; ow < {{ out_spatial[2] }}; ++ow) {
+            for (idx_t od = 0; od < {{ out_spatial[0] }}; ++od) {
+                for (idx_t oh = 0; oh < {{ out_spatial[1] }}; ++oh) {
+                    for (idx_t ow = 0; ow < {{ out_spatial[2] }}; ++ow) {
                         {{ c_type }} max_value = {{ min_literal }};
 {% if indices %}
                         {{ indices_c_type }} max_index = 0;
 {% endif %}
-                        for (size_t kd = 0; kd < {{ kernel_shape[0] }}; ++kd) {
+                        for (idx_t kd = 0; kd < {{ kernel_shape[0] }}; ++kd) {
                             const int id = (int)(od * {{ strides[0] }} + kd * {{ dilations[0] }}) - {{ pads[0] }};
                             if (id < 0 || id >= {{ in_spatial[0] }}) {
                                 continue;
                             }
-                            for (size_t kh = 0; kh < {{ kernel_shape[1] }}; ++kh) {
+                            for (idx_t kh = 0; kh < {{ kernel_shape[1] }}; ++kh) {
                                 const int ih = (int)(oh * {{ strides[1] }} + kh * {{ dilations[1] }}) - {{ pads[1] }};
                                 if (ih < 0 || ih >= {{ in_spatial[1] }}) {
                                     continue;
                                 }
-                                for (size_t kw = 0; kw < {{ kernel_shape[2] }}; ++kw) {
+                                for (idx_t kw = 0; kw < {{ kernel_shape[2] }}; ++kw) {
                                     const int iw = (int)(ow * {{ strides[2] }} + kw * {{ dilations[2] }}) - {{ pads[2] }};
                                     if (iw < 0 || iw >= {{ in_spatial[2] }}) {
                                         continue;

--- a/templates/mean_variance_normalization_op.c.j2
+++ b/templates/mean_variance_normalization_op.c.j2
@@ -1,10 +1,10 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% for axis in non_axes %}
-for (size_t {{ loop_vars[axis] }} = 0; {{ loop_vars[axis] }} < {{ shape[axis] }}; ++{{ loop_vars[axis] }}) {
+for (idx_t {{ loop_vars[axis] }} = 0; {{ loop_vars[axis] }} < {{ shape[axis] }}; ++{{ loop_vars[axis] }}) {
 {% endfor %}
     {{ c_type }} sum = {{ zero_literal }};
 {% for axis in axes %}
-    for (size_t {{ loop_vars[axis] }} = 0; {{ loop_vars[axis] }} < {{ shape[axis] }}; ++{{ loop_vars[axis] }}) {
+    for (idx_t {{ loop_vars[axis] }} = 0; {{ loop_vars[axis] }} < {{ shape[axis] }}; ++{{ loop_vars[axis] }}) {
 {% endfor %}
         sum += {{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %};
 {% for _ in axes %}
@@ -13,7 +13,7 @@ for (size_t {{ loop_vars[axis] }} = 0; {{ loop_vars[axis] }} < {{ shape[axis] }}
     {{ c_type }} mean = sum / {{ reduce_count }};
     {{ c_type }} var = {{ zero_literal }};
 {% for axis in axes %}
-    for (size_t {{ loop_vars[axis] }} = 0; {{ loop_vars[axis] }} < {{ shape[axis] }}; ++{{ loop_vars[axis] }}) {
+    for (idx_t {{ loop_vars[axis] }} = 0; {{ loop_vars[axis] }} < {{ shape[axis] }}; ++{{ loop_vars[axis] }}) {
 {% endfor %}
         {{ c_type }} diff = {{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %} - mean;
         var += diff * diff;
@@ -22,7 +22,7 @@ for (size_t {{ loop_vars[axis] }} = 0; {{ loop_vars[axis] }} < {{ shape[axis] }}
 {% endfor %}
     {{ c_type }} denom = {{ sqrt_fn }}(var / {{ reduce_count }} + {{ epsilon_literal }});
 {% for axis in axes %}
-    for (size_t {{ loop_vars[axis] }} = 0; {{ loop_vars[axis] }} < {{ shape[axis] }}; ++{{ loop_vars[axis] }}) {
+    for (idx_t {{ loop_vars[axis] }} = 0; {{ loop_vars[axis] }} < {{ shape[axis] }}; ++{{ loop_vars[axis] }}) {
 {% endfor %}
         {{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = ({{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %} - mean) / denom;
 {% for _ in axes %}

--- a/templates/multi_input_op.c.j2
+++ b/templates/multi_input_op.c.j2
@@ -1,6 +1,6 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% for dim in shape %}
-for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
 {{ output_expr }} = {{ input_exprs[0] }};
 {% for expr in input_exprs[1:] %}

--- a/templates/negative_log_likelihood_loss_op.c.j2
+++ b/templates/negative_log_likelihood_loss_op.c.j2
@@ -2,14 +2,14 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
     const {{ c_type }} *input_flat = (const {{ c_type }} *){{ input0 }};
     const {{ target_c_type }} *target_flat = (const {{ target_c_type }} *){{ target }};
     {{ c_type }} *output_flat = ({{ c_type }} *){{ output }};
-    const size_t n = {{ n }};
-    const size_t c = {{ c }};
-    const size_t d = {{ d }};
+    const idx_t n = {{ n }};
+    const idx_t c = {{ c }};
+    const idx_t d = {{ d }};
     {{ c_type }} loss_sum = {{ zero_literal }};
     {{ c_type }} weight_sum = {{ zero_literal }};
-    for (size_t n_idx = 0; n_idx < n; ++n_idx) {
-        for (size_t d_idx = 0; d_idx < d; ++d_idx) {
-            size_t target_index = n_idx * d + d_idx;
+    for (idx_t n_idx = 0; n_idx < n; ++n_idx) {
+        for (idx_t d_idx = 0; d_idx < d; ++d_idx) {
+            idx_t target_index = n_idx * d + d_idx;
             {{ target_c_type }} target_value = target_flat[target_index];
             if ((int64_t)target_value == {{ ignore_index }}) {
 {% if reduction == "none" %}
@@ -17,8 +17,8 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% endif %}
                 continue;
             }
-            size_t class_index = (size_t)target_value;
-            size_t input_index = (n_idx * c + class_index) * d + d_idx;
+            idx_t class_index = (idx_t)target_value;
+            idx_t input_index = (n_idx * c + class_index) * d + d_idx;
             {{ c_type }} value = -input_flat[input_index];
 {% if weight %}
             {{ c_type }} sample_weight = {{ weight }}[class_index];

--- a/templates/pad_op.c.j2
+++ b/templates/pad_op.c.j2
@@ -5,10 +5,10 @@ const {{ c_type }} *{{ input0_flat }} = (const {{ c_type }} *){{ input0 }};
 const {{ pads_c_type }} pad_values[] = { {% for value in pads_values %}{{ value }}{{ ", " if not loop.last else "" }}{% endfor %} };
 {% endif %}
 ptrdiff_t pad_begin[{{ output_shape|length }}];
-for (size_t pad_index = 0; pad_index < {{ output_shape|length }}; ++pad_index) {
+for (idx_t pad_index = 0; pad_index < {{ output_shape|length }}; ++pad_index) {
     pad_begin[pad_index] = 0;
 }
-for (size_t axis_index = 0; axis_index < {{ axes_length }}; ++axis_index) {
+for (idx_t axis_index = 0; axis_index < {{ axes_length }}; ++axis_index) {
     ptrdiff_t axis = (ptrdiff_t){{ axes_input }}[axis_index];
     if (axis < 0) {
         axis += {{ output_shape|length }};
@@ -20,14 +20,14 @@ for (size_t axis_index = 0; axis_index < {{ axes_length }}; ++axis_index) {
 }
 {% endif %}
 {% for dim in output_shape %}
-for (size_t {{ out_loop_vars[loop.index0] }} = 0; {{ out_loop_vars[loop.index0] }} < {{ dim }}; ++{{ out_loop_vars[loop.index0] }}) {
+for (idx_t {{ out_loop_vars[loop.index0] }} = 0; {{ out_loop_vars[loop.index0] }} < {{ dim }}; ++{{ out_loop_vars[loop.index0] }}) {
 {% endfor %}
 {{ output }}{% for var in out_loop_vars %}[{{ var }}]{% endfor %} = {{ pad_value_expr }};
 {% for _ in output_shape %}
 }
 {% endfor %}
 {% for dim in output_shape %}
-for (size_t {{ out_loop_vars[loop.index0] }} = 0; {{ out_loop_vars[loop.index0] }} < {{ dim }}; ++{{ out_loop_vars[loop.index0] }}) {
+for (idx_t {{ out_loop_vars[loop.index0] }} = 0; {{ out_loop_vars[loop.index0] }} < {{ dim }}; ++{{ out_loop_vars[loop.index0] }}) {
 {% endfor %}
 ptrdiff_t {{ base_index }} = 0;
 int pad_in_bounds = 1;

--- a/templates/range_op.c.j2
+++ b/templates/range_op.c.j2
@@ -2,7 +2,7 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
     (void){{ limit }};
     const {{ c_type }} start_value = {{ start }}[0];
     const {{ c_type }} delta_value = {{ delta }}[0];
-    for (size_t idx = 0; idx < {{ length }}; ++idx) {
+    for (idx_t idx = 0; idx < {{ length }}; ++idx) {
         {{ output }}[idx] = start_value + (({{ c_type }})idx * delta_value);
     }
 }

--- a/templates/reduce_op.c.j2
+++ b/templates/reduce_op.c.j2
@@ -1,10 +1,10 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% for dim in output_shape %}
-for (size_t {{ output_loop_vars[loop.index0] }} = 0; {{ output_loop_vars[loop.index0] }} < {{ dim }}; ++{{ output_loop_vars[loop.index0] }}) {
+for (idx_t {{ output_loop_vars[loop.index0] }} = 0; {{ output_loop_vars[loop.index0] }} < {{ dim }}; ++{{ output_loop_vars[loop.index0] }}) {
 {% endfor %}
 {{ c_type }} acc = {{ init_literal }};
 {% for dim in reduce_dims %}
-for (size_t {{ reduce_loop_vars[loop.index0] }} = 0; {{ reduce_loop_vars[loop.index0] }} < {{ dim }}; ++{{ reduce_loop_vars[loop.index0] }}) {
+for (idx_t {{ reduce_loop_vars[loop.index0] }} = 0; {{ reduce_loop_vars[loop.index0] }} < {{ dim }}; ++{{ reduce_loop_vars[loop.index0] }}) {
 {% endfor %}
 {{ update_expr }}
 {% for _ in reduce_dims %}

--- a/templates/reduce_op_dynamic.c.j2
+++ b/templates/reduce_op_dynamic.c.j2
@@ -1,13 +1,13 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
-    size_t axis_count = {{ axes_count }};
+    idx_t axis_count = {{ axes_count }};
     bool reduce_mask[{{ input_shape | length }}];
-    for (size_t i = 0; i < {{ input_shape | length }}; ++i) {
+    for (idx_t i = 0; i < {{ input_shape | length }}; ++i) {
         reduce_mask[i] = false;
     }
     if (axis_count == 0) {
 {% if noop_with_empty_axes %}
 {% for dim in input_shape %}
-        for (size_t {{ input_loop_vars[loop.index0] }} = 0; {{ input_loop_vars[loop.index0] }} < {{ dim }}; ++{{ input_loop_vars[loop.index0] }}) {
+        for (idx_t {{ input_loop_vars[loop.index0] }} = 0; {{ input_loop_vars[loop.index0] }} < {{ dim }}; ++{{ input_loop_vars[loop.index0] }}) {
 {% endfor %}
         {{ output }}{{ input_index_expr }} = {{ input0 }}{{ input_index_expr }};
 {% for _ in input_shape %}
@@ -15,12 +15,12 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% endfor %}
         return;
 {% else %}
-        for (size_t i = 0; i < {{ input_shape | length }}; ++i) {
+        for (idx_t i = 0; i < {{ input_shape | length }}; ++i) {
             reduce_mask[i] = true;
         }
 {% endif %}
     } else {
-        for (size_t i = 0; i < axis_count; ++i) {
+        for (idx_t i = 0; i < axis_count; ++i) {
             int axis = (int){{ axes_input }}[i];
             if (axis < 0) {
                 axis += {{ input_shape | length }};
@@ -30,29 +30,29 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
             }
         }
     }
-    size_t reduce_count = 1;
+    idx_t reduce_count = 1;
 {% for dim in input_shape %}
     if (reduce_mask[{{ loop.index0 }}]) {
         reduce_count *= {{ dim }};
     }
 {% endfor %}
 {% for dim in output_shape %}
-    for (size_t {{ output_loop_vars[loop.index0] }} = 0; {{ output_loop_vars[loop.index0] }} < {{ dim }}; ++{{ output_loop_vars[loop.index0] }}) {
+    for (idx_t {{ output_loop_vars[loop.index0] }} = 0; {{ output_loop_vars[loop.index0] }} < {{ dim }}; ++{{ output_loop_vars[loop.index0] }}) {
 {% endfor %}
         {{ output }}{{ output_loop_index_expr }} = {{ init_literal }};
 {% for _ in output_shape %}
     }
 {% endfor %}
 {% for dim in input_shape %}
-    for (size_t {{ input_loop_vars[loop.index0] }} = 0; {{ input_loop_vars[loop.index0] }} < {{ dim }}; ++{{ input_loop_vars[loop.index0] }}) {
+    for (idx_t {{ input_loop_vars[loop.index0] }} = 0; {{ input_loop_vars[loop.index0] }} < {{ dim }}; ++{{ input_loop_vars[loop.index0] }}) {
 {% endfor %}
-        size_t out_indices[{{ output_shape | length }}];
+        idx_t out_indices[{{ output_shape | length }}];
 {% if keepdims %}
 {% for axis in range(input_shape | length) %}
         out_indices[{{ axis }}] = reduce_mask[{{ axis }}] ? 0 : {{ input_loop_vars[axis] }};
 {% endfor %}
 {% else %}
-        size_t out_pos = 0;
+        idx_t out_pos = 0;
 {% for axis in range(input_shape | length) %}
         if (!reduce_mask[{{ axis }}]) {
             out_indices[out_pos++] = {{ input_loop_vars[axis] }};
@@ -66,7 +66,7 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% endfor %}
 {% if post_expr %}
 {% for dim in output_shape %}
-    for (size_t {{ output_loop_vars[loop.index0] }} = 0; {{ output_loop_vars[loop.index0] }} < {{ dim }}; ++{{ output_loop_vars[loop.index0] }}) {
+    for (idx_t {{ output_loop_vars[loop.index0] }} = 0; {{ output_loop_vars[loop.index0] }} < {{ dim }}; ++{{ output_loop_vars[loop.index0] }}) {
 {% endfor %}
         {{ c_type }} *out_ptr = &{{ output }}{{ output_loop_index_expr }};
         {{ post_expr }}

--- a/templates/resize_op.c.j2
+++ b/templates/resize_op.c.j2
@@ -5,7 +5,7 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% if roi_input %}
     double roi[{{ rank * 2 }}];
 {% if roi_axes %}
-    for (size_t r = 0; r < {{ rank }}; ++r) {
+    for (idx_t r = 0; r < {{ rank }}; ++r) {
         roi[r] = 0.0;
         roi[r + {{ rank }}] = 1.0;
     }
@@ -14,7 +14,7 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
     roi[{{ axis + rank }}] = (double){{ roi_input }}[{{ roi_axis_map[loop.index0] + (axes | length) }}];
 {% endfor %}
 {% else %}
-    for (size_t r = 0; r < {{ rank * 2 }}; ++r) {
+    for (idx_t r = 0; r < {{ rank * 2 }}; ++r) {
         roi[r] = (double){{ roi_input }}[r];
     }
 {% endif %}
@@ -28,7 +28,7 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% endif %}
 {% if scales_input %}
 {% if scales_axes %}
-    for (size_t r = 0; r < {{ rank }}; ++r) {
+    for (idx_t r = 0; r < {{ rank }}; ++r) {
         scales[r] = 1.0;
     }
 {% for axis in axes %}
@@ -61,14 +61,14 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% endif %}
     }
 {% endfor %}
-    for (size_t r = 0; r < {{ rank }}; ++r) {
+    for (idx_t r = 0; r < {{ rank }}; ++r) {
         scales[r] = 1.0;
     }
 {% for axis in axes %}
     scales[{{ axis }}] = scale_value;
 {% endfor %}
 {% else %}
-    for (size_t r = 0; r < {{ rank }}; ++r) {
+    for (idx_t r = 0; r < {{ rank }}; ++r) {
         scales[r] = 1.0;
     }
 {% for axis in axes %}
@@ -81,7 +81,7 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% endfor %}
 {% endif %}
 {% for dim in output_shape %}
-for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
 int use_extrapolation = 0;
 {% for dim in range(rank) %}

--- a/templates/rms_normalization_op.c.j2
+++ b/templates/rms_normalization_op.c.j2
@@ -1,10 +1,10 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% for dim in prefix_shape %}
-for (size_t {{ prefix_loop_vars[loop.index0] }} = 0; {{ prefix_loop_vars[loop.index0] }} < {{ dim }}; ++{{ prefix_loop_vars[loop.index0] }}) {
+for (idx_t {{ prefix_loop_vars[loop.index0] }} = 0; {{ prefix_loop_vars[loop.index0] }} < {{ dim }}; ++{{ prefix_loop_vars[loop.index0] }}) {
 {% endfor %}
     {{ c_type }} sum = {{ zero_literal }};
 {% for dim in norm_shape %}
-    for (size_t {{ norm_loop_vars[loop.index0] }} = 0; {{ norm_loop_vars[loop.index0] }} < {{ dim }}; ++{{ norm_loop_vars[loop.index0] }}) {
+    for (idx_t {{ norm_loop_vars[loop.index0] }} = 0; {{ norm_loop_vars[loop.index0] }} < {{ dim }}; ++{{ norm_loop_vars[loop.index0] }}) {
 {% endfor %}
         {{ c_type }} value = {{ input0 }}{% for var in prefix_loop_vars %}[{{ var }}]{% endfor %}{% for var in norm_loop_vars %}[{{ var }}]{% endfor %};
         sum += value * value;
@@ -14,7 +14,7 @@ for (size_t {{ prefix_loop_vars[loop.index0] }} = 0; {{ prefix_loop_vars[loop.in
     {{ c_type }} mean_square = sum / {{ inner }};
     {{ c_type }} denom = {{ sqrt_fn }}(mean_square + {{ epsilon_literal }});
 {% for dim in norm_shape %}
-    for (size_t {{ norm_loop_vars[loop.index0] }} = 0; {{ norm_loop_vars[loop.index0] }} < {{ dim }}; ++{{ norm_loop_vars[loop.index0] }}) {
+    for (idx_t {{ norm_loop_vars[loop.index0] }} = 0; {{ norm_loop_vars[loop.index0] }} < {{ dim }}; ++{{ norm_loop_vars[loop.index0] }}) {
 {% endfor %}
         {{ c_type }} value = {{ input0 }}{% for var in prefix_loop_vars %}[{{ var }}]{% endfor %}{% for var in norm_loop_vars %}[{{ var }}]{% endfor %} / denom;
         value = value * {{ scale }}{% for var in scale_index_vars %}[{{ var }}]{% endfor %};

--- a/templates/slice_op.c.j2
+++ b/templates/slice_op.c.j2
@@ -1,6 +1,6 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% for dim in output_shape %}
-for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
 {{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = {{ input0 }}{% for idx in input_indices %}[{{ idx }}]{% endfor %};
 {% for _ in output_shape %}

--- a/templates/slice_op_dynamic.c.j2
+++ b/templates/slice_op_dynamic.c.j2
@@ -1,16 +1,16 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
-    const size_t input_rank = {{ input_rank }};
-    const size_t input_dims[] = { {% for dim in input_shape %}{{ dim }}{% if not loop.last %}, {% endif %}{% endfor %} };
-    size_t start_indices[{{ input_rank }}];
-    size_t step_values[{{ input_rank }}];
+    const idx_t input_rank = {{ input_rank }};
+    const idx_t input_dims[] = { {% for dim in input_shape %}{{ dim }}{% if not loop.last %}, {% endif %}{% endfor %} };
+    idx_t start_indices[{{ input_rank }}];
+    idx_t step_values[{{ input_rank }}];
 {% if ends_input %}
     (void){{ ends_input }};
 {% endif %}
-    for (size_t idx = 0; idx < input_rank; ++idx) {
+    for (idx_t idx = 0; idx < input_rank; ++idx) {
         start_indices[idx] = 0;
         step_values[idx] = 1;
     }
-    for (size_t i = 0; i < {{ starts_len }}; ++i) {
+    for (idx_t i = 0; i < {{ starts_len }}; ++i) {
 {% if axes_input %}
         int64_t axis_value = (int64_t){{ axes_input }}[i];
 {% else %}
@@ -19,7 +19,7 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
         if (axis_value < 0) {
             axis_value += (int64_t)input_rank;
         }
-        size_t axis = (size_t)axis_value;
+        idx_t axis = (idx_t)axis_value;
         int64_t dim = (int64_t)input_dims[axis];
         int64_t start_value = (int64_t){{ starts_input }}[i];
         if (start_value < 0) {
@@ -35,11 +35,11 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% if steps_input %}
         step_value = (int64_t){{ steps_input }}[i];
 {% endif %}
-        start_indices[axis] = (size_t)start_value;
-        step_values[axis] = (size_t)step_value;
+        start_indices[axis] = (idx_t)start_value;
+        step_values[axis] = (idx_t)step_value;
     }
 {% for dim in output_shape %}
-    for (size_t {{ output_loop_vars[loop.index0] }} = 0; {{ output_loop_vars[loop.index0] }} < {{ dim }}; ++{{ output_loop_vars[loop.index0] }}) {
+    for (idx_t {{ output_loop_vars[loop.index0] }} = 0; {{ output_loop_vars[loop.index0] }} < {{ dim }}; ++{{ output_loop_vars[loop.index0] }}) {
 {% endfor %}
         {{ output }}{% for var in output_loop_vars %}[{{ var }}]{% endfor %} = {{ input0 }}{% for var in output_loop_vars %}[start_indices[{{ loop.index0 }}] + ({{ var }} * step_values[{{ loop.index0 }}])]{% endfor %};
 {% for _ in output_shape %}

--- a/templates/softmax_cross_entropy_loss_op.c.j2
+++ b/templates/softmax_cross_entropy_loss_op.c.j2
@@ -5,14 +5,14 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% if log_prob %}
     {{ c_type }} *log_prob_flat = ({{ c_type }} *){{ log_prob }};
 {% endif %}
-    const size_t n = {{ n }};
-    const size_t c = {{ c }};
-    const size_t d = {{ d }};
+    const idx_t n = {{ n }};
+    const idx_t c = {{ c }};
+    const idx_t d = {{ d }};
     {{ c_type }} loss_sum = {{ zero_literal }};
     {{ c_type }} weight_sum = {{ zero_literal }};
-    for (size_t n_idx = 0; n_idx < n; ++n_idx) {
-        for (size_t d_idx = 0; d_idx < d; ++d_idx) {
-            size_t target_index = n_idx * d + d_idx;
+    for (idx_t n_idx = 0; n_idx < n; ++n_idx) {
+        for (idx_t d_idx = 0; d_idx < d; ++d_idx) {
+            idx_t target_index = n_idx * d + d_idx;
             {{ target_c_type }} target_value = target_flat[target_index];
 {% if use_ignore_index %}
             if ((int64_t)target_value == {{ ignore_index }}) {
@@ -22,24 +22,24 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
                 continue;
             }
 {% endif %}
-            size_t class_index = (size_t)target_value;
-            size_t base = (n_idx * c * d) + d_idx;
+            idx_t class_index = (idx_t)target_value;
+            idx_t base = (n_idx * c * d) + d_idx;
             {{ c_type }} max_value = input_flat[base];
-            for (size_t c_idx = 1; c_idx < c; ++c_idx) {
+            for (idx_t c_idx = 1; c_idx < c; ++c_idx) {
                 {{ c_type }} value = input_flat[base + c_idx * d];
                 if (value > max_value) {
                     max_value = value;
                 }
             }
             {{ c_type }} sum = {{ zero_literal }};
-            for (size_t c_idx = 0; c_idx < c; ++c_idx) {
+            for (idx_t c_idx = 0; c_idx < c; ++c_idx) {
                 {{ c_type }} value = input_flat[base + c_idx * d] - max_value;
                 sum += {{ exp_fn }}(value);
             }
             {{ c_type }} logsum = {{ log_fn }}(sum);
 {% if log_prob %}
             {{ c_type }} loss_value = {{ zero_literal }};
-            for (size_t c_idx = 0; c_idx < c; ++c_idx) {
+            for (idx_t c_idx = 0; c_idx < c; ++c_idx) {
                 {{ c_type }} log_prob_value = input_flat[base + c_idx * d] - max_value - logsum;
                 log_prob_flat[base + c_idx * d] = log_prob_value;
                 if (c_idx == class_index) {

--- a/templates/softmax_op.c.j2
+++ b/templates/softmax_op.c.j2
@@ -1,26 +1,26 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
     const {{ c_type }} *input_flat = (const {{ c_type }} *){{ input0 }};
     {{ c_type }} *output_flat = ({{ c_type }} *){{ output }};
-    const size_t outer = {{ outer }};
-    const size_t axis_size = {{ axis_size }};
-    const size_t inner = {{ inner }};
-    for (size_t outer_idx = 0; outer_idx < outer; ++outer_idx) {
-        for (size_t inner_idx = 0; inner_idx < inner; ++inner_idx) {
-            size_t base = (outer_idx * axis_size * inner) + inner_idx;
+    const idx_t outer = {{ outer }};
+    const idx_t axis_size = {{ axis_size }};
+    const idx_t inner = {{ inner }};
+    for (idx_t outer_idx = 0; outer_idx < outer; ++outer_idx) {
+        for (idx_t inner_idx = 0; inner_idx < inner; ++inner_idx) {
+            idx_t base = (outer_idx * axis_size * inner) + inner_idx;
             {{ c_type }} max_value = input_flat[base];
-            for (size_t axis_idx = 1; axis_idx < axis_size; ++axis_idx) {
+            for (idx_t axis_idx = 1; axis_idx < axis_size; ++axis_idx) {
                 {{ c_type }} value = input_flat[base + axis_idx * inner];
                 if (value > max_value) {
                     max_value = value;
                 }
             }
             {{ c_type }} sum = 0;
-            for (size_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
+            for (idx_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
                 {{ c_type }} value = {{ exp_fn }}(input_flat[base + axis_idx * inner] - max_value);
                 output_flat[base + axis_idx * inner] = value;
                 sum += value;
             }
-            for (size_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
+            for (idx_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
                 output_flat[base + axis_idx * inner] /= sum;
             }
         }

--- a/templates/space_to_depth_op.c.j2
+++ b/templates/space_to_depth_op.c.j2
@@ -1,18 +1,18 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
     const {{ c_type }} *input_data = (const {{ c_type }} *){{ input0 }};
     {{ c_type }} *output_data = ({{ c_type }} *){{ output }};
-    size_t output_index = 0;
-    for (size_t n = 0; n < {{ batch }}; ++n) {
-        for (size_t c_out = 0; c_out < {{ out_channels }}; ++c_out) {
-            size_t c_in = c_out % {{ in_channels }};
-            size_t temp = c_out / {{ in_channels }};
-            size_t offset_h = temp / {{ blocksize }};
-            size_t offset_w = temp % {{ blocksize }};
-            for (size_t h_out = 0; h_out < {{ out_h }}; ++h_out) {
-                size_t h_in = h_out * {{ blocksize }} + offset_h;
-                for (size_t w_out = 0; w_out < {{ out_w }}; ++w_out) {
-                    size_t w_in = w_out * {{ blocksize }} + offset_w;
-                    size_t input_index = ((n * {{ in_channels }} + c_in) * {{ in_h }} + h_in) * {{ in_w }} + w_in;
+    idx_t output_index = 0;
+    for (idx_t n = 0; n < {{ batch }}; ++n) {
+        for (idx_t c_out = 0; c_out < {{ out_channels }}; ++c_out) {
+            idx_t c_in = c_out % {{ in_channels }};
+            idx_t temp = c_out / {{ in_channels }};
+            idx_t offset_h = temp / {{ blocksize }};
+            idx_t offset_w = temp % {{ blocksize }};
+            for (idx_t h_out = 0; h_out < {{ out_h }}; ++h_out) {
+                idx_t h_in = h_out * {{ blocksize }} + offset_h;
+                for (idx_t w_out = 0; w_out < {{ out_w }}; ++w_out) {
+                    idx_t w_in = w_out * {{ blocksize }} + offset_w;
+                    idx_t input_index = ((n * {{ in_channels }} + c_in) * {{ in_h }} + h_in) * {{ in_w }} + w_in;
                     output_data[output_index] = input_data[input_index];
                     output_index++;
                 }

--- a/templates/split_op.c.j2
+++ b/templates/split_op.c.j2
@@ -1,12 +1,12 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
     const {{ c_type }} *input_data = (const {{ c_type }} *){{ input0 }};
     {{ c_type }} *output_ptrs[] = { {% for output in outputs %}({{ c_type }} *){{ output }}{% if not loop.last %}, {% endif %}{% endfor %} };
-    const size_t axis_sizes[] = { {% for axis in axis_sizes %}{{ axis }}{% if not loop.last %}, {% endif %}{% endfor %} };
-    for (size_t outer_idx = 0; outer_idx < {{ outer }}; ++outer_idx) {
-        size_t input_base = outer_idx * {{ axis_total }} * {{ inner }};
-        size_t axis_offset = 0;
-        for (size_t output_idx = 0; output_idx < {{ output_count }}; ++output_idx) {
-            size_t copy_elems = axis_sizes[output_idx] * {{ inner }};
+    const idx_t axis_sizes[] = { {% for axis in axis_sizes %}{{ axis }}{% if not loop.last %}, {% endif %}{% endfor %} };
+    for (idx_t outer_idx = 0; outer_idx < {{ outer }}; ++outer_idx) {
+        idx_t input_base = outer_idx * {{ axis_total }} * {{ inner }};
+        idx_t axis_offset = 0;
+        for (idx_t output_idx = 0; output_idx < {{ output_count }}; ++output_idx) {
+            idx_t copy_elems = axis_sizes[output_idx] * {{ inner }};
             memcpy(
                 output_ptrs[output_idx] + outer_idx * copy_elems,
                 input_data + input_base + axis_offset,

--- a/templates/testbench.c.j2
+++ b/templates/testbench.c.j2
@@ -38,7 +38,7 @@ int main(void) {
 {% for input in inputs %}
     {{ input.c_type }} {{ input.name }}{{ input.array_suffix }};
     {{ input.c_type }} *{{ input.name }}_ptr = ({{ input.c_type }} *){{ input.name }};
-    for (size_t i = 0; i < {{ input.count }}; ++i) {
+    for (idx_t i = 0; i < {{ input.count }}; ++i) {
 {% if input.constant_name %}
         {{ input.name }}_ptr[i] = {{ input.constant_name }}[i];
 {% else %}
@@ -59,7 +59,7 @@ int main(void) {
     printf("\"{{ input.name }}\":{\"shape\":[{{ input.shape_literal }}],\"data\":");
     printf("[");
 {% for depth in range(input.rank) %}
-for (size_t {{ input.loop_vars[depth] }} = 0; {{ input.loop_vars[depth] }} < {{ input.shape[depth] }}; ++{{ input.loop_vars[depth] }}) {
+for (idx_t {{ input.loop_vars[depth] }} = 0; {{ input.loop_vars[depth] }} < {{ input.shape[depth] }}; ++{{ input.loop_vars[depth] }}) {
     if ({{ input.loop_vars[depth] }}) {
         printf(",");
     }
@@ -84,7 +84,7 @@ printf("{{ input.print_format }}", {{ input.print_cast }}{{ input.name }}_ptr[{{
     printf("\"{{ output.name }}\":{\"shape\":[{{ output.shape_literal }}],\"data\":");
     printf("[");
 {% for depth in range(output.rank) %}
-for (size_t {{ output.loop_vars[depth] }} = 0; {{ output.loop_vars[depth] }} < {{ output.shape[depth] }}; ++{{ output.loop_vars[depth] }}) {
+for (idx_t {{ output.loop_vars[depth] }} = 0; {{ output.loop_vars[depth] }} < {{ output.shape[depth] }}; ++{{ output.loop_vars[depth] }}) {
     if ({{ output.loop_vars[depth] }}) {
         printf(",");
     }

--- a/templates/tile_op.c.j2
+++ b/templates/tile_op.c.j2
@@ -1,11 +1,11 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
     const {{ c_type }} *input_data = (const {{ c_type }} *){{ input0 }};
     {{ c_type }} *output_data = ({{ c_type }} *){{ output }};
-    size_t output_index = 0;
+    idx_t output_index = 0;
 {% for dim in output_shape %}
-    for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+    for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
-        size_t input_index = {{ input_index_expr }};
+        idx_t input_index = {{ input_index_expr }};
         output_data[output_index] = input_data[input_index];
         output_index++;
 {% for _ in output_shape %}

--- a/templates/transpose_op.c.j2
+++ b/templates/transpose_op.c.j2
@@ -1,6 +1,6 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% for dim in output_shape %}
-for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
 {{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = {{ input0 }}{% for var in input_indices %}[{{ var }}]{% endfor %};
 {% for _ in output_shape %}

--- a/templates/trilu_op.c.j2
+++ b/templates/trilu_op.c.j2
@@ -6,14 +6,14 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
     const {{ k_c_type }} *k_data = (const {{ k_c_type }} *){{ k_input }};
     k = (int64_t)k_data[0];
     {% endif %}
-    size_t rows = {{ rows }};
-    size_t cols = {{ cols }};
-    size_t batch_size = {{ batch_size }};
-    for (size_t batch = 0; batch < batch_size; ++batch) {
-        size_t base = batch * rows * cols;
-        for (size_t row = 0; row < rows; ++row) {
-            for (size_t col = 0; col < cols; ++col) {
-                size_t offset = base + row * cols + col;
+    idx_t rows = {{ rows }};
+    idx_t cols = {{ cols }};
+    idx_t batch_size = {{ batch_size }};
+    for (idx_t batch = 0; batch < batch_size; ++batch) {
+        idx_t base = batch * rows * cols;
+        for (idx_t row = 0; row < rows; ++row) {
+            for (idx_t col = 0; col < cols; ++col) {
+                idx_t offset = base + row * cols + col;
                 {% if upper %}
                 if ((int64_t)col - (int64_t)row >= k) {
                     output_data[offset] = input_data[offset];

--- a/templates/unary_op.c.j2
+++ b/templates/unary_op.c.j2
@@ -1,6 +1,6 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% for dim in shape %}
-for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
 {% if operator == "relu" %}
 {{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = {{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %} > {{ zero_literal }} ? {{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %} : {{ zero_literal }};

--- a/templates/where_op.c.j2
+++ b/templates/where_op.c.j2
@@ -1,6 +1,6 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% for dim in output_shape %}
-for (size_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
 {{ output_expr }} = {{ condition_expr }} ? {{ x_expr }} : {{ y_expr }};
 {% for _ in output_shape %}

--- a/tests/golden/add_initializer_model.c
+++ b/tests/golden/add_initializer_model.c
@@ -19,9 +19,13 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
 #include <float.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Weight 1:
@@ -52,8 +56,8 @@ static inline float ref_scalar_f32_add(float a, float b) {
  * Attrs: n/a
  */
 static inline void node0_add(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_add(input0[i0][i1], input1[i0][i1]);
         }
     }

--- a/tests/golden/add_model.c
+++ b/tests/golden/add_model.c
@@ -19,9 +19,13 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
 #include <float.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 static inline float ref_scalar_f32_add(float a, float b) {
     return a + b;
@@ -36,9 +40,9 @@ static inline float ref_scalar_f32_add(float a, float b) {
  * Attrs: n/a
  */
 static inline void node0_add(const float input0[restrict 2][3][4], const float input1[restrict 2][3][4], float output[restrict 2][3][4]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
-            for (size_t i2 = 0; i2 < 4; ++i2) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
+            for (idx_t i2 = 0; i2 < 4; ++i2) {
                 output[i0][i1][i2] = ref_scalar_f32_add(input0[i0][i1][i2], input1[i0][i1][i2]);
             }
         }

--- a/tests/golden/add_model_no_restrict.c
+++ b/tests/golden/add_model_no_restrict.c
@@ -19,9 +19,13 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
 #include <float.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 static inline float ref_scalar_f32_add(float a, float b) {
     return a + b;
@@ -36,9 +40,9 @@ static inline float ref_scalar_f32_add(float a, float b) {
  * Attrs: n/a
  */
 static inline void node0_add(const float input0[2][3][4], const float input1[2][3][4], float output[2][3][4]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
-            for (size_t i2 = 0; i2 < 4; ++i2) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
+            for (idx_t i2 = 0; i2 < 4; ++i2) {
                 output[i0][i1][i2] = ref_scalar_f32_add(input0[i0][i1][i2], input1[i0][i1][i2]);
             }
         }

--- a/tests/golden/add_model_testbench.c
+++ b/tests/golden/add_model_testbench.c
@@ -19,11 +19,14 @@
  *   n/a
  */
 
-#include <stddef.h>
-#include <stdio.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <math.h>
 #include <float.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 static inline float ref_scalar_f32_add(float a, float b) {
     return a + b;
@@ -38,9 +41,9 @@ static inline float ref_scalar_f32_add(float a, float b) {
  * Attrs: n/a
  */
 static inline void node0_add(const float input0[restrict 2][3][4], const float input1[restrict 2][3][4], float output[restrict 2][3][4]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
-            for (size_t i2 = 0; i2 < 4; ++i2) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
+            for (idx_t i2 = 0; i2 < 4; ++i2) {
                 output[i0][i1][i2] = ref_scalar_f32_add(input0[i0][i1][i2], input1[i0][i1][i2]);
             }
         }
@@ -78,12 +81,12 @@ static int64_t rng_next_i64(void) {
 int main(void) {
     float a[2][3][4];
     float *a_ptr = (float *)a;
-    for (size_t i = 0; i < 24; ++i) {
+    for (idx_t i = 0; i < 24; ++i) {
         a_ptr[i] = rng_next_float();
     }
     float b[2][3][4];
     float *b_ptr = (float *)b;
-    for (size_t i = 0; i < 24; ++i) {
+    for (idx_t i = 0; i < 24; ++i) {
         b_ptr[i] = rng_next_float();
     }
     float out[2][3][4];
@@ -92,17 +95,17 @@ int main(void) {
     printf("{\"inputs\":{");
             printf("\"a\":{\"shape\":[2,3,4],\"data\":");
                 printf("[");
-                for (size_t i0 = 0; i0 < 2; ++i0) {
+                for (idx_t i0 = 0; i0 < 2; ++i0) {
                     if (i0) {
                         printf(",");
                     }
                     printf("[");
-                    for (size_t i1 = 0; i1 < 3; ++i1) {
+                    for (idx_t i1 = 0; i1 < 3; ++i1) {
                         if (i1) {
                             printf(",");
                         }
                         printf("[");
-                        for (size_t i2 = 0; i2 < 4; ++i2) {
+                        for (idx_t i2 = 0; i2 < 4; ++i2) {
                             if (i2) {
                                 printf(",");
                             }
@@ -116,17 +119,17 @@ int main(void) {
             printf(",");
             printf("\"b\":{\"shape\":[2,3,4],\"data\":");
                 printf("[");
-                for (size_t i0 = 0; i0 < 2; ++i0) {
+                for (idx_t i0 = 0; i0 < 2; ++i0) {
                     if (i0) {
                         printf(",");
                     }
                     printf("[");
-                    for (size_t i1 = 0; i1 < 3; ++i1) {
+                    for (idx_t i1 = 0; i1 < 3; ++i1) {
                         if (i1) {
                             printf(",");
                         }
                         printf("[");
-                        for (size_t i2 = 0; i2 < 4; ++i2) {
+                        for (idx_t i2 = 0; i2 < 4; ++i2) {
                             if (i2) {
                                 printf(",");
                             }
@@ -140,17 +143,17 @@ int main(void) {
             printf("},\"outputs\":{");
             printf("\"out\":{\"shape\":[2,3,4],\"data\":");
                 printf("[");
-                for (size_t i0 = 0; i0 < 2; ++i0) {
+                for (idx_t i0 = 0; i0 < 2; ++i0) {
                     if (i0) {
                         printf(",");
                     }
                     printf("[");
-                    for (size_t i1 = 0; i1 < 3; ++i1) {
+                    for (idx_t i1 = 0; i1 < 3; ++i1) {
                         if (i1) {
                             printf(",");
                         }
                         printf("[");
-                        for (size_t i2 = 0; i2 < 4; ++i2) {
+                        for (idx_t i2 = 0; i2 < 4; ++i2) {
                             if (i2) {
                                 printf(",");
                             }

--- a/tests/golden/dynamic_dims_model.c
+++ b/tests/golden/dynamic_dims_model.c
@@ -19,9 +19,13 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
 #include <float.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 static inline float ref_scalar_f32_relu(float a) {
     return a > 0.0f ? a : 0.0f;
@@ -36,8 +40,8 @@ static inline float ref_scalar_f32_relu(float a) {
  * Attrs: n/a
  */
 static inline void node0_relu(int N, int C, const float input0[restrict N][C], float output[restrict N][C]) {
-    for (size_t i0 = 0; i0 < N; ++i0) {
-        for (size_t i1 = 0; i1 < C; ++i1) {
+    for (idx_t i0 = 0; i0 < N; ++i0) {
+        for (idx_t i1 = 0; i1 < C; ++i1) {
             output[i0][i1] = ref_scalar_f32_relu(input0[i0][i1]);
         }
     }

--- a/tests/golden/matmul_model.c
+++ b/tests/golden/matmul_model.c
@@ -19,7 +19,11 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -30,10 +34,10 @@
  * Attrs: n/a
  */
 static inline void node0_matmul(const float input0[restrict 2][3], const float input1[restrict 3][4], float output[restrict 2][4]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 4; ++i1) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 4; ++i1) {
             float acc = 0.0f;
-            for (size_t k = 0; k < 3; ++k) {
+            for (idx_t k = 0; k < 3; ++k) {
                 acc += input0[i0][k] * input1[k][i1];
             }
             output[i0][i1] = acc;

--- a/tests/golden/mul_add_model.c
+++ b/tests/golden/mul_add_model.c
@@ -19,9 +19,13 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
 #include <float.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 static inline float ref_scalar_f32_mul(float a, float b) {
     return a * b;
@@ -40,8 +44,8 @@ static inline float ref_scalar_f32_add(float a, float b) {
  * Attrs: n/a
  */
 static inline void node0_mul(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_mul(input0[i0][i1], input1[i0][i1]);
         }
     }
@@ -56,8 +60,8 @@ static inline void node0_mul(const float input0[restrict 2][3], const float inpu
  * Attrs: n/a
  */
 static inline void node1_add(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_add(input0[i0][i1], input1[i0][i1]);
         }
     }

--- a/tests/golden/mul_add_relu_model.c
+++ b/tests/golden/mul_add_relu_model.c
@@ -19,9 +19,13 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
 #include <float.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 static inline float ref_scalar_f32_mul(float a, float b) {
     return a * b;
@@ -44,8 +48,8 @@ static inline float ref_scalar_f32_relu(float a) {
  * Attrs: n/a
  */
 static inline void node0_mul(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_mul(input0[i0][i1], input1[i0][i1]);
         }
     }
@@ -60,8 +64,8 @@ static inline void node0_mul(const float input0[restrict 2][3], const float inpu
  * Attrs: n/a
  */
 static inline void node1_add(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_add(input0[i0][i1], input1[i0][i1]);
         }
     }
@@ -76,8 +80,8 @@ static inline void node1_add(const float input0[restrict 2][3], const float inpu
  * Attrs: n/a
  */
 static inline void node2_relu(const float input0[restrict 2][3], float output[restrict 2][3]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_relu(input0[i0][i1]);
         }
     }

--- a/tests/golden/mul_model.c
+++ b/tests/golden/mul_model.c
@@ -19,9 +19,13 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
 #include <float.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 static inline float ref_scalar_f32_mul(float a, float b) {
     return a * b;
@@ -36,8 +40,8 @@ static inline float ref_scalar_f32_mul(float a, float b) {
  * Attrs: n/a
  */
 static inline void node0_mul(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_mul(input0[i0][i1], input1[i0][i1]);
         }
     }

--- a/tests/golden/op_argreduce_arg_max.c
+++ b/tests/golden/op_argreduce_arg_max.c
@@ -19,8 +19,11 @@
  *   n/a
  */
 
-#include <stddef.h>
 #include <stdint.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -34,12 +37,12 @@
  *   select_last_index: 0
  */
 static inline void node0_argmax(const float input0[restrict 2][3][4], int64_t output[restrict 2][1][4]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 1; ++i1) {
-            for (size_t i2 = 0; i2 < 4; ++i2) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 1; ++i1) {
+            for (idx_t i2 = 0; i2 < 4; ++i2) {
                 float best = input0[i0][0][i2];
                 int64_t best_index = 0;
-                for (size_t r0 = 1; r0 < 3; ++r0) {
+                for (idx_t r0 = 1; r0 < 3; ++r0) {
                     float candidate = input0[i0][r0][i2];
                     if (candidate > best) {
                         best = candidate;

--- a/tests/golden/op_attention_attention.c
+++ b/tests/golden/op_attention_attention.c
@@ -19,8 +19,12 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:

--- a/tests/golden/op_averagepool_average_pool.c
+++ b/tests/golden/op_averagepool_average_pool.c
@@ -19,7 +19,11 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -32,13 +36,13 @@
  *   strides: [2, 2]
  */
 static inline void node0_averagepool(const float input0[restrict 1][1][4][4], float output[restrict 1][1][2][2]) {
-    for (size_t n = 0; n < 1; ++n) {
-        for (size_t c = 0; c < 1; ++c) {
-            for (size_t oh = 0; oh < 2; ++oh) {
-                for (size_t ow = 0; ow < 2; ++ow) {
+    for (idx_t n = 0; n < 1; ++n) {
+        for (idx_t c = 0; c < 1; ++c) {
+            for (idx_t oh = 0; oh < 2; ++oh) {
+                for (idx_t ow = 0; ow < 2; ++ow) {
                     float acc = 0.0f;
-                    size_t count = 0;
-                    for (size_t kh = 0; kh < 2; ++kh) {
+                    idx_t count = 0;
+                    for (idx_t kh = 0; kh < 2; ++kh) {
                         const int ih = (int)(oh * 2 + kh) - 0;
                         if (ih < 0 || ih >= 4) {
                             if (0) {
@@ -46,7 +50,7 @@ static inline void node0_averagepool(const float input0[restrict 1][1][4][4], fl
                             }
                             continue;
                         }
-                        for (size_t kw = 0; kw < 2; ++kw) {
+                        for (idx_t kw = 0; kw < 2; ++kw) {
                             const int iw = (int)(ow * 2 + kw) - 0;
                             if (iw < 0 || iw >= 4) {
                                 if (0) {

--- a/tests/golden/op_batchnorm_batch_normalization.c
+++ b/tests/golden/op_batchnorm_batch_normalization.c
@@ -19,8 +19,12 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Weight 1:
@@ -76,11 +80,11 @@ static const float weight4_var[3] = {
  *   epsilon: 9.999999747378752e-06
  */
 static inline void node0_batchnormalization(const float input0[restrict 2][3][2][2], const float scale[restrict 3], const float bias[restrict 3], const float mean[restrict 3], const float variance[restrict 3], float output[restrict 2][3][2][2]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
-            for (size_t i2 = 0; i2 < 2; ++i2) {
-                for (size_t i3 = 0; i3 < 2; ++i3) {
-                    size_t c = i1;
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
+            for (idx_t i2 = 0; i2 < 2; ++i2) {
+                for (idx_t i3 = 0; i3 < 2; ++i3) {
+                    idx_t c = i1;
                     float denom = sqrtf(variance[c] + 9.99999975e-06f);
                     output[i0][i1][i2][i3] = (input0[i0][i1][i2][i3] - mean[c]) / denom * scale[c] + bias[c];
                 }

--- a/tests/golden/op_binary_mul.c
+++ b/tests/golden/op_binary_mul.c
@@ -19,9 +19,13 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
 #include <float.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 static inline float ref_scalar_f32_mul(float a, float b) {
     return a * b;
@@ -36,8 +40,8 @@ static inline float ref_scalar_f32_mul(float a, float b) {
  * Attrs: n/a
  */
 static inline void node0_mul(const float input0[restrict 2][3], const float input1[restrict 2][3], float output[restrict 2][3]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_mul(input0[i0][i1], input1[i0][i1]);
         }
     }

--- a/tests/golden/op_cast_cast.c
+++ b/tests/golden/op_cast_cast.c
@@ -19,8 +19,11 @@
  *   n/a
  */
 
-#include <stddef.h>
 #include <stdint.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -32,8 +35,8 @@
  *   to: 6
  */
 static inline void node0_cast(const float input0[restrict 2][3], int32_t output[restrict 2][3]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = (int32_t)input0[i0][i1];
         }
     }

--- a/tests/golden/op_clip_clip.c
+++ b/tests/golden/op_clip_clip.c
@@ -19,7 +19,11 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Weight 1:
@@ -52,8 +56,8 @@ static const float weight2_max[1] = {
  * Attrs: n/a
  */
 static inline void node0_clip(const float input0[restrict 2][3], const float input_min[restrict 1], const float input_max[restrict 1], float output[restrict 2][3]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
             float value = input0[i0][i1];
             if (value < input_min[0]) {
                 value = input_min[0];

--- a/tests/golden/op_concat_concat.c
+++ b/tests/golden/op_concat_concat.c
@@ -19,8 +19,12 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <string.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -33,23 +37,23 @@
  */
 static inline void node0_concat(const float input_0[restrict 1][2][3], const float input_1[restrict 1][2][1], float output[restrict 1][2][4]) {
     const void *inputs[] = { input_0, input_1 };
-    const size_t axis_sizes[] = { 3, 1 };
-    size_t concat_axis = 0;
-    for (size_t idx = 0; idx < 2; ++idx) {
+    const idx_t axis_sizes[] = { 3, 1 };
+    idx_t concat_axis = 0;
+    for (idx_t idx = 0; idx < 2; ++idx) {
         concat_axis += axis_sizes[idx];
     }
     if (concat_axis == 0) {
         return;
     }
-    for (size_t outer_idx = 0; outer_idx < 2; ++outer_idx) {
-        size_t output_offset = outer_idx * concat_axis * 1;
-        size_t axis_offset = 0;
-        for (size_t input_idx = 0; input_idx < 2; ++input_idx) {
-            size_t axis = axis_sizes[input_idx];
-            size_t copy_elems = axis * 1;
+    for (idx_t outer_idx = 0; outer_idx < 2; ++outer_idx) {
+        idx_t output_offset = outer_idx * concat_axis * 1;
+        idx_t axis_offset = 0;
+        for (idx_t input_idx = 0; input_idx < 2; ++input_idx) {
+            idx_t axis = axis_sizes[input_idx];
+            idx_t copy_elems = axis * 1;
             const unsigned char *input_bytes =
             (const unsigned char *)inputs[input_idx];
-            size_t input_offset = outer_idx * copy_elems;
+            idx_t input_offset = outer_idx * copy_elems;
             memcpy(
             ((unsigned char *)output) + (output_offset + axis_offset) * sizeof(float),
             input_bytes + input_offset * sizeof(float),

--- a/tests/golden/op_constantofshape_constant_of_shape.c
+++ b/tests/golden/op_constantofshape_constant_of_shape.c
@@ -19,8 +19,11 @@
  *   n/a
  */
 
-#include <stddef.h>
 #include <stdint.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Weight 1:
@@ -48,9 +51,9 @@ name: "fill"
  */
 static inline void node0_constantofshape(const int64_t input0[restrict 3], float output[restrict 2][3][4]) {
     (void)input0;
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
-            for (size_t i2 = 0; i2 < 4; ++i2) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
+            for (idx_t i2 = 0; i2 < 4; ++i2) {
                 output[i0][i1][i2] = 1.25f;
             }
         }

--- a/tests/golden/op_conv_conv.c
+++ b/tests/golden/op_conv_conv.c
@@ -19,7 +19,11 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Weight 1:
@@ -66,17 +70,17 @@ static const float weight2_bias[1] = {
  *   strides: [1, 1]
  */
 static inline void node0_conv(const float input0[restrict 1][1][4][4], const float weights[restrict 1][1][3][3], const float bias[restrict 1], float output[restrict 1][1][4][4]) {
-    for (size_t n = 0; n < 1; ++n) {
-        for (size_t g = 0; g < 1; ++g) {
-            for (size_t oc = 0; oc < 1; ++oc) {
-                const size_t oc_global = g * 1 + oc;
-                for (size_t od0 = 0; od0 < 4; ++od0) {
-                    for (size_t od1 = 0; od1 < 4; ++od1) {
+    for (idx_t n = 0; n < 1; ++n) {
+        for (idx_t g = 0; g < 1; ++g) {
+            for (idx_t oc = 0; oc < 1; ++oc) {
+                const idx_t oc_global = g * 1 + oc;
+                for (idx_t od0 = 0; od0 < 4; ++od0) {
+                    for (idx_t od1 = 0; od1 < 4; ++od1) {
                         float acc = bias[oc_global];
-                        for (size_t ic = 0; ic < 1; ++ic) {
-                            const size_t ic_global = g * 1 + ic;
-                            for (size_t kd0 = 0; kd0 < 3; ++kd0) {
-                                for (size_t kd1 = 0; kd1 < 3; ++kd1) {
+                        for (idx_t ic = 0; ic < 1; ++ic) {
+                            const idx_t ic_global = g * 1 + ic;
+                            for (idx_t kd0 = 0; kd0 < 3; ++kd0) {
+                                for (idx_t kd1 = 0; kd1 < 3; ++kd1) {
                                     const int id0 = (int)(od0 * 1 + kd0 * 1) - 1;
                                     const int id1 = (int)(od1 * 1 + kd1 * 1) - 1;
                                     if (id0 < 0 || id0 >= 4 || id1 < 0 || id1 >= 4) {

--- a/tests/golden/op_cumsum_cumsum.c
+++ b/tests/golden/op_cumsum_cumsum.c
@@ -19,8 +19,11 @@
  *   n/a
  */
 
-#include <stddef.h>
 #include <stdint.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Weight 1:
@@ -44,7 +47,7 @@ static const int64_t weight1_axis[1] = {
  *   reverse: 0
  */
 static inline void node0_cumsum(const float input0[restrict 2][3], float output[restrict 2][3]) {
-    const size_t dims[2] = { 2, 3 };
+    const idx_t dims[2] = { 2, 3 };
     int axis = 1;
     if (axis < 0) {
         axis += 2;
@@ -52,21 +55,21 @@ static inline void node0_cumsum(const float input0[restrict 2][3], float output[
     if (axis < 0 || axis >= 2) {
         return;
     }
-    size_t outer = 1;
+    idx_t outer = 1;
     for (int i = 0; i < axis; ++i) {
         outer *= dims[i];
     }
-    size_t inner = 1;
+    idx_t inner = 1;
     for (int i = axis + 1; i < 2; ++i) {
         inner *= dims[i];
     }
-    size_t axis_dim = dims[axis];
-    for (size_t outer_index = 0; outer_index < outer; ++outer_index) {
-        for (size_t inner_index = 0; inner_index < inner; ++inner_index) {
+    idx_t axis_dim = dims[axis];
+    for (idx_t outer_index = 0; outer_index < outer; ++outer_index) {
+        for (idx_t inner_index = 0; inner_index < inner; ++inner_index) {
             float acc = (float)0;
-            size_t base = (outer_index * axis_dim * inner) + inner_index;
-            for (size_t axis_index = 0; axis_index < axis_dim; ++axis_index) {
-                size_t offset = base + axis_index * inner;
+            idx_t base = (outer_index * axis_dim * inner) + inner_index;
+            for (idx_t axis_index = 0; axis_index < axis_dim; ++axis_index) {
+                idx_t offset = base + axis_index * inner;
                 acc += input0[offset];
                 output[offset] = acc;
             }

--- a/tests/golden/op_depthtospace_depth_to_space.c
+++ b/tests/golden/op_depthtospace_depth_to_space.c
@@ -19,7 +19,11 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -34,18 +38,18 @@
 static inline void node0_depthtospace(const float input0[restrict 1][4][2][2], float output[restrict 1][1][4][4]) {
     const float *input_data = (const float *)input0;
     float *output_data = (float *)output;
-    size_t output_index = 0;
-    for (size_t n = 0; n < 1; ++n) {
-        for (size_t c_out = 0; c_out < 1; ++c_out) {
-            for (size_t h_out = 0; h_out < 4; ++h_out) {
-                size_t h_in = h_out / 2;
-                size_t offset_h = h_out % 2;
-                for (size_t w_out = 0; w_out < 4; ++w_out) {
-                    size_t w_in = w_out / 2;
-                    size_t offset_w = w_out % 2;
-                    size_t c_in;
+    idx_t output_index = 0;
+    for (idx_t n = 0; n < 1; ++n) {
+        for (idx_t c_out = 0; c_out < 1; ++c_out) {
+            for (idx_t h_out = 0; h_out < 4; ++h_out) {
+                idx_t h_in = h_out / 2;
+                idx_t offset_h = h_out % 2;
+                for (idx_t w_out = 0; w_out < 4; ++w_out) {
+                    idx_t w_in = w_out / 2;
+                    idx_t offset_w = w_out % 2;
+                    idx_t c_in;
                     c_in = (offset_h * 2 + offset_w) * 1 + c_out;
-                    size_t input_index = ((n * 4 + c_in) * 2 + h_in) * 2 + w_in;
+                    idx_t input_index = ((n * 4 + c_in) * 2 + h_in) * 2 + w_in;
                     output_data[output_index] = input_data[input_index];
                     output_index++;
                 }

--- a/tests/golden/op_expand_expand.c
+++ b/tests/golden/op_expand_expand.c
@@ -19,8 +19,11 @@
  *   n/a
  */
 
-#include <stddef.h>
 #include <stdint.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Weight 1:
@@ -44,10 +47,10 @@ static const int64_t weight1_shape[2] = {
 static inline void node0_expand(const float input0[restrict 1][3], float output[restrict 2][3]) {
     const float *input_data = (const float *)input0;
     float *output_data = (float *)output;
-    size_t output_index = 0;
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
-            size_t input_index = i1 * 1;
+    idx_t output_index = 0;
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
+            idx_t input_index = i1 * 1;
             output_data[output_index] = input_data[input_index];
             output_index++;
         }

--- a/tests/golden/op_eyelike_eye_like.c
+++ b/tests/golden/op_eyelike_eye_like.c
@@ -19,7 +19,11 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -33,26 +37,26 @@
 static inline void node0_eyelike(const float input0[restrict 3][3], float output[restrict 3][3]) {
     (void)input0;
     float *output_data = (float *)output;
-    size_t total = (size_t)1 * 3 * 3;
-    for (size_t index = 0; index < total; ++index) {
+    idx_t total = (idx_t)1 * 3 * 3;
+    for (idx_t index = 0; index < total; ++index) {
         output_data[index] = 0.0f;
     }
     int k = 0;
-    size_t rows = 3;
-    size_t cols = 3;
-    size_t row_start = k >= 0 ? 0 : (size_t)(-k);
-    size_t col_start = k >= 0 ? (size_t)k : 0;
+    idx_t rows = 3;
+    idx_t cols = 3;
+    idx_t row_start = k >= 0 ? 0 : (idx_t)(-k);
+    idx_t col_start = k >= 0 ? (idx_t)k : 0;
     if (row_start >= rows || col_start >= cols) {
         return;
     }
-    size_t max_rows = rows - row_start;
-    size_t max_cols = cols - col_start;
-    size_t diag_len = max_rows < max_cols ? max_rows : max_cols;
-    for (size_t batch = 0; batch < 1; ++batch) {
-        size_t base = batch * rows * cols;
-        for (size_t diag = 0; diag < diag_len; ++diag) {
-            size_t row = row_start + diag;
-            size_t col = col_start + diag;
+    idx_t max_rows = rows - row_start;
+    idx_t max_cols = cols - col_start;
+    idx_t diag_len = max_rows < max_cols ? max_rows : max_cols;
+    for (idx_t batch = 0; batch < 1; ++batch) {
+        idx_t base = batch * rows * cols;
+        for (idx_t diag = 0; diag < diag_len; ++diag) {
+            idx_t row = row_start + diag;
+            idx_t col = col_start + diag;
             output_data[base + row * cols + col] = ((float)1);
         }
     }

--- a/tests/golden/op_gather_gather.c
+++ b/tests/golden/op_gather_gather.c
@@ -19,8 +19,11 @@
  *   n/a
  */
 
-#include <stddef.h>
 #include <stdint.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -32,8 +35,8 @@
  *   axis: 0
  */
 static inline void node0_gather(const float data[restrict 3][2], const int64_t indices[restrict 2], float output[restrict 2][2]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 2; ++i1) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 2; ++i1) {
             int64_t gather_index = (int64_t)indices[i0];
             if (gather_index < 0) {
                 gather_index += 3;

--- a/tests/golden/op_gatherelements_gather_elements.c
+++ b/tests/golden/op_gatherelements_gather_elements.c
@@ -19,8 +19,11 @@
  *   n/a
  */
 
-#include <stddef.h>
 #include <stdint.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -32,8 +35,8 @@
  *   axis: 0
  */
 static inline void node0_gatherelements(const float data[restrict 2][3], const int64_t indices[restrict 2][3], float output[restrict 2][3]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
             int64_t gather_index = (int64_t)indices[i0][i1];
             if (gather_index < 0) {
                 gather_index += 2;

--- a/tests/golden/op_gemm_gemm.c
+++ b/tests/golden/op_gemm_gemm.c
@@ -19,7 +19,11 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -32,16 +36,16 @@
  *   beta: 1.0
  */
 static inline void node0_gemm(const float input_a[restrict 2][3], const float input_b[restrict 3][4], const float input_c[restrict 2][4], float output[restrict 2][4]) {
-    for (size_t i = 0; i < 2; ++i) {
-        for (size_t j = 0; j < 4; ++j) {
+    for (idx_t i = 0; i < 2; ++i) {
+        for (idx_t j = 0; j < 4; ++j) {
             float acc = 0.0f;
-            for (size_t k = 0; k < 3; ++k) {
+            for (idx_t k = 0; k < 3; ++k) {
                 const float a_val = input_a[i][k];
                 const float b_val = input_b[k][j];
                 acc += a_val * b_val;
             }
-            size_t c_i = i;
-            size_t c_j = j;
+            idx_t c_i = i;
+            idx_t c_j = j;
             const float bias = input_c[c_i][c_j];
             output[i][j] = acc * 1.0f + bias * 1.0f;
         }

--- a/tests/golden/op_gridsample_grid_sample.c
+++ b/tests/golden/op_gridsample_grid_sample.c
@@ -19,8 +19,12 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -57,10 +61,10 @@ static inline void node0_gridsample(const float x[restrict 1][1][2][2], const fl
     const int input_spatial[2] = { 2, 2 };
     const double border_min[2] = { -0.5, -0.5 };
     const double border_max[2] = { 1.5, 1.5 };
-    for (size_t i0 = 0; i0 < 1; ++i0) {
-        for (size_t i1 = 0; i1 < 1; ++i1) {
-            for (size_t i2 = 0; i2 < 2; ++i2) {
-                for (size_t i3 = 0; i3 < 2; ++i3) {
+    for (idx_t i0 = 0; i0 < 1; ++i0) {
+        for (idx_t i1 = 0; i1 < 1; ++i1) {
+            for (idx_t i2 = 0; i2 < 2; ++i2) {
+                for (idx_t i3 = 0; i3 < 2; ++i3) {
                     double coords[2];
                     const double grid_0 = (double)grid[i0][i2][i3][1];
                     coords[0] = ((grid_0 + 1.0) * (double)input_spatial[0] - 1.0) / 2.0;

--- a/tests/golden/op_groupnormalization_group_normalization.c
+++ b/tests/golden/op_groupnormalization_group_normalization.c
@@ -19,8 +19,12 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -33,33 +37,33 @@
  *   num_groups: 2
  */
 static inline void node0_groupnormalization(const float input0[restrict 1][4][2][2], const float scale[restrict 4], const float bias[restrict 4], float output[restrict 1][4][2][2]) {
-    for (size_t i0 = 0; i0 < 1; ++i0) {
-        for (size_t g = 0; g < 2; ++g) {
+    for (idx_t i0 = 0; i0 < 1; ++i0) {
+        for (idx_t g = 0; g < 2; ++g) {
             float sum = 0.0f;
-            for (size_t c_in_group = 0; c_in_group < 2; ++c_in_group) {
-                size_t c = g * 2 + c_in_group;
-                for (size_t i2 = 0; i2 < 2; ++i2) {
-                    for (size_t i3 = 0; i3 < 2; ++i3) {
+            for (idx_t c_in_group = 0; c_in_group < 2; ++c_in_group) {
+                idx_t c = g * 2 + c_in_group;
+                for (idx_t i2 = 0; i2 < 2; ++i2) {
+                    for (idx_t i3 = 0; i3 < 2; ++i3) {
                         sum += input0[i0][c][i2][i3];
                     }
                 }
             }
             float mean = sum / (2 * 4);
             float var = 0.0f;
-            for (size_t c_in_group = 0; c_in_group < 2; ++c_in_group) {
-                size_t c = g * 2 + c_in_group;
-                for (size_t i2 = 0; i2 < 2; ++i2) {
-                    for (size_t i3 = 0; i3 < 2; ++i3) {
+            for (idx_t c_in_group = 0; c_in_group < 2; ++c_in_group) {
+                idx_t c = g * 2 + c_in_group;
+                for (idx_t i2 = 0; i2 < 2; ++i2) {
+                    for (idx_t i3 = 0; i3 < 2; ++i3) {
                         float diff = input0[i0][c][i2][i3] - mean;
                         var += diff * diff;
                     }
                 }
             }
             float denom = sqrtf(var / (2 * 4) + 9.99999975e-06f);
-            for (size_t c_in_group = 0; c_in_group < 2; ++c_in_group) {
-                size_t c = g * 2 + c_in_group;
-                for (size_t i2 = 0; i2 < 2; ++i2) {
-                    for (size_t i3 = 0; i3 < 2; ++i3) {
+            for (idx_t c_in_group = 0; c_in_group < 2; ++c_in_group) {
+                idx_t c = g * 2 + c_in_group;
+                for (idx_t i2 = 0; i2 < 2; ++i2) {
+                    for (idx_t i3 = 0; i3 < 2; ++i3) {
                         output[i0][c][i2][i3] =
                         (input0[i0][c][i2][i3] - mean) / denom * scale[c] + bias[c];
                     }

--- a/tests/golden/op_identity_identity.c
+++ b/tests/golden/op_identity_identity.c
@@ -19,8 +19,12 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <string.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -31,8 +35,8 @@
  * Attrs: n/a
  */
 static inline void node0_identity(const float input0[restrict 2][3], float output[restrict 2][3]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = input0[i0][i1];
         }
     }

--- a/tests/golden/op_instancenormalization_instance_normalization.c
+++ b/tests/golden/op_instancenormalization_instance_normalization.c
@@ -19,8 +19,12 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -32,25 +36,25 @@
  *   epsilon: 9.999999747378752e-06
  */
 static inline void node0_instancenormalization(const float input0[restrict 1][3][2][2], const float scale[restrict 3], const float bias[restrict 3], float output[restrict 1][3][2][2]) {
-    for (size_t i0 = 0; i0 < 1; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
+    for (idx_t i0 = 0; i0 < 1; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
             float sum = 0.0f;
-            for (size_t i2 = 0; i2 < 2; ++i2) {
-                for (size_t i3 = 0; i3 < 2; ++i3) {
+            for (idx_t i2 = 0; i2 < 2; ++i2) {
+                for (idx_t i3 = 0; i3 < 2; ++i3) {
                     sum += input0[i0][i1][i2][i3];
                 }
             }
             float mean = sum / 4;
             float var = 0.0f;
-            for (size_t i2 = 0; i2 < 2; ++i2) {
-                for (size_t i3 = 0; i3 < 2; ++i3) {
+            for (idx_t i2 = 0; i2 < 2; ++i2) {
+                for (idx_t i3 = 0; i3 < 2; ++i3) {
                     float diff = input0[i0][i1][i2][i3] - mean;
                     var += diff * diff;
                 }
             }
             float denom = sqrtf(var / 4 + 9.99999975e-06f);
-            for (size_t i2 = 0; i2 < 2; ++i2) {
-                for (size_t i3 = 0; i3 < 2; ++i3) {
+            for (idx_t i2 = 0; i2 < 2; ++i2) {
+                for (idx_t i3 = 0; i3 < 2; ++i3) {
                     output[i0][i1][i2][i3] =
                     (input0[i0][i1][i2][i3] - mean) / denom * scale[i1] + bias[i1];
                 }

--- a/tests/golden/op_layernormalization_layer_normalization.c
+++ b/tests/golden/op_layernormalization_layer_normalization.c
@@ -19,8 +19,12 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -33,25 +37,25 @@
  *   epsilon: 9.999999747378752e-06
  */
 static inline void node0_layernormalization(const float input0[restrict 2][3][4], const float scale[restrict 3][4], const float bias[restrict 3][4], float output[restrict 2][3][4]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
         float sum = 0.0f;
-        for (size_t i1 = 0; i1 < 3; ++i1) {
-            for (size_t i2 = 0; i2 < 4; ++i2) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
+            for (idx_t i2 = 0; i2 < 4; ++i2) {
                 sum += input0[i0][i1][i2];
             }
         }
         float mean = sum / 12;
         float var = 0.0f;
-        for (size_t i1 = 0; i1 < 3; ++i1) {
-            for (size_t i2 = 0; i2 < 4; ++i2) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
+            for (idx_t i2 = 0; i2 < 4; ++i2) {
                 float diff = input0[i0][i1][i2] - mean;
                 var += diff * diff;
             }
         }
         var = var / 12;
         float inv_std = ((float)1) / sqrtf(var + 9.99999975e-06f);
-        for (size_t i1 = 0; i1 < 3; ++i1) {
-            for (size_t i2 = 0; i2 < 4; ++i2) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
+            for (idx_t i2 = 0; i2 < 4; ++i2) {
                 float value = (input0[i0][i1][i2] - mean) * inv_std;
                 value = value * scale[i1][i2] + bias[i1][i2];
                 output[i0][i1][i2] = value;

--- a/tests/golden/op_logsoftmax_logsoftmax.c
+++ b/tests/golden/op_logsoftmax_logsoftmax.c
@@ -19,8 +19,12 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -34,26 +38,26 @@
 static inline void node0_logsoftmax(const float input0[restrict 2][3], float output[restrict 2][3]) {
     const float *input_flat = (const float *)input0;
     float *output_flat = (float *)output;
-    const size_t outer = 2;
-    const size_t axis_size = 3;
-    const size_t inner = 1;
-    for (size_t outer_idx = 0; outer_idx < outer; ++outer_idx) {
-        for (size_t inner_idx = 0; inner_idx < inner; ++inner_idx) {
-            size_t base = (outer_idx * axis_size * inner) + inner_idx;
+    const idx_t outer = 2;
+    const idx_t axis_size = 3;
+    const idx_t inner = 1;
+    for (idx_t outer_idx = 0; outer_idx < outer; ++outer_idx) {
+        for (idx_t inner_idx = 0; inner_idx < inner; ++inner_idx) {
+            idx_t base = (outer_idx * axis_size * inner) + inner_idx;
             float max_value = input_flat[base];
-            for (size_t axis_idx = 1; axis_idx < axis_size; ++axis_idx) {
+            for (idx_t axis_idx = 1; axis_idx < axis_size; ++axis_idx) {
                 float value = input_flat[base + axis_idx * inner];
                 if (value > max_value) {
                     max_value = value;
                 }
             }
             float sum = 0;
-            for (size_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
+            for (idx_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
                 float value = expf(input_flat[base + axis_idx * inner] - max_value);
                 sum += value;
             }
             float logsum = logf(sum);
-            for (size_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
+            for (idx_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
                 float value = input_flat[base + axis_idx * inner] - max_value;
                 output_flat[base + axis_idx * inner] = value - logsum;
             }

--- a/tests/golden/op_lpnormalization_lp_normalization.c
+++ b/tests/golden/op_lpnormalization_lp_normalization.c
@@ -19,8 +19,12 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -35,18 +39,18 @@
 static inline void node0_lpnormalization(const float input0[restrict 2][3], float output[restrict 2][3]) {
     const float *input_flat = (const float *)input0;
     float *output_flat = (float *)output;
-    const size_t outer = 2;
-    const size_t axis_size = 3;
-    const size_t inner = 1;
-    for (size_t outer_idx = 0; outer_idx < outer; ++outer_idx) {
-        for (size_t inner_idx = 0; inner_idx < inner; ++inner_idx) {
-            size_t base = (outer_idx * axis_size * inner) + inner_idx;
+    const idx_t outer = 2;
+    const idx_t axis_size = 3;
+    const idx_t inner = 1;
+    for (idx_t outer_idx = 0; outer_idx < outer; ++outer_idx) {
+        for (idx_t inner_idx = 0; inner_idx < inner; ++inner_idx) {
+            idx_t base = (outer_idx * axis_size * inner) + inner_idx;
             float acc = 0.0f;
-            for (size_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
+            for (idx_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
                 float value = input_flat[base + axis_idx * inner];
                 acc += fabsf(value);
             }
-            for (size_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
+            for (idx_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
                 output_flat[base + axis_idx * inner] = input_flat[base + axis_idx * inner] / acc;
             }
         }

--- a/tests/golden/op_lrn_lrn.c
+++ b/tests/golden/op_lrn_lrn.c
@@ -19,8 +19,12 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -35,17 +39,17 @@
  *   size: 3
  */
 static inline void node0_lrn(const float input0[restrict 1][3][4][4], float output[restrict 1][3][4][4]) {
-    for (size_t i0 = 0; i0 < 1; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
-            for (size_t i2 = 0; i2 < 4; ++i2) {
-                for (size_t i3 = 0; i3 < 4; ++i3) {
-                    size_t channel_start = i1 > 1 ? i1 - 1 : 0;
-                    size_t channel_end = i1 + 1;
+    for (idx_t i0 = 0; i0 < 1; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
+            for (idx_t i2 = 0; i2 < 4; ++i2) {
+                for (idx_t i3 = 0; i3 < 4; ++i3) {
+                    idx_t channel_start = i1 > 1 ? i1 - 1 : 0;
+                    idx_t channel_end = i1 + 1;
                     if (channel_end >= 3) {
                         channel_end = 3 - 1;
                     }
                     float sum = 0.0f;
-                    for (size_t c = channel_start; c <= channel_end; ++c) {
+                    for (idx_t c = channel_start; c <= channel_end; ++c) {
                         float val = input0[i0][c][i2][i3];
                         sum += val * val;
                     }

--- a/tests/golden/op_lstm_lstm.c
+++ b/tests/golden/op_lstm_lstm.c
@@ -19,9 +19,13 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
 #include <float.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 static inline float ref_scalar_f32_sigmoid(float a) {
     return 1.0f / (1.0f + expf(-a));

--- a/tests/golden/op_matmul_matmul.c
+++ b/tests/golden/op_matmul_matmul.c
@@ -19,7 +19,11 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -30,10 +34,10 @@
  * Attrs: n/a
  */
 static inline void node0_matmul(const float input0[restrict 2][3], const float input1[restrict 3][4], float output[restrict 2][4]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 4; ++i1) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 4; ++i1) {
             float acc = 0.0f;
-            for (size_t k = 0; k < 3; ++k) {
+            for (idx_t k = 0; k < 3; ++k) {
                 acc += input0[i0][k] * input1[k][i1];
             }
             output[i0][i1] = acc;

--- a/tests/golden/op_maxpool_maxpool.c
+++ b/tests/golden/op_maxpool_maxpool.c
@@ -19,8 +19,12 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -35,17 +39,17 @@
  *   strides: [2, 2]
  */
 static inline void node0_maxpool(const float input0[restrict 1][1][4][4], float output[restrict 1][1][2][2]) {
-    for (size_t n = 0; n < 1; ++n) {
-        for (size_t c = 0; c < 1; ++c) {
-            for (size_t oh = 0; oh < 2; ++oh) {
-                for (size_t ow = 0; ow < 2; ++ow) {
+    for (idx_t n = 0; n < 1; ++n) {
+        for (idx_t c = 0; c < 1; ++c) {
+            for (idx_t oh = 0; oh < 2; ++oh) {
+                for (idx_t ow = 0; ow < 2; ++ow) {
                     float max_value = -INFINITY;
-                    for (size_t kh = 0; kh < 2; ++kh) {
+                    for (idx_t kh = 0; kh < 2; ++kh) {
                         const int ih = (int)(oh * 2 + kh * 1) - 0;
                         if (ih < 0 || ih >= 4) {
                             continue;
                         }
-                        for (size_t kw = 0; kw < 2; ++kw) {
+                        for (idx_t kw = 0; kw < 2; ++kw) {
                             const int iw = (int)(ow * 2 + kw * 1) - 0;
                             if (iw < 0 || iw >= 4) {
                                 continue;

--- a/tests/golden/op_meanvariancenormalization_mean_variance_normalization.c
+++ b/tests/golden/op_meanvariancenormalization_mean_variance_normalization.c
@@ -19,8 +19,12 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -32,20 +36,20 @@
  *   axes: [-1]
  */
 static inline void node0_meanvariancenormalization(const float input0[restrict 2][3][4], float output[restrict 2][3][4]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
             float sum = 0.0f;
-            for (size_t i2 = 0; i2 < 4; ++i2) {
+            for (idx_t i2 = 0; i2 < 4; ++i2) {
                 sum += input0[i0][i1][i2];
             }
             float mean = sum / 4;
             float var = 0.0f;
-            for (size_t i2 = 0; i2 < 4; ++i2) {
+            for (idx_t i2 = 0; i2 < 4; ++i2) {
                 float diff = input0[i0][i1][i2] - mean;
                 var += diff * diff;
             }
             float denom = sqrtf(var / 4 + 1e-09f);
-            for (size_t i2 = 0; i2 < 4; ++i2) {
+            for (idx_t i2 = 0; i2 < 4; ++i2) {
                 output[i0][i1][i2] = (input0[i0][i1][i2] - mean) / denom;
             }
         }

--- a/tests/golden/op_multiinputbinary_sum.c
+++ b/tests/golden/op_multiinputbinary_sum.c
@@ -19,9 +19,13 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
 #include <float.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 static inline float ref_scalar_f32_add(float a, float b) {
     return a + b;
@@ -36,8 +40,8 @@ static inline float ref_scalar_f32_add(float a, float b) {
  * Attrs: n/a
  */
 static inline void node0_sum(const float input0[restrict 2][3], const float input1[restrict 2][3], const float input2[restrict 2][3], float output[restrict 2][3]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = input0[i0][i1];
             output[i0][i1] = ref_scalar_f32_add(output[i0][i1], input1[i0][i1]);
             output[i0][i1] = ref_scalar_f32_add(output[i0][i1], input2[i0][i1]);

--- a/tests/golden/op_negativeloglikelihoodloss_negative_log_likelihood_loss.c
+++ b/tests/golden/op_negativeloglikelihoodloss_negative_log_likelihood_loss.c
@@ -19,8 +19,11 @@
  *   n/a
  */
 
-#include <stddef.h>
 #include <stdint.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -35,20 +38,20 @@ static inline void node0_negativeloglikelihoodloss(const float input0[restrict 2
     const float *input_flat = (const float *)input0;
     const int64_t *target_flat = (const int64_t *)target;
     float *output_flat = (float *)output;
-    const size_t n = 2;
-    const size_t c = 3;
-    const size_t d = 1;
+    const idx_t n = 2;
+    const idx_t c = 3;
+    const idx_t d = 1;
     float loss_sum = 0.0f;
     float weight_sum = 0.0f;
-    for (size_t n_idx = 0; n_idx < n; ++n_idx) {
-        for (size_t d_idx = 0; d_idx < d; ++d_idx) {
-            size_t target_index = n_idx * d + d_idx;
+    for (idx_t n_idx = 0; n_idx < n; ++n_idx) {
+        for (idx_t d_idx = 0; d_idx < d; ++d_idx) {
+            idx_t target_index = n_idx * d + d_idx;
             int64_t target_value = target_flat[target_index];
             if ((int64_t)target_value == -1) {
                 continue;
             }
-            size_t class_index = (size_t)target_value;
-            size_t input_index = (n_idx * c + class_index) * d + d_idx;
+            idx_t class_index = (idx_t)target_value;
+            idx_t input_index = (n_idx * c + class_index) * d + d_idx;
             float value = -input_flat[input_index];
             float sample_weight = 1.0f;
             loss_sum += value;

--- a/tests/golden/op_pad_pad.c
+++ b/tests/golden/op_pad_pad.c
@@ -19,8 +19,12 @@
  *   n/a
  */
 
-#include <stddef.h>
 #include <stdint.h>
+#include <stddef.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Weight 1:
@@ -55,13 +59,13 @@ static const float weight2_value[1] = {
  */
 static inline void node0_pad(const float input[restrict 2][3], float output[restrict 2][5]) {
     const float *input_flat = (const float *)input;
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 5; ++i1) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 5; ++i1) {
             output[i0][i1] = 0.0f;
         }
     }
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 5; ++i1) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 5; ++i1) {
             ptrdiff_t pad_index = 0;
             int pad_in_bounds = 1;
             ptrdiff_t pad_idx0 = (ptrdiff_t)i0 - (ptrdiff_t)(0);

--- a/tests/golden/op_range_range.c
+++ b/tests/golden/op_range_range.c
@@ -19,8 +19,11 @@
  *   n/a
  */
 
-#include <stddef.h>
 #include <stdint.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Weight 1:
@@ -67,7 +70,7 @@ static inline void node0_range(const int64_t start[restrict 1], const int64_t li
     (void)limit;
     const int64_t start_value = start[0];
     const int64_t delta_value = delta[0];
-    for (size_t idx = 0; idx < 4; ++idx) {
+    for (idx_t idx = 0; idx < 4; ++idx) {
         output[idx] = start_value + ((int64_t)idx * delta_value);
     }
 }

--- a/tests/golden/op_reduce_reduce_mean.c
+++ b/tests/golden/op_reduce_reduce_mean.c
@@ -19,8 +19,11 @@
  *   n/a
  */
 
-#include <stddef.h>
 #include <stdint.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Weight 1:
@@ -43,11 +46,11 @@ static const int64_t weight1_axes[1] = {
  *   keepdims: 1
  */
 static inline void node0_reducemean(const float input0[restrict 2][3][4], float output[restrict 2][1][4]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 1; ++i1) {
-            for (size_t i2 = 0; i2 < 4; ++i2) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 1; ++i1) {
+            for (idx_t i2 = 0; i2 < 4; ++i2) {
                 float acc = 0.0f;
-                for (size_t r0 = 0; r0 < 3; ++r0) {
+                for (idx_t r0 = 0; r0 < 3; ++r0) {
                     acc += input0[i0][r0][i2];
                 }
                 output[i0][i1][i2] = acc / 3.0f;

--- a/tests/golden/op_reshape_reshape.c
+++ b/tests/golden/op_reshape_reshape.c
@@ -19,9 +19,12 @@
  *   n/a
  */
 
-#include <stddef.h>
 #include <stdint.h>
 #include <string.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Weight 1:

--- a/tests/golden/op_resize_resize.c
+++ b/tests/golden/op_resize_resize.c
@@ -19,9 +19,12 @@
  *   n/a
  */
 
-#include <stddef.h>
 #include <stdint.h>
 #include <math.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Weight 1:
@@ -51,17 +54,17 @@ static inline void node0_resize(const float input0[restrict 1][1][2][2], const i
     double scales[4];
     const double roi[8] = {
         0.0,        0.0,        0.0,        0.0,        1.0,        1.0,        1.0,        1.0    };
-    for (size_t r = 0; r < 4; ++r) {
+    for (idx_t r = 0; r < 4; ++r) {
         scales[r] = 1.0;
     }
     scales[0] = (double)sizes_input[0] / (double)input_shape[0];
     scales[1] = (double)sizes_input[1] / (double)input_shape[1];
     scales[2] = (double)sizes_input[2] / (double)input_shape[2];
     scales[3] = (double)sizes_input[3] / (double)input_shape[3];
-    for (size_t i0 = 0; i0 < 1; ++i0) {
-        for (size_t i1 = 0; i1 < 1; ++i1) {
-            for (size_t i2 = 0; i2 < 4; ++i2) {
-                for (size_t i3 = 0; i3 < 4; ++i3) {
+    for (idx_t i0 = 0; i0 < 1; ++i0) {
+        for (idx_t i1 = 0; i1 < 1; ++i1) {
+            for (idx_t i2 = 0; i2 < 4; ++i2) {
+                for (idx_t i3 = 0; i3 < 4; ++i3) {
                     int use_extrapolation = 0;
                     double x_orig0;
                     x_orig0 = (double)i0 / scales[0];

--- a/tests/golden/op_rmsnormalization_rms_normalization.c
+++ b/tests/golden/op_rmsnormalization_rms_normalization.c
@@ -19,8 +19,12 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -33,16 +37,16 @@
  *   epsilon: 9.999999747378752e-06
  */
 static inline void node0_rmsnormalization(const float input0[restrict 2][3][4], const float scale[restrict 4], float output[restrict 2][3][4]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
             float sum = 0.0f;
-            for (size_t i2 = 0; i2 < 4; ++i2) {
+            for (idx_t i2 = 0; i2 < 4; ++i2) {
                 float value = input0[i0][i1][i2];
                 sum += value * value;
             }
             float mean_square = sum / 4;
             float denom = sqrtf(mean_square + 9.99999975e-06f);
-            for (size_t i2 = 0; i2 < 4; ++i2) {
+            for (idx_t i2 = 0; i2 < 4; ++i2) {
                 float value = input0[i0][i1][i2] / denom;
                 value = value * scale[i2];
                 output[i0][i1][i2] = value;

--- a/tests/golden/op_shape_shape.c
+++ b/tests/golden/op_shape_shape.c
@@ -19,8 +19,11 @@
  *   n/a
  */
 
-#include <stddef.h>
 #include <stdint.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:

--- a/tests/golden/op_size_size.c
+++ b/tests/golden/op_size_size.c
@@ -19,8 +19,11 @@
  *   n/a
  */
 
-#include <stddef.h>
 #include <stdint.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:

--- a/tests/golden/op_slice_slice.c
+++ b/tests/golden/op_slice_slice.c
@@ -19,8 +19,11 @@
  *   n/a
  */
 
-#include <stddef.h>
 #include <stdint.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Weight 1:
@@ -75,9 +78,9 @@ static const int64_t weight4_steps[2] = {
  * Attrs: n/a
  */
 static inline void node0_slice(const float input0[restrict 2][3][4], float output[restrict 2][3][1]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
-            for (size_t i2 = 0; i2 < 1; ++i2) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
+            for (idx_t i2 = 0; i2 < 1; ++i2) {
                 output[i0][i1][i2] = input0[i0][i1][1 + 2 * i2];
             }
         }

--- a/tests/golden/op_softmax_softmax.c
+++ b/tests/golden/op_softmax_softmax.c
@@ -19,8 +19,12 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -34,26 +38,26 @@
 static inline void node0_softmax(const float input0[restrict 2][3], float output[restrict 2][3]) {
     const float *input_flat = (const float *)input0;
     float *output_flat = (float *)output;
-    const size_t outer = 2;
-    const size_t axis_size = 3;
-    const size_t inner = 1;
-    for (size_t outer_idx = 0; outer_idx < outer; ++outer_idx) {
-        for (size_t inner_idx = 0; inner_idx < inner; ++inner_idx) {
-            size_t base = (outer_idx * axis_size * inner) + inner_idx;
+    const idx_t outer = 2;
+    const idx_t axis_size = 3;
+    const idx_t inner = 1;
+    for (idx_t outer_idx = 0; outer_idx < outer; ++outer_idx) {
+        for (idx_t inner_idx = 0; inner_idx < inner; ++inner_idx) {
+            idx_t base = (outer_idx * axis_size * inner) + inner_idx;
             float max_value = input_flat[base];
-            for (size_t axis_idx = 1; axis_idx < axis_size; ++axis_idx) {
+            for (idx_t axis_idx = 1; axis_idx < axis_size; ++axis_idx) {
                 float value = input_flat[base + axis_idx * inner];
                 if (value > max_value) {
                     max_value = value;
                 }
             }
             float sum = 0;
-            for (size_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
+            for (idx_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
                 float value = expf(input_flat[base + axis_idx * inner] - max_value);
                 output_flat[base + axis_idx * inner] = value;
                 sum += value;
             }
-            for (size_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
+            for (idx_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
                 output_flat[base + axis_idx * inner] /= sum;
             }
         }

--- a/tests/golden/op_softmaxcrossentropyloss_softmax_cross_entropy_loss.c
+++ b/tests/golden/op_softmaxcrossentropyloss_softmax_cross_entropy_loss.c
@@ -19,9 +19,12 @@
  *   n/a
  */
 
-#include <stddef.h>
 #include <stdint.h>
 #include <math.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -37,32 +40,32 @@ static inline void node0_softmaxcrossentropyloss(const float input0[restrict 2][
     const int64_t *target_flat = (const int64_t *)target;
     float *output_flat = (float *)output;
     float *log_prob_flat = (float *)log_prob;
-    const size_t n = 2;
-    const size_t c = 3;
-    const size_t d = 1;
+    const idx_t n = 2;
+    const idx_t c = 3;
+    const idx_t d = 1;
     float loss_sum = 0.0f;
     float weight_sum = 0.0f;
-    for (size_t n_idx = 0; n_idx < n; ++n_idx) {
-        for (size_t d_idx = 0; d_idx < d; ++d_idx) {
-            size_t target_index = n_idx * d + d_idx;
+    for (idx_t n_idx = 0; n_idx < n; ++n_idx) {
+        for (idx_t d_idx = 0; d_idx < d; ++d_idx) {
+            idx_t target_index = n_idx * d + d_idx;
             int64_t target_value = target_flat[target_index];
-            size_t class_index = (size_t)target_value;
-            size_t base = (n_idx * c * d) + d_idx;
+            idx_t class_index = (idx_t)target_value;
+            idx_t base = (n_idx * c * d) + d_idx;
             float max_value = input_flat[base];
-            for (size_t c_idx = 1; c_idx < c; ++c_idx) {
+            for (idx_t c_idx = 1; c_idx < c; ++c_idx) {
                 float value = input_flat[base + c_idx * d];
                 if (value > max_value) {
                     max_value = value;
                 }
             }
             float sum = 0.0f;
-            for (size_t c_idx = 0; c_idx < c; ++c_idx) {
+            for (idx_t c_idx = 0; c_idx < c; ++c_idx) {
                 float value = input_flat[base + c_idx * d] - max_value;
                 sum += expf(value);
             }
             float logsum = logf(sum);
             float loss_value = 0.0f;
-            for (size_t c_idx = 0; c_idx < c; ++c_idx) {
+            for (idx_t c_idx = 0; c_idx < c; ++c_idx) {
                 float log_prob_value = input_flat[base + c_idx * d] - max_value - logsum;
                 log_prob_flat[base + c_idx * d] = log_prob_value;
                 if (c_idx == class_index) {

--- a/tests/golden/op_spacetodepth_space_to_depth.c
+++ b/tests/golden/op_spacetodepth_space_to_depth.c
@@ -19,7 +19,11 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -33,18 +37,18 @@
 static inline void node0_spacetodepth(const float input0[restrict 1][1][4][4], float output[restrict 1][4][2][2]) {
     const float *input_data = (const float *)input0;
     float *output_data = (float *)output;
-    size_t output_index = 0;
-    for (size_t n = 0; n < 1; ++n) {
-        for (size_t c_out = 0; c_out < 4; ++c_out) {
-            size_t c_in = c_out % 1;
-            size_t temp = c_out / 1;
-            size_t offset_h = temp / 2;
-            size_t offset_w = temp % 2;
-            for (size_t h_out = 0; h_out < 2; ++h_out) {
-                size_t h_in = h_out * 2 + offset_h;
-                for (size_t w_out = 0; w_out < 2; ++w_out) {
-                    size_t w_in = w_out * 2 + offset_w;
-                    size_t input_index = ((n * 1 + c_in) * 4 + h_in) * 4 + w_in;
+    idx_t output_index = 0;
+    for (idx_t n = 0; n < 1; ++n) {
+        for (idx_t c_out = 0; c_out < 4; ++c_out) {
+            idx_t c_in = c_out % 1;
+            idx_t temp = c_out / 1;
+            idx_t offset_h = temp / 2;
+            idx_t offset_w = temp % 2;
+            for (idx_t h_out = 0; h_out < 2; ++h_out) {
+                idx_t h_in = h_out * 2 + offset_h;
+                for (idx_t w_out = 0; w_out < 2; ++w_out) {
+                    idx_t w_in = w_out * 2 + offset_w;
+                    idx_t input_index = ((n * 1 + c_in) * 4 + h_in) * 4 + w_in;
                     output_data[output_index] = input_data[input_index];
                     output_index++;
                 }

--- a/tests/golden/op_split_split.c
+++ b/tests/golden/op_split_split.c
@@ -19,9 +19,12 @@
  *   n/a
  */
 
-#include <stddef.h>
 #include <stdint.h>
 #include <string.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Weight 1:
@@ -46,12 +49,12 @@ static const int64_t weight1_split[3] = {
 static inline void node0_split(const float input0[restrict 2][6], float output_0[restrict 2][2], float output_1[restrict 2][2], float output_2[restrict 2][2]) {
     const float *input_data = (const float *)input0;
     float *output_ptrs[] = { (float *)output_0, (float *)output_1, (float *)output_2 };
-    const size_t axis_sizes[] = { 2, 2, 2 };
-    for (size_t outer_idx = 0; outer_idx < 2; ++outer_idx) {
-        size_t input_base = outer_idx * 6 * 1;
-        size_t axis_offset = 0;
-        for (size_t output_idx = 0; output_idx < 3; ++output_idx) {
-            size_t copy_elems = axis_sizes[output_idx] * 1;
+    const idx_t axis_sizes[] = { 2, 2, 2 };
+    for (idx_t outer_idx = 0; outer_idx < 2; ++outer_idx) {
+        idx_t input_base = outer_idx * 6 * 1;
+        idx_t axis_offset = 0;
+        for (idx_t output_idx = 0; output_idx < 3; ++output_idx) {
+            idx_t copy_elems = axis_sizes[output_idx] * 1;
             memcpy(
             output_ptrs[output_idx] + outer_idx * copy_elems,
             input_data + input_base + axis_offset,

--- a/tests/golden/op_tile_tile.c
+++ b/tests/golden/op_tile_tile.c
@@ -19,8 +19,11 @@
  *   n/a
  */
 
-#include <stddef.h>
 #include <stdint.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Weight 1:
@@ -44,10 +47,10 @@ static const int64_t weight1_repeats[2] = {
 static inline void node0_tile(const float input0[restrict 2][3], float output[restrict 4][3]) {
     const float *input_data = (const float *)input0;
     float *output_data = (float *)output;
-    size_t output_index = 0;
-    for (size_t i0 = 0; i0 < 4; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
-            size_t input_index = (i0 % 2) * 3 + (i1 % 3) * 1;
+    idx_t output_index = 0;
+    for (idx_t i0 = 0; i0 < 4; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
+            idx_t input_index = (i0 % 2) * 3 + (i1 % 3) * 1;
             output_data[output_index] = input_data[input_index];
             output_index++;
         }

--- a/tests/golden/op_transpose_transpose.c
+++ b/tests/golden/op_transpose_transpose.c
@@ -19,7 +19,11 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -31,9 +35,9 @@
  *   perm: [2, 0, 1]
  */
 static inline void node0_transpose(const float input0[restrict 2][3][4], float output[restrict 4][2][3]) {
-    for (size_t i0 = 0; i0 < 4; ++i0) {
-        for (size_t i1 = 0; i1 < 2; ++i1) {
-            for (size_t i2 = 0; i2 < 3; ++i2) {
+    for (idx_t i0 = 0; i0 < 4; ++i0) {
+        for (idx_t i1 = 0; i1 < 2; ++i1) {
+            for (idx_t i2 = 0; i2 < 3; ++i2) {
                 output[i0][i1][i2] = input0[i1][i2][i0];
             }
         }

--- a/tests/golden/op_unary_tanh.c
+++ b/tests/golden/op_unary_tanh.c
@@ -19,9 +19,13 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
 #include <float.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 static inline float ref_scalar_f32_tanh(float a) {
     return tanhf(a);
@@ -36,8 +40,8 @@ static inline float ref_scalar_f32_tanh(float a) {
  * Attrs: n/a
  */
 static inline void node0_tanh(const float input0[restrict 2][3], float output[restrict 2][3]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_tanh(input0[i0][i1]);
         }
     }

--- a/tests/golden/op_where_where.c
+++ b/tests/golden/op_where_where.c
@@ -19,8 +19,12 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <stdbool.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 /*
  * Node 0:
@@ -31,8 +35,8 @@
  * Attrs: n/a
  */
 static inline void node0_where(const bool condition[restrict 2][3], const float input_x[restrict 2][3], const float input_y[restrict 2][3], float output[restrict 2][3]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = condition[i0][i1] ? input_x[i0][i1] : input_y[i0][i1];
         }
     }

--- a/tests/golden/relu_model.c
+++ b/tests/golden/relu_model.c
@@ -19,9 +19,13 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
 #include <float.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 static inline float ref_scalar_f32_relu(float a) {
     return a > 0.0f ? a : 0.0f;
@@ -36,8 +40,8 @@ static inline float ref_scalar_f32_relu(float a) {
  * Attrs: n/a
  */
 static inline void node0_relu(const float input0[restrict 2][3], float output[restrict 2][3]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_relu(input0[i0][i1]);
         }
     }

--- a/tests/golden/tanh_model.c
+++ b/tests/golden/tanh_model.c
@@ -19,9 +19,13 @@
  *   n/a
  */
 
-#include <stddef.h>
+#include <stdint.h>
 #include <math.h>
 #include <float.h>
+
+#ifndef idx_t
+#define idx_t int32_t
+#endif
 
 static inline float ref_scalar_f32_tanh(float a) {
     return tanhf(a);
@@ -36,8 +40,8 @@ static inline float ref_scalar_f32_tanh(float a) {
  * Attrs: n/a
  */
 static inline void node0_tanh(const float input0[restrict 2][3], float output[restrict 2][3]) {
-    for (size_t i0 = 0; i0 < 2; ++i0) {
-        for (size_t i1 = 0; i1 < 3; ++i1) {
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
             output[i0][i1] = ref_scalar_f32_tanh(input0[i0][i1]);
         }
     }


### PR DESCRIPTION
### Motivation

- Use a dedicated index type `idx_t` instead of `size_t` in generated C code so the codebase can control index width and make it consistent across targets.
- Make `idx_t` configurable at generation time by emitting a `#define idx_t int32_t` in generated headers to default to 32-bit indices.
- Ensure correct includes are emitted (keep `<stddef.h>` when `ptrdiff_t` is used, e.g., in `Pad` code) so generated C compiles cleanly.

### Description

- Replaced instances of `size_t` in Jinja templates with `idx_t` and updated index/stride declarations and loop counters in the templates under `templates/` so generated loops use `idx_t`.
- Updated `CEmitter._collect_includes` to prefer `#include <stdint.h>` by default and to add `#include <stddef.h>` when `PadOp` (or other code that uses `ptrdiff_t`) is present.
- Added `CEmitter._emit_index_type_define()` and inject the `#ifndef idx_t / #define idx_t int32_t / #endif` block into generated outputs so `idx_t` defaults to `int32_t` in produced C files.
- Updated the testbench template to use `idx_t` for its loops and updated golden C fixtures in `tests/golden/` to reflect the new index type and includes.

### Testing

- Ran the full test suite with updated references using `UPDATE_REFS=1 pytest -n auto -q` and the suite completed successfully with `236 passed, 2 skipped, 2 warnings` in `59.13s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69699daf4838832596eaaf021207c02c)