### PR TITLE
docs: relax full test suite requirement in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,8 +86,9 @@ UPDATE_REFS=1 pytest -n auto -q
 ### Test execution policy
 
 Prefer running targeted single tests while working (e.g., a specific test module or
-test case) to keep iteration fast. At the end of every change, run the full test
-suite with reference updates enabled:
+test case) to keep iteration fast. Run the full test suite with reference updates
+enabled when changes impact code generation or test expectations, but it is not
+required for every change:
 
 ```bash
 UPDATE_REFS=1 pytest -n auto -q


### PR DESCRIPTION
### Motivation
- Make the test execution policy less strict so contributors don't have to run the full test suite for every small change, while still requiring full runs when code generation or test expectations are affected.

### Description
- Update `AGENTS.md` test execution policy text to state that running the full test suite with `UPDATE_REFS=1` is required only when changes impact code generation or expected outputs rather than for every change.

### Testing
- Ran `pytest -q`, which completed successfully with `424 passed, 1 skipped, 2 warnings` in `152.77s (0:02:32)`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696ccb70bb648325a26879f965c98679)