### PR TITLE
templates: simplify idx_t indices

### DIFF
--- a/templates/average_pool_op.c.j2
+++ b/templates/average_pool_op.c.j2
@@ -6,7 +6,7 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
                     {{ c_type }} acc = {{ zero_literal }};
                     idx_t count = 0;
                     for (idx_t kh = 0; kh < {{ kernel_h }}; ++kh) {
-                        const int ih = (int)(oh * {{ stride_h }} + kh) - {{ pad_top }};
+                        const idx_t ih = oh * {{ stride_h }} + kh - {{ pad_top }};
                         if (ih < 0 || ih >= {{ in_h }}) {
                             if ({{ count_include_pad }}) {
                                 count += {{ kernel_w }};
@@ -14,7 +14,7 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
                             continue;
                         }
                         for (idx_t kw = 0; kw < {{ kernel_w }}; ++kw) {
-                            const int iw = (int)(ow * {{ stride_w }} + kw) - {{ pad_left }};
+                            const idx_t iw = ow * {{ stride_w }} + kw - {{ pad_left }};
                             if (iw < 0 || iw >= {{ in_w }}) {
                                 if ({{ count_include_pad }}) {
                                     count += 1;

--- a/templates/conv_op.c.j2
+++ b/templates/conv_op.c.j2
@@ -13,7 +13,7 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
                         for (idx_t {{ kernel_indices[dim] }} = 0; {{ kernel_indices[dim] }} < {{ kernel_shape[dim] }}; ++{{ kernel_indices[dim] }}) {
                         {% endfor %}
                             {% for dim in range(spatial_rank) %}
-                            const int {{ in_indices[dim] }} = (int)({{ out_indices[dim] }} * {{ strides[dim] }} + {{ kernel_indices[dim] }} * {{ dilations[dim] }}) - {{ pads_begin[dim] }};
+                            const idx_t {{ in_indices[dim] }} = {{ out_indices[dim] }} * {{ strides[dim] }} + {{ kernel_indices[dim] }} * {{ dilations[dim] }} - {{ pads_begin[dim] }};
                             {% endfor %}
                             if ({% for dim in range(spatial_rank) %}{{ in_indices[dim] }} < 0 || {{ in_indices[dim] }} >= {{ in_spatial[dim] }}{% if not loop.last %} || {% endif %}{% endfor %}) {
                                 continue;

--- a/templates/eye_like_op.c.j2
+++ b/templates/eye_like_op.c.j2
@@ -5,11 +5,11 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
     for (idx_t index = 0; index < total; ++index) {
         output_data[index] = {{ zero_literal }};
     }
-    int k = {{ k }};
+    idx_t k = {{ k }};
     idx_t rows = {{ rows }};
     idx_t cols = {{ cols }};
-    idx_t row_start = k >= 0 ? 0 : (idx_t)(-k);
-    idx_t col_start = k >= 0 ? (idx_t)k : 0;
+    idx_t row_start = k >= 0 ? 0 : -k;
+    idx_t col_start = k >= 0 ? k : 0;
     if (row_start >= rows || col_start >= cols) {
         return;
     }

--- a/templates/maxpool_op.c.j2
+++ b/templates/maxpool_op.c.j2
@@ -8,7 +8,7 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
                 {{ indices_c_type }} max_index = 0;
 {% endif %}
                 for (idx_t kx = 0; kx < {{ kernel_shape[0] }}; ++kx) {
-                    const int ix = (int)(ox * {{ strides[0] }} + kx * {{ dilations[0] }}) - {{ pads[0] }};
+                    const idx_t ix = ox * {{ strides[0] }} + kx * {{ dilations[0] }} - {{ pads[0] }};
                     if (ix < 0 || ix >= {{ in_spatial[0] }}) {
                         continue;
                     }
@@ -37,12 +37,12 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
                     {{ indices_c_type }} max_index = 0;
 {% endif %}
                     for (idx_t kh = 0; kh < {{ kernel_shape[0] }}; ++kh) {
-                        const int ih = (int)(oh * {{ strides[0] }} + kh * {{ dilations[0] }}) - {{ pads[0] }};
+                        const idx_t ih = oh * {{ strides[0] }} + kh * {{ dilations[0] }} - {{ pads[0] }};
                         if (ih < 0 || ih >= {{ in_spatial[0] }}) {
                             continue;
                         }
                         for (idx_t kw = 0; kw < {{ kernel_shape[1] }}; ++kw) {
-                            const int iw = (int)(ow * {{ strides[1] }} + kw * {{ dilations[1] }}) - {{ pads[1] }};
+                            const idx_t iw = ow * {{ strides[1] }} + kw * {{ dilations[1] }} - {{ pads[1] }};
                             if (iw < 0 || iw >= {{ in_spatial[1] }}) {
                                 continue;
                             }
@@ -74,17 +74,17 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
                         {{ indices_c_type }} max_index = 0;
 {% endif %}
                         for (idx_t kd = 0; kd < {{ kernel_shape[0] }}; ++kd) {
-                            const int id = (int)(od * {{ strides[0] }} + kd * {{ dilations[0] }}) - {{ pads[0] }};
+                            const idx_t id = od * {{ strides[0] }} + kd * {{ dilations[0] }} - {{ pads[0] }};
                             if (id < 0 || id >= {{ in_spatial[0] }}) {
                                 continue;
                             }
                             for (idx_t kh = 0; kh < {{ kernel_shape[1] }}; ++kh) {
-                                const int ih = (int)(oh * {{ strides[1] }} + kh * {{ dilations[1] }}) - {{ pads[1] }};
+                                const idx_t ih = oh * {{ strides[1] }} + kh * {{ dilations[1] }} - {{ pads[1] }};
                                 if (ih < 0 || ih >= {{ in_spatial[1] }}) {
                                     continue;
                                 }
                                 for (idx_t kw = 0; kw < {{ kernel_shape[2] }}; ++kw) {
-                                    const int iw = (int)(ow * {{ strides[2] }} + kw * {{ dilations[2] }}) - {{ pads[2] }};
+                                    const idx_t iw = ow * {{ strides[2] }} + kw * {{ dilations[2] }} - {{ pads[2] }};
                                     if (iw < 0 || iw >= {{ in_spatial[2] }}) {
                                         continue;
                                     }

--- a/tests/golden/op_averagepool_average_pool.c
+++ b/tests/golden/op_averagepool_average_pool.c
@@ -43,7 +43,7 @@ static inline void node0_averagepool(const float input0[restrict 1][1][4][4], fl
                     float acc = 0.0f;
                     idx_t count = 0;
                     for (idx_t kh = 0; kh < 2; ++kh) {
-                        const int ih = (int)(oh * 2 + kh) - 0;
+                        const idx_t ih = oh * 2 + kh - 0;
                         if (ih < 0 || ih >= 4) {
                             if (0) {
                                 count += 2;
@@ -51,7 +51,7 @@ static inline void node0_averagepool(const float input0[restrict 1][1][4][4], fl
                             continue;
                         }
                         for (idx_t kw = 0; kw < 2; ++kw) {
-                            const int iw = (int)(ow * 2 + kw) - 0;
+                            const idx_t iw = ow * 2 + kw - 0;
                             if (iw < 0 || iw >= 4) {
                                 if (0) {
                                     count += 1;

--- a/tests/golden/op_conv_conv.c
+++ b/tests/golden/op_conv_conv.c
@@ -81,8 +81,8 @@ static inline void node0_conv(const float input0[restrict 1][1][4][4], const flo
                             const idx_t ic_global = g * 1 + ic;
                             for (idx_t kd0 = 0; kd0 < 3; ++kd0) {
                                 for (idx_t kd1 = 0; kd1 < 3; ++kd1) {
-                                    const int id0 = (int)(od0 * 1 + kd0 * 1) - 1;
-                                    const int id1 = (int)(od1 * 1 + kd1 * 1) - 1;
+                                    const idx_t id0 = od0 * 1 + kd0 * 1 - 1;
+                                    const idx_t id1 = od1 * 1 + kd1 * 1 - 1;
                                     if (id0 < 0 || id0 >= 4 || id1 < 0 || id1 >= 4) {
                                         continue;
                                     }

--- a/tests/golden/op_eyelike_eye_like.c
+++ b/tests/golden/op_eyelike_eye_like.c
@@ -41,11 +41,11 @@ static inline void node0_eyelike(const float input0[restrict 3][3], float output
     for (idx_t index = 0; index < total; ++index) {
         output_data[index] = 0.0f;
     }
-    int k = 0;
+    idx_t k = 0;
     idx_t rows = 3;
     idx_t cols = 3;
-    idx_t row_start = k >= 0 ? 0 : (idx_t)(-k);
-    idx_t col_start = k >= 0 ? (idx_t)k : 0;
+    idx_t row_start = k >= 0 ? 0 : -k;
+    idx_t col_start = k >= 0 ? k : 0;
     if (row_start >= rows || col_start >= cols) {
         return;
     }

--- a/tests/golden/op_maxpool_maxpool.c
+++ b/tests/golden/op_maxpool_maxpool.c
@@ -45,12 +45,12 @@ static inline void node0_maxpool(const float input0[restrict 1][1][4][4], float 
                 for (idx_t ow = 0; ow < 2; ++ow) {
                     float max_value = -INFINITY;
                     for (idx_t kh = 0; kh < 2; ++kh) {
-                        const int ih = (int)(oh * 2 + kh * 1) - 0;
+                        const idx_t ih = oh * 2 + kh * 1 - 0;
                         if (ih < 0 || ih >= 4) {
                             continue;
                         }
                         for (idx_t kw = 0; kw < 2; ++kw) {
-                            const int iw = (int)(ow * 2 + kw * 1) - 0;
+                            const idx_t iw = ow * 2 + kw * 1 - 0;
                             if (iw < 0 || iw >= 4) {
                                 continue;
                             }


### PR DESCRIPTION
### Motivation
- Remove redundant `(idx_t)` casts from index calculations to rely on the project `idx_t` typedef and avoid unnecessary casts and potential type/width noise in generated C.
- Ensure other templates use `idx_t` for temporary index variables where appropriate to keep index types consistent across generated kernels.

### Description
- Dropped redundant casts and simplified index assignments in `templates/conv_op.c.j2` and `templates/maxpool_op.c.j2` by computing expressions directly into `idx_t` temporaries. 
- Converted temporary index variables from `int` to `idx_t` in `templates/average_pool_op.c.j2` and `templates/eye_like_op.c.j2`, and simplified related arithmetic (removed explicit negative-`k` casts).
- Updated golden outputs for Conv, MaxPool, AveragePool and EyeLike (`tests/golden/op_conv_conv.c`, `tests/golden/op_maxpool_maxpool.c`, `tests/golden/op_averagepool_average_pool.c`, `tests/golden/op_eyelike_eye_like.c`) to reflect the template changes.

### Testing
- Ran `UPDATE_REFS=1 pytest -n auto -q`, which completed successfully with `236 passed, 2 skipped, 2 warnings` (about 55.3s).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6969a45c9e908325a4a720c6ab33ef98)