### PR TITLE
docs: sort ONNX support tables and stabilize histogram ordering

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -7,10 +7,10 @@
 | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 18 | ████████████████████████████ |
 | Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 18 | ████████████████████████████ |
 | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 18 | ████████████████████████████ |
-| Unsupported elem_type 26 (INT2) for tensor '*'. | 15 | ████████████████████████ |
+| Unsupported elem_type 21 (UINT4) for tensor '*'. | 15 | ████████████████████████ |
 | Unsupported elem_type 22 (INT4) for tensor '*'. | 15 | ████████████████████████ |
 | Unsupported elem_type 25 (UINT2) for tensor '*'. | 15 | ████████████████████████ |
-| Unsupported elem_type 21 (UINT4) for tensor '*'. | 15 | ████████████████████████ |
+| Unsupported elem_type 26 (INT2) for tensor '*'. | 15 | ████████████████████████ |
 | Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 12 | ███████████████████ |
 | Testbench execution failed: exit code -11 (signal 11: SIGSEGV) | 9 | ██████████████ |
 | AveragePool has unsupported attributes | 6 | █████████ |
@@ -18,29 +18,29 @@
 | Unsupported op CenterCropPad | 6 | █████████ |
 | And expects identical input/output shapes | 5 | ████████ |
 | Unsupported op Col2Im | 5 | ████████ |
-| Unsupported op AffineGrid | 4 | ██████ |
-| Unsupported op If | 4 | ██████ |
-| Unsupported elem_type 8 (STRING) for tensor '*'. | 4 | ██████ |
 | Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 4 | ██████ |
+| Unsupported elem_type 8 (STRING) for tensor '*'. | 4 | ██████ |
+| Unsupported op AffineGrid | 4 | ██████ |
 | Unsupported op Compress | 4 | ██████ |
+| Unsupported op If | 4 | ██████ |
 | AveragePool supports auto_pad=NOTSET only | 3 | █████ |
 | Unsupported op Bernoulli | 3 | █████ |
 | Unsupported op RandomUniformLike | 3 | █████ |
-| Unsupported op Adagrad | 2 | ███ |
-| Unsupported op Adam | 2 | ███ |
-| Unsupported op TreeEnsemble | 2 | ███ |
 | AveragePool expects 2D kernel_shape | 2 | ███ |
 | AveragePool supports ceil_mode=0 only | 2 | ███ |
-| Unsupported op DeformConv | 2 | ███ |
 | BatchNormalization must have 5 inputs and 1 output | 2 | ███ |
 | BitwiseAnd expects identical input/output shapes | 2 | ███ |
-| Unsupported op BitwiseNot | 2 | ███ |
 | BitwiseOr expects identical input/output shapes | 2 | ███ |
 | BitwiseXor expects identical input/output shapes | 2 | ███ |
+| Unsupported op Adagrad | 2 | ███ |
+| Unsupported op Adam | 2 | ███ |
+| Unsupported op BitwiseNot | 2 | ███ |
 | Unsupported op BlackmanWindow | 2 | ███ |
+| Unsupported op DeformConv | 2 | ███ |
+| Unsupported op TreeEnsemble | 2 | ███ |
+| Pad value input must be a scalar | 1 | ██ |
 | Unsupported op ArrayFeatureExtractor | 1 | ██ |
 | Unsupported op Binarizer | 1 | ██ |
-| Pad value input must be a scalar | 1 | ██ |
 
 ## Local ONNX file support histogram
 
@@ -49,8 +49,8 @@
 | Error message | Count | Histogram |
 | --- | --- | --- |
 | Unsupported op ScatterND | 4 | ██████████████████████████████ |
+| ONNX Runtime failed to run | 2 | ███████████████ |
 | Unsupported LSTM direction b'*' | 2 | ███████████████ |
 | Unsupported op QLinearAdd | 2 | ███████████████ |
 | Unsupported op QLinearMul | 2 | ███████████████ |
-| ONNX Runtime failed to run | 2 | ███████████████ |
 | Gemm bias input must be broadcastable to output shape, got (2,) vs (2, 4) | 1 | ████████ |

--- a/tests/test_official_onnx_files_docs.py
+++ b/tests/test_official_onnx_files_docs.py
@@ -37,7 +37,7 @@ def _render_onnx_file_support_table(
         "| File | Supported | Error |",
         "| --- | --- | --- |",
     ]
-    for expectation in expectations:
+    for expectation in sorted(expectations, key=lambda item: item.path):
         supported = "✅" if _is_success_message(expectation.error) else "❌"
         message = expectation.error.replace("\n", " ").strip()
         lines.append(f"| {expectation.path} | {supported} | {message} |")
@@ -117,7 +117,10 @@ def _render_error_histogram_markdown(
         "| Error message | Count | Histogram |",
         "| --- | --- | --- |",
     ]
-    for error, count in counts.most_common():
+    for error, count in sorted(
+        counts.items(),
+        key=lambda item: (-item[1], item[0]),
+    ):
         lines.append(f"| {error} | {count} | {bar(count)} |")
     lines.append("")
     return "\n".join(lines)


### PR DESCRIPTION
### Motivation
- Ensure generated markdown tables are stable and deterministic by sorting table rows by file path to satisfy documentation generation requirements.
- Make the error-histogram output deterministic so ref generation and diffs are reproducible across runs.

### Description
- Sort expectations by `item.path` in `_render_onnx_file_support_table` to order the `OFFICIAL_ONNX_FILE_SUPPORT.md` tables by file path.
- Replace `Counter.most_common()` with a deterministic `sorted(counts.items(), key=lambda item: (-item[1], item[0]))` in `_render_error_histogram_markdown` to stabilize histogram ordering.
- Regenerated `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md` to reflect the deterministic ordering.

### Testing
- Ran `UPDATE_REFS=1 pytest -q tests/test_official_onnx_files_docs.py` which passed (1 passed in 1.83s; real 3.28s).
- Ran `pytest -q tests/test_official_onnx_files_docs.py` which passed (1 passed in 1.16s; real 2.57s).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696d979ec5d483258bfc0a871c2739fc)