### PR TITLE
lowering: infer TopK k from output shape

### DIFF
--- a/prompts/fix_random_test.py
+++ b/prompts/fix_random_test.py
@@ -79,6 +79,11 @@ def main() -> None:
         "templates/*_op.c.j2 file, update runtime/evaluator.py for numpy checks, "
         "and refresh tests/expected_errors entries when support status changes."
     )
+    prompt_lines.append(
+        "Model inspection hint: when an input is dynamic (e.g., scalar tensors like "
+        "TopK's k), check the model's input/output shapes via onnx.load(...) to "
+        "see if the value can be inferred from value_info or output shapes."
+    )
     prompt_lines.append("\nAnalyze the root cause and implement a fix.")
     prompt_lines.append(
         "At the end, reflect on what general information would have helped you fix "

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_top_k_smallest__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_top_k_smallest__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "TopK k input must be a constant initializer",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_top_k_smallest/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_top_k_smallest/test_data_set_0",
   "operators": [
     "TopK"


### PR DESCRIPTION
### Motivation

- Allow lowering of `TopK` when the `k` input is not a constant initializer by inferring the requested `k` from available shape information so models that provide `k` as an input (but have statically-known shapes/value_info) are supported.

### Description

- Change `_read_k` in `src/emx_onnx_cgen/lowering/topk.py` to return `None` when the `k` input is not a constant initializer and add logic to infer `k` from the outputs' shape when missing.
- Add validation that `values` and `indices` output shapes match, require `k` to be a 1-element tensor if dynamic, and validate `k` bounds against the input axis dimension in `lower_topk`.
- Update the failure-finding helper `prompts/fix_random_test.py` to include a model-inspection hint about checking `value_info`/output shapes for dynamic scalar inputs.
- Mark the TopK smallest backend test expectation as passing by updating `tests/expected_errors/...test_top_k_smallest...json` to `"OK (max ULP 0)"`.

### Testing

- Ran the model verification command `PYTHONPATH=src python -m emx_onnx_cgen.cli verify onnx-org/onnx/backend/test/data/node/test_top_k_smallest/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_top_k_smallest/test_data_set_0` which completed successfully (`OK (max ULP 0)`) in approximately `1.16s`.
- The modified lowering code exercised by the verification run produced no errors and the updated expectation file was validated by the same verification command.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6971ec8942448325b270fa96bf697078)