### PR TITLE
codegen: emit NaN/Inf testbench literals and refresh refs

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -284,10 +284,10 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_blackmanwindow_symmetric/model.onnx | ❌ | Unsupported op BlackmanWindow |
 | onnx-org/onnx/backend/test/data/node/test_blackmanwindow_symmetric_expanded/model.onnx | ❌ | Cast input and output shapes must match |
 | onnx-org/onnx/backend/test/data/node/test_cast_BFLOAT16_to_FLOAT/model.onnx | ❌ | Unsupported elem_type 16 (BFLOAT16) for tensor 'input'. |
-| onnx-org/onnx/backend/test/data/node/test_cast_DOUBLE_to_FLOAT/model.onnx | ❌ | Failed to build testbench. |
-| onnx-org/onnx/backend/test/data/node/test_cast_DOUBLE_to_FLOAT16/model.onnx | ❌ | Failed to build testbench. |
-| onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_DOUBLE/model.onnx | ❌ | Failed to build testbench. |
-| onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_FLOAT/model.onnx | ❌ | Failed to build testbench. |
+| onnx-org/onnx/backend/test/data/node/test_cast_DOUBLE_to_FLOAT/model.onnx | ❌ | ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_DOUBLE_to_FLOAT/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11 |
+| onnx-org/onnx/backend/test/data/node/test_cast_DOUBLE_to_FLOAT16/model.onnx | ❌ | ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_DOUBLE_to_FLOAT16/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11 |
+| onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_DOUBLE/model.onnx | ❌ | ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_DOUBLE/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11 |
+| onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_FLOAT/model.onnx | ❌ | ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_FLOAT/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11 |
 | onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_FLOAT4E2M1/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'output'. |
 | onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_FLOAT8E4M3FN/model.onnx | ❌ | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'output'. |
 | onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_FLOAT8E4M3FNUZ/model.onnx | ❌ | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor 'output'. |
@@ -308,8 +308,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_cast_FLOAT8E5M2_to_FLOAT/model.onnx | ❌ | Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'input'. |
 | onnx-org/onnx/backend/test/data/node/test_cast_FLOAT8E5M2_to_FLOAT16/model.onnx | ❌ | Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'input'. |
 | onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_BFLOAT16/model.onnx | ❌ | Unsupported elem_type 16 (BFLOAT16) for tensor 'output'. |
-| onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_DOUBLE/model.onnx | ❌ | Failed to build testbench. |
-| onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_FLOAT16/model.onnx | ❌ | Failed to build testbench. |
+| onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_DOUBLE/model.onnx | ❌ | ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_DOUBLE/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11 |
+| onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_FLOAT16/model.onnx | ❌ | ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_FLOAT16/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11 |
 | onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_FLOAT4E2M1/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'output'. |
 | onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_FLOAT8E4M3FN/model.onnx | ❌ | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'output'. |
 | onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_FLOAT8E4M3FNUZ/model.onnx | ❌ | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor 'output'. |
@@ -463,14 +463,14 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_and_pad/model.onnx | ❌ | Unsupported op CenterCropPad |
 | onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_and_pad_expanded/model.onnx | ❌ | Out of tolerance (max ULP 2827146620) |
 | onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_axes_chw/model.onnx | ❌ | Unsupported op CenterCropPad |
-| onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_axes_chw_expanded/model.onnx | ❌ | Out of tolerance (max ULP 3113727168) |
+| onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_axes_chw_expanded/model.onnx | ❌ | Out of tolerance (max ULP 2628197611) |
 | onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_axes_hwc/model.onnx | ❌ | Unsupported op CenterCropPad |
-| onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_axes_hwc_expanded/model.onnx | ❌ | Out of tolerance (max ULP 2416571251) |
-| onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_expanded/model.onnx | ❌ | Out of tolerance (max ULP 3001582704) |
+| onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_axes_hwc_expanded/model.onnx | ❌ | Out of tolerance (max ULP 2398134387) |
+| onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_expanded/model.onnx | ❌ | Out of tolerance (max ULP 2919007646) |
 | onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_negative_axes_hwc/model.onnx | ❌ | Unsupported op CenterCropPad |
-| onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_negative_axes_hwc_expanded/model.onnx | ❌ | Out of tolerance (max ULP 2774559114) |
+| onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_negative_axes_hwc_expanded/model.onnx | ❌ | Out of tolerance (max ULP 3109602238) |
 | onnx-org/onnx/backend/test/data/node/test_center_crop_pad_pad/model.onnx | ❌ | Unsupported op CenterCropPad |
-| onnx-org/onnx/backend/test/data/node/test_center_crop_pad_pad_expanded/model.onnx | ❌ | Out of tolerance (max ULP 2771587255) |
+| onnx-org/onnx/backend/test/data/node/test_center_crop_pad_pad_expanded/model.onnx | ❌ | Out of tolerance (max ULP 2861363383) |
 | onnx-org/onnx/backend/test/data/node/test_clip/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_clip_default_inbounds/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_clip_default_inbounds_expanded/model.onnx | ✅ | OK (max ULP 0) |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -2,47 +2,47 @@
 
 | Error message | Count | Histogram |
 | --- | --- | --- |
-| Failed to build testbench. | 24 | ██████████████████████████████ |
-| Out of tolerance (max ULP 4294967295) | 21 | ██████████████████████████ |
-| Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 18 | ██████████████████████ |
-| Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 18 | ██████████████████████ |
-| Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 18 | ██████████████████████ |
-| Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 18 | ██████████████████████ |
-| Unsupported elem_type 26 (INT2) for tensor '*'. | 15 | ███████████████████ |
-| Unsupported elem_type 22 (INT4) for tensor '*'. | 15 | ███████████████████ |
-| Unsupported elem_type 25 (UINT2) for tensor '*'. | 15 | ███████████████████ |
-| Unsupported elem_type 21 (UINT4) for tensor '*'. | 15 | ███████████████████ |
-| Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 12 | ███████████████ |
-| Where output shape must be (1, 1), got (1,) | 10 | ████████████ |
-| Testbench execution failed: exit code -11 (signal 11: SIGSEGV) | 9 | ███████████ |
-| AveragePool has unsupported attributes | 6 | ████████ |
-| Unsupported elem_type 16 (BFLOAT16) for tensor '*'. | 6 | ████████ |
-| Unsupported op CenterCropPad | 6 | ████████ |
-| And expects identical input/output shapes | 5 | ██████ |
-| Unsupported op Col2Im | 5 | ██████ |
-| Unsupported op AffineGrid | 4 | █████ |
-| Unsupported op If | 4 | █████ |
-| Unsupported elem_type 8 (STRING) for tensor '*'. | 4 | █████ |
-| Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 4 | █████ |
-| Unsupported op Compress | 4 | █████ |
+| Out of tolerance (max ULP 4294967295) | 21 | ██████████████████████████████ |
+| Failed to build testbench. | 18 | ██████████████████████████ |
+| Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 18 | ██████████████████████████ |
+| Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 18 | ██████████████████████████ |
+| Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 18 | ██████████████████████████ |
+| Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 18 | ██████████████████████████ |
+| Unsupported elem_type 26 (INT2) for tensor '*'. | 15 | █████████████████████ |
+| Unsupported elem_type 22 (INT4) for tensor '*'. | 15 | █████████████████████ |
+| Unsupported elem_type 25 (UINT2) for tensor '*'. | 15 | █████████████████████ |
+| Unsupported elem_type 21 (UINT4) for tensor '*'. | 15 | █████████████████████ |
+| Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 12 | █████████████████ |
+| Where output shape must be (1, 1), got (1,) | 10 | ██████████████ |
+| Testbench execution failed: exit code -11 (signal 11: SIGSEGV) | 9 | █████████████ |
+| AveragePool has unsupported attributes | 6 | █████████ |
+| Unsupported elem_type 16 (BFLOAT16) for tensor '*'. | 6 | █████████ |
+| Unsupported op CenterCropPad | 6 | █████████ |
+| And expects identical input/output shapes | 5 | ███████ |
+| Unsupported op Col2Im | 5 | ███████ |
+| Unsupported op AffineGrid | 4 | ██████ |
+| Unsupported op If | 4 | ██████ |
+| Unsupported elem_type 8 (STRING) for tensor '*'. | 4 | ██████ |
+| Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 4 | ██████ |
+| Unsupported op Compress | 4 | ██████ |
 | Out of tolerance (max ULP 1818802) | 3 | ████ |
 | AveragePool supports auto_pad=NOTSET only | 3 | ████ |
 | Unsupported op Bernoulli | 3 | ████ |
 | Unsupported op RandomUniformLike | 3 | ████ |
-| Unsupported op Adagrad | 2 | ██ |
-| Unsupported op Adam | 2 | ██ |
-| Unsupported op TreeEnsemble | 2 | ██ |
-| AveragePool expects 2D kernel_shape | 2 | ██ |
-| AveragePool supports ceil_mode=0 only | 2 | ██ |
-| Unsupported op DeformConv | 2 | ██ |
-| BatchNormalization must have 5 inputs and 1 output | 2 | ██ |
-| BitwiseAnd expects identical input/output shapes | 2 | ██ |
-| Unsupported op BitwiseNot | 2 | ██ |
-| BitwiseOr expects identical input/output shapes | 2 | ██ |
-| BitwiseXor expects identical input/output shapes | 2 | ██ |
-| Unsupported op BlackmanWindow | 2 | ██ |
-| Cast input and output shapes must match | 2 | ██ |
-| Out of tolerance (max ULP 1084227585) | 2 | ██ |
+| Unsupported op Adagrad | 2 | ███ |
+| Unsupported op Adam | 2 | ███ |
+| Unsupported op TreeEnsemble | 2 | ███ |
+| AveragePool expects 2D kernel_shape | 2 | ███ |
+| AveragePool supports ceil_mode=0 only | 2 | ███ |
+| Unsupported op DeformConv | 2 | ███ |
+| BatchNormalization must have 5 inputs and 1 output | 2 | ███ |
+| BitwiseAnd expects identical input/output shapes | 2 | ███ |
+| Unsupported op BitwiseNot | 2 | ███ |
+| BitwiseOr expects identical input/output shapes | 2 | ███ |
+| BitwiseXor expects identical input/output shapes | 2 | ███ |
+| Unsupported op BlackmanWindow | 2 | ███ |
+| Cast input and output shapes must match | 2 | ███ |
+| Out of tolerance (max ULP 1084227585) | 2 | ███ |
 | Out of tolerance (max ULP 2143208269) | 1 | █ |
 | Unsupported op ArrayFeatureExtractor | 1 | █ |
 | Unsupported op Binarizer | 1 | █ |
@@ -70,12 +70,24 @@
 | Out of tolerance (max ULP 1072671123) | 1 | █ |
 | Out of tolerance (max ULP 1068382978) | 1 | █ |
 | Out of tolerance (max ULP 15953592) | 1 | █ |
+| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_DOUBLE_to_FLOAT/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
+ | 1 | █ |
+| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_DOUBLE_to_FLOAT16/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
+ | 1 | █ |
+| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_DOUBLE/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
+ | 1 | █ |
+| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_FLOAT/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
+ | 1 | █ |
+| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_DOUBLE/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
+ | 1 | █ |
+| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_FLOAT16/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
+ | 1 | █ |
 | Out of tolerance (max ULP 2827146620) | 1 | █ |
-| Out of tolerance (max ULP 3113727168) | 1 | █ |
-| Out of tolerance (max ULP 2416571251) | 1 | █ |
-| Out of tolerance (max ULP 3001582704) | 1 | █ |
-| Out of tolerance (max ULP 2774559114) | 1 | █ |
-| Out of tolerance (max ULP 2771587255) | 1 | █ |
+| Out of tolerance (max ULP 2628197611) | 1 | █ |
+| Out of tolerance (max ULP 2398134387) | 1 | █ |
+| Out of tolerance (max ULP 2919007646) | 1 | █ |
+| Out of tolerance (max ULP 3109602238) | 1 | █ |
+| Out of tolerance (max ULP 2861363383) | 1 | █ |
 | Out of tolerance (max ULP 1069384066) | 1 | █ |
 | Out of tolerance (max ULP 1072630820) | 1 | █ |
 | Out of tolerance (max ULP 1065353216) | 1 | █ |

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cast_DOUBLE_to_FLOAT16__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cast_DOUBLE_to_FLOAT16__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_DOUBLE_to_FLOAT16/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11\n",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_cast_DOUBLE_to_FLOAT16/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_cast_DOUBLE_to_FLOAT16/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cast_DOUBLE_to_FLOAT__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cast_DOUBLE_to_FLOAT__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_DOUBLE_to_FLOAT/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11\n",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_cast_DOUBLE_to_FLOAT/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_cast_DOUBLE_to_FLOAT/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cast_FLOAT16_to_DOUBLE__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cast_FLOAT16_to_DOUBLE__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_DOUBLE/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11\n",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_DOUBLE/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_DOUBLE/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cast_FLOAT16_to_FLOAT__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cast_FLOAT16_to_FLOAT__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_FLOAT/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11\n",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_FLOAT/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_FLOAT/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cast_FLOAT_to_DOUBLE__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cast_FLOAT_to_DOUBLE__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_DOUBLE/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11\n",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_DOUBLE/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_DOUBLE/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cast_FLOAT_to_FLOAT16__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cast_FLOAT_to_FLOAT16__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_FLOAT16/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11\n",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_FLOAT16/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_FLOAT16/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_axes_chw_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_axes_chw_expanded__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Out of tolerance (max ULP 3113727168)",
+  "error": "Out of tolerance (max ULP 2628197611)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_axes_chw_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_axes_chw_expanded/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_axes_hwc_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_axes_hwc_expanded__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Out of tolerance (max ULP 2416571251)",
+  "error": "Out of tolerance (max ULP 2398134387)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_axes_hwc_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_axes_hwc_expanded/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_expanded__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Out of tolerance (max ULP 3001582704)",
+  "error": "Out of tolerance (max ULP 2919007646)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_expanded/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_negative_axes_hwc_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_negative_axes_hwc_expanded__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Out of tolerance (max ULP 2774559114)",
+  "error": "Out of tolerance (max ULP 3109602238)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_negative_axes_hwc_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_negative_axes_hwc_expanded/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_pad_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_pad_expanded__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Out of tolerance (max ULP 2771587255)",
+  "error": "Out of tolerance (max ULP 2861363383)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_center_crop_pad_pad_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_center_crop_pad_pad_expanded/test_data_set_0"
 }


### PR DESCRIPTION
### Motivation
- Testbench C builds failed when generated test data contained non-finite floats because NaN/Inf were emitted as invalid C tokens and `math.h` was not included when only testbench constants needed it.
- Golden references need updating after regenerating test outputs with the new behavior.

### Description
- Added `import math` and implemented `_testbench_requires_math` to detect non-finite float testbench inputs and conditionally inject `#include <math.h>` into emitted includes.
- Updated `_format_float` and `_format_double` to emit `NAN` and `INFINITY` (with sign for negative infinity) for non-finite values so emitted C tokens are valid, and adjusted `_format_float16`/hex helpers accordingly.
- Updated `src/emx_onnx_cgen/codegen/c_emitter.py` and refreshed generated artifacts: `OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`, and several `tests/expected_errors/*.onnx.json` snapshots to reflect the new runtime vs build outcomes.

### Testing
- Ran the full test refresh with `UPDATE_REFS=1 pytest -n auto -q`, which completed successfully and updated golden files (test run: `824 passed, 1 skipped`, with 2 warnings). 
- Committed the refreshed references and verified the changed `tests/expected_errors` entries now reflect ONNX Runtime errors instead of previous "Failed to build testbench." outcomes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696d6603e1c88325846ec0d7b7172df2)