### PR TITLE
codegen: emit nested testbench arrays

### DIFF
--- a/templates/testbench.c.j2
+++ b/templates/testbench.c.j2
@@ -35,22 +35,42 @@ int main(void) {
 {% for dim in dim_args %}
     int {{ dim.name }} = {{ dim.value }};
 {% endfor %}
+
 {% for input in inputs %}
     {{ input.c_type }} {{ input.name }}{{ input.array_suffix }};
-    {{ input.c_type }} *{{ input.name }}_ptr = ({{ input.c_type }} *){{ input.name }};
-    for (idx_t i = 0; i < {{ input.count }}; ++i) {
 {% if input.constant_name %}
-        {{ input.name }}_ptr[i] = {{ input.constant_name }}[i];
+{% if input.rank == 0 %}
+    {{ input.name }} = {{ input.constant_name }}[0];
 {% else %}
-        {{ input.name }}_ptr[i] = {{ input.random_expr }};
-{% endif %}
+{% for depth in range(input.rank) %}
+    for (idx_t {{ input.loop_vars[depth] }} = 0; {{ input.loop_vars[depth] }} < {{ input.shape[depth] }}; ++{{ input.loop_vars[depth] }}) {
+{% endfor %}
+        {{ input.name }}{{ input.array_index_expr }} = {{ input.constant_name }}[{{ input.index_expr }}];
+{% for depth in range(input.rank - 1, -1, -1) %}
     }
 {% endfor %}
+{% endif %}
+{% else %}
+{% if input.rank == 0 %}
+    {{ input.name }} = {{ input.random_expr }};
+{% else %}
+{% for depth in range(input.rank) %}
+    for (idx_t {{ input.loop_vars[depth] }} = 0; {{ input.loop_vars[depth] }} < {{ input.shape[depth] }}; ++{{ input.loop_vars[depth] }}) {
+{% endfor %}
+        {{ input.name }}{{ input.array_index_expr }} = {{ input.random_expr }};
+{% for depth in range(input.rank - 1, -1, -1) %}
+    }
+{% endfor %}
+{% endif %}
+{% endif %}
+{% endfor %}
+
 {% for output in outputs %}
     {{ output.c_type }} {{ output.name }}{{ output.array_suffix }};
-    {{ output.c_type }} *{{ output.name }}_ptr = ({{ output.c_type }} *){{ output.name }};
 {% endfor %}
+
     {{ model_name }}({% for dim in dim_args %}{{ dim.name }}, {% endfor %}{% for input in inputs %}{{ input.name }}, {% endfor %}{% for output in outputs %}{{ output.name }}{% if not loop.last %}, {% endif %}{% endfor %});
+
     printf("{\"inputs\":{");
 {% for input in inputs %}
 {% if not loop.first %}
@@ -67,7 +87,7 @@ for (idx_t {{ input.loop_vars[depth] }} = 0; {{ input.loop_vars[depth] }} < {{ i
     printf("[");
 {% endif %}
 {% endfor %}
-printf("{{ input.print_format }}", {{ input.print_cast }}{{ input.name }}_ptr[{{ input.index_expr }}]);
+printf("{{ input.print_format }}", {{ input.print_cast }}{{ input.name }}{{ input.array_index_expr }});
 {% for depth in range(input.rank - 1, -1, -1) %}
 {% if depth < input.rank - 1 %}
     printf("]");
@@ -76,6 +96,7 @@ printf("{{ input.print_format }}", {{ input.print_cast }}{{ input.name }}_ptr[{{
 {% endfor %}
     printf("]}");
 {% endfor %}
+
     printf("},\"outputs\":{");
 {% for output in outputs %}
 {% if not loop.first %}
@@ -92,7 +113,7 @@ for (idx_t {{ output.loop_vars[depth] }} = 0; {{ output.loop_vars[depth] }} < {{
     printf("[");
 {% endif %}
 {% endfor %}
-printf("{{ output.print_format }}", {{ output.print_cast }}{{ output.name }}_ptr[{{ output.index_expr }}]);
+printf("{{ output.print_format }}", {{ output.print_cast }}{{ output.name }}{{ output.array_index_expr }});
 {% for depth in range(output.rank - 1, -1, -1) %}
 {% if depth < output.rank - 1 %}
     printf("]");

--- a/tests/golden/add_model_testbench.c
+++ b/tests/golden/add_model_testbench.c
@@ -79,91 +79,101 @@ static int64_t rng_next_i64(void) {
 
 
 int main(void) {
+
     float a[2][3][4];
-    float *a_ptr = (float *)a;
-    for (idx_t i = 0; i < 24; ++i) {
-        a_ptr[i] = rng_next_float();
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
+            for (idx_t i2 = 0; i2 < 4; ++i2) {
+                a[i0][i1][i2] = rng_next_float();
+            }
+        }
     }
     float b[2][3][4];
-    float *b_ptr = (float *)b;
-    for (idx_t i = 0; i < 24; ++i) {
-        b_ptr[i] = rng_next_float();
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
+            for (idx_t i2 = 0; i2 < 4; ++i2) {
+                b[i0][i1][i2] = rng_next_float();
+            }
+        }
     }
+
     float out[2][3][4];
-    float *out_ptr = (float *)out;
+
     model(a, b, out);
+
     printf("{\"inputs\":{");
-            printf("\"a\":{\"shape\":[2,3,4],\"data\":");
-                printf("[");
-                for (idx_t i0 = 0; i0 < 2; ++i0) {
-                    if (i0) {
-                        printf(",");
-                    }
-                    printf("[");
-                    for (idx_t i1 = 0; i1 < 3; ++i1) {
-                        if (i1) {
-                            printf(",");
-                        }
-                        printf("[");
-                        for (idx_t i2 = 0; i2 < 4; ++i2) {
-                            if (i2) {
-                                printf(",");
-                            }
-                            printf("%.8g", (double)a_ptr[((i0 * 3 + i1) * 4 + i2)]);
-                        }
-                        printf("]");
-                    }
-                    printf("]");
-                }
-                printf("]}");
+    printf("\"a\":{\"shape\":[2,3,4],\"data\":");
+    printf("[");
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        if (i0) {
             printf(",");
-            printf("\"b\":{\"shape\":[2,3,4],\"data\":");
-                printf("[");
-                for (idx_t i0 = 0; i0 < 2; ++i0) {
-                    if (i0) {
-                        printf(",");
-                    }
-                    printf("[");
-                    for (idx_t i1 = 0; i1 < 3; ++i1) {
-                        if (i1) {
-                            printf(",");
-                        }
-                        printf("[");
-                        for (idx_t i2 = 0; i2 < 4; ++i2) {
-                            if (i2) {
-                                printf(",");
-                            }
-                            printf("%.8g", (double)b_ptr[((i0 * 3 + i1) * 4 + i2)]);
-                        }
-                        printf("]");
-                    }
-                    printf("]");
+        }
+        printf("[");
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
+            if (i1) {
+                printf(",");
+            }
+            printf("[");
+            for (idx_t i2 = 0; i2 < 4; ++i2) {
+                if (i2) {
+                    printf(",");
                 }
-                printf("]}");
-            printf("},\"outputs\":{");
-            printf("\"out\":{\"shape\":[2,3,4],\"data\":");
-                printf("[");
-                for (idx_t i0 = 0; i0 < 2; ++i0) {
-                    if (i0) {
-                        printf(",");
-                    }
-                    printf("[");
-                    for (idx_t i1 = 0; i1 < 3; ++i1) {
-                        if (i1) {
-                            printf(",");
-                        }
-                        printf("[");
-                        for (idx_t i2 = 0; i2 < 4; ++i2) {
-                            if (i2) {
-                                printf(",");
-                            }
-                            printf("%.8g", (double)out_ptr[((i0 * 3 + i1) * 4 + i2)]);
-                        }
-                        printf("]");
-                    }
-                    printf("]");
+                printf("%.8g", (double)a[i0][i1][i2]);
+            }
+            printf("]");
+        }
+        printf("]");
+    }
+    printf("]}");
+    printf(",");
+    printf("\"b\":{\"shape\":[2,3,4],\"data\":");
+    printf("[");
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        if (i0) {
+            printf(",");
+        }
+        printf("[");
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
+            if (i1) {
+                printf(",");
+            }
+            printf("[");
+            for (idx_t i2 = 0; i2 < 4; ++i2) {
+                if (i2) {
+                    printf(",");
                 }
-                printf("]}");
-            printf("}}\n");
+                printf("%.8g", (double)b[i0][i1][i2]);
+            }
+            printf("]");
+        }
+        printf("]");
+    }
+    printf("]}");
+
+    printf("},\"outputs\":{");
+    printf("\"out\":{\"shape\":[2,3,4],\"data\":");
+    printf("[");
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        if (i0) {
+            printf(",");
+        }
+        printf("[");
+        for (idx_t i1 = 0; i1 < 3; ++i1) {
+            if (i1) {
+                printf(",");
+            }
+            printf("[");
+            for (idx_t i2 = 0; i2 < 4; ++i2) {
+                if (i2) {
+                    printf(",");
+                }
+                printf("%.8g", (double)out[i0][i1][i2]);
+            }
+            printf("]");
+        }
+        printf("]");
+    }
+    printf("]}");
+    printf("}}\n");
     return 0;
 }


### PR DESCRIPTION
### Motivation

- Replace flat pointer-based testbench generation with nested array access so multi-dimensional inputs/outputs are emitted as natural C arrays and `*_ptr` helpers are eliminated.
- Make the emitted testbench easier to read and correctly index multi-dimensional data during initialization and JSON printing.

### Description

- Add `array_index_expr` (e.g. `"[i0][i1]"`) to the testbench metadata in `CEmitter._emit_testbench` so templates can address arrays with nested indices using `"array_name" + array_index_expr`.
- Update `templates/testbench.c.j2` to emit nested `for` loops for initializing constants and random inputs, to special-case rank-0 scalars, and to print inputs/outputs using nested indexing instead of flattened `*_ptr` accesses.
- Refresh the golden test output `tests/golden/add_model_testbench.c` to reflect the new nested initialization and printing layout.

### Testing

- Ran `UPDATE_REFS=1 pytest -n auto -q`, and the test suite completed with `245 passed, 2 skipped, 2 warnings` (tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6969f4be111c8325a51de5276d0c6a8e)