### PR TITLE
tests: update golden refs

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -200,11 +200,11 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_scaled_expanded/model.onnx | ✅ | OK (max ULP 3) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_softcap/model.onnx | ✅ | OK (max ULP 3) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_softcap_expanded/model.onnx | ✅ | OK (max ULP 4) |
-| onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present/model.onnx | ✅ | OK (max ULP 4) |
+| onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present/model.onnx | ✅ | OK (max ULP 5) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_expanded/model.onnx | ✅ | OK (max ULP 4) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul/model.onnx | ✅ | OK (max ULP 4) |
-| onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias/model.onnx | ✅ | OK (max ULP 4) |
-| onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask/model.onnx | ✅ | OK (max ULP 4) |
+| onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias/model.onnx | ✅ | OK (max ULP 5) |
+| onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask/model.onnx | ✅ | OK (max ULP 3) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal/model.onnx | ✅ | OK (max ULP 4) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal_expanded/model.onnx | ✅ | OK (max ULP 5) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_expanded/model.onnx | ✅ | OK (max ULP 5) |

--- a/src/emx_onnx_cgen/codegen/c_emitter.py
+++ b/src/emx_onnx_cgen/codegen/c_emitter.py
@@ -7342,6 +7342,7 @@ class CEmitter:
                 [("input0", op.input0), ("output", op.output)]
             )
             input_suffix = self._param_array_suffix(op.input_shape)
+            output_shape = CEmitter._codegen_shape(op.output_shape)
             output_suffix = self._param_array_suffix(op.output_shape)
             param_decls = self._build_param_decls(
                 [
@@ -7349,6 +7350,7 @@ class CEmitter:
                     (params["output"], c_type, output_suffix, False),
                 ]
             )
+            loop_vars = CEmitter._loop_vars(op.output_shape)
             rendered = reshape_template.render(
                 model_name=model.name,
                 op_name=op_name,
@@ -7359,6 +7361,8 @@ class CEmitter:
                 input_suffix=input_suffix,
                 output_suffix=output_suffix,
                 element_count=CEmitter._element_count(op.output_shape),
+                output_shape=output_shape,
+                loop_vars=loop_vars,
             ).rstrip()
             return with_node_comment(rendered)
         if isinstance(op, IdentityOp):

--- a/templates/reshape_op.c.j2
+++ b/templates/reshape_op.c.j2
@@ -1,3 +1,14 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
-    memcpy({{ output }}, {{ input0 }}, sizeof({{ c_type }}) * {{ element_count }});
+    const {{ c_type }} *input0_data = (const {{ c_type }} *){{ input0 }};
+{% for dim in output_shape %}
+    for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+{% endfor %}
+    idx_t linear_idx = 0;
+{% for dim in output_shape %}
+    linear_idx = linear_idx * {{ dim }} + {{ loop_vars[loop.index0] }};
+{% endfor %}
+    {{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = input0_data[linear_idx];
+{% for _ in output_shape %}
+    }
+{% endfor %}
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "OK (max ULP 4)",
+  "error": "OK (max ULP 5)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "OK (max ULP 4)",
+  "error": "OK (max ULP 3)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present_qk_matmul_bias__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present_qk_matmul_bias__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "OK (max ULP 4)",
+  "error": "OK (max ULP 5)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias/test_data_set_0"
 }

--- a/tests/golden/op_reshape_reshape.c
+++ b/tests/golden/op_reshape_reshape.c
@@ -46,7 +46,15 @@ static const int64_t weight1_shape[2] = {
  * Attrs: n/a
  */
 static inline void node0_reshape(const float input0[restrict 2][3][4], float output[restrict 2][12]) {
-    memcpy(output, input0, sizeof(float) * 24);
+    const float *input0_data = (const float *)input0;
+    for (idx_t i0 = 0; i0 < 2; ++i0) {
+        for (idx_t i1 = 0; i1 < 12; ++i1) {
+            idx_t linear_idx = 0;
+            linear_idx = linear_idx * 2 + i0;
+            linear_idx = linear_idx * 12 + i1;
+            output[i0][i1] = input0_data[linear_idx];
+        }
+    }
 }
 
 void model(const float in0[restrict 2][3][4], float out[restrict 2][12]) {


### PR DESCRIPTION
### Motivation

- Refresh reference artifacts after a refs run to keep golden outputs and support data in sync with current codegen behavior.
- Reflect the codegen change that now emits explicit loop nests for `Reshape` instead of using `memcpy` so recorded golden output matches emitted C.

### Description

- Update `src/emx_onnx_cgen/codegen/c_emitter.py` to compute `output_shape` and `loop_vars` and pass them into the reshape template.
- Replace the `memcpy`-based reshape emission with an explicit nested-loop per-element copy by changing `templates/reshape_op.c.j2` to compute a `linear_idx` and assign elements inside generated loops.
- Refresh test baselines and metadata by updating `tests/golden/op_reshape_reshape.c`, `OFFICIAL_ONNX_FILE_SUPPORT.md`, and a few `tests/expected_errors/*.json` entries to match the current outputs.

### Testing

- Ran `UPDATE_REFS=1 pytest -n auto -q` which completed successfully with `2127 passed, 1 skipped` and reported `2 warnings`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696e0f71a88c8325b4b8b571a9111e55)