### PR TITLE
codegen: fix broadcasted binary ops

### DIFF
--- a/src/emx_onnx_cgen/compiler.py
+++ b/src/emx_onnx_cgen/compiler.py
@@ -537,6 +537,8 @@ def _lower_binary_unary(graph: Graph, node: Node) -> BinaryOp | UnaryOp:
         op_spec = binary_op_symbol(function, node.attrs, dtype=op_dtype)
         if op_spec is None:
             raise UnsupportedOpError("Unsupported op BitShift")
+        input0_shape = value_shape(graph, node.inputs[0], node)
+        input1_shape = value_shape(graph, node.inputs[1], node)
         output_shape = value_shape(graph, node.outputs[0], node)
         return BinaryOp(
             input0=node.inputs[0],
@@ -544,6 +546,8 @@ def _lower_binary_unary(graph: Graph, node: Node) -> BinaryOp | UnaryOp:
             output=node.outputs[0],
             function=function,
             operator_kind=op_spec.kind,
+            input0_shape=input0_shape,
+            input1_shape=input1_shape,
             shape=output_shape,
             dtype=op_dtype,
             input_dtype=op_dtype,
@@ -577,6 +581,8 @@ def _lower_binary_unary(graph: Graph, node: Node) -> BinaryOp | UnaryOp:
             raise UnsupportedOpError(
                 f"{node.op_type} expects bool output, got {output_dtype.onnx_name}"
             )
+        input0_shape = value_shape(graph, node.inputs[0], node)
+        input1_shape = value_shape(graph, node.inputs[1], node)
         output_shape = value_shape(graph, node.outputs[0], node)
         return BinaryOp(
             input0=node.inputs[0],
@@ -584,6 +590,8 @@ def _lower_binary_unary(graph: Graph, node: Node) -> BinaryOp | UnaryOp:
             output=node.outputs[0],
             function=function,
             operator_kind=op_spec.kind,
+            input0_shape=input0_shape,
+            input1_shape=input1_shape,
             shape=output_shape,
             dtype=output_dtype,
             input_dtype=input_dtype,
@@ -598,6 +606,8 @@ def _lower_binary_unary(graph: Graph, node: Node) -> BinaryOp | UnaryOp:
             raise UnsupportedOpError(
                 f"{node.op_type} must have 2 inputs and 1 output"
             )
+        input0_shape = value_shape(graph, node.inputs[0], node)
+        input1_shape = value_shape(graph, node.inputs[1], node)
         output_shape = value_shape(graph, node.outputs[0], node)
         return BinaryOp(
             input0=node.inputs[0],
@@ -605,6 +615,8 @@ def _lower_binary_unary(graph: Graph, node: Node) -> BinaryOp | UnaryOp:
             output=node.outputs[0],
             function=function,
             operator_kind=op_spec.kind,
+            input0_shape=input0_shape,
+            input1_shape=input1_shape,
             shape=output_shape,
             dtype=op_dtype,
             input_dtype=op_dtype,

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_add_bcast__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_add_bcast__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Out of tolerance (max ULP 2143208269)",
+  "error": "OK",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_add_bcast/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_add_bcast/test_data_set_0"
 }


### PR DESCRIPTION
### Motivation
- The Add bcast backend test was failing verification due to codegen emitting elementwise binaries without accounting for per-input shapes, causing incorrect indexing for broadcasted operands.

### Description
- Add `input0_shape` and `input1_shape` fields to the `BinaryOp` dataclass so binary ops carry each input's shape into codegen. 
- Populate `input0_shape` / `input1_shape` during lowering in `compiler._lower_binary_unary` for all binary cases so the emitter has the original input shapes. 
- Update `CEmitter` to use per-input shapes when building parameter suffixes and to generate broadcast-aware index expressions for binary ops. 
- Update the golden expectation for the `test_add_bcast` model to reflect successful verification.

### Testing
- Ran the targeted test `pytest tests/test_official_onnx_files.py::test_official_onnx_expected_errors -k test_add_bcast` which passed in 2.23s.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696d706316a083259c0e9939d39371cb)