### PR TITLE
verify: disable onnxruntime threading for deterministic runs

### DIFF
--- a/src/emx_onnx_cgen/cli.py
+++ b/src/emx_onnx_cgen/cli.py
@@ -23,6 +23,7 @@ from ._build_info import BUILD_DATE, GIT_VERSION
 from .compiler import Compiler, CompilerOptions
 from .errors import CodegenError, ShapeInferenceError, UnsupportedOpError
 from .onnx_import import import_onnx
+from .onnxruntime_utils import make_deterministic_session_options
 from .testbench import decode_testbench_array
 from .verification import format_success_message, max_ulp_diff
 
@@ -463,8 +464,11 @@ def _verify_model(
         }
     try:
         ort_started = time.perf_counter()
+        sess_options = make_deterministic_session_options(ort)
         sess = ort.InferenceSession(
-            model.SerializeToString(), providers=["CPUExecutionProvider"]
+            model.SerializeToString(),
+            sess_options=sess_options,
+            providers=["CPUExecutionProvider"],
         )
         ort_outputs = sess.run(None, inputs)
     except Exception as exc:

--- a/src/emx_onnx_cgen/compiler.py
+++ b/src/emx_onnx_cgen/compiler.py
@@ -10,6 +10,7 @@ import onnx
 
 from shared.scalar_types import ScalarType
 
+from .onnxruntime_utils import make_deterministic_session_options
 from .codegen.c_emitter import (
     AttentionOp,
     AveragePoolOp,
@@ -348,8 +349,10 @@ class Compiler:
                 model_with_outputs.graph.output.append(value_info)
                 existing_outputs.add(value.name)
             output_names = [output.name for output in model_with_outputs.graph.output]
+            sess_options = make_deterministic_session_options(ort)
             sess = ort.InferenceSession(
                 model_with_outputs.SerializeToString(),
+                sess_options=sess_options,
                 providers=["CPUExecutionProvider"],
             )
             output_arrays = sess.run(None, self._options.testbench_inputs)

--- a/src/emx_onnx_cgen/onnxruntime_utils.py
+++ b/src/emx_onnx_cgen/onnxruntime_utils.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def make_deterministic_session_options(ort: Any) -> Any:
+    options = ort.SessionOptions()
+    options.intra_op_num_threads = 1
+    options.inter_op_num_threads = 1
+    options.execution_mode = ort.ExecutionMode.ORT_SEQUENTIAL
+    return options


### PR DESCRIPTION
### Motivation
- Ensure deterministic ONNX Runtime behavior during verification and shape concretization by disabling threading and forcing sequential execution.

### Description
- Add `src/emx_onnx_cgen/onnxruntime_utils.py` with `make_deterministic_session_options` that sets `intra_op_num_threads=1`, `inter_op_num_threads=1`, and `execution_mode=ORT_SEQUENTIAL`.
- Use `make_deterministic_session_options` when creating `ort.InferenceSession` in `src/emx_onnx_cgen/cli.py` during `verify` runs.
- Use `make_deterministic_session_options` in `src/emx_onnx_cgen/compiler.py` when running ONNX Runtime to concretize shapes from testbench inputs.

### Testing
- Ran `pytest tests/test_cli.py -q --durations=1`, which passed (2 passed) and completed in approximately 5.67s with the slowest test reported at 1.72s.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696e1601b24483259341b3c8c5c9d9ac)