### PR TITLE
tests: group tolerance and ONNX Runtime errors in histogram

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -2,106 +2,46 @@
 
 | Error message | Count | Histogram |
 | --- | --- | --- |
-| Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 18 | ██████████████████████████████ |
-| Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 18 | ██████████████████████████████ |
-| Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 18 | ██████████████████████████████ |
-| Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 18 | ██████████████████████████████ |
-| Unsupported elem_type 26 (INT2) for tensor '*'. | 15 | █████████████████████████ |
-| Unsupported elem_type 22 (INT4) for tensor '*'. | 15 | █████████████████████████ |
-| Unsupported elem_type 25 (UINT2) for tensor '*'. | 15 | █████████████████████████ |
-| Unsupported elem_type 21 (UINT4) for tensor '*'. | 15 | █████████████████████████ |
-| Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 12 | ████████████████████ |
-| Testbench execution failed: exit code -11 (signal 11: SIGSEGV) | 9 | ███████████████ |
-| AveragePool has unsupported attributes | 6 | ██████████ |
-| Unsupported elem_type 16 (BFLOAT16) for tensor '*'. | 6 | ██████████ |
-| Unsupported op CenterCropPad | 6 | ██████████ |
-| And expects identical input/output shapes | 5 | ████████ |
-| Unsupported op Col2Im | 5 | ████████ |
-| Unsupported op AffineGrid | 4 | ███████ |
-| Unsupported op If | 4 | ███████ |
-| Unsupported elem_type 8 (STRING) for tensor '*'. | 4 | ███████ |
-| Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 4 | ███████ |
-| Unsupported op Compress | 4 | ███████ |
-| AveragePool supports auto_pad=NOTSET only | 3 | █████ |
-| Unsupported op Bernoulli | 3 | █████ |
-| Unsupported op RandomUniformLike | 3 | █████ |
-| Unsupported op Adagrad | 2 | ███ |
-| Unsupported op Adam | 2 | ███ |
-| Unsupported op TreeEnsemble | 2 | ███ |
-| Out of tolerance (max ULP 2645975) | 2 | ███ |
-| AveragePool expects 2D kernel_shape | 2 | ███ |
-| AveragePool supports ceil_mode=0 only | 2 | ███ |
-| Unsupported op DeformConv | 2 | ███ |
-| BatchNormalization must have 5 inputs and 1 output | 2 | ███ |
-| BitwiseAnd expects identical input/output shapes | 2 | ███ |
-| Unsupported op BitwiseNot | 2 | ███ |
-| BitwiseOr expects identical input/output shapes | 2 | ███ |
-| BitwiseXor expects identical input/output shapes | 2 | ███ |
-| Unsupported op BlackmanWindow | 2 | ███ |
-| Unsupported op ArrayFeatureExtractor | 1 | ██ |
-| Unsupported op Binarizer | 1 | ██ |
-| Out of tolerance (max ULP 2687518) | 1 | ██ |
-| Out of tolerance (max ULP 6196633) | 1 | ██ |
-| Out of tolerance (max ULP 1996849) | 1 | ██ |
-| Out of tolerance (max ULP 2367254) | 1 | ██ |
-| Out of tolerance (max ULP 1993303) | 1 | ██ |
-| Out of tolerance (max ULP 54812) | 1 | ██ |
-| Out of tolerance (max ULP 1833014) | 1 | ██ |
-| Out of tolerance (max ULP 2557716) | 1 | ██ |
-| Out of tolerance (max ULP 79888) | 1 | ██ |
-| Out of tolerance (max ULP 2436080) | 1 | ██ |
-| Out of tolerance (max ULP 2946491) | 1 | ██ |
-| Out of tolerance (max ULP 3942617) | 1 | ██ |
-| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_attention_4d_diff_heads_mask4d_padded_kv/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 12, max supported IR version: 11
- | 1 | ██ |
-| Pad value input must be a scalar | 1 | ██ |
-| Out of tolerance (max ULP 2304394) | 1 | ██ |
-| Out of tolerance (max ULP 2485323) | 1 | ██ |
-| Out of tolerance (max ULP 2246145) | 1 | ██ |
-| Out of tolerance (max ULP 70687) | 1 | ██ |
-| Out of tolerance (max ULP 1813037) | 1 | ██ |
-| Out of tolerance (max ULP 85177) | 1 | ██ |
-| Out of tolerance (max ULP 2077807) | 1 | ██ |
-| Out of tolerance (max ULP 9163003) | 1 | ██ |
-| Out of tolerance (max ULP 15309573) | 1 | ██ |
-| Out of tolerance (max ULP 7917190) | 1 | ██ |
-| Out of tolerance (max ULP 11061934) | 1 | ██ |
-| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_DOUBLE_to_FLOAT/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
- | 1 | ██ |
-| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_DOUBLE_to_FLOAT16/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
- | 1 | ██ |
-| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_DOUBLE/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
- | 1 | ██ |
-| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_FLOAT/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
- | 1 | ██ |
-| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_DOUBLE/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
- | 1 | ██ |
-| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_FLOAT16/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
- | 1 | ██ |
-| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
- | 1 | ██ |
-| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT16/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
- | 1 | ██ |
-| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT16_expanded/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
- | 1 | ██ |
-| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT_expanded/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
- | 1 | ██ |
-| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_DOUBLE/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
- | 1 | ██ |
-| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_DOUBLE_expanded/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
- | 1 | ██ |
-| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
- | 1 | ██ |
-| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT_expanded/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
- | 1 | ██ |
-| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_DOUBLE/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
- | 1 | ██ |
-| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_DOUBLE_expanded/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
- | 1 | ██ |
-| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT16/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
- | 1 | ██ |
-| ONNX Runtime failed to run onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT16_expanded/model.onnx: [ONNXRuntimeError] : 1 : FAIL : /onnxruntime_src/onnxruntime/core/graph/model.cc:181 onnxruntime::Model::Model(onnx::ModelProto&&, const onnxruntime::PathString&, const onnxruntime::IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&, const onnxruntime::ModelOptions&) Unsupported model IR version: 13, max supported IR version: 11
- | 1 | ██ |
+| Out of tolerance | 25 | ██████████████████████████████ |
+| ONNX Runtime failed to run | 19 | ███████████████████████ |
+| Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 18 | ██████████████████████ |
+| Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 18 | ██████████████████████ |
+| Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 18 | ██████████████████████ |
+| Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 18 | ██████████████████████ |
+| Unsupported elem_type 26 (INT2) for tensor '*'. | 15 | ██████████████████ |
+| Unsupported elem_type 22 (INT4) for tensor '*'. | 15 | ██████████████████ |
+| Unsupported elem_type 25 (UINT2) for tensor '*'. | 15 | ██████████████████ |
+| Unsupported elem_type 21 (UINT4) for tensor '*'. | 15 | ██████████████████ |
+| Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 12 | ██████████████ |
+| Testbench execution failed: exit code -11 (signal 11: SIGSEGV) | 9 | ███████████ |
+| AveragePool has unsupported attributes | 6 | ███████ |
+| Unsupported elem_type 16 (BFLOAT16) for tensor '*'. | 6 | ███████ |
+| Unsupported op CenterCropPad | 6 | ███████ |
+| And expects identical input/output shapes | 5 | ██████ |
+| Unsupported op Col2Im | 5 | ██████ |
+| Unsupported op AffineGrid | 4 | █████ |
+| Unsupported op If | 4 | █████ |
+| Unsupported elem_type 8 (STRING) for tensor '*'. | 4 | █████ |
+| Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 4 | █████ |
+| Unsupported op Compress | 4 | █████ |
+| AveragePool supports auto_pad=NOTSET only | 3 | ████ |
+| Unsupported op Bernoulli | 3 | ████ |
+| Unsupported op RandomUniformLike | 3 | ████ |
+| Unsupported op Adagrad | 2 | ██ |
+| Unsupported op Adam | 2 | ██ |
+| Unsupported op TreeEnsemble | 2 | ██ |
+| AveragePool expects 2D kernel_shape | 2 | ██ |
+| AveragePool supports ceil_mode=0 only | 2 | ██ |
+| Unsupported op DeformConv | 2 | ██ |
+| BatchNormalization must have 5 inputs and 1 output | 2 | ██ |
+| BitwiseAnd expects identical input/output shapes | 2 | ██ |
+| Unsupported op BitwiseNot | 2 | ██ |
+| BitwiseOr expects identical input/output shapes | 2 | ██ |
+| BitwiseXor expects identical input/output shapes | 2 | ██ |
+| Unsupported op BlackmanWindow | 2 | ██ |
+| Unsupported op ArrayFeatureExtractor | 1 | █ |
+| Unsupported op Binarizer | 1 | █ |
+| Pad value input must be a scalar | 1 | █ |
 
 ## Local ONNX file support histogram
 
@@ -113,7 +53,6 @@
 | Unsupported LSTM direction b'*' | 2 | ███████████████ |
 | Unsupported op QLinearAdd | 2 | ███████████████ |
 | Unsupported op QLinearMul | 2 | ███████████████ |
+| ONNX Runtime failed to run | 2 | ███████████████ |
 | Gemm bias input must be broadcastable to output shape, got (2,) vs (2, 4) | 1 | ████████ |
-| Out of tolerance (max ULP 591626278) | 1 | ████████ |
-| ONNX Runtime failed to run onnx2c-org/test/local_ops/test_resize_downsample_sizes_linear_1D/model.onnx: [ONNXRuntimeError] : 10 : INVALID_GRAPH : This is an invalid model. In Node, ("sclbl-onnx-node1", Resize, "", -1) : ("X": tensor(float),"","","sizes": tensor(int64),) -> ("Y": tensor(float),) , Error Node (sclbl-onnx-node1)'s input 1 is marked single but has an empty string in the graph | 1 | ████████ |
-| ONNX Runtime failed to run onnx2c-org/test/local_ops/test_resize_downsample_sizes_linear_1D_align/model.onnx: [ONNXRuntimeError] : 10 : INVALID_GRAPH : This is an invalid model. In Node, ("sclbl-onnx-node1", Resize, "", -1) : ("X": tensor(float),"","","sizes": tensor(int64),) -> ("Y": tensor(float),) , Error Node (sclbl-onnx-node1)'s input 1 is marked single but has an empty string in the graph | 1 | ████████ |
+| Out of tolerance | 1 | ████████ |

--- a/tests/test_official_onnx_files_docs.py
+++ b/tests/test_official_onnx_files_docs.py
@@ -88,6 +88,10 @@ def _render_error_histogram_markdown(
     title: str = "# Error frequency",
 ) -> str:
     def _sanitize_error(error: str) -> str:
+        if error.startswith("Out of tolerance"):
+            return "Out of tolerance"
+        if error.startswith("ONNX Runtime failed to run"):
+            return "ONNX Runtime failed to run"
         return re.sub(r"'[^']*'", "'*'", error)
 
     errors = [


### PR DESCRIPTION
### Motivation
- Reduce noise in the error histogram by aggregating many variant messages for the same root cause into single buckets for easier inspection.
- Improve determinism of the histogram output by collapsing per-model numeric variants into high-level categories.

### Description
- Update `tests/test_official_onnx_files_docs.py` to map messages starting with `"Out of tolerance"` to a single `"Out of tolerance"` label and messages starting with `"ONNX Runtime failed to run"` to `"ONNX Runtime failed to run"` in the histogram sanitizer (`_sanitize_error`).
- Keep existing generic sanitization that collapses quoted substrings to `'*'` for other errors.
- Regenerate `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md` so the histogram reflects the new aggregated buckets (e.g. `Out of tolerance` and `ONNX Runtime failed to run` counts now shown as single lines).

### Testing
- Ran the targeted test file with reference regeneration: `UPDATE_REFS=1 pytest tests/test_official_onnx_files_docs.py -q`, which passed (1 passed in 2.94s).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696d85322fa08325be021a9ac610af5e)