### PR TITLE
templates: use idx_t for slice and other index temporaries

### DIFF
--- a/templates/average_pool_op.c.j2
+++ b/templates/average_pool_op.c.j2
@@ -6,7 +6,7 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
                     {{ c_type }} acc = {{ zero_literal }};
                     idx_t count = 0;
                     for (idx_t kh = 0; kh < {{ kernel_h }}; ++kh) {
-                        const int ih = (int)(oh * {{ stride_h }} + kh) - {{ pad_top }};
+                        const idx_t ih = oh * {{ stride_h }} + kh - {{ pad_top }};
                         if (ih < 0 || ih >= {{ in_h }}) {
                             if ({{ count_include_pad }}) {
                                 count += {{ kernel_w }};
@@ -14,7 +14,7 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
                             continue;
                         }
                         for (idx_t kw = 0; kw < {{ kernel_w }}; ++kw) {
-                            const int iw = (int)(ow * {{ stride_w }} + kw) - {{ pad_left }};
+                            const idx_t iw = ow * {{ stride_w }} + kw - {{ pad_left }};
                             if (iw < 0 || iw >= {{ in_w }}) {
                                 if ({{ count_include_pad }}) {
                                     count += 1;

--- a/templates/conv_op.c.j2
+++ b/templates/conv_op.c.j2
@@ -13,7 +13,7 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
                         for (idx_t {{ kernel_indices[dim] }} = 0; {{ kernel_indices[dim] }} < {{ kernel_shape[dim] }}; ++{{ kernel_indices[dim] }}) {
                         {% endfor %}
                             {% for dim in range(spatial_rank) %}
-                            const int {{ in_indices[dim] }} = (int)({{ out_indices[dim] }} * {{ strides[dim] }} + {{ kernel_indices[dim] }} * {{ dilations[dim] }}) - {{ pads_begin[dim] }};
+                            const idx_t {{ in_indices[dim] }} = {{ out_indices[dim] }} * {{ strides[dim] }} + {{ kernel_indices[dim] }} * {{ dilations[dim] }} - {{ pads_begin[dim] }};
                             {% endfor %}
                             if ({% for dim in range(spatial_rank) %}{{ in_indices[dim] }} < 0 || {{ in_indices[dim] }} >= {{ in_spatial[dim] }}{% if not loop.last %} || {% endif %}{% endfor %}) {
                                 continue;

--- a/templates/eye_like_op.c.j2
+++ b/templates/eye_like_op.c.j2
@@ -5,11 +5,11 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
     for (idx_t index = 0; index < total; ++index) {
         output_data[index] = {{ zero_literal }};
     }
-    int k = {{ k }};
+    idx_t k = {{ k }};
     idx_t rows = {{ rows }};
     idx_t cols = {{ cols }};
-    idx_t row_start = k >= 0 ? 0 : (idx_t)(-k);
-    idx_t col_start = k >= 0 ? (idx_t)k : 0;
+    idx_t row_start = k >= 0 ? 0 : -k;
+    idx_t col_start = k >= 0 ? k : 0;
     if (row_start >= rows || col_start >= cols) {
         return;
     }

--- a/templates/gather_elements_op.c.j2
+++ b/templates/gather_elements_op.c.j2
@@ -2,7 +2,7 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% for dim in output_shape %}
 for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
-int64_t gather_index = (int64_t){{ indices }}{% for var in loop_vars %}[{{ var }}]{% endfor %};
+idx_t gather_index = {{ indices }}{% for var in loop_vars %}[{{ var }}]{% endfor %};
 if (gather_index < 0) {
     gather_index += {{ axis_dim }};
 }

--- a/templates/gather_op.c.j2
+++ b/templates/gather_op.c.j2
@@ -2,7 +2,7 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% for dim in output_shape %}
 for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
-int64_t gather_index = (int64_t){{ indices }}{% for var in indices_indices %}[{{ var }}]{% endfor %};
+idx_t gather_index = {{ indices }}{% for var in indices_indices %}[{{ var }}]{% endfor %};
 if (gather_index < 0) {
     gather_index += {{ axis_dim }};
 }

--- a/templates/maxpool_op.c.j2
+++ b/templates/maxpool_op.c.j2
@@ -8,7 +8,7 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
                 {{ indices_c_type }} max_index = 0;
 {% endif %}
                 for (idx_t kx = 0; kx < {{ kernel_shape[0] }}; ++kx) {
-                    const int ix = (int)(ox * {{ strides[0] }} + kx * {{ dilations[0] }}) - {{ pads[0] }};
+                    const idx_t ix = ox * {{ strides[0] }} + kx * {{ dilations[0] }} - {{ pads[0] }};
                     if (ix < 0 || ix >= {{ in_spatial[0] }}) {
                         continue;
                     }
@@ -37,12 +37,12 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
                     {{ indices_c_type }} max_index = 0;
 {% endif %}
                     for (idx_t kh = 0; kh < {{ kernel_shape[0] }}; ++kh) {
-                        const int ih = (int)(oh * {{ strides[0] }} + kh * {{ dilations[0] }}) - {{ pads[0] }};
+                        const idx_t ih = oh * {{ strides[0] }} + kh * {{ dilations[0] }} - {{ pads[0] }};
                         if (ih < 0 || ih >= {{ in_spatial[0] }}) {
                             continue;
                         }
                         for (idx_t kw = 0; kw < {{ kernel_shape[1] }}; ++kw) {
-                            const int iw = (int)(ow * {{ strides[1] }} + kw * {{ dilations[1] }}) - {{ pads[1] }};
+                            const idx_t iw = ow * {{ strides[1] }} + kw * {{ dilations[1] }} - {{ pads[1] }};
                             if (iw < 0 || iw >= {{ in_spatial[1] }}) {
                                 continue;
                             }
@@ -74,17 +74,17 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
                         {{ indices_c_type }} max_index = 0;
 {% endif %}
                         for (idx_t kd = 0; kd < {{ kernel_shape[0] }}; ++kd) {
-                            const int id = (int)(od * {{ strides[0] }} + kd * {{ dilations[0] }}) - {{ pads[0] }};
+                            const idx_t id = od * {{ strides[0] }} + kd * {{ dilations[0] }} - {{ pads[0] }};
                             if (id < 0 || id >= {{ in_spatial[0] }}) {
                                 continue;
                             }
                             for (idx_t kh = 0; kh < {{ kernel_shape[1] }}; ++kh) {
-                                const int ih = (int)(oh * {{ strides[1] }} + kh * {{ dilations[1] }}) - {{ pads[1] }};
+                                const idx_t ih = oh * {{ strides[1] }} + kh * {{ dilations[1] }} - {{ pads[1] }};
                                 if (ih < 0 || ih >= {{ in_spatial[1] }}) {
                                     continue;
                                 }
                                 for (idx_t kw = 0; kw < {{ kernel_shape[2] }}; ++kw) {
-                                    const int iw = (int)(ow * {{ strides[2] }} + kw * {{ dilations[2] }}) - {{ pads[2] }};
+                                    const idx_t iw = ow * {{ strides[2] }} + kw * {{ dilations[2] }} - {{ pads[2] }};
                                     if (iw < 0 || iw >= {{ in_spatial[2] }}) {
                                         continue;
                                     }

--- a/templates/slice_op_dynamic.c.j2
+++ b/templates/slice_op_dynamic.c.j2
@@ -12,16 +12,16 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
     }
     for (idx_t i = 0; i < {{ starts_len }}; ++i) {
 {% if axes_input %}
-        int64_t axis_value = (int64_t){{ axes_input }}[i];
+        idx_t axis_value = {{ axes_input }}[i];
 {% else %}
-        int64_t axis_value = (int64_t)i;
+        idx_t axis_value = i;
 {% endif %}
         if (axis_value < 0) {
-            axis_value += (int64_t)input_rank;
+            axis_value += input_rank;
         }
-        idx_t axis = (idx_t)axis_value;
-        int64_t dim = (int64_t)input_dims[axis];
-        int64_t start_value = (int64_t){{ starts_input }}[i];
+        idx_t axis = axis_value;
+        idx_t dim = input_dims[axis];
+        idx_t start_value = {{ starts_input }}[i];
         if (start_value < 0) {
             start_value += dim;
         }
@@ -31,12 +31,12 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
         if (start_value > dim) {
             start_value = dim;
         }
-        int64_t step_value = 1;
+        idx_t step_value = 1;
 {% if steps_input %}
-        step_value = (int64_t){{ steps_input }}[i];
+        step_value = {{ steps_input }}[i];
 {% endif %}
-        start_indices[axis] = (idx_t)start_value;
-        step_values[axis] = (idx_t)step_value;
+        start_indices[axis] = start_value;
+        step_values[axis] = step_value;
     }
 {% for dim in output_shape %}
     for (idx_t {{ output_loop_vars[loop.index0] }} = 0; {{ output_loop_vars[loop.index0] }} < {{ dim }}; ++{{ output_loop_vars[loop.index0] }}) {

--- a/tests/golden/op_averagepool_average_pool.c
+++ b/tests/golden/op_averagepool_average_pool.c
@@ -43,7 +43,7 @@ static inline void node0_averagepool(const float input0[restrict 1][1][4][4], fl
                     float acc = 0.0f;
                     idx_t count = 0;
                     for (idx_t kh = 0; kh < 2; ++kh) {
-                        const int ih = (int)(oh * 2 + kh) - 0;
+                        const idx_t ih = oh * 2 + kh - 0;
                         if (ih < 0 || ih >= 4) {
                             if (0) {
                                 count += 2;
@@ -51,7 +51,7 @@ static inline void node0_averagepool(const float input0[restrict 1][1][4][4], fl
                             continue;
                         }
                         for (idx_t kw = 0; kw < 2; ++kw) {
-                            const int iw = (int)(ow * 2 + kw) - 0;
+                            const idx_t iw = ow * 2 + kw - 0;
                             if (iw < 0 || iw >= 4) {
                                 if (0) {
                                     count += 1;

--- a/tests/golden/op_conv_conv.c
+++ b/tests/golden/op_conv_conv.c
@@ -81,8 +81,8 @@ static inline void node0_conv(const float input0[restrict 1][1][4][4], const flo
                             const idx_t ic_global = g * 1 + ic;
                             for (idx_t kd0 = 0; kd0 < 3; ++kd0) {
                                 for (idx_t kd1 = 0; kd1 < 3; ++kd1) {
-                                    const int id0 = (int)(od0 * 1 + kd0 * 1) - 1;
-                                    const int id1 = (int)(od1 * 1 + kd1 * 1) - 1;
+                                    const idx_t id0 = od0 * 1 + kd0 * 1 - 1;
+                                    const idx_t id1 = od1 * 1 + kd1 * 1 - 1;
                                     if (id0 < 0 || id0 >= 4 || id1 < 0 || id1 >= 4) {
                                         continue;
                                     }

--- a/tests/golden/op_eyelike_eye_like.c
+++ b/tests/golden/op_eyelike_eye_like.c
@@ -41,11 +41,11 @@ static inline void node0_eyelike(const float input0[restrict 3][3], float output
     for (idx_t index = 0; index < total; ++index) {
         output_data[index] = 0.0f;
     }
-    int k = 0;
+    idx_t k = 0;
     idx_t rows = 3;
     idx_t cols = 3;
-    idx_t row_start = k >= 0 ? 0 : (idx_t)(-k);
-    idx_t col_start = k >= 0 ? (idx_t)k : 0;
+    idx_t row_start = k >= 0 ? 0 : -k;
+    idx_t col_start = k >= 0 ? k : 0;
     if (row_start >= rows || col_start >= cols) {
         return;
     }

--- a/tests/golden/op_gather_gather.c
+++ b/tests/golden/op_gather_gather.c
@@ -37,7 +37,7 @@
 static inline void node0_gather(const float data[restrict 3][2], const int64_t indices[restrict 2], float output[restrict 2][2]) {
     for (idx_t i0 = 0; i0 < 2; ++i0) {
         for (idx_t i1 = 0; i1 < 2; ++i1) {
-            int64_t gather_index = (int64_t)indices[i0];
+            idx_t gather_index = indices[i0];
             if (gather_index < 0) {
                 gather_index += 3;
             }

--- a/tests/golden/op_gatherelements_gather_elements.c
+++ b/tests/golden/op_gatherelements_gather_elements.c
@@ -37,7 +37,7 @@
 static inline void node0_gatherelements(const float data[restrict 2][3], const int64_t indices[restrict 2][3], float output[restrict 2][3]) {
     for (idx_t i0 = 0; i0 < 2; ++i0) {
         for (idx_t i1 = 0; i1 < 3; ++i1) {
-            int64_t gather_index = (int64_t)indices[i0][i1];
+            idx_t gather_index = indices[i0][i1];
             if (gather_index < 0) {
                 gather_index += 2;
             }

--- a/tests/golden/op_maxpool_maxpool.c
+++ b/tests/golden/op_maxpool_maxpool.c
@@ -45,12 +45,12 @@ static inline void node0_maxpool(const float input0[restrict 1][1][4][4], float 
                 for (idx_t ow = 0; ow < 2; ++ow) {
                     float max_value = -INFINITY;
                     for (idx_t kh = 0; kh < 2; ++kh) {
-                        const int ih = (int)(oh * 2 + kh * 1) - 0;
+                        const idx_t ih = oh * 2 + kh * 1 - 0;
                         if (ih < 0 || ih >= 4) {
                             continue;
                         }
                         for (idx_t kw = 0; kw < 2; ++kw) {
-                            const int iw = (int)(ow * 2 + kw * 1) - 0;
+                            const idx_t iw = ow * 2 + kw * 1 - 0;
                             if (iw < 0 || iw >= 4) {
                                 continue;
                             }


### PR DESCRIPTION
### Motivation
- Make index temporaries use the project typedef `idx_t` to avoid redundant casts and keep index arithmetic consistent across generated kernels. 
- Extend the prior change for `gather`-style indices to other templates that used `int`/`int64_t` temporaries for axes, starts, steps and spatial index arithmetic. 

### Description
- Replaced local temporaries and removed explicit casts in templates to use `idx_t` (notably in `slice_op_dynamic.c.j2`) and applied the same pattern in `gather_op.c.j2` and `gather_elements_op.c.j2`. 
- Replaced `int`/`int64_t` index temporaries with `idx_t` in spatial kernels including `conv_op.c.j2`, `average_pool_op.c.j2`, and `maxpool_op.c.j2`. 
- Simplified `eye_like_op.c.j2` to use `idx_t` for `k` and related computations and removed unnecessary casts. 
- Updated the corresponding golden outputs under `tests/golden/` to match the changed generated code. 

### Testing
- Ran `UPDATE_REFS=1 pytest -n auto -q` which completed successfully with `236 passed, 2 skipped, 2 warnings` in ~58.3s.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6969a45c9e908325a4a720c6ab33ef98)