### PR TITLE
verification: treat matching NaNs as equal in ULP diff and refresh cast baselines

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -284,10 +284,10 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_blackmanwindow_symmetric/model.onnx | ❌ | Unsupported op BlackmanWindow |
 | onnx-org/onnx/backend/test/data/node/test_blackmanwindow_symmetric_expanded/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_cast_BFLOAT16_to_FLOAT/model.onnx | ❌ | Unsupported elem_type 16 (BFLOAT16) for tensor 'input'. |
-| onnx-org/onnx/backend/test/data/node/test_cast_DOUBLE_to_FLOAT/model.onnx | ❌ | Out of tolerance (max ULP 4294967295) |
-| onnx-org/onnx/backend/test/data/node/test_cast_DOUBLE_to_FLOAT16/model.onnx | ❌ | Out of tolerance (max ULP 65535) |
-| onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_DOUBLE/model.onnx | ❌ | Out of tolerance (max ULP 18446744073709551615) |
-| onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_FLOAT/model.onnx | ❌ | Out of tolerance (max ULP 4294967295) |
+| onnx-org/onnx/backend/test/data/node/test_cast_DOUBLE_to_FLOAT/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_cast_DOUBLE_to_FLOAT16/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_DOUBLE/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_FLOAT/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_FLOAT4E2M1/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'output'. |
 | onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_FLOAT8E4M3FN/model.onnx | ❌ | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'output'. |
 | onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_FLOAT8E4M3FNUZ/model.onnx | ❌ | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor 'output'. |
@@ -308,8 +308,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_cast_FLOAT8E5M2_to_FLOAT/model.onnx | ❌ | Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'input'. |
 | onnx-org/onnx/backend/test/data/node/test_cast_FLOAT8E5M2_to_FLOAT16/model.onnx | ❌ | Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'input'. |
 | onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_BFLOAT16/model.onnx | ❌ | Unsupported elem_type 16 (BFLOAT16) for tensor 'output'. |
-| onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_DOUBLE/model.onnx | ❌ | Out of tolerance (max ULP 18446744073709551615) |
-| onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_FLOAT16/model.onnx | ❌ | Out of tolerance (max ULP 65535) |
+| onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_DOUBLE/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_FLOAT16/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_FLOAT4E2M1/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'output'. |
 | onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_FLOAT8E4M3FN/model.onnx | ❌ | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'output'. |
 | onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_FLOAT8E4M3FNUZ/model.onnx | ❌ | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor 'output'. |
@@ -345,13 +345,13 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_cast_no_saturate_FLOAT_to_FLOAT8E5M2FNUZ/model.onnx | ❌ | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor 'output'. |
 | onnx-org/onnx/backend/test/data/node/test_castlike_BFLOAT16_to_FLOAT/model.onnx | ❌ | Unsupported elem_type 16 (BFLOAT16) for tensor 'input'. |
 | onnx-org/onnx/backend/test/data/node/test_castlike_BFLOAT16_to_FLOAT_expanded/model.onnx | ❌ | Unsupported elem_type 16 (BFLOAT16) for tensor 'input'. |
-| onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT/model.onnx | ❌ | Out of tolerance (max ULP 4294967295) |
-| onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT16/model.onnx | ❌ | Out of tolerance (max ULP 65535) |
-| onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT16_expanded/model.onnx | ❌ | Out of tolerance (max ULP 65535) |
-| onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT_expanded/model.onnx | ❌ | Out of tolerance (max ULP 4294967295) |
-| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_DOUBLE/model.onnx | ❌ | Out of tolerance (max ULP 18446744073709551615) |
-| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_DOUBLE_expanded/model.onnx | ❌ | Out of tolerance (max ULP 18446744073709551615) |
-| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT/model.onnx | ❌ | Out of tolerance (max ULP 4294967295) |
+| onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT16/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT16_expanded/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT_expanded/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_DOUBLE/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_DOUBLE_expanded/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT4E2M1/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'like'. |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT4E2M1_expanded/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'like'. |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT8E4M3FN/model.onnx | ❌ | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'like'. |
@@ -362,7 +362,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT8E5M2FNUZ/model.onnx | ❌ | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor 'like'. |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT8E5M2FNUZ_expanded/model.onnx | ❌ | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor 'like'. |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT8E5M2_expanded/model.onnx | ❌ | Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'like'. |
-| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT_expanded/model.onnx | ❌ | Out of tolerance (max ULP 4294967295) |
+| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT_expanded/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_INT2/model.onnx | ❌ | Unsupported elem_type 26 (INT2) for tensor 'like'. |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_INT2_expanded/model.onnx | ❌ | Unsupported elem_type 26 (INT2) for tensor 'like'. |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_INT4/model.onnx | ❌ | Unsupported elem_type 22 (INT4) for tensor 'like'. |
@@ -393,10 +393,10 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT8E5M2_to_FLOAT_expanded/model.onnx | ❌ | Unsupported elem_type 19 (FLOAT8E5M2) for tensor 'input'. |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_BFLOAT16/model.onnx | ❌ | Unsupported elem_type 16 (BFLOAT16) for tensor 'like'. |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_BFLOAT16_expanded/model.onnx | ❌ | Unsupported elem_type 16 (BFLOAT16) for tensor 'like'. |
-| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_DOUBLE/model.onnx | ❌ | Out of tolerance (max ULP 18446744073709551615) |
-| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_DOUBLE_expanded/model.onnx | ❌ | Out of tolerance (max ULP 18446744073709551615) |
-| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT16/model.onnx | ❌ | Out of tolerance (max ULP 65535) |
-| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT16_expanded/model.onnx | ❌ | Out of tolerance (max ULP 65535) |
+| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_DOUBLE/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_DOUBLE_expanded/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT16/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT16_expanded/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT4E2M1/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'like'. |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT4E2M1_expanded/model.onnx | ❌ | Unsupported elem_type 23 (FLOAT4E2M1) for tensor 'like'. |
 | onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT8E4M3FN/model.onnx | ❌ | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor 'like'. |
@@ -774,7 +774,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_l1normalization_axis_0/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_l1normalization_axis_1/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_l1normalization_axis_last/model.onnx | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_l2normalization_axis_0/model.onnx | ❌ | Out of tolerance (max ULP 4294967295) |
+| onnx-org/onnx/backend/test/data/node/test_l2normalization_axis_0/model.onnx | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/node/test_l2normalization_axis_1/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_layer_normalization_2d_axis0/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_layer_normalization_2d_axis0_expanded/model.onnx | ✅ | OK (max ULP 0) |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -2,7 +2,7 @@
 
 | Error message | Count | Histogram |
 | --- | --- | --- |
-| Out of tolerance | 39 | ██████████████████████████████ |
+| Out of tolerance | 22 | ██████████████████ |
 | Missing output 1 in testbench data | 38 | █████████████████████████████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | █████████████████████████ |
 | Test data input count does not match model inputs: 1 vs 3. | 27 | █████████████████████ |

--- a/src/emx_onnx_cgen/verification.py
+++ b/src/emx_onnx_cgen/verification.py
@@ -37,7 +37,7 @@ def max_ulp_diff(actual: np.ndarray, expected: np.ndarray) -> int:
     nan_mask = np.isnan(actual_cast) | np.isnan(expected_cast)
     if nan_mask.any():
         both_nan = np.isnan(actual_cast) & np.isnan(expected_cast)
-        if not np.all(both_nan):
+        if np.any(nan_mask & ~both_nan):
             uint_dtype = _float_uint_dtype(expected_cast)
             return int(np.iinfo(uint_dtype).max)
         actual_cast = actual_cast[~nan_mask]

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cast_DOUBLE_to_FLOAT16__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cast_DOUBLE_to_FLOAT16__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Out of tolerance (max ULP 65535)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_cast_DOUBLE_to_FLOAT16/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_cast_DOUBLE_to_FLOAT16/test_data_set_0",
   "operators": [
     "Cast"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cast_DOUBLE_to_FLOAT__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cast_DOUBLE_to_FLOAT__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Out of tolerance (max ULP 4294967295)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_cast_DOUBLE_to_FLOAT/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_cast_DOUBLE_to_FLOAT/test_data_set_0",
   "operators": [
     "Cast"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cast_FLOAT16_to_DOUBLE__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cast_FLOAT16_to_DOUBLE__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Out of tolerance (max ULP 18446744073709551615)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_DOUBLE/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_DOUBLE/test_data_set_0",
   "operators": [
     "Cast"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cast_FLOAT16_to_FLOAT__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cast_FLOAT16_to_FLOAT__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Out of tolerance (max ULP 4294967295)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_FLOAT/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_cast_FLOAT16_to_FLOAT/test_data_set_0",
   "operators": [
     "Cast"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cast_FLOAT_to_DOUBLE__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cast_FLOAT_to_DOUBLE__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Out of tolerance (max ULP 18446744073709551615)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_DOUBLE/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_DOUBLE/test_data_set_0",
   "operators": [
     "Cast"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cast_FLOAT_to_FLOAT16__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cast_FLOAT_to_FLOAT16__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Out of tolerance (max ULP 65535)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_FLOAT16/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_cast_FLOAT_to_FLOAT16/test_data_set_0",
   "operators": [
     "Cast"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_DOUBLE_to_FLOAT16__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_DOUBLE_to_FLOAT16__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Out of tolerance (max ULP 65535)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT16/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT16/test_data_set_0",
   "operators": [
     "CastLike"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_DOUBLE_to_FLOAT16_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_DOUBLE_to_FLOAT16_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Out of tolerance (max ULP 65535)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT16_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT16_expanded/test_data_set_0",
   "operators": [
     "Cast"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_DOUBLE_to_FLOAT__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_DOUBLE_to_FLOAT__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Out of tolerance (max ULP 4294967295)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT/test_data_set_0",
   "operators": [
     "CastLike"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_DOUBLE_to_FLOAT_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_DOUBLE_to_FLOAT_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Out of tolerance (max ULP 4294967295)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_castlike_DOUBLE_to_FLOAT_expanded/test_data_set_0",
   "operators": [
     "Cast"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT16_to_DOUBLE__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT16_to_DOUBLE__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Out of tolerance (max ULP 18446744073709551615)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_DOUBLE/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_DOUBLE/test_data_set_0",
   "operators": [
     "CastLike"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT16_to_DOUBLE_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT16_to_DOUBLE_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Out of tolerance (max ULP 18446744073709551615)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_DOUBLE_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_DOUBLE_expanded/test_data_set_0",
   "operators": [
     "Cast"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT16_to_FLOAT__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT16_to_FLOAT__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Out of tolerance (max ULP 4294967295)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT/test_data_set_0",
   "operators": [
     "CastLike"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT16_to_FLOAT_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT16_to_FLOAT_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Out of tolerance (max ULP 4294967295)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT16_to_FLOAT_expanded/test_data_set_0",
   "operators": [
     "Cast"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT_to_DOUBLE__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT_to_DOUBLE__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Out of tolerance (max ULP 18446744073709551615)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_DOUBLE/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_DOUBLE/test_data_set_0",
   "operators": [
     "CastLike"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT_to_DOUBLE_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT_to_DOUBLE_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Out of tolerance (max ULP 18446744073709551615)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_DOUBLE_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_DOUBLE_expanded/test_data_set_0",
   "operators": [
     "Cast"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT_to_FLOAT16__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT_to_FLOAT16__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Out of tolerance (max ULP 65535)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT16/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT16/test_data_set_0",
   "operators": [
     "CastLike"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT_to_FLOAT16_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_castlike_FLOAT_to_FLOAT16_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Out of tolerance (max ULP 65535)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT16_expanded/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_castlike_FLOAT_to_FLOAT16_expanded/test_data_set_0",
   "operators": [
     "Cast"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_l2normalization_axis_0__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_l2normalization_axis_0__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Out of tolerance (max ULP 4294967295)",
+  "error": "OK (max ULP 1)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_l2normalization_axis_0/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_l2normalization_axis_0/test_data_set_0",
   "operators": [
     "LpNormalization"


### PR DESCRIPTION
### Motivation

- Prevent false positive "Out of tolerance" failures when both actual and expected outputs contain NaNs in the same positions by making ULP comparisons NaN-safe.

### Description

- Adjust `max_ulp_diff` in `src/emx_onnx_cgen/verification.py` to treat matching NaNs as equal and only return the max-ULP sentinel when NaNs differ between actual and expected.
- Update expected-error baselines for various `Cast`/`CastLike` and `LpNormalization` tests under `tests/expected_errors/` to reflect the corrected verification behavior.
- Refresh entries in `OFFICIAL_ONNX_FILE_SUPPORT.md` and `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md` to mark the affected cast/castlike/l2normalization tests as passing and adjust the histogram counts accordingly.

### Testing

- Ran targeted official-file verification subset via pytest: `pytest tests/test_official_onnx_files.py -k "cast_DOUBLE_to_FLOAT or cast_DOUBLE_to_FLOAT16 or cast_FLOAT16_to_FLOAT or cast_FLOAT16_to_DOUBLE or cast_FLOAT_to_DOUBLE or cast_FLOAT_to_FLOAT16 or castlike_DOUBLE_to_FLOAT or castlike_DOUBLE_to_FLOAT_expanded or castlike_DOUBLE_to_FLOAT16 or castlike_DOUBLE_to_FLOAT16_expanded or castlike_FLOAT16_to_FLOAT or castlike_FLOAT16_to_FLOAT_expanded or castlike_FLOAT16_to_DOUBLE or castlike_FLOAT16_to_DOUBLE_expanded or castlike_FLOAT_to_DOUBLE or castlike_FLOAT_to_DOUBLE_expanded or castlike_FLOAT_to_FLOAT16 or castlike_FLOAT_to_FLOAT16_expanded or l2normalization_axis_0"` and observed `34 passed, 1842 deselected` in 38.92s.
- Executed CLI verification of the previously failing `onnx-org` cast/castlike models and confirmed they now report `OK (max ULP 0)` or the expected small ULP for `l2normalization_axis_0` in automated runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6971e73af0a08325b78b424912313507)