### PR TITLE
testbench: emit hex float JSON output

### DIFF
--- a/src/emx_onnx_cgen/cli.py
+++ b/src/emx_onnx_cgen/cli.py
@@ -19,6 +19,7 @@ from ._build_info import BUILD_DATE, GIT_VERSION
 from .compiler import Compiler, CompilerOptions
 from .errors import CodegenError, ShapeInferenceError, UnsupportedOpError
 from .onnx_import import import_onnx
+from .testbench import decode_testbench_array
 
 LOGGER = logging.getLogger(__name__)
 
@@ -293,7 +294,7 @@ def _handle_verify(args: argparse.Namespace) -> int:
         return 1
 
     inputs = {
-        name: np.array(value["data"], dtype=input_dtypes[name].np_dtype)
+        name: decode_testbench_array(value["data"], input_dtypes[name].np_dtype)
         for name, value in payload["inputs"].items()
     }
     sess = ort.InferenceSession(
@@ -319,7 +320,7 @@ def _handle_verify(args: argparse.Namespace) -> int:
             if output_payload is None:
                 raise AssertionError(f"Missing output {value.name} in testbench data")
             info = output_dtypes[value.name]
-            output_data = np.array(output_payload["data"], dtype=info.np_dtype)
+            output_data = decode_testbench_array(output_payload["data"], info.np_dtype)
             if np.issubdtype(info.np_dtype, np.floating):
                 np.testing.assert_allclose(
                     output_data, ort_out, rtol=1e-4, atol=1e-5

--- a/src/emx_onnx_cgen/codegen/c_emitter.py
+++ b/src/emx_onnx_cgen/codegen/c_emitter.py
@@ -9990,11 +9990,11 @@ class CEmitter:
     @staticmethod
     def _print_format(dtype: ScalarType) -> str:
         if dtype == ScalarType.F16:
-            return "%.8g"
+            return "\\\"%a\\\""
         if dtype == ScalarType.F32:
-            return "%.8g"
+            return "\\\"%a\\\""
         if dtype == ScalarType.F64:
-            return "%.17g"
+            return "\\\"%a\\\""
         if dtype == ScalarType.BOOL:
             return "%d"
         if dtype == ScalarType.U64:

--- a/src/emx_onnx_cgen/testbench.py
+++ b/src/emx_onnx_cgen/testbench.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+def _convert_hex_floats(value: Any) -> Any:
+    if isinstance(value, list):
+        return [_convert_hex_floats(item) for item in value]
+    if isinstance(value, str):
+        return float.fromhex(value)
+    return value
+
+
+def decode_testbench_array(data: object, dtype: np.dtype) -> np.ndarray:
+    """Decode testbench JSON data into a numpy array.
+
+    Floating-point values are expected to be hex strings (C99 %a formatting).
+    """
+    if np.issubdtype(dtype, np.floating):
+        data = _convert_hex_floats(data)
+    return np.array(data, dtype=dtype)

--- a/tests/golden/add_model_testbench.c
+++ b/tests/golden/add_model_testbench.c
@@ -118,7 +118,7 @@ int main(void) {
                 if (i2) {
                     printf(",");
                 }
-                printf("%.8g", (double)a[i0][i1][i2]);
+                printf("\"%a\"", (double)a[i0][i1][i2]);
             }
             printf("]");
         }
@@ -142,7 +142,7 @@ int main(void) {
                 if (i2) {
                     printf(",");
                 }
-                printf("%.8g", (double)b[i0][i1][i2]);
+                printf("\"%a\"", (double)b[i0][i1][i2]);
             }
             printf("]");
         }
@@ -167,7 +167,7 @@ int main(void) {
                 if (i2) {
                     printf(",");
                 }
-                printf("%.8g", (double)out[i0][i1][i2]);
+                printf("\"%a\"", (double)out[i0][i1][i2]);
             }
             printf("]");
         }

--- a/tests/test_official_onnx_files.py
+++ b/tests/test_official_onnx_files.py
@@ -16,6 +16,7 @@ import pytest
 from onnx import numpy_helper
 
 from emx_onnx_cgen.compiler import Compiler, CompilerOptions
+from emx_onnx_cgen.testbench import decode_testbench_array
 
 OFFICIAL_ONNX_FILE_EXPECTATIONS_PATH = (
     Path(__file__).resolve().parent / "official_onnx_expected_errors.json"
@@ -343,7 +344,7 @@ def _assert_outputs_match(
         output_payload = outputs.get(name)
         if output_payload is None:
             raise AssertionError(f"Missing output {name} in testbench data")
-        output_data = np.array(output_payload["data"], dtype=expected.dtype)
+        output_data = decode_testbench_array(output_payload["data"], expected.dtype)
         output_data = output_data.reshape(expected.shape)
         if np.issubdtype(expected.dtype, np.floating):
             np.testing.assert_allclose(output_data, expected, rtol=1e-4, atol=1e-5)

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -25,6 +25,7 @@ from emx_onnx_cgen.lowering.squeeze import lower_squeeze
 from emx_onnx_cgen.lowering import variadic as _variadic  # noqa: F401
 from emx_onnx_cgen.lowering.registry import get_lowering
 from emx_onnx_cgen.onnx_import import import_onnx
+from emx_onnx_cgen.testbench import decode_testbench_array
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
@@ -2169,7 +2170,9 @@ def _run_testbench_compare(model: onnx.ModelProto) -> None:
         output_payload = outputs_payload.get(output_info.name)
         if output_payload is None:
             raise AssertionError(f"Missing output {output_info.name} in testbench data")
-        output_data = np.array(output_payload["data"], dtype=ort_output.dtype)
+        output_data = decode_testbench_array(
+            output_payload["data"], ort_output.dtype
+        )
         output_data = output_data.reshape(ort_output.shape)
         if np.issubdtype(ort_output.dtype, np.floating):
             np.testing.assert_allclose(


### PR DESCRIPTION
### Motivation
- Improve numeric fidelity and round-trip safety of the emitted testbench JSON by printing floating-point values using C99 hex-float format instead of decimal formatting.
- Make testbench output unambiguous for parsing and comparison across platforms and formatting differences.

### Description
- Change the testbench float print format in the C emitter to emit C99 hex-float strings (returning `"%a"` for `F16/F32/F64`).
- Update the testbench golden fixture to quote float values using `%a` in the generated C `printf` calls.
- Add a helper `decode_testbench_array` in `src/emx_onnx_cgen/testbench.py` to decode hex-float strings back to numpy arrays (parsing hex strings with `float.fromhex`).
- Wire the decoder into the CLI verification path and test suites by replacing direct `np.array(..., dtype=...)` usages with `decode_testbench_array(...)` for inputs and outputs.

### Testing
- Ran the full test suite with updated references using `UPDATE_REFS=1 pytest -n auto -q`, total time `59.69s`, result: `245 passed, 2 skipped, 2 warnings`.
- Updated the golden testbench reference to match the new hex-float output format via the reference refresh step (`UPDATE_REFS=1`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6969f8987b8483259b46e7619fb60d9d)