### PR TITLE
tests: split official ONNX doc generation into dedicated docs test

### DIFF
--- a/tests/test_official_onnx_files.py
+++ b/tests/test_official_onnx_files.py
@@ -2,11 +2,9 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import shutil
 import subprocess
 import tempfile
-from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
@@ -24,13 +22,6 @@ from emx_onnx_cgen.verification import max_ulp_diff
 EXPECTED_ERRORS_ROOT = Path(__file__).resolve().parent / "expected_errors"
 OFFICIAL_ONNX_PREFIX = "onnx-org/onnx/backend/test/data/"
 LOCAL_ONNX_PREFIX = "onnx2c-org/test/local_ops/"
-OFFICIAL_ONNX_FILE_SUPPORT_PATH = (
-    Path(__file__).resolve().parents[1] / "OFFICIAL_ONNX_FILE_SUPPORT.md"
-)
-OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM_PATH = (
-    Path(__file__).resolve().parents[1] / "OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md"
-)
-ONNX_VERSION_PATH = Path(__file__).resolve().parents[1] / "onnx-org" / "VERSION_NUMBER"
 LOCAL_ONNX_DATA_ROOT = (
     Path(__file__).resolve().parents[1] / "onnx2c-org" / "test" / "local_ops"
 )
@@ -199,118 +190,6 @@ _LOCAL_ONNX_FILE_EXPECTATIONS = _load_expectations_from_root(
     .as_posix(),
     path_filter=lambda repo_relative: repo_relative.startswith(LOCAL_ONNX_PREFIX),
 )
-
-
-def _is_success_message(message: str) -> bool:
-    return message == "" or message.startswith("OK")
-
-
-def _render_onnx_file_support_table(
-    expectations: list[OnnxFileExpectation],
-) -> list[str]:
-    lines = [
-        "| File | Supported | Error |",
-        "| --- | --- | --- |",
-    ]
-    for expectation in expectations:
-        supported = "✅" if _is_success_message(expectation.error) else "❌"
-        message = expectation.error.replace("\n", " ").strip()
-        lines.append(f"| {expectation.path} | {supported} | {message} |")
-    return lines
-
-
-def _render_onnx_file_support_markdown(
-    official_expectations: list[OnnxFileExpectation],
-    local_expectations: list[OnnxFileExpectation],
-) -> str:
-    supported_count = sum(
-        1
-        for expectation in official_expectations
-        if _is_success_message(expectation.error)
-    )
-    total_count = len(official_expectations)
-    onnx_version = ONNX_VERSION_PATH.read_text(encoding="utf-8").strip()
-    local_supported = sum(
-        1
-        for expectation in local_expectations
-        if _is_success_message(expectation.error)
-    )
-    local_total = len(local_expectations)
-    lines = [
-        "# Official ONNX file support",
-        "",
-        f"Support {supported_count} / {total_count} official ONNX files.",
-        "",
-        f"ONNX version: {onnx_version}",
-        "",
-        "See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md) for the error histogram.",
-        "",
-        *_render_onnx_file_support_table(official_expectations),
-        "",
-        "## Local ONNX file support",
-        "",
-        "Local tests: `onnx2c-org/test/local_ops`.",
-        "",
-        f"Support {local_supported} / {local_total} local ONNX files.",
-        "",
-        *_render_onnx_file_support_table(local_expectations),
-    ]
-    return "\n".join(lines)
-
-
-def _render_error_histogram_markdown(
-    expectations: list[OnnxFileExpectation],
-    title: str = "# Error frequency",
-) -> str:
-    def _sanitize_error(error: str) -> str:
-        return re.sub(r"'[^']*'", "'*'", error)
-
-    errors = [
-        _sanitize_error(expectation.error)
-        for expectation in expectations
-        if expectation.error and not _is_success_message(expectation.error)
-    ]
-    counts = Counter(errors)
-    if not counts:
-        return ""
-    max_count = max(counts.values())
-    bar_width = 30
-
-    def bar(count: int) -> str:
-        if max_count == 0:
-            return ""
-        length = max(1, round(count / max_count * bar_width))
-        return "█" * length
-
-    lines = [
-        title,
-        "",
-        "| Error message | Count | Histogram |",
-        "| --- | --- | --- |",
-    ]
-    for error, count in counts.most_common():
-        lines.append(f"| {error} | {count} | {bar(count)} |")
-    lines.append("")
-    return "\n".join(lines)
-
-
-def _render_support_histogram_markdown(
-    official_expectations: list[OnnxFileExpectation],
-    local_expectations: list[OnnxFileExpectation],
-) -> str:
-    official_histogram = _render_error_histogram_markdown(official_expectations)
-    local_histogram = _render_error_histogram_markdown(
-        local_expectations,
-        title="### Error frequency",
-    )
-    return "\n".join(
-        [
-            official_histogram,
-            "## Local ONNX file support histogram",
-            "",
-            local_histogram,
-        ]
-    ).strip() + "\n"
 
 
 def _collect_onnx_files(data_root: Path) -> list[str]:
@@ -726,37 +605,3 @@ def test_local_onnx_expected_errors() -> None:
         _set_local_onnx_file_expectations(actual_expectations)
         return
 
-
-@pytest.mark.order(after="test_official_onnx_expected_errors")
-def test_official_onnx_file_support_doc() -> None:
-    if not ONNX_VERSION_PATH.exists():
-        _maybe_init_onnx_org()
-    if not ONNX_VERSION_PATH.exists():
-        pytest.skip(
-            "onnx-org version metadata is unavailable. Initialize the onnx-org "
-            "submodule and fetch its data files or set ONNX_ORG_AUTO_INIT=0 to skip auto-init."
-        )
-    official_expectations = _load_official_onnx_file_expectations()
-    local_expectations = _load_local_onnx_file_expectations()
-    expected_markdown = _render_onnx_file_support_markdown(
-        official_expectations,
-        local_expectations,
-    )
-    expected_histogram = _render_support_histogram_markdown(
-        official_expectations,
-        local_expectations,
-    )
-    if os.getenv("UPDATE_REFS"):
-        OFFICIAL_ONNX_FILE_SUPPORT_PATH.write_text(
-            expected_markdown,
-            encoding="utf-8",
-        )
-        OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM_PATH.write_text(
-            expected_histogram,
-            encoding="utf-8",
-        )
-        return
-    actual_markdown = OFFICIAL_ONNX_FILE_SUPPORT_PATH.read_text(encoding="utf-8")
-    actual_histogram = OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM_PATH.read_text(encoding="utf-8")
-    assert actual_markdown == expected_markdown
-    assert actual_histogram == expected_histogram

--- a/tests/test_official_onnx_files_docs.py
+++ b/tests/test_official_onnx_files_docs.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import os
+import re
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+from test_official_onnx_files import (
+    OnnxFileExpectation,
+    _load_local_onnx_file_expectations,
+    _load_official_onnx_file_expectations,
+    _maybe_init_onnx_org,
+)
+
+OFFICIAL_ONNX_FILE_SUPPORT_PATH = (
+    Path(__file__).resolve().parents[1] / "OFFICIAL_ONNX_FILE_SUPPORT.md"
+)
+OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM_PATH = (
+    Path(__file__).resolve().parents[1] / "OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md"
+)
+ONNX_VERSION_PATH = Path(__file__).resolve().parents[1] / "onnx-org" / "VERSION_NUMBER"
+
+
+def _is_success_message(message: str) -> bool:
+    return message == "" or message.startswith("OK")
+
+
+def _render_onnx_file_support_table(
+    expectations: list[OnnxFileExpectation],
+) -> list[str]:
+    lines = [
+        "| File | Supported | Error |",
+        "| --- | --- | --- |",
+    ]
+    for expectation in expectations:
+        supported = "✅" if _is_success_message(expectation.error) else "❌"
+        message = expectation.error.replace("\n", " ").strip()
+        lines.append(f"| {expectation.path} | {supported} | {message} |")
+    return lines
+
+
+def _render_onnx_file_support_markdown(
+    official_expectations: list[OnnxFileExpectation],
+    local_expectations: list[OnnxFileExpectation],
+) -> str:
+    supported_count = sum(
+        1
+        for expectation in official_expectations
+        if _is_success_message(expectation.error)
+    )
+    total_count = len(official_expectations)
+    onnx_version = ONNX_VERSION_PATH.read_text(encoding="utf-8").strip()
+    local_supported = sum(
+        1
+        for expectation in local_expectations
+        if _is_success_message(expectation.error)
+    )
+    local_total = len(local_expectations)
+    lines = [
+        "# Official ONNX file support",
+        "",
+        f"Support {supported_count} / {total_count} official ONNX files.",
+        "",
+        f"ONNX version: {onnx_version}",
+        "",
+        "See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md) for the error histogram.",
+        "",
+        *_render_onnx_file_support_table(official_expectations),
+        "",
+        "## Local ONNX file support",
+        "",
+        "Local tests: `onnx2c-org/test/local_ops`.",
+        "",
+        f"Support {local_supported} / {local_total} local ONNX files.",
+        "",
+        *_render_onnx_file_support_table(local_expectations),
+    ]
+    return "\n".join(lines)
+
+
+def _render_error_histogram_markdown(
+    expectations: list[OnnxFileExpectation],
+    title: str = "# Error frequency",
+) -> str:
+    def _sanitize_error(error: str) -> str:
+        return re.sub(r"'[^']*'", "'*'", error)
+
+    errors = [
+        _sanitize_error(expectation.error)
+        for expectation in expectations
+        if expectation.error and not _is_success_message(expectation.error)
+    ]
+    counts = Counter(errors)
+    if not counts:
+        return ""
+    max_count = max(counts.values())
+    bar_width = 30
+
+    def bar(count: int) -> str:
+        if max_count == 0:
+            return ""
+        length = max(1, round(count / max_count * bar_width))
+        return "█" * length
+
+    lines = [
+        title,
+        "",
+        "| Error message | Count | Histogram |",
+        "| --- | --- | --- |",
+    ]
+    for error, count in counts.most_common():
+        lines.append(f"| {error} | {count} | {bar(count)} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _render_support_histogram_markdown(
+    official_expectations: list[OnnxFileExpectation],
+    local_expectations: list[OnnxFileExpectation],
+) -> str:
+    official_histogram = _render_error_histogram_markdown(official_expectations)
+    local_histogram = _render_error_histogram_markdown(
+        local_expectations,
+        title="### Error frequency",
+    )
+    return "\n".join(
+        [
+            official_histogram,
+            "## Local ONNX file support histogram",
+            "",
+            local_histogram,
+        ]
+    ).strip() + "\n"
+
+
+@pytest.mark.order(after="test_official_onnx_expected_errors")
+def test_official_onnx_file_support_doc() -> None:
+    if not ONNX_VERSION_PATH.exists():
+        _maybe_init_onnx_org()
+    if not ONNX_VERSION_PATH.exists():
+        pytest.skip(
+            "onnx-org version metadata is unavailable. Initialize the onnx-org "
+            "submodule and fetch its data files or set ONNX_ORG_AUTO_INIT=0 to skip auto-init."
+        )
+    official_expectations = _load_official_onnx_file_expectations()
+    local_expectations = _load_local_onnx_file_expectations()
+    expected_markdown = _render_onnx_file_support_markdown(
+        official_expectations,
+        local_expectations,
+    )
+    expected_histogram = _render_support_histogram_markdown(
+        official_expectations,
+        local_expectations,
+    )
+    if os.getenv("UPDATE_REFS"):
+        OFFICIAL_ONNX_FILE_SUPPORT_PATH.write_text(
+            expected_markdown,
+            encoding="utf-8",
+        )
+        OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM_PATH.write_text(
+            expected_histogram,
+            encoding="utf-8",
+        )
+        return
+    actual_markdown = OFFICIAL_ONNX_FILE_SUPPORT_PATH.read_text(encoding="utf-8")
+    actual_histogram = OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM_PATH.read_text(
+        encoding="utf-8"
+    )
+    assert actual_markdown == expected_markdown
+    assert actual_histogram == expected_histogram


### PR DESCRIPTION
### Motivation
- Separate the markdown generation / doc snapshot logic from the ONNX file verification test to keep the verification test focused on collecting and asserting expected errors.
- Make the doc-generation helpers and snapshot assertions reusable and easier to run independently when updating golden references.
- Reduce test-module size and responsibility by moving rendering helpers into a dedicated `tests/test_official_onnx_files_docs.py` module.

### Description
- Removed the markdown rendering and histogram helpers and the `test_official_onnx_file_support_doc` test from `tests/test_official_onnx_files.py` to keep it focused on expectation checks.
- Added a new file `tests/test_official_onnx_files_docs.py` containing the moved helpers and the `test_official_onnx_file_support_doc` test that writes or validates `OFFICIAL_ONNX_FILE_SUPPORT.md` and `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`.
- Adjusted imports and references so the docs test imports shared helpers/types from the verification test module and reads the `onnx-org` version metadata.

### Testing
- Ran `pytest -q tests/test_official_onnx_files_docs.py`, which failed due to a mismatch between the generated markdown and the committed `OFFICIAL_ONNX_FILE_SUPPORT.md` (1 failed, ~1.31s).
- The failure indicates the existing golden snapshot must be updated deliberately (use `UPDATE_REFS=1 pytest -q tests/test_official_onnx_files_docs.py` to refresh references if the change is intended).
- No other test suites were run as part of this change; further CI/full-test runs are recommended before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696c55635d8c8325a28232a78141091c)