### PR TITLE
codegen: emit placeholder for empty scalar testbench data and refresh reference outputs

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -110,7 +110,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_diff_heads_sizes_causal_expanded/model.onnx | ❌ | Where output shape must be (1, 1), got (1,) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_diff_heads_sizes_expanded/model.onnx | ❌ | Out of tolerance (max ULP 4294967295) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_diff_heads_sizes_scaled/model.onnx | ✅ | OK (max ULP 4) |
-| onnx-org/onnx/backend/test/data/node/test_attention_3d_diff_heads_sizes_scaled_expanded/model.onnx | ❌ | Failed to build testbench. |
+| onnx-org/onnx/backend/test/data/node/test_attention_3d_diff_heads_sizes_scaled_expanded/model.onnx | ❌ | Out of tolerance (max ULP 4294967295) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_diff_heads_sizes_softcap/model.onnx | ✅ | OK (max ULP 4) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_diff_heads_sizes_softcap_expanded/model.onnx | ❌ | Out of tolerance (max ULP 4294967295) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_diff_heads_with_past_and_present/model.onnx | ✅ | OK (max ULP 4) |
@@ -123,13 +123,13 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_gqa_causal_expanded/model.onnx | ❌ | Where output shape must be (1, 1), got (1,) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_gqa_expanded/model.onnx | ❌ | Out of tolerance (max ULP 4294967295) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_gqa_scaled/model.onnx | ✅ | OK (max ULP 3) |
-| onnx-org/onnx/backend/test/data/node/test_attention_3d_gqa_scaled_expanded/model.onnx | ❌ | Failed to build testbench. |
+| onnx-org/onnx/backend/test/data/node/test_attention_3d_gqa_scaled_expanded/model.onnx | ❌ | Out of tolerance (max ULP 4294967295) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_gqa_softcap/model.onnx | ✅ | OK (max ULP 3) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_gqa_softcap_expanded/model.onnx | ❌ | Out of tolerance (max ULP 4294967295) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_gqa_with_past_and_present/model.onnx | ✅ | OK (max ULP 5) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_gqa_with_past_and_present_expanded/model.onnx | ❌ | Out of tolerance (max ULP 4294967295) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_scaled/model.onnx | ✅ | OK (max ULP 4) |
-| onnx-org/onnx/backend/test/data/node/test_attention_3d_scaled_expanded/model.onnx | ❌ | Failed to build testbench. |
+| onnx-org/onnx/backend/test/data/node/test_attention_3d_scaled_expanded/model.onnx | ❌ | Out of tolerance (max ULP 4294967295) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_softcap/model.onnx | ✅ | OK (max ULP 3) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_softcap_expanded/model.onnx | ❌ | Out of tolerance (max ULP 4294967295) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_transpose_verification/model.onnx | ✅ | OK (max ULP 0) |
@@ -170,7 +170,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_diff_heads_sizes_causal_expanded/model.onnx | ❌ | Where output shape must be (1, 1), got (1,) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_diff_heads_sizes_expanded/model.onnx | ❌ | Out of tolerance (max ULP 2004067) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_diff_heads_sizes_scaled/model.onnx | ✅ | OK (max ULP 3) |
-| onnx-org/onnx/backend/test/data/node/test_attention_4d_diff_heads_sizes_scaled_expanded/model.onnx | ❌ | Failed to build testbench. |
+| onnx-org/onnx/backend/test/data/node/test_attention_4d_diff_heads_sizes_scaled_expanded/model.onnx | ❌ | Out of tolerance (max ULP 62279) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_diff_heads_sizes_softcap/model.onnx | ✅ | OK (max ULP 3) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_diff_heads_sizes_softcap_expanded/model.onnx | ❌ | Out of tolerance (max ULP 4294967295) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_diff_heads_with_past_and_present/model.onnx | ✅ | OK (max ULP 4) |
@@ -189,7 +189,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_gqa_causal_expanded/model.onnx | ❌ | Where output shape must be (1, 1), got (1,) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_gqa_expanded/model.onnx | ❌ | Out of tolerance (max ULP 3777733) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_gqa_scaled/model.onnx | ✅ | OK (max ULP 3) |
-| onnx-org/onnx/backend/test/data/node/test_attention_4d_gqa_scaled_expanded/model.onnx | ❌ | Failed to build testbench. |
+| onnx-org/onnx/backend/test/data/node/test_attention_4d_gqa_scaled_expanded/model.onnx | ❌ | Out of tolerance (max ULP 6562330) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_gqa_softcap/model.onnx | ✅ | OK (max ULP 3) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_gqa_softcap_expanded/model.onnx | ❌ | Out of tolerance (max ULP 4294967295) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_gqa_with_past_and_present/model.onnx | ✅ | OK (max ULP 5) |
@@ -197,7 +197,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_gqa_with_past_and_present_fp16/model.onnx | ✅ | OK (max ULP 5) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_gqa_with_past_and_present_fp16_expanded/model.onnx | ❌ | Out of tolerance (max ULP 300) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_scaled/model.onnx | ✅ | OK (max ULP 4) |
-| onnx-org/onnx/backend/test/data/node/test_attention_4d_scaled_expanded/model.onnx | ❌ | Failed to build testbench. |
+| onnx-org/onnx/backend/test/data/node/test_attention_4d_scaled_expanded/model.onnx | ❌ | Out of tolerance (max ULP 74574) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_softcap/model.onnx | ✅ | OK (max ULP 3) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_softcap_expanded/model.onnx | ❌ | Out of tolerance (max ULP 4294967295) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present/model.onnx | ✅ | OK (max ULP 5) |
@@ -345,13 +345,13 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_cast_no_saturate_FLOAT_to_FLOAT8E5M2FNUZ/model.onnx | ❌ | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor 'output'. |
 | onnx-org/onnx/backend/test/data/node/test_castlike_BFLOAT16_to_FLOAT/model.onnx | ❌ | Unsupported elem_type 16 (BFLOAT16) for tensor 'input'. |
 | onnx-org/onnx/backend/test/data/node/test_castlike_BFLOAT16_to_FLOAT_expanded/model.onnx | ❌ | Unsupported elem_type 16 (BFLOAT16) for tensor 'input'. |
-| onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT/model.onnx | ❌ | Failed to build testbench. |
-| onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT16/model.onnx | ❌ | Failed to build testbench. |
-| onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT16_expanded/model.onnx | ❌ | Failed to build testbench. |
-| onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT_expanded/model.onnx | ❌ | Failed to build testbench. |
-| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_DOUBLE/model.onnx | ❌ | Failed to build testbench. |
-| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_DOUBLE_expanded/model.onnx | ❌ | Failed to build testbench. |
-| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT/model.onnx | ❌ | Failed to build testbench. |
+| onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT/model.onnx | ❌ | ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11 |
+| onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT16/model.onnx | ❌ | ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT16/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11 |
+| onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT16_expanded/model.onnx | ❌ | ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT16_expanded/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11 |
+| onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT_expanded/model.onnx | ❌ | ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT_expanded/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11 |
+| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_DOUBLE/model.onnx | ❌ | ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_DOUBLE/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11 |
+| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_DOUBLE_expanded/model.onnx | ❌ | ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_DOUBLE_expanded/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11 |
+| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT/model.onnx | ❌ | ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11 |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT4E2M1/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'like'. |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT4E2M1_expanded/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'like'. |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT8E4M3FN/model.onnx | ❌ | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'like'. |
@@ -362,7 +362,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT8E5M2FNUZ/model.onnx | ❌ | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor 'like'. |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT8E5M2FNUZ_expanded/model.onnx | ❌ | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor 'like'. |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT8E5M2_expanded/model.onnx | ❌ | Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'like'. |
-| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT_expanded/model.onnx | ❌ | Failed to build testbench. |
+| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT_expanded/model.onnx | ❌ | ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT_expanded/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11 |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_INT2/model.onnx | ❌ | Unsupported elem_type 26 (INT2) for tensor 'like'. |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_INT2_expanded/model.onnx | ❌ | Unsupported elem_type 26 (INT2) for tensor 'like'. |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_INT4/model.onnx | ❌ | Unsupported elem_type 22 (INT4) for tensor 'like'. |
@@ -393,10 +393,10 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT8E5M2_to_FLOAT_expanded/model.onnx | ❌ | Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'input'. |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_BFLOAT16/model.onnx | ❌ | Unsupported elem_type 16 (BFLOAT16) for tensor 'like'. |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_BFLOAT16_expanded/model.onnx | ❌ | Unsupported elem_type 16 (BFLOAT16) for tensor 'like'. |
-| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_DOUBLE/model.onnx | ❌ | Failed to build testbench. |
-| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_DOUBLE_expanded/model.onnx | ❌ | Failed to build testbench. |
-| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT16/model.onnx | ❌ | Failed to build testbench. |
-| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT16_expanded/model.onnx | ❌ | Failed to build testbench. |
+| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_DOUBLE/model.onnx | ❌ | ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_DOUBLE/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11 |
+| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_DOUBLE_expanded/model.onnx | ❌ | ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_DOUBLE_expanded/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11 |
+| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT16/model.onnx | ❌ | ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT16/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11 |
+| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT16_expanded/model.onnx | ❌ | ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT16_expanded/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11 |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT4E2M1/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'like'. |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT4E2M1_expanded/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'like'. |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT8E4M3FN/model.onnx | ❌ | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'like'. |
@@ -463,14 +463,14 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_and_pad/model.onnx | ❌ | Unsupported op CenterCropPad |
 | onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_and_pad_expanded/model.onnx | ❌ | Out of tolerance (max ULP 2827146620) |
 | onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_axes_chw/model.onnx | ❌ | Unsupported op CenterCropPad |
-| onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_axes_chw_expanded/model.onnx | ❌ | Out of tolerance (max ULP 2628197611) |
+| onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_axes_chw_expanded/model.onnx | ❌ | Out of tolerance (max ULP 2162567595) |
 | onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_axes_hwc/model.onnx | ❌ | Unsupported op CenterCropPad |
-| onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_axes_hwc_expanded/model.onnx | ❌ | Out of tolerance (max ULP 2398134387) |
-| onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_expanded/model.onnx | ❌ | Out of tolerance (max ULP 2919007646) |
+| onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_axes_hwc_expanded/model.onnx | ❌ | Out of tolerance (max ULP 2260728201) |
+| onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_expanded/model.onnx | ❌ | Out of tolerance (max ULP 2134203891) |
 | onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_negative_axes_hwc/model.onnx | ❌ | Unsupported op CenterCropPad |
-| onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_negative_axes_hwc_expanded/model.onnx | ❌ | Out of tolerance (max ULP 3109602238) |
+| onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_negative_axes_hwc_expanded/model.onnx | ❌ | Out of tolerance (max ULP 3159500101) |
 | onnx-org/onnx/backend/test/data/node/test_center_crop_pad_pad/model.onnx | ❌ | Unsupported op CenterCropPad |
-| onnx-org/onnx/backend/test/data/node/test_center_crop_pad_pad_expanded/model.onnx | ❌ | Out of tolerance (max ULP 2861363383) |
+| onnx-org/onnx/backend/test/data/node/test_center_crop_pad_pad_expanded/model.onnx | ❌ | Out of tolerance (max ULP 2553782455) |
 | onnx-org/onnx/backend/test/data/node/test_clip/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_clip_default_inbounds/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_clip_default_inbounds_expanded/model.onnx | ✅ | OK (max ULP 0) |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -2,47 +2,46 @@
 
 | Error message | Count | Histogram |
 | --- | --- | --- |
-| Out of tolerance (max ULP 4294967295) | 21 | ██████████████████████████████ |
-| Failed to build testbench. | 18 | ██████████████████████████ |
-| Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 18 | ██████████████████████████ |
-| Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 18 | ██████████████████████████ |
-| Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 18 | ██████████████████████████ |
-| Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 18 | ██████████████████████████ |
-| Unsupported elem_type 26 (INT2) for tensor '*'. | 15 | █████████████████████ |
-| Unsupported elem_type 22 (INT4) for tensor '*'. | 15 | █████████████████████ |
-| Unsupported elem_type 25 (UINT2) for tensor '*'. | 15 | █████████████████████ |
-| Unsupported elem_type 21 (UINT4) for tensor '*'. | 15 | █████████████████████ |
-| Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 12 | █████████████████ |
-| Where output shape must be (1, 1), got (1,) | 10 | ██████████████ |
-| Testbench execution failed: exit code -11 (signal 11: SIGSEGV) | 9 | █████████████ |
-| AveragePool has unsupported attributes | 6 | █████████ |
-| Unsupported elem_type 16 (BFLOAT16) for tensor '*'. | 6 | █████████ |
-| Unsupported op CenterCropPad | 6 | █████████ |
-| And expects identical input/output shapes | 5 | ███████ |
-| Unsupported op Col2Im | 5 | ███████ |
-| Unsupported op AffineGrid | 4 | ██████ |
-| Unsupported op If | 4 | ██████ |
-| Unsupported elem_type 8 (STRING) for tensor '*'. | 4 | ██████ |
-| Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 4 | ██████ |
-| Unsupported op Compress | 4 | ██████ |
+| Out of tolerance (max ULP 4294967295) | 24 | ██████████████████████████████ |
+| Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 18 | ██████████████████████ |
+| Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 18 | ██████████████████████ |
+| Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 18 | ██████████████████████ |
+| Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 18 | ██████████████████████ |
+| Unsupported elem_type 26 (INT2) for tensor '*'. | 15 | ███████████████████ |
+| Unsupported elem_type 22 (INT4) for tensor '*'. | 15 | ███████████████████ |
+| Unsupported elem_type 25 (UINT2) for tensor '*'. | 15 | ███████████████████ |
+| Unsupported elem_type 21 (UINT4) for tensor '*'. | 15 | ███████████████████ |
+| Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 12 | ███████████████ |
+| Where output shape must be (1, 1), got (1,) | 10 | ████████████ |
+| Testbench execution failed: exit code -11 (signal 11: SIGSEGV) | 9 | ███████████ |
+| AveragePool has unsupported attributes | 6 | ████████ |
+| Unsupported elem_type 16 (BFLOAT16) for tensor '*'. | 6 | ████████ |
+| Unsupported op CenterCropPad | 6 | ████████ |
+| And expects identical input/output shapes | 5 | ██████ |
+| Unsupported op Col2Im | 5 | ██████ |
+| Unsupported op AffineGrid | 4 | █████ |
+| Unsupported op If | 4 | █████ |
+| Unsupported elem_type 8 (STRING) for tensor '*'. | 4 | █████ |
+| Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 4 | █████ |
+| Unsupported op Compress | 4 | █████ |
 | Out of tolerance (max ULP 1818802) | 3 | ████ |
 | AveragePool supports auto_pad=NOTSET only | 3 | ████ |
 | Unsupported op Bernoulli | 3 | ████ |
 | Unsupported op RandomUniformLike | 3 | ████ |
-| Unsupported op Adagrad | 2 | ███ |
-| Unsupported op Adam | 2 | ███ |
-| Unsupported op TreeEnsemble | 2 | ███ |
-| AveragePool expects 2D kernel_shape | 2 | ███ |
-| AveragePool supports ceil_mode=0 only | 2 | ███ |
-| Unsupported op DeformConv | 2 | ███ |
-| BatchNormalization must have 5 inputs and 1 output | 2 | ███ |
-| BitwiseAnd expects identical input/output shapes | 2 | ███ |
-| Unsupported op BitwiseNot | 2 | ███ |
-| BitwiseOr expects identical input/output shapes | 2 | ███ |
-| BitwiseXor expects identical input/output shapes | 2 | ███ |
-| Unsupported op BlackmanWindow | 2 | ███ |
-| Cast input and output shapes must match | 2 | ███ |
-| Out of tolerance (max ULP 1084227585) | 2 | ███ |
+| Unsupported op Adagrad | 2 | ██ |
+| Unsupported op Adam | 2 | ██ |
+| Unsupported op TreeEnsemble | 2 | ██ |
+| AveragePool expects 2D kernel_shape | 2 | ██ |
+| AveragePool supports ceil_mode=0 only | 2 | ██ |
+| Unsupported op DeformConv | 2 | ██ |
+| BatchNormalization must have 5 inputs and 1 output | 2 | ██ |
+| BitwiseAnd expects identical input/output shapes | 2 | ██ |
+| Unsupported op BitwiseNot | 2 | ██ |
+| BitwiseOr expects identical input/output shapes | 2 | ██ |
+| BitwiseXor expects identical input/output shapes | 2 | ██ |
+| Unsupported op BlackmanWindow | 2 | ██ |
+| Cast input and output shapes must match | 2 | ██ |
+| Out of tolerance (max ULP 1084227585) | 2 | ██ |
 | Out of tolerance (max ULP 2143208269) | 1 | █ |
 | Unsupported op ArrayFeatureExtractor | 1 | █ |
 | Unsupported op Binarizer | 1 | █ |
@@ -54,14 +53,17 @@
 | Pad value input must be a scalar | 1 | █ |
 | Out of tolerance (max ULP 3668711) | 1 | █ |
 | Out of tolerance (max ULP 2004067) | 1 | █ |
+| Out of tolerance (max ULP 62279) | 1 | █ |
 | Out of tolerance (max ULP 2460850) | 1 | █ |
 | Out of tolerance (max ULP 2363933) | 1 | █ |
 | Out of tolerance (max ULP 1556056) | 1 | █ |
 | Out of tolerance (max ULP 222) | 1 | █ |
 | Out of tolerance (max ULP 6539519) | 1 | █ |
 | Out of tolerance (max ULP 3777733) | 1 | █ |
+| Out of tolerance (max ULP 6562330) | 1 | █ |
 | Out of tolerance (max ULP 3042080) | 1 | █ |
 | Out of tolerance (max ULP 300) | 1 | █ |
+| Out of tolerance (max ULP 74574) | 1 | █ |
 | Out of tolerance (max ULP 1902013) | 1 | █ |
 | Out of tolerance (max ULP 1071538375) | 1 | █ |
 | Out of tolerance (max ULP 85699935) | 1 | █ |
@@ -82,12 +84,36 @@
  | 1 | █ |
 | ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_FLOAT16/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
  | 1 | █ |
+| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
+ | 1 | █ |
+| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT16/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
+ | 1 | █ |
+| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT16_expanded/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
+ | 1 | █ |
+| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT_expanded/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
+ | 1 | █ |
+| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_DOUBLE/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
+ | 1 | █ |
+| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_DOUBLE_expanded/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
+ | 1 | █ |
+| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
+ | 1 | █ |
+| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT_expanded/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
+ | 1 | █ |
+| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_DOUBLE/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
+ | 1 | █ |
+| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_DOUBLE_expanded/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
+ | 1 | █ |
+| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT16/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
+ | 1 | █ |
+| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT16_expanded/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
+ | 1 | █ |
 | Out of tolerance (max ULP 2827146620) | 1 | █ |
-| Out of tolerance (max ULP 2628197611) | 1 | █ |
-| Out of tolerance (max ULP 2398134387) | 1 | █ |
-| Out of tolerance (max ULP 2919007646) | 1 | █ |
-| Out of tolerance (max ULP 3109602238) | 1 | █ |
-| Out of tolerance (max ULP 2861363383) | 1 | █ |
+| Out of tolerance (max ULP 2162567595) | 1 | █ |
+| Out of tolerance (max ULP 2260728201) | 1 | █ |
+| Out of tolerance (max ULP 2134203891) | 1 | █ |
+| Out of tolerance (max ULP 3159500101) | 1 | █ |
+| Out of tolerance (max ULP 2553782455) | 1 | █ |
 | Out of tolerance (max ULP 1069384066) | 1 | █ |
 | Out of tolerance (max ULP 1072630820) | 1 | █ |
 | Out of tolerance (max ULP 1065353216) | 1 | █ |

--- a/src/emx_onnx_cgen/codegen/c_emitter.py
+++ b/src/emx_onnx_cgen/codegen/c_emitter.py
@@ -9456,6 +9456,7 @@ class CEmitter:
         dim_names: Mapping[int, str] | None,
     ) -> tuple[str | int, ...]:
         dim_names = dim_names or {}
+        shape = CEmitter._codegen_shape(shape)
         return tuple(
             dim_names.get(index, dim) for index, dim in enumerate(shape)
         )
@@ -9602,10 +9603,13 @@ class CEmitter:
             constant_lines = None
             if constant_values is not None:
                 constant_name = f"{name}_testbench_data"
-                constant_lines = [
-                    self._format_value(value, dtype)
-                    for value in constant_values
-                ]
+                if constant_values:
+                    constant_lines = [
+                        self._format_value(value, dtype)
+                        for value in constant_values
+                    ]
+                else:
+                    constant_lines = [self._format_value(0, dtype)]
             inputs.append(
                 {
                     "name": name,

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_diff_heads_sizes_scaled_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_diff_heads_sizes_scaled_expanded__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "Out of tolerance (max ULP 4294967295)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_attention_3d_diff_heads_sizes_scaled_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_attention_3d_diff_heads_sizes_scaled_expanded/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_gqa_scaled_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_gqa_scaled_expanded__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "Out of tolerance (max ULP 4294967295)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_attention_3d_gqa_scaled_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_attention_3d_gqa_scaled_expanded/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_scaled_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_scaled_expanded__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "Out of tolerance (max ULP 4294967295)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_attention_3d_scaled_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_attention_3d_scaled_expanded/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_diff_heads_sizes_scaled_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_diff_heads_sizes_scaled_expanded__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "Out of tolerance (max ULP 62279)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_attention_4d_diff_heads_sizes_scaled_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_attention_4d_diff_heads_sizes_scaled_expanded/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_gqa_scaled_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_gqa_scaled_expanded__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "Out of tolerance (max ULP 6562330)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_attention_4d_gqa_scaled_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_attention_4d_gqa_scaled_expanded/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_scaled_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_scaled_expanded__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "Out of tolerance (max ULP 74574)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_attention_4d_scaled_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_attention_4d_scaled_expanded/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_DOUBLE_to_FLOAT16__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_DOUBLE_to_FLOAT16__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT16/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11\n",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT16/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT16/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_DOUBLE_to_FLOAT16_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_DOUBLE_to_FLOAT16_expanded__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT16_expanded/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11\n",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT16_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT16_expanded/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_DOUBLE_to_FLOAT__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_DOUBLE_to_FLOAT__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11\n",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_DOUBLE_to_FLOAT_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_DOUBLE_to_FLOAT_expanded__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT_expanded/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11\n",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT_expanded/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT16_to_DOUBLE__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT16_to_DOUBLE__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_DOUBLE/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11\n",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_DOUBLE/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_DOUBLE/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT16_to_DOUBLE_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT16_to_DOUBLE_expanded__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_DOUBLE_expanded/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11\n",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_DOUBLE_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_DOUBLE_expanded/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT16_to_FLOAT__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT16_to_FLOAT__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11\n",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT16_to_FLOAT_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT16_to_FLOAT_expanded__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT_expanded/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11\n",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT_expanded/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT_to_DOUBLE__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT_to_DOUBLE__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_DOUBLE/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11\n",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_DOUBLE/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_DOUBLE/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT_to_DOUBLE_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT_to_DOUBLE_expanded__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_DOUBLE_expanded/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11\n",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_DOUBLE_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_DOUBLE_expanded/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT_to_FLOAT16__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT_to_FLOAT16__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT16/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11\n",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT16/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT16/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT_to_FLOAT16_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT_to_FLOAT16_expanded__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT16_expanded/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11\n",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT16_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT16_expanded/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_axes_chw_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_axes_chw_expanded__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Out of tolerance (max ULP 2628197611)",
+  "error": "Out of tolerance (max ULP 2162567595)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_axes_chw_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_axes_chw_expanded/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_axes_hwc_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_axes_hwc_expanded__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Out of tolerance (max ULP 2398134387)",
+  "error": "Out of tolerance (max ULP 2260728201)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_axes_hwc_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_axes_hwc_expanded/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_expanded__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Out of tolerance (max ULP 2919007646)",
+  "error": "Out of tolerance (max ULP 2134203891)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_expanded/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_negative_axes_hwc_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_negative_axes_hwc_expanded__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Out of tolerance (max ULP 3109602238)",
+  "error": "Out of tolerance (max ULP 3159500101)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_negative_axes_hwc_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_center_crop_pad_crop_negative_axes_hwc_expanded/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_pad_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_pad_expanded__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Out of tolerance (max ULP 2861363383)",
+  "error": "Out of tolerance (max ULP 2553782455)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_center_crop_pad_pad_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_center_crop_pad_pad_expanded/test_data_set_0"
 }


### PR DESCRIPTION
### Motivation

- Avoid generating testbenches with missing static data when input `constant_values` arrays are empty, which resulted in undeclared identifiers and build failures during verification. 
- Ensure shape expressions used for emitted code reflect the emitter's normalized codegen shape to prevent mismatched loop/index expressions. 
- Refresh generated support documents and expected-error snapshots to match the verifier outputs after the emission fixes.

### Description

- Make `_shape_dim_exprs` call `CEmitter._codegen_shape` so shape expressions use the codegen-normalized shape. 
- Ensure the testbench emission code emits a zero placeholder when a `constant_values` list is present but empty by emitting `self._format_value(0, dtype)` for the constant lines. 
- Update generated files `OFFICIAL_ONNX_FILE_SUPPORT.md` and `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md` to reflect the new verification results. 
- Refresh expectation snapshots under `tests/expected_errors/` to match the updated verifier outputs for affected models.

### Testing

- Ran `UPDATE_REFS=1 pytest -n auto -q`, which completed successfully with `824 passed, 1 skipped, 2 warnings`.
- The reference refresh run produced updated support documents and expected-error files that are included in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696d7050a99c8325963459e018f21a2c)