### PR TITLE
codegen: drop redundant idx_t casts in pad

### DIFF
--- a/templates/pad_op.c.j2
+++ b/templates/pad_op.c.j2
@@ -4,16 +4,16 @@ const {{ c_type }} *{{ input0_flat }} = (const {{ c_type }} *){{ input0 }};
 {% if pads_values %}
 const {{ pads_c_type }} pad_values[] = { {% for value in pads_values %}{{ value }}{{ ", " if not loop.last else "" }}{% endfor %} };
 {% endif %}
-ptrdiff_t pad_begin[{{ output_shape|length }}];
+idx_t pad_begin[{{ output_shape|length }}];
 for (idx_t pad_index = 0; pad_index < {{ output_shape|length }}; ++pad_index) {
     pad_begin[pad_index] = 0;
 }
 for (idx_t axis_index = 0; axis_index < {{ axes_length }}; ++axis_index) {
-    ptrdiff_t axis = (ptrdiff_t){{ axes_input }}[axis_index];
+    idx_t axis = (idx_t){{ axes_input }}[axis_index];
     if (axis < 0) {
         axis += {{ output_shape|length }};
     }
-    if (axis >= 0 && axis < (ptrdiff_t){{ output_shape|length }}) {
+    if (axis >= 0 && axis < {{ output_shape|length }}) {
         pad_begin[axis] = {% if pads_input %}{{ pads_input }}[axis_index]{% else %}pad_values[axis_index]{% endif %};
     }
 }
@@ -28,35 +28,35 @@ for (idx_t {{ out_loop_vars[loop.index0] }} = 0; {{ out_loop_vars[loop.index0] }
 {% for dim in output_shape %}
 for (idx_t {{ out_loop_vars[loop.index0] }} = 0; {{ out_loop_vars[loop.index0] }} < {{ dim }}; ++{{ out_loop_vars[loop.index0] }}) {
 {% endfor %}
-ptrdiff_t {{ base_index }} = 0;
+idx_t {{ base_index }} = 0;
 int pad_in_bounds = 1;
 {% for index in range(output_shape|length) %}
-ptrdiff_t {{ idx_vars[index] }} = (ptrdiff_t){{ out_loop_vars[index] }} - (ptrdiff_t)({{ pad_begin_exprs[index] }});
+    idx_t {{ idx_vars[index] }} = {{ out_loop_vars[index] }} - (idx_t)({{ pad_begin_exprs[index] }});
 if ({{ input_shape[index] }} == 0) {
     pad_in_bounds = 0;
 }
 {% if mode == "constant" %}
-if (pad_in_bounds && ({{ idx_vars[index] }} < 0 || {{ idx_vars[index] }} >= (ptrdiff_t){{ input_shape[index] }})) {
+if (pad_in_bounds && ({{ idx_vars[index] }} < 0 || {{ idx_vars[index] }} >= {{ input_shape[index] }})) {
     pad_in_bounds = 0;
 }
 {% elif mode == "edge" %}
 if (pad_in_bounds && {{ idx_vars[index] }} < 0) {
     {{ idx_vars[index] }} = 0;
-} else if (pad_in_bounds && {{ idx_vars[index] }} >= (ptrdiff_t){{ input_shape[index] }}) {
-    {{ idx_vars[index] }} = (ptrdiff_t){{ input_shape[index] }} - 1;
+} else if (pad_in_bounds && {{ idx_vars[index] }} >= {{ input_shape[index] }}) {
+    {{ idx_vars[index] }} = {{ input_shape[index] }} - 1;
 }
 {% elif mode == "wrap" %}
 if (pad_in_bounds) {
-    {{ idx_vars[index] }} %= (ptrdiff_t){{ input_shape[index] }};
+    {{ idx_vars[index] }} %= {{ input_shape[index] }};
     if ({{ idx_vars[index] }} < 0) {
-        {{ idx_vars[index] }} += (ptrdiff_t){{ input_shape[index] }};
+        {{ idx_vars[index] }} += {{ input_shape[index] }};
     }
 }
 {% elif mode == "reflect" %}
 if (pad_in_bounds && {{ input_shape[index] }} == 1) {
     {{ idx_vars[index] }} = 0;
 } else if (pad_in_bounds) {
-    ptrdiff_t {{ reflect_vars[index] }} = (ptrdiff_t){{ input_shape[index] }} - 1;
+    idx_t {{ reflect_vars[index] }} = {{ input_shape[index] }} - 1;
     {{ idx_vars[index] }} %= (2 * {{ reflect_vars[index] }});
     if ({{ idx_vars[index] }} < 0) {
         {{ idx_vars[index] }} += 2 * {{ reflect_vars[index] }};

--- a/tests/golden/op_pad_pad.c
+++ b/tests/golden/op_pad_pad.c
@@ -66,23 +66,23 @@ static inline void node0_pad(const float input[restrict 2][3], float output[rest
     }
     for (idx_t i0 = 0; i0 < 2; ++i0) {
         for (idx_t i1 = 0; i1 < 5; ++i1) {
-            ptrdiff_t pad_index = 0;
+            idx_t pad_index = 0;
             int pad_in_bounds = 1;
-            ptrdiff_t pad_idx0 = (ptrdiff_t)i0 - (ptrdiff_t)(0);
+            idx_t pad_idx0 = i0 - (idx_t)(0);
             if (2 == 0) {
                 pad_in_bounds = 0;
             }
-            if (pad_in_bounds && (pad_idx0 < 0 || pad_idx0 >= (ptrdiff_t)2)) {
+            if (pad_in_bounds && (pad_idx0 < 0 || pad_idx0 >= 2)) {
                 pad_in_bounds = 0;
             }
             if (pad_in_bounds) {
                 pad_index += pad_idx0 * 3;
             }
-            ptrdiff_t pad_idx1 = (ptrdiff_t)i1 - (ptrdiff_t)(1);
+            idx_t pad_idx1 = i1 - (idx_t)(1);
             if (3 == 0) {
                 pad_in_bounds = 0;
             }
-            if (pad_in_bounds && (pad_idx1 < 0 || pad_idx1 >= (ptrdiff_t)3)) {
+            if (pad_in_bounds && (pad_idx1 < 0 || pad_idx1 >= 3)) {
                 pad_in_bounds = 0;
             }
             if (pad_in_bounds) {


### PR DESCRIPTION
### Motivation
- Simplify Pad codegen by removing unnecessary `(idx_t)` casts where operands are already `idx_t` or compile-time integer literals to improve readability and avoid redundant conversions.
- Keep necessary casts for values that may come from wider input types (e.g. `pads_input`) to ensure correct narrowing when needed.
- Update golden output to match the new deterministic template output.

### Description
- Updated `templates/pad_op.c.j2` to remove redundant casts and use `idx_t` consistently for `pad_begin`, `axis`, `base_index`, per-dimension index vars, and reflect vars, while retaining casts where `pad_begin_exprs` may be a wider type.
- Replaced occurrences of `ptrdiff_t` with `idx_t` in the pad template and simplified literal/variable casts around bounds checks and modular arithmetic.
- Updated `tests/golden/op_pad_pad.c` to reflect the new emitted C code with the simplified `idx_t` usage.

### Testing
- Ran `pytest tests/test_golden_ops.py -k pad -q`, which succeeded with `1 passed, 51 deselected`.
- The updated golden test `tests/golden/op_pad_pad.c` matches the generated output from the modified template.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696e49c5833c832581439adad40a144b)