### PR TITLE
codegen: carry per-input shapes for binary ops and add verification docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,20 @@ pytest -n auto -q
 
 When reporting executed tests, include the test duration in your feedback.
 
+### Verification (single ONNX model)
+
+To reproduce verification for an ONNX model, use the expectation entry as the
+source of truth for CLI arguments:
+
+1. Locate the model's expected error JSON in `tests/expected_errors/` (file
+   names are the repo-relative path with `/` replaced by `__`).
+2. Read the `command_line` field to capture the exact CLI arguments.
+3. Run verification by invoking the CLI with the recorded command line:
+
+```bash
+PYTHONPATH=src python -m emx_onnx_cgen.cli <command_line from JSON>
+```
+
 ### Golden reference updates
 
 Golden tests compare generated code against reference files. To refresh references

--- a/src/emx_onnx_cgen/compiler.py
+++ b/src/emx_onnx_cgen/compiler.py
@@ -537,6 +537,8 @@ def _lower_binary_unary(graph: Graph, node: Node) -> BinaryOp | UnaryOp:
         op_spec = binary_op_symbol(function, node.attrs, dtype=op_dtype)
         if op_spec is None:
             raise UnsupportedOpError("Unsupported op BitShift")
+        input0_shape = value_shape(graph, node.inputs[0], node)
+        input1_shape = value_shape(graph, node.inputs[1], node)
         output_shape = value_shape(graph, node.outputs[0], node)
         return BinaryOp(
             input0=node.inputs[0],
@@ -544,6 +546,8 @@ def _lower_binary_unary(graph: Graph, node: Node) -> BinaryOp | UnaryOp:
             output=node.outputs[0],
             function=function,
             operator_kind=op_spec.kind,
+            input0_shape=input0_shape,
+            input1_shape=input1_shape,
             shape=output_shape,
             dtype=op_dtype,
             input_dtype=op_dtype,
@@ -577,6 +581,8 @@ def _lower_binary_unary(graph: Graph, node: Node) -> BinaryOp | UnaryOp:
             raise UnsupportedOpError(
                 f"{node.op_type} expects bool output, got {output_dtype.onnx_name}"
             )
+        input0_shape = value_shape(graph, node.inputs[0], node)
+        input1_shape = value_shape(graph, node.inputs[1], node)
         output_shape = value_shape(graph, node.outputs[0], node)
         return BinaryOp(
             input0=node.inputs[0],
@@ -584,6 +590,8 @@ def _lower_binary_unary(graph: Graph, node: Node) -> BinaryOp | UnaryOp:
             output=node.outputs[0],
             function=function,
             operator_kind=op_spec.kind,
+            input0_shape=input0_shape,
+            input1_shape=input1_shape,
             shape=output_shape,
             dtype=output_dtype,
             input_dtype=input_dtype,
@@ -598,6 +606,8 @@ def _lower_binary_unary(graph: Graph, node: Node) -> BinaryOp | UnaryOp:
             raise UnsupportedOpError(
                 f"{node.op_type} must have 2 inputs and 1 output"
             )
+        input0_shape = value_shape(graph, node.inputs[0], node)
+        input1_shape = value_shape(graph, node.inputs[1], node)
         output_shape = value_shape(graph, node.outputs[0], node)
         return BinaryOp(
             input0=node.inputs[0],
@@ -605,6 +615,8 @@ def _lower_binary_unary(graph: Graph, node: Node) -> BinaryOp | UnaryOp:
             output=node.outputs[0],
             function=function,
             operator_kind=op_spec.kind,
+            input0_shape=input0_shape,
+            input1_shape=input1_shape,
             shape=output_shape,
             dtype=op_dtype,
             input_dtype=op_dtype,

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_add_bcast__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_add_bcast__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Out of tolerance (max ULP 2143208269)",
+  "error": "OK",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_add_bcast/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_add_bcast/test_data_set_0"
 }


### PR DESCRIPTION
### Motivation

- Binary elementwise ops emitted incorrect indexing for broadcasted operands because per-input shapes were not preserved into codegen. 
- The verification workflow for single ONNX models was not documented, so reproducing a failing case required inspection of tests and CLI usage. 

### Description

- Add `input0_shape` and `input1_shape` fields to the `BinaryOp` dataclass so binary ops carry each input's original shape into codegen. 
- Populate `input0_shape` / `input1_shape` in the lowering pass implemented by `_lower_binary_unary` so all binary cases include per-input shapes. 
- Update `CEmitter` to use per-input shapes when building parameter suffixes and when generating broadcast-aware index expressions (via `_broadcast_index_expr`) and to return correct input shape mappings for binary ops. 
- Update the expected-errors fixture for the `test_add_bcast` model to reflect successful verification (`"error": "OK"`).
- Document a step-by-step verification workflow for a single ONNX model in `AGENTS.md`, including using the `command_line` entry from `tests/expected_errors/` and the CLI invocation `PYTHONPATH=src python -m emx_onnx_cgen.cli <command_line from JSON>`.

### Testing

- Ran the targeted verification test `pytest tests/test_official_onnx_files.py::test_official_onnx_expected_errors -k test_add_bcast` which passed in 3.35s.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696d706316a083259c0e9939d39371cb)