### PR TITLE
prompts: ignore "Unsupported elem_type" expectations in fix_random_test

### DIFF
--- a/prompts/fix_random_test.py
+++ b/prompts/fix_random_test.py
@@ -29,7 +29,11 @@ def load_failing_entries() -> list[dict[str, str]]:
     )
     for repo_relative in repo_paths:
         expectation = _load_expectation_for_repo_relative(repo_relative)
-        if expectation.error.startswith("OK") or expectation.error == "":
+        if (
+            expectation.error.startswith("OK")
+            or expectation.error == ""
+            or "Unsupported elem_type" in expectation.error
+        ):
             continue
         json_path = _expected_errors_path_for_repo_relative(repo_relative)
         reproduction_cmd = ""


### PR DESCRIPTION
### Motivation
- Avoid prompting fixes for known unsupported element-type errors by excluding expectations whose `error` contains "Unsupported elem_type" when selecting a random failing test.

### Description
- Add a check in `load_failing_entries()` in `prompts/fix_random_test.py` to skip expectations where `"Unsupported elem_type" in expectation.error` so these entries are not included in the failure selection.

### Testing
- Ran `python -m pytest tests/test_official_onnx_files.py -q`, which reported `79 passed` after `289.74s` before the run was manually interrupted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6971de8c3a9883259d187ca003b08979)