### PR TITLE
codegen: use scalar reductions for ScatterND

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1080 / 1802 official ONNX files.
+Support 1085 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -1370,11 +1370,11 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_scatter_elements_without_axis/model.onnx | ❌ | Unsupported op ScatterElements |
 | onnx-org/onnx/backend/test/data/node/test_scatter_with_axis/model.onnx | ❌ | Unsupported op Scatter |
 | onnx-org/onnx/backend/test/data/node/test_scatter_without_axis/model.onnx | ❌ | Unsupported op Scatter |
-| onnx-org/onnx/backend/test/data/node/test_scatternd/model.onnx | ❌ | Unsupported op ScatterND |
-| onnx-org/onnx/backend/test/data/node/test_scatternd_add/model.onnx | ❌ | Unsupported op ScatterND |
-| onnx-org/onnx/backend/test/data/node/test_scatternd_max/model.onnx | ❌ | Unsupported op ScatterND |
-| onnx-org/onnx/backend/test/data/node/test_scatternd_min/model.onnx | ❌ | Unsupported op ScatterND |
-| onnx-org/onnx/backend/test/data/node/test_scatternd_multiply/model.onnx | ❌ | Unsupported op ScatterND |
+| onnx-org/onnx/backend/test/data/node/test_scatternd/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_scatternd_add/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_scatternd_max/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_scatternd_min/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_scatternd_multiply/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_sce_NCd1_mean_weight_negative_ii/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx | ✅ | OK (max ULP 1) |
@@ -1815,7 +1815,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 
 Local tests: `onnx2c-org/test/local_ops`.
 
-Support 61 / 74 local ONNX files.
+Support 65 / 74 local ONNX files.
 
 | File | Supported | Error |
 | --- | --- | --- |
@@ -1887,9 +1887,9 @@ Support 61 / 74 local ONNX files.
 | test_resize_downsample_sizes_linear_1D/model.onnx | ❌ | ONNX Runtime failed to run onnx2c-org/test/local_ops/test_resize_downsample_sizes_linear_1D/model.onnx: [ONNXRuntimeError] : 10 : INVALID_GRAPH : This is an invalid model. In Node, ("sclbl-onnx-node1", Resize, "", -1) : ("X": tensor(float),"","","sizes": tensor(int64),) -> ("Y": tensor(float),) , Error Node (sclbl-onnx-node1)'s input 1 is marked single but has an empty string in the graph |
 | test_resize_downsample_sizes_linear_1D_align/model.onnx | ❌ | ONNX Runtime failed to run onnx2c-org/test/local_ops/test_resize_downsample_sizes_linear_1D_align/model.onnx: [ONNXRuntimeError] : 10 : INVALID_GRAPH : This is an invalid model. In Node, ("sclbl-onnx-node1", Resize, "", -1) : ("X": tensor(float),"","","sizes": tensor(int64),) -> ("Y": tensor(float),) , Error Node (sclbl-onnx-node1)'s input 1 is marked single but has an empty string in the graph |
 | test_scalar_input_to_node/model.onnx | ✅ | OK (max ULP 0) |
-| test_scatternd_indices_1x1x2/model.onnx | ❌ | Unsupported op ScatterND |
-| test_scatternd_indices_1x2x2/model.onnx | ❌ | Unsupported op ScatterND |
-| test_scatternd_indices_2x2x2/model.onnx | ❌ | Unsupported op ScatterND |
-| test_scatternd_indices_3x2/model.onnx | ❌ | Unsupported op ScatterND |
+| test_scatternd_indices_1x1x2/model.onnx | ✅ | OK (max ULP 0) |
+| test_scatternd_indices_1x2x2/model.onnx | ✅ | OK (max ULP 0) |
+| test_scatternd_indices_2x2x2/model.onnx | ✅ | OK (max ULP 0) |
+| test_scatternd_indices_3x2/model.onnx | ✅ | OK (max ULP 0) |
 | test_shape_const_out/model.onnx | ✅ | OK (max ULP 0) |
 | test_slice_end_INT64_MAX/model.onnx | ✅ | OK (max ULP 0) |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -42,7 +42,6 @@
 | Unsupported op Col2Im | 5 | ██ |
 | Unsupported op DequantizeLinear | 5 | ██ |
 | Unsupported op If | 5 | ██ |
-| Unsupported op ScatterND | 5 | ██ |
 | Xor expects identical input/output shapes | 5 | ██ |
 | Sum expects identical input/output shapes | 4 | █ |
 | Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 4 | █ |
@@ -156,9 +155,8 @@ Mismatched elements: 2 / 6 (33.3%)
 
 | Error message | Count | Histogram |
 | --- | --- | --- |
-| Unsupported op ScatterND | 4 | ██████████████████████████████ |
-| ONNX Runtime failed to run | 2 | ███████████████ |
-| Unsupported LSTM direction b'*' | 2 | ███████████████ |
-| Unsupported op QLinearAdd | 2 | ███████████████ |
-| Unsupported op QLinearMul | 2 | ███████████████ |
-| Gemm bias input must be broadcastable to output shape, got (2,) vs (2, 4) | 1 | ████████ |
+| ONNX Runtime failed to run | 2 | ██████████████████████████████ |
+| Unsupported LSTM direction b'*' | 2 | ██████████████████████████████ |
+| Unsupported op QLinearAdd | 2 | ██████████████████████████████ |
+| Unsupported op QLinearMul | 2 | ██████████████████████████████ |
+| Gemm bias input must be broadcastable to output shape, got (2,) vs (2, 4) | 1 | ███████████████ |

--- a/src/emx_onnx_cgen/compiler.py
+++ b/src/emx_onnx_cgen/compiler.py
@@ -34,6 +34,7 @@ from .codegen.c_emitter import (
     GemmOp,
     GatherOp,
     GatherElementsOp,
+    ScatterNDOp,
     ExpandOp,
     RangeOp,
     LpPoolOp,
@@ -91,6 +92,7 @@ from .lowering import cumsum as _cumsum  # noqa: F401
 from .lowering.flatten import lower_flatten
 from .lowering.gather import lower_gather
 from .lowering.gather_elements import lower_gather_elements
+from .lowering import scatter_nd as _scatter_nd  # noqa: F401
 from .lowering.gemm import resolve_gemm_spec, validate_gemm_bias_shape
 from .lowering.lrn import LrnSpec, resolve_lrn_spec
 from .lowering.logsoftmax import lower_logsoftmax
@@ -457,6 +459,7 @@ class Compiler:
             | ConcatOp
             | GatherElementsOp
             | GatherOp
+            | ScatterNDOp
             | TransposeOp
             | ConstantOfShapeOp
             | ReshapeOp

--- a/src/emx_onnx_cgen/lowering/scatter_nd.py
+++ b/src/emx_onnx_cgen/lowering/scatter_nd.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from shared.scalar_types import ScalarType
+
+from ..codegen.c_emitter import ScatterNDOp
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Node
+from .common import value_dtype, value_shape
+from .registry import register_lowering
+
+_ALLOWED_REDUCTIONS = {"none", "add", "mul", "min", "max"}
+
+
+@register_lowering("ScatterND")
+def lower_scatternd(graph: Graph, node: Node) -> ScatterNDOp:
+    if len(node.inputs) != 3 or len(node.outputs) != 1:
+        raise UnsupportedOpError("ScatterND must have 3 inputs and 1 output")
+    data_name, indices_name, updates_name = node.inputs
+    output_name = node.outputs[0]
+    data_shape = value_shape(graph, data_name, node)
+    indices_shape = value_shape(graph, indices_name, node)
+    updates_shape = value_shape(graph, updates_name, node)
+    output_shape = value_shape(graph, output_name, node)
+    if output_shape != data_shape:
+        raise ShapeInferenceError(
+            "ScatterND output shape must match data shape, "
+            f"got {output_shape} vs {data_shape}"
+        )
+    if len(indices_shape) < 1:
+        raise ShapeInferenceError("ScatterND indices must have rank >= 1")
+    index_depth = indices_shape[-1]
+    if index_depth <= 0:
+        raise ShapeInferenceError(
+            "ScatterND indices final dimension must be >= 1"
+        )
+    if index_depth > len(data_shape):
+        raise ShapeInferenceError(
+            "ScatterND indices final dimension must be <= data rank, "
+            f"got {index_depth} vs {len(data_shape)}"
+        )
+    expected_updates_shape = indices_shape[:-1] + data_shape[index_depth:]
+    if updates_shape != expected_updates_shape:
+        raise ShapeInferenceError(
+            "ScatterND updates shape must be "
+            f"{expected_updates_shape}, got {updates_shape}"
+        )
+    data_dtype = value_dtype(graph, data_name, node)
+    updates_dtype = value_dtype(graph, updates_name, node)
+    if updates_dtype != data_dtype:
+        raise UnsupportedOpError(
+            "ScatterND updates dtype must match data dtype, "
+            f"got {updates_dtype.onnx_name} vs {data_dtype.onnx_name}"
+        )
+    indices_dtype = value_dtype(graph, indices_name, node)
+    if indices_dtype not in {ScalarType.I64, ScalarType.I32}:
+        raise UnsupportedOpError(
+            "ScatterND indices must be int32 or int64, "
+            f"got {indices_dtype.onnx_name}"
+        )
+    reduction_attr = node.attrs.get("reduction", "none")
+    if isinstance(reduction_attr, bytes):
+        reduction = reduction_attr.decode()
+    else:
+        reduction = str(reduction_attr)
+    if reduction not in _ALLOWED_REDUCTIONS:
+        raise UnsupportedOpError(
+            "ScatterND reduction must be one of "
+            f"{sorted(_ALLOWED_REDUCTIONS)}, got {reduction}"
+        )
+    return ScatterNDOp(
+        data=data_name,
+        indices=indices_name,
+        updates=updates_name,
+        output=output_name,
+        data_shape=data_shape,
+        indices_shape=indices_shape,
+        updates_shape=updates_shape,
+        output_shape=output_shape,
+        reduction=reduction,
+        dtype=data_dtype,
+        indices_dtype=indices_dtype,
+    )

--- a/templates/scatter_nd_op.c.j2
+++ b/templates/scatter_nd_op.c.j2
@@ -1,0 +1,42 @@
+static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
+{% for dim in output_shape %}
+for (idx_t {{ output_loop_vars[loop.index0] }} = 0; {{ output_loop_vars[loop.index0] }} < {{ dim }}; ++{{ output_loop_vars[loop.index0] }}) {
+{% endfor %}
+    {{ output }}{% for var in output_loop_vars %}[{{ var }}]{% endfor %} = {{ data }}{% for var in output_loop_vars %}[{{ var }}]{% endfor %};
+{% for _ in output_shape %}
+}
+{% endfor %}
+
+{% if indices_prefix_shape %}
+{% for dim in indices_prefix_shape %}
+for (idx_t {{ indices_prefix_loop_vars[loop.index0] }} = 0; {{ indices_prefix_loop_vars[loop.index0] }} < {{ dim }}; ++{{ indices_prefix_loop_vars[loop.index0] }}) {
+{% endfor %}
+{% endif %}
+{% for idx in range(index_depth) %}
+    idx_t index{{ idx }} = {{ indices }}{% for var in indices_prefix_loop_vars %}[{{ var }}]{% endfor %}[{{ idx }}];
+    if (index{{ idx }} < 0) {
+        index{{ idx }} += {{ data_shape[idx] }};
+    }
+{% endfor %}
+{% if tail_shape %}
+{% for dim in tail_shape %}
+    for (idx_t {{ tail_loop_vars[loop.index0] }} = 0; {{ tail_loop_vars[loop.index0] }} < {{ dim }}; ++{{ tail_loop_vars[loop.index0] }}) {
+{% endfor %}
+{% endif %}
+    {{ c_type }} update_val = {{ updates_index_expr }};
+{% if reduction_function %}
+    {{ output_index_expr }} = {{ reduction_function }}({{ output_index_expr }}, update_val);
+{% else %}
+    {{ output_index_expr }} = update_val;
+{% endif %}
+{% if tail_shape %}
+{% for _ in tail_shape %}
+    }
+{% endfor %}
+{% endif %}
+{% if indices_prefix_shape %}
+{% for _ in indices_prefix_shape %}
+}
+{% endfor %}
+{% endif %}
+}

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_scatternd__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_scatternd__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Unsupported op ScatterND",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_scatternd/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_scatternd/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_scatternd_add__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_scatternd_add__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Unsupported op ScatterND",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_scatternd_add/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_scatternd_add/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_scatternd_max__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_scatternd_max__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Unsupported op ScatterND",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_scatternd_max/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_scatternd_max/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_scatternd_min__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_scatternd_min__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Unsupported op ScatterND",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_scatternd_min/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_scatternd_min/test_data_set_0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_scatternd_multiply__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_scatternd_multiply__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Unsupported op ScatterND",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_scatternd_multiply/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_scatternd_multiply/test_data_set_0"
 }

--- a/tests/expected_errors/onnx2c-org__test__local_ops__test_scatternd_indices_1x1x2__model.onnx.json
+++ b/tests/expected_errors/onnx2c-org__test__local_ops__test_scatternd_indices_1x1x2__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Unsupported op ScatterND",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx2c-org/test/local_ops/test_scatternd_indices_1x1x2/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx2c-org/test/local_ops/test_scatternd_indices_1x1x2/test_data_set_0"
 }

--- a/tests/expected_errors/onnx2c-org__test__local_ops__test_scatternd_indices_1x2x2__model.onnx.json
+++ b/tests/expected_errors/onnx2c-org__test__local_ops__test_scatternd_indices_1x2x2__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Unsupported op ScatterND",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx2c-org/test/local_ops/test_scatternd_indices_1x2x2/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx2c-org/test/local_ops/test_scatternd_indices_1x2x2/test_data_set_0"
 }

--- a/tests/expected_errors/onnx2c-org__test__local_ops__test_scatternd_indices_2x2x2__model.onnx.json
+++ b/tests/expected_errors/onnx2c-org__test__local_ops__test_scatternd_indices_2x2x2__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Unsupported op ScatterND",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx2c-org/test/local_ops/test_scatternd_indices_2x2x2/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx2c-org/test/local_ops/test_scatternd_indices_2x2x2/test_data_set_0"
 }

--- a/tests/expected_errors/onnx2c-org__test__local_ops__test_scatternd_indices_3x2__model.onnx.json
+++ b/tests/expected_errors/onnx2c-org__test__local_ops__test_scatternd_indices_3x2__model.onnx.json
@@ -1,4 +1,4 @@
 {
-  "error": "Unsupported op ScatterND",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx2c-org/test/local_ops/test_scatternd_indices_3x2/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx2c-org/test/local_ops/test_scatternd_indices_3x2/test_data_set_0"
 }


### PR DESCRIPTION
### Motivation
- Ensure ScatterND reductions are emitted via the existing scalar-function infrastructure instead of being implemented with ad-hoc logic in the C template, following the reviewer request to route reductions through scalar functions.

### Description
- Add a mapping `_SCATTERND_REDUCTION_FUNCTIONS` and helper `_scatternd_reduction_function` to map ONNX `reduction` strings to `ScalarFunction` values.  
- Resolve the scalar reduction via the `ScalarFunctionRegistry` in `CEmitter` and pass a `reduction_function` name into the ScatterND template instead of a manual branched implementation.  
- Simplify `templates/scatter_nd_op.c.j2` to call the resolved scalar reduction function when present and fall back to assignment for `none`.  
- Wire the changes into codegen by updating `src/emx_onnx_cgen/codegen/c_emitter.py` to compute and render `reduction_function` and adjust template registration/usage accordingly.

### Testing
- Ran the ScatterND unit/ORT comparison tests with `pytest -n auto -q tests/test_ops.py -k scatternd` which passed (`2 passed`).
- Verified official ONNX ScatterND test files with `UPDATE_REFS=1 pytest -n auto -q tests/test_official_onnx_files.py -k scatternd` which passed (`9 passed`).
- Regenerated ONNX support docs with `UPDATE_REFS=1 pytest -n auto -q tests/test_official_onnx_files_docs.py` which passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696e09555b188325a26b9815a90b2c49)