### PR TITLE
Add TopK operator support

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1085 / 1802 official ONNX files.
+Support 1092 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -1607,13 +1607,13 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_thresholdedrelu_expanded_ver18/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_tile/model.onnx | ❌ | Tile repeats input must be a constant initializer |
 | onnx-org/onnx/backend/test/data/node/test_tile_precomputed/model.onnx | ❌ | Tile repeats input must be a constant initializer |
-| onnx-org/onnx/backend/test/data/node/test_top_k/model.onnx | ❌ | Unsupported op TopK |
-| onnx-org/onnx/backend/test/data/node/test_top_k_negative_axis/model.onnx | ❌ | Unsupported op TopK |
-| onnx-org/onnx/backend/test/data/node/test_top_k_same_values/model.onnx | ❌ | Unsupported op TopK |
-| onnx-org/onnx/backend/test/data/node/test_top_k_same_values_2d/model.onnx | ❌ | Unsupported op TopK |
-| onnx-org/onnx/backend/test/data/node/test_top_k_same_values_largest/model.onnx | ❌ | Unsupported op TopK |
-| onnx-org/onnx/backend/test/data/node/test_top_k_smallest/model.onnx | ❌ | Unsupported op TopK |
-| onnx-org/onnx/backend/test/data/node/test_top_k_uint64/model.onnx | ❌ | Unsupported op TopK |
+| onnx-org/onnx/backend/test/data/node/test_top_k/model.onnx | ✅ |  |
+| onnx-org/onnx/backend/test/data/node/test_top_k_negative_axis/model.onnx | ✅ |  |
+| onnx-org/onnx/backend/test/data/node/test_top_k_same_values/model.onnx | ✅ |  |
+| onnx-org/onnx/backend/test/data/node/test_top_k_same_values_2d/model.onnx | ✅ |  |
+| onnx-org/onnx/backend/test/data/node/test_top_k_same_values_largest/model.onnx | ✅ |  |
+| onnx-org/onnx/backend/test/data/node/test_top_k_smallest/model.onnx | ✅ |  |
+| onnx-org/onnx/backend/test/data/node/test_top_k_uint64/model.onnx | ✅ |  |
 | onnx-org/onnx/backend/test/data/node/test_training_dropout/model.onnx | ❌ | Dropout supports only the data input and 1 or 2 outputs |
 | onnx-org/onnx/backend/test/data/node/test_training_dropout_default/model.onnx | ❌ | Dropout supports only the data input and 1 or 2 outputs |
 | onnx-org/onnx/backend/test/data/node/test_training_dropout_default_mask/model.onnx | ❌ | Dropout supports only the data input and 1 or 2 outputs |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -25,7 +25,6 @@
 | Unsupported op RotaryEmbedding | 8 | ███ |
 | tuple index out of range | 8 | ███ |
 | Unsupported op TfIdfVectorizer | 7 | ██ |
-| Unsupported op TopK | 7 | ██ |
 | AveragePool has unsupported attributes | 6 | ██ |
 | Missing output 2 in testbench data | 6 | ██ |
 | Unsupported elem_type 16 (BFLOAT16) for tensor '*'. | 6 | ██ |

--- a/SUPPORT_OPS.md
+++ b/SUPPORT_OPS.md
@@ -2,7 +2,7 @@
 
 Operators are marked supported when they appear in an ONNX file with a successful verify result.
 
-Supported operators: 132 / 198
+Supported operators: 133 / 198
 
 | Operator | Supported |
 | --- | --- |
@@ -188,7 +188,7 @@ Supported operators: 132 / 198
 | TfIdfVectorizer | ❌ |
 | ThresholdedRelu | ✅ |
 | Tile | ❌ |
-| TopK | ❌ |
+| TopK | ✅ |
 | Transpose | ✅ |
 | Trilu | ✅ |
 | Unique | ❌ |

--- a/src/emx_onnx_cgen/compiler.py
+++ b/src/emx_onnx_cgen/compiler.py
@@ -121,6 +121,7 @@ from .lowering.reduce import (
     REDUCE_OUTPUTS_FLOAT_ONLY,
 )
 from .lowering import arg_reduce as _arg_reduce  # noqa: F401
+from .lowering import topk as _topk  # noqa: F401
 from .lowering.reshape import lower_reshape
 from .lowering.resize import lower_resize
 from .lowering.grid_sample import lower_grid_sample

--- a/src/emx_onnx_cgen/lowering/topk.py
+++ b/src/emx_onnx_cgen/lowering/topk.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import numpy as np
+
+from shared.scalar_types import ScalarType
+
+from ..codegen.c_emitter import TopKOp
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Initializer, Node
+from ..lowering.common import shape_product, value_dtype, value_shape
+from ..validation import normalize_axis
+from .registry import register_lowering
+
+
+def _find_initializer(graph: Graph, name: str) -> Initializer | None:
+    for initializer in graph.initializers:
+        if initializer.name == name:
+            return initializer
+    return None
+
+
+def _read_k(graph: Graph, name: str, node: Node) -> int:
+    initializer = _find_initializer(graph, name)
+    if initializer is None:
+        raise UnsupportedOpError(
+            f"{node.op_type} k input must be a constant initializer"
+        )
+    if initializer.type.dtype not in {ScalarType.I64, ScalarType.I32}:
+        raise UnsupportedOpError(
+            f"{node.op_type} k input must be int64 or int32"
+        )
+    data = np.array(initializer.data, dtype=np.int64).reshape(-1)
+    if data.size != 1:
+        raise ShapeInferenceError(
+            f"{node.op_type} k input must contain a single value"
+        )
+    k = int(data[0])
+    if k <= 0:
+        raise ShapeInferenceError(
+            f"{node.op_type} k must be a positive value, got {k}"
+        )
+    return k
+
+
+def _topk_dtype_supported(dtype: ScalarType) -> bool:
+    return not dtype.is_bool
+
+
+def lower_topk(graph: Graph, node: Node) -> TopKOp:
+    if node.op_type != "TopK":
+        raise UnsupportedOpError(f"Unsupported op {node.op_type}")
+    if len(node.inputs) != 2 or len(node.outputs) != 2:
+        raise UnsupportedOpError(
+            f"{node.op_type} must have 2 inputs and 2 outputs"
+        )
+    input_name = node.inputs[0]
+    k_name = node.inputs[1]
+    output_values = node.outputs[0]
+    output_indices = node.outputs[1]
+    input_shape = value_shape(graph, input_name, node)
+    shape_product(input_shape)
+    axis = int(node.attrs.get("axis", -1))
+    axis = normalize_axis(axis, input_shape, node)
+    k = _read_k(graph, k_name, node)
+    axis_dim = input_shape[axis]
+    if k > axis_dim:
+        raise ShapeInferenceError(
+            f"{node.op_type} k {k} exceeds axis dimension {axis_dim}"
+        )
+    output_shape_expected = list(input_shape)
+    output_shape_expected[axis] = k
+    output_shape = tuple(output_shape_expected)
+    values_shape = value_shape(graph, output_values, node)
+    if values_shape != output_shape:
+        raise ShapeInferenceError(
+            f"{node.op_type} values output shape must be {output_shape}, got {values_shape}"
+        )
+    indices_shape = value_shape(graph, output_indices, node)
+    if indices_shape != output_shape:
+        raise ShapeInferenceError(
+            f"{node.op_type} indices output shape must be {output_shape}, got {indices_shape}"
+        )
+    input_dtype = value_dtype(graph, input_name, node)
+    if not _topk_dtype_supported(input_dtype):
+        raise UnsupportedOpError(
+            f"{node.op_type} does not support dtype {input_dtype.onnx_name}"
+        )
+    values_dtype = value_dtype(graph, output_values, node)
+    if values_dtype != input_dtype:
+        raise UnsupportedOpError(
+            f"{node.op_type} values output dtype must be {input_dtype.onnx_name}"
+        )
+    indices_dtype = value_dtype(graph, output_indices, node)
+    if indices_dtype != ScalarType.I64:
+        raise UnsupportedOpError(
+            f"{node.op_type} indices output dtype must be int64"
+        )
+    largest = bool(int(node.attrs.get("largest", 1)))
+    sorted_output = bool(int(node.attrs.get("sorted", 1)))
+    return TopKOp(
+        input0=input_name,
+        output_values=output_values,
+        output_indices=output_indices,
+        input_shape=input_shape,
+        output_shape=output_shape,
+        axis=axis,
+        k=k,
+        largest=largest,
+        sorted=sorted_output,
+        input_dtype=input_dtype,
+        output_values_dtype=values_dtype,
+        output_indices_dtype=indices_dtype,
+    )
+
+
+register_lowering("TopK")(lower_topk)

--- a/templates/topk_op.c.j2
+++ b/templates/topk_op.c.j2
@@ -1,0 +1,50 @@
+static inline int {{ op_name }}_better({{ input_c_type }} a, {{ output_indices_c_type }} ai, {{ input_c_type }} b, {{ output_indices_c_type }} bi) {
+    return {{ compare_expr }};
+}
+
+static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
+{% for dim in outer_shape %}
+for (idx_t {{ outer_loop_vars[loop.index0] }} = 0; {{ outer_loop_vars[loop.index0] }} < {{ dim }}; ++{{ outer_loop_vars[loop.index0] }}) {
+{% endfor %}
+{{ input_c_type }} best_values[{{ k }}];
+{{ output_indices_c_type }} best_indices[{{ k }}];
+for (idx_t {{ reduce_var }} = 0; {{ reduce_var }} < {{ k }}; ++{{ reduce_var }}) {
+    best_values[{{ reduce_var }}] = {{ input0 }}{{ input_index_expr }};
+    best_indices[{{ reduce_var }}] = ({{ output_indices_c_type }}){{ reduce_var }};
+}
+for (idx_t i = 1; i < {{ k }}; ++i) {
+    idx_t j = i;
+    while (j > 0
+        && {{ op_name }}_better(best_values[j], best_indices[j], best_values[j - 1], best_indices[j - 1])) {
+        {{ input_c_type }} temp_value = best_values[j - 1];
+        {{ output_indices_c_type }} temp_index = best_indices[j - 1];
+        best_values[j - 1] = best_values[j];
+        best_indices[j - 1] = best_indices[j];
+        best_values[j] = temp_value;
+        best_indices[j] = temp_index;
+        --j;
+    }
+}
+for (idx_t {{ reduce_var }} = {{ k }}; {{ reduce_var }} < {{ axis_dim }}; ++{{ reduce_var }}) {
+    {{ input_c_type }} candidate = {{ input0 }}{{ input_index_expr }};
+    {{ output_indices_c_type }} candidate_index = ({{ output_indices_c_type }}){{ reduce_var }};
+    if ({{ op_name }}_better(candidate, candidate_index, best_values[{{ k - 1 }}], best_indices[{{ k - 1 }}])) {
+        idx_t pos = {{ k - 1 }};
+        while (pos > 0
+            && {{ op_name }}_better(candidate, candidate_index, best_values[pos - 1], best_indices[pos - 1])) {
+            best_values[pos] = best_values[pos - 1];
+            best_indices[pos] = best_indices[pos - 1];
+            --pos;
+        }
+        best_values[pos] = candidate;
+        best_indices[pos] = candidate_index;
+    }
+}
+for (idx_t {{ k_var }} = 0; {{ k_var }} < {{ k }}; ++{{ k_var }}) {
+    {{ output_values }}{{ output_index_expr }} = best_values[{{ k_var }}];
+    {{ output_indices }}{{ output_index_expr }} = best_indices[{{ k_var }}];
+}
+{% for _ in outer_shape %}
+}
+{% endfor %}
+}

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_top_k__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_top_k__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op TopK",
+  "error": "",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_top_k/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_top_k/test_data_set_0",
   "operators": [
     "TopK"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_top_k_negative_axis__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_top_k_negative_axis__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op TopK",
+  "error": "",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_top_k_negative_axis/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_top_k_negative_axis/test_data_set_0",
   "operators": [
     "TopK"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_top_k_same_values_2d__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_top_k_same_values_2d__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op TopK",
+  "error": "",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_top_k_same_values_2d/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_top_k_same_values_2d/test_data_set_0",
   "operators": [
     "TopK"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_top_k_same_values__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_top_k_same_values__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op TopK",
+  "error": "",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_top_k_same_values/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_top_k_same_values/test_data_set_0",
   "operators": [
     "TopK"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_top_k_same_values_largest__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_top_k_same_values_largest__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op TopK",
+  "error": "",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_top_k_same_values_largest/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_top_k_same_values_largest/test_data_set_0",
   "operators": [
     "TopK"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_top_k_smallest__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_top_k_smallest__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op TopK",
+  "error": "",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_top_k_smallest/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_top_k_smallest/test_data_set_0",
   "operators": [
     "TopK"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_top_k_uint64__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_top_k_uint64__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op TopK",
+  "error": "",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_top_k_uint64/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_top_k_uint64/test_data_set_0",
   "operators": [
     "TopK"

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -12,7 +12,7 @@ import onnx
 import onnxruntime as ort
 import pytest
 
-from onnx import TensorProto, helper
+from onnx import TensorProto, helper, numpy_helper
 
 from shared.scalar_types import ScalarType
 
@@ -1479,6 +1479,17 @@ def _arg_reduce_output_shape(
     return [dim for dim_axis, dim in enumerate(input_shape) if dim_axis != axis]
 
 
+def _topk_output_shape(
+    input_shape: list[int], axis: int, k: int
+) -> list[int]:
+    rank = len(input_shape)
+    if axis < 0:
+        axis += rank
+    output_shape = list(input_shape)
+    output_shape[axis] = k
+    return output_shape
+
+
 def _make_arg_reduce_model(
     *,
     op_type: str,
@@ -1505,6 +1516,48 @@ def _make_arg_reduce_model(
         f"{op_type.lower()}_graph",
         [input_info],
         [output],
+    )
+    model = helper.make_model(
+        graph,
+        producer_name="onnx2c",
+        opset_imports=[helper.make_operatorsetid("", opset)],
+    )
+    model.ir_version = 7
+    onnx.checker.check_model(model)
+    return model
+
+
+def _make_topk_model(
+    *,
+    input_shape: list[int],
+    output_shape: list[int],
+    axis: int,
+    k: int,
+    largest: int,
+    sorted: int,
+    dtype: int,
+    opset: int = 13,
+) -> onnx.ModelProto:
+    input_info = helper.make_tensor_value_info("input", dtype, input_shape)
+    values_info = helper.make_tensor_value_info("values", dtype, output_shape)
+    indices_info = helper.make_tensor_value_info(
+        "indices", TensorProto.INT64, output_shape
+    )
+    k_init = numpy_helper.from_array(np.array([k], dtype=np.int64), name="k")
+    node = helper.make_node(
+        "TopK",
+        inputs=[input_info.name, "k"],
+        outputs=[values_info.name, indices_info.name],
+        axis=axis,
+        largest=largest,
+        sorted=sorted,
+    )
+    graph = helper.make_graph(
+        [node],
+        "topk_graph",
+        [input_info],
+        [values_info, indices_info],
+        initializer=[k_init],
     )
     model = helper.make_model(
         graph,
@@ -2742,6 +2795,33 @@ ARG_REDUCE_CASES = [
     },
 ]
 
+TOPK_CASES = [
+    {
+        "name": "TopKLargestAxis1",
+        "input_shape": [3, 4],
+        "axis": 1,
+        "k": 2,
+        "largest": 1,
+        "sorted": 1,
+    },
+    {
+        "name": "TopKSmallestAxis0",
+        "input_shape": [4, 3],
+        "axis": 0,
+        "k": 2,
+        "largest": 0,
+        "sorted": 1,
+    },
+    {
+        "name": "TopKNegativeAxis",
+        "input_shape": [2, 3, 4],
+        "axis": -1,
+        "k": 3,
+        "largest": 1,
+        "sorted": 1,
+    },
+]
+
 AVG_POOL_CASES = [
     {
         "name": "Kernel2Stride2",
@@ -3111,6 +3191,23 @@ def test_arg_reduce_matches_onnxruntime(case: dict[str, object]) -> None:
     _run_ort_compare(model)
 
 
+@pytest.mark.parametrize("case", TOPK_CASES, ids=lambda case: case["name"])
+def test_topk_matches_onnxruntime(case: dict[str, object]) -> None:
+    output_shape = _topk_output_shape(
+        case["input_shape"], case["axis"], case["k"]
+    )
+    model = _make_topk_model(
+        input_shape=case["input_shape"],
+        output_shape=output_shape,
+        axis=case["axis"],
+        k=case["k"],
+        largest=case["largest"],
+        sorted=case["sorted"],
+        dtype=TensorProto.FLOAT,
+    )
+    _run_ort_compare(model)
+
+
 def test_argmax_select_last_index_matches_numpy() -> None:
     input_shape = [2, 4]
     axis = 1
@@ -3135,6 +3232,32 @@ def test_argmax_select_last_index_matches_numpy() -> None:
     expected = data.shape[axis] - 1 - np.argmax(flipped, axis=axis)
     expected = np.expand_dims(expected, axis=axis)
     np.testing.assert_array_equal(outputs["output"], expected.astype(np.int64))
+
+
+def test_topk_tiebreaker_matches_numpy() -> None:
+    input_shape = [1, 4]
+    axis = 1
+    k = 2
+    output_shape = _topk_output_shape(input_shape, axis, k)
+    model = _make_topk_model(
+        input_shape=input_shape,
+        output_shape=output_shape,
+        axis=axis,
+        k=k,
+        largest=1,
+        sorted=1,
+        dtype=TensorProto.FLOAT,
+    )
+    compiler = Compiler()
+    data = np.array([[1.0, 2.0, 2.0, 0.5]], dtype=np.float32)
+    outputs = compiler.run(model, {"input": data})
+    order = np.argsort(-data, axis=axis, kind="stable")
+    expected_indices = np.take(order, np.arange(k), axis=axis)
+    expected_values = np.take_along_axis(data, expected_indices, axis=axis)
+    np.testing.assert_allclose(outputs["values"], expected_values, rtol=1e-5, atol=1e-6)
+    np.testing.assert_array_equal(
+        outputs["indices"], expected_indices.astype(np.int64)
+    )
 
 
 def test_reduce_op_axes_input_matches_numpy() -> None:


### PR DESCRIPTION
### Motivation
- Implement support for the ONNX `TopK` operator so models using `TopK` can be lowered, emitted to C and verified instead of being reported as unsupported.

### Description
- Add lowering logic `lower_topk` in `src/emx_onnx_cgen/lowering/topk.py` to validate shapes/attrs and produce a `TopKOp` IR node.
- Add `TopKOp` dataclass and integrate handling across the C emitter (`src/emx_onnx_cgen/codegen/c_emitter.py`) including template lookup and rendering paths for lowering and emission.
- Add a Jinja2 C template `templates/topk_op.c.j2` implementing stable top-k selection with tiebreaker semantics and wire it into the emitter.
- Add runtime evaluator implementation in `src/emx_onnx_cgen/runtime/evaluator.py` to emulate `TopK` for verification/constant folding and update tests/expected references and docs to mark `TopK` supported.

### Testing
- Ran `UPDATE_REFS=1 pytest tests/test_official_onnx_files_docs.py -q` which passed and updated references (1 passed, duration 2.63s). 
- Ran `pytest tests/test_ops.py -k topk -q` which exercised the new TopK unit/ORT comparison tests and succeeded (`4 passed, 151 deselected`, duration 0.90s).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696e2b3c18548325be8f8b1213198bd5)