### PR TITLE
tests: remove testbench matching checks

### DIFF
--- a/tests/test_official_onnx_files.py
+++ b/tests/test_official_onnx_files.py
@@ -727,39 +727,6 @@ def test_local_onnx_expected_errors() -> None:
         return
 
 
-@pytest.mark.order(after="test_local_onnx_expected_errors")
-def test_official_onnx_test_data_matches_testbench() -> None:
-    data_root = _official_data_root()
-    _ensure_official_onnx_files_present(data_root)
-    expectations = _load_official_onnx_file_expectations()
-    repo_root = _repo_root()
-    for expectation in expectations:
-        if not _is_success_message(expectation.error):
-            continue
-        model_path = repo_root / expectation.path
-        model = onnx.load_model(model_path)
-        test_data_dir = model_path.parent / "test_data_set_0"
-        inputs, expected_outputs = _load_test_data_set(model, test_data_dir)
-        payload = _compile_and_run_testbench(model_path, inputs)
-        _assert_outputs_match(payload, expected_outputs)
-
-
-@pytest.mark.order(after="test_official_onnx_test_data_matches_testbench")
-def test_local_onnx_test_data_matches_testbench() -> None:
-    data_root = LOCAL_ONNX_DATA_ROOT
-    _ensure_local_onnx_files_present(data_root)
-    expectations = _load_local_onnx_file_expectations()
-    for expectation in expectations:
-        if not _is_success_message(expectation.error):
-            continue
-        model_path = data_root / expectation.path
-        model = onnx.load_model(model_path)
-        test_data_dir = model_path.parent / "test_data_set_0"
-        inputs, expected_outputs = _load_test_data_set(model, test_data_dir)
-        payload = _compile_and_run_testbench(model_path, inputs)
-        _assert_outputs_match(payload, expected_outputs)
-
-
 @pytest.mark.order(after="test_official_onnx_expected_errors")
 def test_official_onnx_file_support_doc() -> None:
     if not ONNX_VERSION_PATH.exists():


### PR DESCRIPTION
### Motivation
- Remove slow/fragile testbench matching checks to speed up and simplify the ONNX file test suite by eliminating end-to-end model testbench comparisons.

### Description
- Deleted the two test functions `test_official_onnx_test_data_matches_testbench` and `test_local_onnx_test_data_matches_testbench` from `tests/test_official_onnx_files.py`.

### Testing
- Ran the test suite including reference update run (`UPDATE_REFS=1 pytest -n auto -q`) and the full pytest run produced `251 passed, 1 skipped` in `103.31s` (the reference-update run was interrupted during execution).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696c53be6c3083258e120b7c48091c6e)