### PR TITLE
Add Adagrad operator support

### DIFF
--- a/prompts/fix_random_test.py
+++ b/prompts/fix_random_test.py
@@ -84,6 +84,11 @@ def main() -> None:
         "TopK's k), check the model's input/output shapes via onnx.load(...) to "
         "see if the value can be inferred from value_info or output shapes."
     )
+    prompt_lines.append(
+        "Optimizer op hint: training optimizers (e.g., Adagrad) group variadic "
+        "inputs as parameters, gradients, and accumulators; outputs mirror the "
+        "parameter order followed by updated accumulators."
+    )
     prompt_lines.append("\nAnalyze the root cause and implement a fix.")
     prompt_lines.append(
         "At the end, reflect on what general information would have helped you fix "

--- a/src/emx_onnx_cgen/compiler.py
+++ b/src/emx_onnx_cgen/compiler.py
@@ -45,6 +45,7 @@ from .codegen.c_emitter import (
     QuantizeLinearOp,
     LrnOp,
     LstmOp,
+    AdagradOp,
     LogSoftmaxOp,
     HardmaxOp,
     NegativeLogLikelihoodLossOp,
@@ -105,6 +106,7 @@ from .lowering.gemm import resolve_gemm_spec, validate_gemm_bias_shape
 from .lowering.lrn import LrnSpec, resolve_lrn_spec
 from .lowering.logsoftmax import lower_logsoftmax
 from .lowering import hardmax as _hardmax  # noqa: F401
+from .lowering import adagrad as _adagrad  # noqa: F401
 from .lowering import group_normalization as _group_normalization  # noqa: F401
 from .lowering import instance_normalization as _instance_normalization  # noqa: F401
 from .lowering import layer_normalization as _layer_normalization  # noqa: F401
@@ -506,6 +508,7 @@ class Compiler:
             | RMSNormalizationOp
             | LrnOp
             | LstmOp
+            | AdagradOp
             | SoftmaxOp
             | LogSoftmaxOp
             | HardmaxOp

--- a/src/emx_onnx_cgen/lowering/adagrad.py
+++ b/src/emx_onnx_cgen/lowering/adagrad.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from shared.scalar_types import ScalarType
+
+from ..codegen.c_emitter import AdagradOp
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Node
+from .common import value_dtype, value_shape
+from .registry import register_lowering
+
+
+def _is_scalar_shape(shape: tuple[int, ...]) -> bool:
+    return shape == () or shape == (1,)
+
+
+@register_lowering("Adagrad")
+def lower_adagrad(graph: Graph, node: Node) -> AdagradOp:
+    if len(node.inputs) < 5:
+        raise UnsupportedOpError("Adagrad must have at least 5 inputs")
+    if len(node.outputs) < 2:
+        raise UnsupportedOpError("Adagrad must have at least 2 outputs")
+    if (len(node.inputs) - 2) % 3 != 0:
+        raise UnsupportedOpError(
+            "Adagrad inputs must be R, T, Xs, Gs, Hs with matching counts"
+        )
+    tensor_count = (len(node.inputs) - 2) // 3
+    if len(node.outputs) != tensor_count * 2:
+        raise UnsupportedOpError(
+            "Adagrad outputs must be X_news followed by H_news"
+        )
+    rate_name = node.inputs[0]
+    timestep_name = node.inputs[1]
+    rate_shape = value_shape(graph, rate_name, node)
+    timestep_shape = value_shape(graph, timestep_name, node)
+    if not _is_scalar_shape(rate_shape):
+        raise UnsupportedOpError("Adagrad R input must be a scalar")
+    if not _is_scalar_shape(timestep_shape):
+        raise UnsupportedOpError("Adagrad T input must be a scalar")
+    rate_dtype = value_dtype(graph, rate_name, node)
+    if rate_dtype not in {ScalarType.F32, ScalarType.F64}:
+        raise UnsupportedOpError(
+            "Adagrad R input must be float or double"
+        )
+    timestep_dtype = value_dtype(graph, timestep_name, node)
+    if timestep_dtype != ScalarType.I64:
+        raise UnsupportedOpError("Adagrad T input must be int64")
+
+    inputs = node.inputs[2 : 2 + tensor_count]
+    gradients = node.inputs[2 + tensor_count : 2 + tensor_count * 2]
+    accumulators = node.inputs[2 + tensor_count * 2 : 2 + tensor_count * 3]
+    outputs = node.outputs[:tensor_count]
+    accumulator_outputs = node.outputs[tensor_count:]
+    if not inputs or not gradients or not accumulators:
+        raise UnsupportedOpError("Adagrad requires X, G, H inputs")
+    dtype = value_dtype(graph, inputs[0], node)
+    if dtype not in {ScalarType.F32, ScalarType.F64}:
+        raise UnsupportedOpError("Adagrad supports float and double tensors only")
+    if rate_dtype != dtype:
+        raise UnsupportedOpError(
+            "Adagrad R input dtype must match tensor dtype"
+        )
+    input_shapes: list[tuple[int, ...]] = []
+    output_shapes: list[tuple[int, ...]] = []
+    for index, (x_name, g_name, h_name, out_name, h_out_name) in enumerate(
+        zip(inputs, gradients, accumulators, outputs, accumulator_outputs)
+    ):
+        x_dtype = value_dtype(graph, x_name, node)
+        g_dtype = value_dtype(graph, g_name, node)
+        h_dtype = value_dtype(graph, h_name, node)
+        out_dtype = value_dtype(graph, out_name, node)
+        h_out_dtype = value_dtype(graph, h_out_name, node)
+        if {x_dtype, g_dtype, h_dtype, out_dtype, h_out_dtype} != {dtype}:
+            raise UnsupportedOpError(
+                "Adagrad inputs and outputs must share the same dtype"
+            )
+        x_shape = value_shape(graph, x_name, node)
+        g_shape = value_shape(graph, g_name, node)
+        h_shape = value_shape(graph, h_name, node)
+        out_shape = value_shape(graph, out_name, node)
+        h_out_shape = value_shape(graph, h_out_name, node)
+        if x_shape != g_shape or x_shape != h_shape:
+            raise ShapeInferenceError(
+                f"Adagrad inputs X/G/H shapes must match for tensor {index}"
+            )
+        if out_shape != x_shape or h_out_shape != x_shape:
+            raise ShapeInferenceError(
+                f"Adagrad outputs must match X shape for tensor {index}"
+            )
+        input_shapes.append(x_shape)
+        output_shapes.append(out_shape)
+
+    norm_coefficient = float(node.attrs.get("norm_coefficient", 0.0))
+    epsilon = float(node.attrs.get("epsilon", 0.0))
+    decay_factor = float(node.attrs.get("decay_factor", 0.0))
+
+    return AdagradOp(
+        rate=rate_name,
+        timestep=timestep_name,
+        inputs=tuple(inputs),
+        gradients=tuple(gradients),
+        accumulators=tuple(accumulators),
+        outputs=tuple(outputs),
+        accumulator_outputs=tuple(accumulator_outputs),
+        rate_shape=rate_shape,
+        timestep_shape=timestep_shape,
+        tensor_shapes=tuple(input_shapes),
+        output_shapes=tuple(output_shapes),
+        dtype=dtype,
+        rate_dtype=rate_dtype,
+        timestep_dtype=timestep_dtype,
+        norm_coefficient=norm_coefficient,
+        epsilon=epsilon,
+        decay_factor=decay_factor,
+    )

--- a/templates/adagrad_op.c.j2
+++ b/templates/adagrad_op.c.j2
@@ -1,0 +1,16 @@
+static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
+    const {{ c_type }} r = {{ rate }}[0] / ({{ one_literal }} + ({{ c_type }}){{ timestep }}[0] * {{ decay_factor_literal }});
+{% for tensor in tensors %}
+{% for dim in tensor.shape %}
+    for (idx_t {{ tensor.loop_vars[loop.index0] }} = 0; {{ tensor.loop_vars[loop.index0] }} < {{ dim }}; ++{{ tensor.loop_vars[loop.index0] }}) {
+{% endfor %}
+        {{ c_type }} g_regularized = {{ norm_coefficient_literal }} * {{ tensor.input_expr }} + {{ tensor.grad_expr }};
+        {{ c_type }} h_new = {{ tensor.acc_expr }} + g_regularized * g_regularized;
+        {{ tensor.acc_output_expr }} = h_new;
+        {{ c_type }} h_adaptive = {{ sqrt_fn }}(h_new) + {{ epsilon_literal }};
+        {{ tensor.output_expr }} = {{ tensor.input_expr }} - r * g_regularized / h_adaptive;
+{% for _ in tensor.shape %}
+    }
+{% endfor %}
+{% endfor %}
+}

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_adagrad__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_adagrad__model.onnx.json
@@ -1,7 +1,0 @@
-{
-  "error": "Unsupported op Adagrad",
-  "command_line": "verify onnx-org/onnx/backend/test/data/node/test_adagrad/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_adagrad/test_data_set_0",
-  "operators": [
-    "ai.onnx.preview.training::Adagrad"
-  ]
-}

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_adagrad_multiple__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_adagrad_multiple__model.onnx.json
@@ -1,7 +1,0 @@
-{
-  "error": "Unsupported op Adagrad",
-  "command_line": "verify onnx-org/onnx/backend/test/data/node/test_adagrad_multiple/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_adagrad_multiple/test_data_set_0",
-  "operators": [
-    "ai.onnx.preview.training::Adagrad"
-  ]
-}


### PR DESCRIPTION
### Motivation
- Enable support for the ONNX training optimizer `Adagrad` which previously reported `Unsupported op Adagrad` in expected-error entries.
- Provide lowering, codegen, and runtime evaluation so Adagrad models can be lowered to C and verified against NumPy/ORT-style behavior.

### Description
- Add lowering with validations in `src/emx_onnx_cgen/lowering/adagrad.py` to parse inputs/outputs, validate scalar `R` and `T`, dtypes, and matching tensor shapes and counts, and emit an `AdagradOp` dataclass for codegen.
- Extend codegen in `src/emx_onnx_cgen/codegen/c_emitter.py` to handle `AdagradOp` (op metadata mapping, param/arg building, rendering logic) and register a new Jinja2 template `templates/adagrad_op.c.j2` that implements the per-element Adagrad update loop.
- Add runtime evaluator support in `src/emx_onnx_cgen/runtime/evaluator.py` with `_eval_adagrad` to compute expected outputs for verification/constant folding using NumPy semantics.
- Register the lowering import in `src/emx_onnx_cgen/compiler.py`, wire templates in the emitter, and update helper paths so `Adagrad` is recognized end-to-end; also remove the corresponding failing expected-error JSON entries from `tests/expected_errors/` and add a helpful hint to `prompts/fix_random_test.py` about optimizer input ordering.

### Testing
- Ran model verification for single- and multi-tensor Adagrad tests using the CLI: `PYTHONPATH=src python -m emx_onnx_cgen.cli verify onnx-org/onnx/backend/test/data/node/test_adagrad/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_adagrad/test_data_set_0`, completed in `real 0m1.047s` and succeeded.
- Ran the multi-tensor variant `PYTHONPATH=src python -m emx_onnx_cgen.cli verify onnx-org/onnx/backend/test/data/node/test_adagrad_multiple/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_adagrad_multiple/test_data_set_0`, completed in `real 0m1.051s` and succeeded.
- No automated unit tests were added in this change; the two verification runs above served as targeted checks and both completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6971fb0058a8832593453ee3e57a2103)