### PR TITLE
tests: remove unused ONNX test helpers

### DIFF
--- a/src/emx_onnx_cgen/verification.py
+++ b/src/emx_onnx_cgen/verification.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Iterable
-
 import numpy as np
 
 
@@ -50,14 +48,6 @@ def max_ulp_diff(actual: np.ndarray, expected: np.ndarray) -> int:
     ordered_expected = _float_to_ordered_int(expected_cast)
     deltas = ordered_actual.astype(np.int64) - ordered_expected.astype(np.int64)
     return int(np.max(np.abs(deltas)))
-
-
-def max_ulp_for_pairs(pairs: Iterable[tuple[np.ndarray, np.ndarray]]) -> int:
-    max_ulp = 0
-    for actual, expected in pairs:
-        if np.issubdtype(expected.dtype, np.floating):
-            max_ulp = max(max_ulp, max_ulp_diff(actual, expected))
-    return int(max_ulp)
 
 
 def format_success_message(max_ulp: int) -> str:


### PR DESCRIPTION
### Motivation
- Remove dead code and unused imports from the ONNX test harness to simplify the test file and avoid unused dependencies.
- Also remove the unused `max_ulp_for_pairs` helper and its `typing.Iterable` import from the verification utilities.

### Description
- Delete unused test helper functions from `tests/test_official_onnx_files.py`: `_load_test_data_set`, `_compile_and_run_testbench`, and `_assert_outputs_match`.
- Remove now-unused imports from the test file, including `tempfile`, `onnx`, `numpy as np`, `numpy_helper`, `decode_testbench_array`, and the reference to `max_ulp_diff`.
- Remove the `max_ulp_for_pairs` function and the `typing.Iterable` import from `src/emx_onnx_cgen/verification.py`.
- Keep test logic that enumerates and verifies ONNX files intact and only remove helpers that were not referenced.

### Testing
- Ran `pytest -n auto -q` and the suite completed successfully with `426 passed, 1 skipped, 2 warnings` in ~77.8s.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696c5fd5ad008325a4a01d61ed67d4a1)