### PR TITLE
build: add setuptools_scm to CI requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [build-system]
-requires = ["setuptools>=61"]
+requires = ["setuptools>=61", "setuptools_scm[toml]>=7.0"]
 build-backend = "build_backend"
 backend-path = ["."]
 
 [project]
 name = "emx-onnx-cgen"
-version = "0.2.0"
 description = "emmtrix ONNX-to-C Code Generator"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"
+dynamic = ["version"]
 
 [project.scripts]
 emx-onnx-cgen = "emx_onnx_cgen.cli:main"
@@ -18,3 +18,6 @@ package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools_scm]
+write_to = "src/emx_onnx_cgen/_version.py"

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -26,3 +26,4 @@ onnxoptimizer>=0.3.13
 # Dev tooling (recommended)
 ruff>=0.6.0
 black>=24.0.0
+setuptools_scm[toml]>=7.0


### PR DESCRIPTION
### Motivation
- Ensure the `setuptools_scm` backend used for VCS-driven versioning is available in CI so builds that rely on it succeed.

### Description
- Add `setuptools_scm[toml]>=7.0` to `requirements-ci.txt` so CI installs the same versioning backend declared in `pyproject.toml`.

### Testing
- No automated tests were run for this change (per instruction: `Keine tests ausführen`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696fb71b4570832591dc571dd0408076)