### PR TITLE
verify: use ULP-only tolerance checks

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -27,7 +27,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_adam/model.onnx | ❌ | Unsupported op Adam |
 | onnx-org/onnx/backend/test/data/node/test_adam_multiple/model.onnx | ❌ | Unsupported op Adam |
 | onnx-org/onnx/backend/test/data/node/test_add/model.onnx | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_add_bcast/model.onnx | ❌ | Not equal to tolerance rtol=0.0001, atol=1e-05  Mismatched elements: 55 / 60 (91.7%) Max absolute difference among violations: 3.490335 Max relative difference among violations: 84.4747  ACTUAL: array([[[ 1.091592,  0.040604,  0.165592,  0.514611,  2.044984],         [-0.977278,  0.950088, -0.151357,  1.660834,  0.810756],         [ 1.122782,  3.695167,  2.628596, -0.855603,  1.393952],...  DESIRED: array([[[ 1.091592,  0.040604,  0.165592,  0.514611,  2.044984],         [-1.649738,  0.590535, -0.964504, -1.829501,  0.588025],         [-0.528417,  1.09472 , -0.052109, -1.604608,  0.621289],... |
+| onnx-org/onnx/backend/test/data/node/test_add_bcast/model.onnx | ❌ | Out of tolerance (max ULP 2143208269) |
 | onnx-org/onnx/backend/test/data/node/test_add_int16/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_add_int8/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_add_uint16/model.onnx | ✅ | OK (max ULP 0) |
@@ -100,12 +100,12 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_atanh_example/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d/model.onnx | ✅ | OK (max ULP 4) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_attn_mask/model.onnx | ✅ | OK (max ULP 3) |
-| onnx-org/onnx/backend/test/data/node/test_attention_3d_attn_mask_expanded/model.onnx | ❌ | Not equal to tolerance rtol=0.0001, atol=1e-05  nan location mismatch:  ACTUAL: array([[[nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan,          nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan],         [nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan,...  DESIRED: array([[[0.216069, 0.568473, 0.478865, 0.274843, 0.307853, 0.475815,          0.316015, 0.479875, 0.704013, 0.482877, 0.520319, 0.628602,          0.370084, 0.575148, 0.582313, 0.681792, 0.646259, 0.418965,... |
+| onnx-org/onnx/backend/test/data/node/test_attention_3d_attn_mask_expanded/model.onnx | ❌ | Out of tolerance (max ULP 4294967295) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_causal/model.onnx | ✅ | OK (max ULP 3) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_causal_expanded/model.onnx | ❌ | Where output shape must be (1, 1), got (1,) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_diff_heads_sizes/model.onnx | ✅ | OK (max ULP 3) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_diff_heads_sizes_attn_mask/model.onnx | ✅ | OK (max ULP 3) |
-| onnx-org/onnx/backend/test/data/node/test_attention_3d_diff_heads_sizes_attn_mask_expanded/model.onnx | ❌ | Not equal to tolerance rtol=0.0001, atol=1e-05  nan location mismatch:  ACTUAL: array([[[nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan,          nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan,          nan, nan, nan, nan, nan, nan],...  DESIRED: array([[[0.313025, 0.256659, 0.415442, 0.438531, 0.707696, 0.54395 ,          0.253743, 0.544114, 0.597431, 0.692815, 0.471582, 0.519003,          0.636791, 0.309616, 0.413838, 0.251433, 0.391316, 0.472403,... |
+| onnx-org/onnx/backend/test/data/node/test_attention_3d_diff_heads_sizes_attn_mask_expanded/model.onnx | ❌ | Out of tolerance (max ULP 4294967295) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_diff_heads_sizes_causal/model.onnx | ✅ | OK (max ULP 2) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_diff_heads_sizes_causal_expanded/model.onnx | ❌ | Where output shape must be (1, 1), got (1,) |
 
@@ -113,7 +113,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 
 Local tests: `onnx2c-org/test/local_ops`.
 
-Support 61 / 74 local ONNX files.
+Support 60 / 74 local ONNX files.
 
 | File | Supported | Error |
 | --- | --- | --- |
@@ -148,7 +148,7 @@ Support 61 / 74 local ONNX files.
 | test_lstm_intermediate_h/model.onnx | ✅ | OK (max ULP 2) |
 | test_lstm_missing_inputs/model.onnx | ✅ | OK (max ULP 1) |
 | test_lstm_reverse/model.onnx | ❌ | Unsupported LSTM direction b'reverse' |
-| test_lstm_seq_length/model.onnx | ✅ | OK (max ULP 591626278) |
+| test_lstm_seq_length/model.onnx | ❌ | Out of tolerance (max ULP 591626278) |
 | test_lstm_simple/model.onnx | ✅ | OK (max ULP 0) |
 | test_lstm_with_initial_state/model.onnx | ✅ | OK (max ULP 4) |
 | test_lstm_y_c/model.onnx | ✅ | OK (max ULP 2) |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -10,41 +10,11 @@
 | Unsupported op Adagrad | 2 | ███████ |
 | Unsupported op Adam | 2 | ███████ |
 | Unsupported op TreeEnsemble | 2 | ███████ |
+| Out of tolerance (max ULP 4294967295) | 2 | ███████ |
 | Where output shape must be (1, 1), got (1,) | 2 | ███████ |
-| 
-Not equal to tolerance rtol=0.0001, atol=1e-05
-
-Mismatched elements: 55 / 60 (91.7%)
-Max absolute difference among violations: 3.490335
-Max relative difference among violations: 84.4747
- ACTUAL: array([[[ 1.091592,  0.040604,  0.165592,  0.514611,  2.044984],
-        [-0.977278,  0.950088, -0.151357,  1.660834,  0.810756],
-        [ 1.122782,  3.695167,  2.628596, -0.855603,  1.393952],...
- DESIRED: array([[[ 1.091592,  0.040604,  0.165592,  0.514611,  2.044984],
-        [-1.649738,  0.590535, -0.964504, -1.829501,  0.588025],
-        [-0.528417,  1.09472 , -0.052109, -1.604608,  0.621289],... | 1 | ███ |
+| Out of tolerance (max ULP 2143208269) | 1 | ███ |
 | Unsupported op ArrayFeatureExtractor | 1 | ███ |
 | Unsupported op Binarizer | 1 | ███ |
-| 
-Not equal to tolerance rtol=0.0001, atol=1e-05
-
-nan location mismatch:
- ACTUAL: array([[[nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan,
-         nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan],
-        [nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan,...
- DESIRED: array([[[0.216069, 0.568473, 0.478865, 0.274843, 0.307853, 0.475815,
-         0.316015, 0.479875, 0.704013, 0.482877, 0.520319, 0.628602,
-         0.370084, 0.575148, 0.582313, 0.681792, 0.646259, 0.418965,... | 1 | ███ |
-| 
-Not equal to tolerance rtol=0.0001, atol=1e-05
-
-nan location mismatch:
- ACTUAL: array([[[nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan,
-         nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan,
-         nan, nan, nan, nan, nan, nan],...
- DESIRED: array([[[0.313025, 0.256659, 0.415442, 0.438531, 0.707696, 0.54395 ,
-         0.253743, 0.544114, 0.597431, 0.692815, 0.471582, 0.519003,
-         0.636791, 0.309616, 0.413838, 0.251433, 0.391316, 0.472403,... | 1 | ███ |
 
 ## Local ONNX file support histogram
 
@@ -57,5 +27,6 @@ nan location mismatch:
 | Unsupported op QLinearAdd | 2 | ███████████████ |
 | Unsupported op QLinearMul | 2 | ███████████████ |
 | Gemm bias input must be broadcastable to output shape, got (2,) vs (2, 4) | 1 | ████████ |
+| Out of tolerance (max ULP 591626278) | 1 | ████████ |
 | ONNX Runtime failed to run onnx2c-org/test/local_ops/test_resize_downsample_sizes_linear_1D/model.onnx: [ONNXRuntimeError] : 10 : INVALID_GRAPH : This is an invalid model. In Node, ("sclbl-onnx-node1", Resize, "", -1) : ("X": tensor(float),"","","sizes": tensor(int64),) -> ("Y": tensor(float),) , Error Node (sclbl-onnx-node1)'s input 1 is marked single but has an empty string in the graph | 1 | ████████ |
 | ONNX Runtime failed to run onnx2c-org/test/local_ops/test_resize_downsample_sizes_linear_1D_align/model.onnx: [ONNXRuntimeError] : 10 : INVALID_GRAPH : This is an invalid model. In Node, ("sclbl-onnx-node1", Resize, "", -1) : ("X": tensor(float),"","","sizes": tensor(int64),) -> ("Y": tensor(float),) , Error Node (sclbl-onnx-node1)'s input 1 is marked single but has an empty string in the graph | 1 | ████████ |

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_add_bcast__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_add_bcast__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "\nNot equal to tolerance rtol=0.0001, atol=1e-05\n\nMismatched elements: 55 / 60 (91.7%)\nMax absolute difference among violations: 3.490335\nMax relative difference among violations: 84.4747\n ACTUAL: array([[[ 1.091592,  0.040604,  0.165592,  0.514611,  2.044984],\n        [-0.977278,  0.950088, -0.151357,  1.660834,  0.810756],\n        [ 1.122782,  3.695167,  2.628596, -0.855603,  1.393952],...\n DESIRED: array([[[ 1.091592,  0.040604,  0.165592,  0.514611,  2.044984],\n        [-1.649738,  0.590535, -0.964504, -1.829501,  0.588025],\n        [-0.528417,  1.09472 , -0.052109, -1.604608,  0.621289],...",
+  "error": "Out of tolerance (max ULP 2143208269)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_add_bcast/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_add_bcast/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_attn_mask_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_attn_mask_expanded__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "\nNot equal to tolerance rtol=0.0001, atol=1e-05\n\nnan location mismatch:\n ACTUAL: array([[[nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan,\n         nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan],\n        [nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan,...\n DESIRED: array([[[0.216069, 0.568473, 0.478865, 0.274843, 0.307853, 0.475815,\n         0.316015, 0.479875, 0.704013, 0.482877, 0.520319, 0.628602,\n         0.370084, 0.575148, 0.582313, 0.681792, 0.646259, 0.418965,...",
+  "error": "Out of tolerance (max ULP 4294967295)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_attention_3d_attn_mask_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_attention_3d_attn_mask_expanded/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_diff_heads_sizes_attn_mask_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_diff_heads_sizes_attn_mask_expanded__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "\nNot equal to tolerance rtol=0.0001, atol=1e-05\n\nnan location mismatch:\n ACTUAL: array([[[nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan,\n         nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan,\n         nan, nan, nan, nan, nan, nan],...\n DESIRED: array([[[0.313025, 0.256659, 0.415442, 0.438531, 0.707696, 0.54395 ,\n         0.253743, 0.544114, 0.597431, 0.692815, 0.471582, 0.519003,\n         0.636791, 0.309616, 0.413838, 0.251433, 0.391316, 0.472403,...",
+  "error": "Out of tolerance (max ULP 4294967295)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_attention_3d_diff_heads_sizes_attn_mask_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_attention_3d_diff_heads_sizes_attn_mask_expanded/test_data_set_0"
 }

--- a/tests/expected_errors/onnx2c-org__test__local_ops__test_lstm_seq_length__model.onnx.json
+++ b/tests/expected_errors/onnx2c-org__test__local_ops__test_lstm_seq_length__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "OK (max ULP 591626278)",
+  "error": "Out of tolerance (max ULP 591626278)",
   "command_line": "verify onnx2c-org/test/local_ops/test_lstm_seq_length/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx2c-org/test/local_ops/test_lstm_seq_length/test_data_set_0"
 }


### PR DESCRIPTION
### Motivation
- Make verification deterministic and focused on ULP differences by removing mixed rtol/atol checks and using ULP as the only float accuracy metric.
- Allow test authors and CI to configure a maximum tolerated ULP via CLI so failing models produce an explicit, consistent error.

### Description
- Added a `--max-ulp` CLI option to `verify` with default `100` and used it as the failure threshold (`src/emx_onnx_cgen/cli.py`).
- Switched floating-output verification to compute only the maximum ULP using `max_ulp_diff` and removed the `np.testing.assert_allclose` rtol/atol check for floats, while preserving exact equality for non-float outputs.
- Emit the explicit failure message `Out of tolerance (max ULP ...)` when the observed max ULP exceeds `args.max_ulp`.
- Updated golden/expected error snapshots and the official ONNX support summary to reflect the new ULP-based failures (`tests/expected_errors/*`, `OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`).

### Testing
- Ran the full test suite with reference refresh: `UPDATE_REFS=1 pytest -n auto -q`, which completed in `82.55s` and reported `426 passed, 1 skipped, 2 warnings`.
- Updated expected reference files as part of the run to reflect ULP-based verification behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696c5bfa27e48325a55b66cb621d8762)