### PR TITLE
lowering: add NonZero operator support

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1042,7 +1042,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_nonmaxsuppression_suppress_by_IOU_and_scores/model.onnx | ❌ | Unsupported op NonMaxSuppression |
 | onnx-org/onnx/backend/test/data/node/test_nonmaxsuppression_two_batches/model.onnx | ❌ | Unsupported op NonMaxSuppression |
 | onnx-org/onnx/backend/test/data/node/test_nonmaxsuppression_two_classes/model.onnx | ❌ | Unsupported op NonMaxSuppression |
-| onnx-org/onnx/backend/test/data/node/test_nonzero_example/model.onnx | ❌ | Unsupported op NonZero |
+| onnx-org/onnx/backend/test/data/node/test_nonzero_example/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_not_2d/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_not_3d/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_not_4d/model.onnx | ✅ | OK (max ULP 0) |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -140,7 +140,6 @@ Mismatched elements: 2 / 6 (33.3%)
 | Unsupported op Binarizer | 1 | █ |
 | Unsupported op MatMulInteger | 1 | █ |
 | Unsupported op MelWeightMatrix | 1 | █ |
-| Unsupported op NonZero | 1 | █ |
 | Unsupported op OptionalGetElement | 1 | █ |
 | Unsupported op QLinearConv | 1 | █ |
 | Unsupported op Upsample | 1 | █ |

--- a/SUPPORT_OPS.md
+++ b/SUPPORT_OPS.md
@@ -112,7 +112,7 @@ Supported operators: 132 / 198
 | Neg | ✅ |
 | NegativeLogLikelihoodLoss | ✅ |
 | NonMaxSuppression | ❌ |
-| NonZero | ❌ |
+| NonZero | ✅ |
 | Not | ✅ |
 | OneHot | ❌ |
 | OptionalGetElement | ❌ |

--- a/src/emx_onnx_cgen/codegen/c_emitter.py
+++ b/src/emx_onnx_cgen/codegen/c_emitter.py
@@ -970,6 +970,16 @@ class SizeOp:
 
 
 @dataclass(frozen=True)
+class NonZeroOp:
+    input0: str
+    output: str
+    input_shape: tuple[int, ...]
+    output_shape: tuple[int, ...]
+    dtype: ScalarType
+    input_dtype: ScalarType
+
+
+@dataclass(frozen=True)
 class ExpandOp:
     input0: str
     output: str
@@ -1117,6 +1127,7 @@ class LoweredModel:
         | ConstantOfShapeOp
         | ShapeOp
         | SizeOp
+        | NonZeroOp
         | ExpandOp
         | CumSumOp
         | RangeOp
@@ -1289,6 +1300,7 @@ class CEmitter:
         | ConstantOfShapeOp
         | ShapeOp
         | SizeOp
+        | NonZeroOp
         | ExpandOp
         | CumSumOp
         | RangeOp
@@ -1435,6 +1447,8 @@ class CEmitter:
         if isinstance(op, ShapeOp):
             return (op.input0, op.output)
         if isinstance(op, SizeOp):
+            return (op.input0, op.output)
+        if isinstance(op, NonZeroOp):
             return (op.input0, op.output)
         if isinstance(op, ExpandOp):
             return (op.input0, op.output)
@@ -1595,6 +1609,7 @@ class CEmitter:
         | ConstantOfShapeOp
         | ShapeOp
         | SizeOp
+        | NonZeroOp
         | ExpandOp
         | CumSumOp
         | RangeOp
@@ -1651,6 +1666,7 @@ class CEmitter:
         | ConstantOfShapeOp
         | ShapeOp
         | SizeOp
+        | NonZeroOp
         | ExpandOp
         | CumSumOp
         | RangeOp
@@ -2426,6 +2442,15 @@ class CEmitter:
                 dtype=op.dtype,
                 input_dtype=op.input_dtype,
             )
+        if isinstance(op, NonZeroOp):
+            return NonZeroOp(
+                input0=name_map.get(op.input0, op.input0),
+                output=name_map.get(op.output, op.output),
+                input_shape=op.input_shape,
+                output_shape=op.output_shape,
+                dtype=op.dtype,
+                input_dtype=op.input_dtype,
+            )
         if isinstance(op, ExpandOp):
             return ExpandOp(
                 input0=name_map.get(op.input0, op.input0),
@@ -2609,6 +2634,7 @@ class CEmitter:
                 ),
                 "shape": self._env.get_template("shape_op.c.j2"),
                 "size": self._env.get_template("size_op.c.j2"),
+                "nonzero": self._env.get_template("nonzero_op.c.j2"),
                 "expand": self._env.get_template("expand_op.c.j2"),
                 "cumsum": self._env.get_template("cumsum_op.c.j2"),
                 "range": self._env.get_template("range_op.c.j2"),
@@ -2704,6 +2730,7 @@ class CEmitter:
         constant_of_shape_template = templates["constant_of_shape"]
         shape_template = templates["shape"]
         size_template = templates["size"]
+        nonzero_template = templates["nonzero"]
         expand_template = templates["expand"]
         cumsum_template = templates["cumsum"]
         range_template = templates["range"]
@@ -2784,6 +2811,7 @@ class CEmitter:
                 constant_of_shape_template=constant_of_shape_template,
                 shape_template=shape_template,
                 size_template=size_template,
+                nonzero_template=nonzero_template,
                 expand_template=expand_template,
                 cumsum_template=cumsum_template,
                 range_template=range_template,
@@ -3417,6 +3445,7 @@ class CEmitter:
             | ConstantOfShapeOp
             | ShapeOp
             | SizeOp
+            | NonZeroOp
             | ExpandOp
             | CumSumOp
             | RangeOp
@@ -3628,6 +3657,7 @@ class CEmitter:
             | ConstantOfShapeOp
             | ShapeOp
             | SizeOp
+            | NonZeroOp
             | ExpandOp
             | CumSumOp
             | RangeOp
@@ -3783,6 +3813,7 @@ class CEmitter:
             | ConstantOfShapeOp
             | ShapeOp
             | SizeOp
+            | NonZeroOp
             | ExpandOp
             | CumSumOp
             | RangeOp
@@ -3873,6 +3904,7 @@ class CEmitter:
             | ConstantOfShapeOp
             | ShapeOp
             | SizeOp
+            | NonZeroOp
             | ExpandOp
             | CumSumOp
             | RangeOp
@@ -3979,6 +4011,7 @@ class CEmitter:
         | ConstantOfShapeOp
         | ShapeOp
         | SizeOp
+        | NonZeroOp
         | ExpandOp
         | CumSumOp
         | RangeOp
@@ -4159,6 +4192,9 @@ class CEmitter:
         if isinstance(op, SizeOp):
             args.extend([op.input0, op.output])
             return ", ".join(args)
+        if isinstance(op, NonZeroOp):
+            args.extend([op.input0, op.output])
+            return ", ".join(args)
         if isinstance(op, ExpandOp):
             args.extend([op.input0, op.output])
             return ", ".join(args)
@@ -4329,6 +4365,7 @@ class CEmitter:
         | ConstantOfShapeOp
         | ShapeOp
         | SizeOp
+        | NonZeroOp
         | ExpandOp
         | CumSumOp
         | RangeOp
@@ -4384,6 +4421,7 @@ class CEmitter:
         | ConstantOfShapeOp
         | ShapeOp
         | SizeOp
+        | NonZeroOp
         | ExpandOp
         | CumSumOp
         | RangeOp
@@ -5029,6 +5067,15 @@ class CEmitter:
                 dtype=op.dtype,
                 input_dtype=op.input_dtype,
             )
+        if isinstance(op, NonZeroOp):
+            return NonZeroOp(
+                input0=temp_map.get(op.input0, op.input0),
+                output=temp_map.get(op.output, op.output),
+                input_shape=op.input_shape,
+                output_shape=op.output_shape,
+                dtype=op.dtype,
+                input_dtype=op.input_dtype,
+            )
         if isinstance(op, ExpandOp):
             return ExpandOp(
                 input0=temp_map.get(op.input0, op.input0),
@@ -5375,6 +5422,7 @@ class CEmitter:
         | ConstantOfShapeOp
         | ShapeOp
         | SizeOp
+        | NonZeroOp
         | ExpandOp
         | CumSumOp
         | RangeOp
@@ -5439,6 +5487,7 @@ class CEmitter:
         constant_of_shape_template,
         shape_template,
         size_template,
+        nonzero_template,
         expand_template,
         cumsum_template,
         range_template,
@@ -8551,6 +8600,47 @@ class CEmitter:
                 value=CEmitter._format_literal(op.dtype, op.value),
             ).rstrip()
             return with_node_comment(rendered)
+        if isinstance(op, NonZeroOp):
+            params = self._shared_param_map(
+                [("input0", op.input0), ("output", op.output)]
+            )
+            input_dim_names = _dim_names_for(op.input0)
+            output_dim_names = _dim_names_for(op.output)
+            input_shape = CEmitter._shape_dim_exprs(
+                op.input_shape, input_dim_names
+            )
+            loop_vars = CEmitter._loop_vars(op.input_shape)
+            input_suffix = self._param_array_suffix(
+                op.input_shape, input_dim_names
+            )
+            output_suffix = self._param_array_suffix(
+                op.output_shape, output_dim_names
+            )
+            param_decls = self._build_param_decls(
+                [
+                    (params["input0"], op.input_dtype.c_type, input_suffix, True),
+                    (params["output"], c_type, output_suffix, False),
+                ]
+            )
+            input_expr = f"{params['input0']}" + "".join(
+                f"[{var}]" for var in loop_vars
+            )
+            rendered = nonzero_template.render(
+                model_name=model.name,
+                op_name=op_name,
+                input0=params["input0"],
+                output=params["output"],
+                params=param_decls,
+                input_c_type=op.input_dtype.c_type,
+                output_c_type=c_type,
+                input_suffix=input_suffix,
+                output_suffix=output_suffix,
+                input_shape=input_shape,
+                loop_vars=loop_vars,
+                input_expr=input_expr,
+                zero_literal=op.input_dtype.zero_literal,
+            ).rstrip()
+            return with_node_comment(rendered)
         if isinstance(op, ExpandOp):
             params = self._shared_param_map(
                 [("input0", op.input0), ("output", op.output)]
@@ -9138,6 +9228,8 @@ class CEmitter:
             return tuple(inputs)
         if isinstance(op, CastOp):
             return ((op.input0, op.shape),)
+        if isinstance(op, NonZeroOp):
+            return ((op.input0, op.input_shape),)
         if isinstance(op, QuantizeLinearOp):
             scale_shape = (
                 ()
@@ -9225,6 +9317,7 @@ class CEmitter:
             | ConstantOfShapeOp
             | ShapeOp
             | SizeOp
+            | NonZeroOp
             | ExpandOp
             | RangeOp
             | SplitOp
@@ -9292,6 +9385,7 @@ class CEmitter:
         | ConstantOfShapeOp
         | ShapeOp
         | SizeOp
+        | NonZeroOp
         | ExpandOp
         | RangeOp
         | SplitOp,
@@ -9437,6 +9531,7 @@ class CEmitter:
         | ConstantOfShapeOp
         | ShapeOp
         | SizeOp
+        | NonZeroOp
         | ExpandOp
         | CumSumOp
         | RangeOp
@@ -9539,6 +9634,8 @@ class CEmitter:
             return op.output_shape
         if isinstance(op, SizeOp):
             return op.output_shape
+        if isinstance(op, NonZeroOp):
+            return op.output_shape
         if isinstance(op, ExpandOp):
             return op.output_shape
         if isinstance(op, CumSumOp):
@@ -9594,6 +9691,7 @@ class CEmitter:
         | ConstantOfShapeOp
         | ShapeOp
         | SizeOp
+        | NonZeroOp
         | ExpandOp
         | CumSumOp
         | RangeOp

--- a/src/emx_onnx_cgen/compiler.py
+++ b/src/emx_onnx_cgen/compiler.py
@@ -45,6 +45,7 @@ from .codegen.c_emitter import (
     LogSoftmaxOp,
     HardmaxOp,
     NegativeLogLikelihoodLossOp,
+    NonZeroOp,
     NodeInfo,
     PadOp,
     SplitOp,
@@ -107,6 +108,7 @@ from .lowering import mean_variance_normalization as _mean_variance_normalizatio
 from .lowering.negative_log_likelihood_loss import (
     lower_negative_log_likelihood_loss,
 )
+from .lowering import nonzero as _nonzero  # noqa: F401
 from .lowering.expand import lower_expand
 from .lowering.range import lower_range
 from .lowering.split import lower_split
@@ -473,6 +475,7 @@ class Compiler:
             | ArgReduceOp
             | ShapeOp
             | PadOp
+            | NonZeroOp
             | ExpandOp
             | CumSumOp
             | RangeOp
@@ -521,6 +524,7 @@ class Compiler:
             | ArgReduceOp
             | ShapeOp
             | PadOp
+            | NonZeroOp
             | ExpandOp
             | CumSumOp
             | RangeOp

--- a/src/emx_onnx_cgen/lowering/nonzero.py
+++ b/src/emx_onnx_cgen/lowering/nonzero.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from shared.scalar_types import ScalarType
+
+from ..codegen.c_emitter import NonZeroOp
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Node
+from .common import value_dtype, value_shape
+from .registry import register_lowering
+
+
+@register_lowering("NonZero")
+def lower_nonzero(graph: Graph, node: Node) -> NonZeroOp:
+    if len(node.inputs) != 1 or len(node.outputs) != 1:
+        raise UnsupportedOpError("NonZero must have 1 input and 1 output")
+    input_shape = value_shape(graph, node.inputs[0], node)
+    if len(input_shape) == 0:
+        raise UnsupportedOpError("NonZero does not support scalar inputs")
+    output_shape = value_shape(graph, node.outputs[0], node)
+    if len(output_shape) != 2:
+        raise ShapeInferenceError("NonZero output must be 2D")
+    if output_shape[0] != len(input_shape):
+        raise ShapeInferenceError(
+            "NonZero output shape must be "
+            f"({len(input_shape)}, N), got {output_shape}"
+        )
+    if output_shape[0] < 0 or output_shape[1] < 0:
+        raise ShapeInferenceError(
+            "NonZero output shape must be non-negative"
+        )
+    output_dtype = value_dtype(graph, node.outputs[0], node)
+    if output_dtype != ScalarType.I64:
+        raise UnsupportedOpError("NonZero output dtype must be int64")
+    input_dtype = value_dtype(graph, node.inputs[0], node)
+    return NonZeroOp(
+        input0=node.inputs[0],
+        output=node.outputs[0],
+        input_shape=input_shape,
+        output_shape=output_shape,
+        dtype=output_dtype,
+        input_dtype=input_dtype,
+    )

--- a/src/emx_onnx_cgen/runtime/evaluator.py
+++ b/src/emx_onnx_cgen/runtime/evaluator.py
@@ -34,6 +34,7 @@ from ..lowering.global_max_pool import lower_global_max_pool
 from ..lowering.negative_log_likelihood_loss import (
     lower_negative_log_likelihood_loss,
 )
+from ..lowering.nonzero import lower_nonzero
 from ..lowering.pad import lower_pad
 from ..lowering.expand import lower_expand
 from ..lowering.range import lower_range
@@ -1594,6 +1595,16 @@ def _eval_shape(evaluator: Evaluator, node: Node) -> None:
 def _eval_size(evaluator: Evaluator, node: Node) -> None:
     op = lower_size(evaluator.graph, node)
     evaluator.values[op.output] = np.array(op.value, dtype=np.int64)
+
+
+@register_evaluator("NonZero")
+def _eval_nonzero(evaluator: Evaluator, node: Node) -> None:
+    op = lower_nonzero(evaluator.graph, node)
+    values = evaluator.values[op.input0]
+    indices = np.nonzero(values)
+    evaluator.values[op.output] = np.stack(indices, axis=0).astype(
+        np.int64, copy=False
+    )
 
 
 @register_evaluator("Expand")

--- a/templates/nonzero_op.c.j2
+++ b/templates/nonzero_op.c.j2
@@ -1,0 +1,15 @@
+static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
+    idx_t out_index = 0;
+{% for dim in input_shape %}
+    for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+{% endfor %}
+        if ({{ input_expr }} != {{ zero_literal }}) {
+{% for var in loop_vars %}
+            {{ output }}[{{ loop.index0 }}][out_index] = ({{ output_c_type }}){{ var }};
+{% endfor %}
+            ++out_index;
+        }
+{% for _ in input_shape %}
+    }
+{% endfor %}
+}

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_nonzero_example__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_nonzero_example__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op NonZero",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_nonzero_example/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_nonzero_example/test_data_set_0",
   "operators": [
     "NonZero"

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1251,6 +1251,36 @@ def _make_size_model(*, input_shape: list[int], opset: int = 13) -> onnx.ModelPr
     return model
 
 
+def _make_nonzero_model(
+    *,
+    input_shape: list[int],
+    output_shape: list[int],
+    input_dtype: int,
+    opset: int = 13,
+) -> onnx.ModelProto:
+    input_info = helper.make_tensor_value_info(
+        "input", input_dtype, input_shape
+    )
+    output = helper.make_tensor_value_info(
+        "output", TensorProto.INT64, output_shape
+    )
+    node = helper.make_node("NonZero", inputs=["input"], outputs=[output.name])
+    graph = helper.make_graph(
+        [node],
+        "nonzero_graph",
+        [input_info],
+        [output],
+    )
+    model = helper.make_model(
+        graph,
+        producer_name="onnx2c",
+        opset_imports=[helper.make_operatorsetid("", opset)],
+    )
+    model.ir_version = 7
+    onnx.checker.check_model(model)
+    return model
+
+
 def _make_slice_model() -> onnx.ModelProto:
     input_shape = [2, 3, 4]
     output_shape = [2, 3, 1]
@@ -3170,6 +3200,21 @@ def test_size_matches_onnxruntime() -> None:
     _run_ort_compare(model)
 
 
+def test_nonzero_matches_onnxruntime() -> None:
+    model = _make_nonzero_model(
+        input_shape=[2, 2],
+        output_shape=[2, 3],
+        input_dtype=TensorProto.FLOAT,
+    )
+    inputs = {"input": np.array([[1.0, 0.0], [2.0, 3.0]], dtype=np.float32)}
+    session = ort.InferenceSession(
+        model.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    ort_output = session.run(None, inputs)[0]
+    compiled = Compiler().run(model, inputs)["output"]
+    np.testing.assert_array_equal(compiled, ort_output)
+
+
 def test_expand_matches_onnxruntime() -> None:
     model = _make_expand_model(
         input_shape=[3, 1],
@@ -3310,6 +3355,19 @@ def test_size_run() -> None:
     outputs = compiler.run(model, {"in0": data})
     expected = np.array(data.size, dtype=np.int64)
     np.testing.assert_array_equal(outputs["out"], expected)
+
+
+def test_nonzero_run_matches_numpy() -> None:
+    model = _make_nonzero_model(
+        input_shape=[2, 2],
+        output_shape=[2, 3],
+        input_dtype=TensorProto.FLOAT,
+    )
+    compiler = Compiler()
+    data = np.array([[1.0, 0.0], [2.0, 3.0]], dtype=np.float32)
+    outputs = compiler.run(model, {"input": data})
+    expected = np.stack(np.nonzero(data), axis=0).astype(np.int64)
+    np.testing.assert_array_equal(outputs["output"], expected)
 
 
 def test_constant_of_shape_run() -> None:


### PR DESCRIPTION
### Motivation
- Add support for the ONNX `NonZero` operator so official test files and runtime comparisons that use `NonZero` can be handled by the compiler and verifier.
- Provide lowering, codegen, and runtime evaluation for `NonZero` while validating shapes and dtypes to preserve determinism and explicit errors.

### Description
- Add `src/emx_onnx_cgen/lowering/nonzero.py` implementing `lower_nonzero` with shape and dtype validation and registration in the lowering registry. 
- Wire a new `NonZeroOp` dataclass into the codegen surface (`src/emx_onnx_cgen/codegen/c_emitter.py`) and load/render a new Jinja2 template `templates/nonzero_op.c.j2` to emit C for `NonZero`.
- Implement runtime evaluation support in `src/emx_onnx_cgen/runtime/evaluator.py` using `numpy.nonzero`, and import the lowering in the compiler (`src/emx_onnx_cgen/compiler.py`).
- Add unit and ORT-comparison tests in `tests/test_ops.py` and update expected-errors and support docs (`tests/expected_errors/...json`, `SUPPORT_OPS.md`, `OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`) to mark `NonZero` supported.

### Testing
- Ran `pytest tests/test_ops.py -k nonzero`, which executed the two new NonZero tests and succeeded: 2 passed, 151 deselected in 2.52s.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696e2b4390e48325b4ef125661163381)