### PR TITLE
docs: render operator support table from expectation JSONs

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1080 / 1802 official ONNX files.
+Support 1085 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -992,8 +992,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_mul_uint64/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_mul_uint8/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_mvn/model.onnx | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_mvn_expanded/model.onnx | ✅ | OK (max ULP 3) |
-| onnx-org/onnx/backend/test/data/node/test_mvn_expanded_ver18/model.onnx | ✅ | OK (max ULP 3) |
+| onnx-org/onnx/backend/test/data/node/test_mvn_expanded/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_mvn_expanded_ver18/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_neg/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_neg_example/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_nesterov_momentum/model.onnx | ❌ | Unsupported op Momentum |
@@ -1370,11 +1370,11 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_scatter_elements_without_axis/model.onnx | ❌ | Unsupported op ScatterElements |
 | onnx-org/onnx/backend/test/data/node/test_scatter_with_axis/model.onnx | ❌ | Unsupported op Scatter |
 | onnx-org/onnx/backend/test/data/node/test_scatter_without_axis/model.onnx | ❌ | Unsupported op Scatter |
-| onnx-org/onnx/backend/test/data/node/test_scatternd/model.onnx | ❌ | Unsupported op ScatterND |
-| onnx-org/onnx/backend/test/data/node/test_scatternd_add/model.onnx | ❌ | Unsupported op ScatterND |
-| onnx-org/onnx/backend/test/data/node/test_scatternd_max/model.onnx | ❌ | Unsupported op ScatterND |
-| onnx-org/onnx/backend/test/data/node/test_scatternd_min/model.onnx | ❌ | Unsupported op ScatterND |
-| onnx-org/onnx/backend/test/data/node/test_scatternd_multiply/model.onnx | ❌ | Unsupported op ScatterND |
+| onnx-org/onnx/backend/test/data/node/test_scatternd/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_scatternd_add/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_scatternd_max/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_scatternd_min/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_scatternd_multiply/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_sce_NCd1_mean_weight_negative_ii/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_sce_NCd1_mean_weight_negative_ii_expanded/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_sce_NCd1_mean_weight_negative_ii_log_prob/model.onnx | ✅ | OK (max ULP 1) |
@@ -1815,7 +1815,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 
 Local tests: `onnx2c-org/test/local_ops`.
 
-Support 61 / 74 local ONNX files.
+Support 65 / 74 local ONNX files.
 
 | File | Supported | Error |
 | --- | --- | --- |
@@ -1887,9 +1887,9 @@ Support 61 / 74 local ONNX files.
 | test_resize_downsample_sizes_linear_1D/model.onnx | ❌ | ONNX Runtime failed to run onnx2c-org/test/local_ops/test_resize_downsample_sizes_linear_1D/model.onnx: [ONNXRuntimeError] : 10 : INVALID_GRAPH : This is an invalid model. In Node, ("sclbl-onnx-node1", Resize, "", -1) : ("X": tensor(float),"","","sizes": tensor(int64),) -> ("Y": tensor(float),) , Error Node (sclbl-onnx-node1)'s input 1 is marked single but has an empty string in the graph |
 | test_resize_downsample_sizes_linear_1D_align/model.onnx | ❌ | ONNX Runtime failed to run onnx2c-org/test/local_ops/test_resize_downsample_sizes_linear_1D_align/model.onnx: [ONNXRuntimeError] : 10 : INVALID_GRAPH : This is an invalid model. In Node, ("sclbl-onnx-node1", Resize, "", -1) : ("X": tensor(float),"","","sizes": tensor(int64),) -> ("Y": tensor(float),) , Error Node (sclbl-onnx-node1)'s input 1 is marked single but has an empty string in the graph |
 | test_scalar_input_to_node/model.onnx | ✅ | OK (max ULP 0) |
-| test_scatternd_indices_1x1x2/model.onnx | ❌ | Unsupported op ScatterND |
-| test_scatternd_indices_1x2x2/model.onnx | ❌ | Unsupported op ScatterND |
-| test_scatternd_indices_2x2x2/model.onnx | ❌ | Unsupported op ScatterND |
-| test_scatternd_indices_3x2/model.onnx | ❌ | Unsupported op ScatterND |
+| test_scatternd_indices_1x1x2/model.onnx | ✅ | OK (max ULP 0) |
+| test_scatternd_indices_1x2x2/model.onnx | ✅ | OK (max ULP 0) |
+| test_scatternd_indices_2x2x2/model.onnx | ✅ | OK (max ULP 0) |
+| test_scatternd_indices_3x2/model.onnx | ✅ | OK (max ULP 0) |
 | test_shape_const_out/model.onnx | ✅ | OK (max ULP 0) |
 | test_slice_end_INT64_MAX/model.onnx | ✅ | OK (max ULP 0) |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -42,7 +42,6 @@
 | Unsupported op Col2Im | 5 | ██ |
 | Unsupported op DequantizeLinear | 5 | ██ |
 | Unsupported op If | 5 | ██ |
-| Unsupported op ScatterND | 5 | ██ |
 | Xor expects identical input/output shapes | 5 | ██ |
 | Sum expects identical input/output shapes | 4 | █ |
 | Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 4 | █ |
@@ -156,9 +155,8 @@ Mismatched elements: 2 / 6 (33.3%)
 
 | Error message | Count | Histogram |
 | --- | --- | --- |
-| Unsupported op ScatterND | 4 | ██████████████████████████████ |
-| ONNX Runtime failed to run | 2 | ███████████████ |
-| Unsupported LSTM direction b'*' | 2 | ███████████████ |
-| Unsupported op QLinearAdd | 2 | ███████████████ |
-| Unsupported op QLinearMul | 2 | ███████████████ |
-| Gemm bias input must be broadcastable to output shape, got (2,) vs (2, 4) | 1 | ████████ |
+| ONNX Runtime failed to run | 2 | ██████████████████████████████ |
+| Unsupported LSTM direction b'*' | 2 | ██████████████████████████████ |
+| Unsupported op QLinearAdd | 2 | ██████████████████████████████ |
+| Unsupported op QLinearMul | 2 | ██████████████████████████████ |
+| Gemm bias input must be broadcastable to output shape, got (2,) vs (2, 4) | 1 | ███████████████ |

--- a/SUPPORT_OPS.md
+++ b/SUPPORT_OPS.md
@@ -2,7 +2,7 @@
 
 Operators are marked supported when they appear in an ONNX file with a successful verify result.
 
-Supported operators: 131 / 198
+Supported operators: 132 / 198
 
 | Operator | Supported |
 | --- | --- |
@@ -151,7 +151,7 @@ Supported operators: 131 / 198
 | Scan | ❌ |
 | Scatter | ❌ |
 | ScatterElements | ❌ |
-| ScatterND | ❌ |
+| ScatterND | ✅ |
 | Selu | ✅ |
 | SequenceAt | ❌ |
 | SequenceConstruct | ❌ |


### PR DESCRIPTION
### Motivation
- Make operator coverage visible as a machine-generated table by deriving supported/unsupported operators from the expectation JSON files rather than a simple list. 
- Provide a stable reference file that marks every operator seen in the expectation data as supported or not supported to aid review and tracking.

### Description
- Implemented `_render_supported_ops_markdown` to collect all operators from `official_expectations` and `local_expectations` and mark operators appearing in successful (`OK`) runs as supported. 
- Added `SUPPORT_OPS_PATH` and wired writing/validation of `SUPPORT_OPS.md` into the existing docs generation flow when `UPDATE_REFS=1` and into the test assertions when not updating. 
- Regenerated `SUPPORT_OPS.md` containing a markdown table with every operator found in the expectation JSONs and a `✅`/`❌` supported marker, and refreshed related reference files (`OFFICIAL_ONNX_FILE_SUPPORT.md` and `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`) to reflect current expectation data. 

### Testing
- Ran `UPDATE_REFS=1 pytest tests/test_official_onnx_files_docs.py -q` which regenerated references and `SUPPORT_OPS.md` and passed (`1 passed in 2.40s`).
- The test also performs the non-`UPDATE_REFS` validation by comparing the on-disk `OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`, and `SUPPORT_OPS.md` to the rendered output via `_render_*` functions when run without `UPDATE_REFS`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696e1f1b1bb48325992a8a65c4f8bf69)