### PR TITLE
Add QLinearMatMul support (lowering, codegen, runtime, tests)

### DIFF
--- a/prompts/fix_random_test.py
+++ b/prompts/fix_random_test.py
@@ -84,6 +84,11 @@ def main() -> None:
         "TopK's k), check the model's input/output shapes via onnx.load(...) to "
         "see if the value can be inferred from value_info or output shapes."
     )
+    prompt_lines.append(
+        "Quantized op hint: check onnx-org/onnx/reference/ops/op_qlinear*.py and "
+        "note scale/zero_point constraints (often scalar shapes and int8/uint8 "
+        "dtypes) to guide lowering validation and codegen math."
+    )
     prompt_lines.append("\nAnalyze the root cause and implement a fix.")
     prompt_lines.append(
         "At the end, reflect on what general information would have helped you fix "

--- a/src/emx_onnx_cgen/codegen/__init__.py
+++ b/src/emx_onnx_cgen/codegen/__init__.py
@@ -7,6 +7,7 @@ from .c_emitter import (
     GemmOp,
     LoweredModel,
     MatMulOp,
+    QLinearMatMulOp,
     ShapeOp,
     UnaryOp,
 )
@@ -20,6 +21,7 @@ __all__ = [
     "GemmOp",
     "LoweredModel",
     "MatMulOp",
+    "QLinearMatMulOp",
     "ShapeOp",
     "UnaryOp",
 ]

--- a/src/emx_onnx_cgen/codegen/c_emitter.py
+++ b/src/emx_onnx_cgen/codegen/c_emitter.py
@@ -251,6 +251,42 @@ class MatMulOp:
     dtype: ScalarType
 
 
+@dataclass(frozen=True)
+class QLinearMatMulOp:
+    input0: str
+    input0_scale: str
+    input0_zero_point: str
+    input1: str
+    input1_scale: str
+    input1_zero_point: str
+    output_scale: str
+    output_zero_point: str
+    output: str
+    input0_shape: tuple[int, ...]
+    input1_shape: tuple[int, ...]
+    output_shape: tuple[int, ...]
+    batch_shape: tuple[int, ...]
+    input0_batch_shape: tuple[int, ...]
+    input1_batch_shape: tuple[int, ...]
+    m: int
+    n: int
+    k: int
+    left_vector: bool
+    right_vector: bool
+    input0_dtype: ScalarType
+    input1_dtype: ScalarType
+    dtype: ScalarType
+    input0_scale_dtype: ScalarType
+    input1_scale_dtype: ScalarType
+    output_scale_dtype: ScalarType
+    input0_scale_shape: tuple[int, ...]
+    input1_scale_shape: tuple[int, ...]
+    output_scale_shape: tuple[int, ...]
+    input0_zero_shape: tuple[int, ...]
+    input1_zero_shape: tuple[int, ...]
+    output_zero_shape: tuple[int, ...]
+
+
 class EinsumKind(str, Enum):
     REDUCE_ALL = "reduce_all"
     SUM_J = "sum_j"
@@ -1190,6 +1226,7 @@ class LoweredModel:
         | ClipOp
         | CastOp
         | QuantizeLinearOp
+        | QLinearMatMulOp
         | MatMulOp
         | EinsumOp
         | GemmOp
@@ -1375,6 +1412,7 @@ class CEmitter:
         | ClipOp
         | CastOp
         | QuantizeLinearOp
+        | QLinearMatMulOp
         | MatMulOp
         | EinsumOp
         | GemmOp
@@ -1452,6 +1490,18 @@ class CEmitter:
                 names.append(op.zero_point)
             names.append(op.output)
             return tuple(names)
+        if isinstance(op, QLinearMatMulOp):
+            return (
+                op.input0,
+                op.input0_scale,
+                op.input0_zero_point,
+                op.input1,
+                op.input1_scale,
+                op.input1_zero_point,
+                op.output_scale,
+                op.output_zero_point,
+                op.output,
+            )
         if isinstance(op, MatMulOp):
             return (op.input0, op.input1, op.output)
         if isinstance(op, EinsumOp):
@@ -1708,6 +1758,7 @@ class CEmitter:
         | ClipOp
         | CastOp
         | QuantizeLinearOp
+        | QLinearMatMulOp
         | MatMulOp
         | EinsumOp
         | GemmOp
@@ -1771,6 +1822,7 @@ class CEmitter:
         | ClipOp
         | CastOp
         | QuantizeLinearOp
+        | QLinearMatMulOp
         | MatMulOp
         | EinsumOp
         | GemmOp
@@ -1902,6 +1954,47 @@ class CEmitter:
                 dtype=op.dtype,
                 input_dtype=op.input_dtype,
                 scale_dtype=op.scale_dtype,
+            )
+        if isinstance(op, QLinearMatMulOp):
+            return QLinearMatMulOp(
+                input0=name_map.get(op.input0, op.input0),
+                input0_scale=name_map.get(op.input0_scale, op.input0_scale),
+                input0_zero_point=name_map.get(
+                    op.input0_zero_point, op.input0_zero_point
+                ),
+                input1=name_map.get(op.input1, op.input1),
+                input1_scale=name_map.get(op.input1_scale, op.input1_scale),
+                input1_zero_point=name_map.get(
+                    op.input1_zero_point, op.input1_zero_point
+                ),
+                output_scale=name_map.get(op.output_scale, op.output_scale),
+                output_zero_point=name_map.get(
+                    op.output_zero_point, op.output_zero_point
+                ),
+                output=name_map.get(op.output, op.output),
+                input0_shape=op.input0_shape,
+                input1_shape=op.input1_shape,
+                output_shape=op.output_shape,
+                batch_shape=op.batch_shape,
+                input0_batch_shape=op.input0_batch_shape,
+                input1_batch_shape=op.input1_batch_shape,
+                m=op.m,
+                n=op.n,
+                k=op.k,
+                left_vector=op.left_vector,
+                right_vector=op.right_vector,
+                input0_dtype=op.input0_dtype,
+                input1_dtype=op.input1_dtype,
+                dtype=op.dtype,
+                input0_scale_dtype=op.input0_scale_dtype,
+                input1_scale_dtype=op.input1_scale_dtype,
+                output_scale_dtype=op.output_scale_dtype,
+                input0_scale_shape=op.input0_scale_shape,
+                input1_scale_shape=op.input1_scale_shape,
+                output_scale_shape=op.output_scale_shape,
+                input0_zero_shape=op.input0_zero_shape,
+                input1_zero_shape=op.input1_zero_shape,
+                output_zero_shape=op.output_zero_shape,
             )
         if isinstance(op, MatMulOp):
             return MatMulOp(
@@ -2818,6 +2911,9 @@ class CEmitter:
                 "quantize_linear": self._env.get_template(
                     "quantize_linear_op.c.j2"
                 ),
+                "qlinear_matmul": self._env.get_template(
+                    "qlinear_matmul_op.c.j2"
+                ),
                 "matmul": self._env.get_template("matmul_op.c.j2"),
                 "einsum": self._env.get_template("einsum_op.c.j2"),
                 "gemm": self._env.get_template("gemm_op.c.j2"),
@@ -2947,6 +3043,7 @@ class CEmitter:
         clip_template = templates["clip"]
         cast_template = templates["cast"]
         quantize_linear_template = templates["quantize_linear"]
+        qlinear_matmul_template = templates["qlinear_matmul"]
         matmul_template = templates["matmul"]
         einsum_template = templates["einsum"]
         gemm_template = templates["gemm"]
@@ -3034,6 +3131,7 @@ class CEmitter:
                 clip_template=clip_template,
                 cast_template=cast_template,
                 quantize_linear_template=quantize_linear_template,
+                qlinear_matmul_template=qlinear_matmul_template,
                 matmul_template=matmul_template,
                 einsum_template=einsum_template,
                 gemm_template=gemm_template,
@@ -3217,6 +3315,7 @@ class CEmitter:
         clip_template = templates["clip"]
         cast_template = templates["cast"]
         quantize_linear_template = templates["quantize_linear"]
+        qlinear_matmul_template = templates["qlinear_matmul"]
         matmul_template = templates["matmul"]
         einsum_template = templates["einsum"]
         gemm_template = templates["gemm"]
@@ -3304,6 +3403,7 @@ class CEmitter:
                 clip_template=clip_template,
                 cast_template=cast_template,
                 quantize_linear_template=quantize_linear_template,
+                qlinear_matmul_template=qlinear_matmul_template,
                 matmul_template=matmul_template,
                 einsum_template=einsum_template,
                 gemm_template=gemm_template,
@@ -3712,6 +3812,7 @@ class CEmitter:
             | ClipOp
             | CastOp
             | QuantizeLinearOp
+            | QLinearMatMulOp
             | MatMulOp
             | EinsumOp
             | GemmOp
@@ -3945,6 +4046,7 @@ class CEmitter:
             | ClipOp
             | CastOp
             | QuantizeLinearOp
+            | QLinearMatMulOp
             | MatMulOp
             | EinsumOp
             | GemmOp
@@ -4093,7 +4195,7 @@ class CEmitter:
         ):
             return True
         if any(
-            isinstance(op, (LpPoolOp, QuantizeLinearOp))
+            isinstance(op, (LpPoolOp, QuantizeLinearOp, QLinearMatMulOp))
             for op in resolved_ops
         ):
             return True
@@ -4107,6 +4209,7 @@ class CEmitter:
             | ClipOp
             | CastOp
             | QuantizeLinearOp
+            | QLinearMatMulOp
             | MatMulOp
             | EinsumOp
             | GemmOp
@@ -4186,7 +4289,8 @@ class CEmitter:
         ):
             return True
         if any(
-            isinstance(op, QuantizeLinearOp) and op.dtype.is_integer
+            isinstance(op, (QuantizeLinearOp, QLinearMatMulOp))
+            and op.dtype.is_integer
             for op in resolved_ops
         ):
             return True
@@ -4202,6 +4306,7 @@ class CEmitter:
             | ClipOp
             | CastOp
             | QuantizeLinearOp
+            | QLinearMatMulOp
             | MatMulOp
             | EinsumOp
             | GemmOp
@@ -4311,6 +4416,7 @@ class CEmitter:
         | ClipOp
         | CastOp
         | QuantizeLinearOp
+        | QLinearMatMulOp
         | MatMulOp
         | EinsumOp
         | GemmOp
@@ -4378,6 +4484,21 @@ class CEmitter:
             return ", ".join(args)
         if isinstance(op, WhereOp):
             args.extend([op.condition, op.input_x, op.input_y, op.output])
+            return ", ".join(args)
+        if isinstance(op, QLinearMatMulOp):
+            args.extend(
+                [
+                    op.input0,
+                    op.input0_scale,
+                    op.input0_zero_point,
+                    op.input1,
+                    op.input1_scale,
+                    op.input1_zero_point,
+                    op.output_scale,
+                    op.output_zero_point,
+                    op.output,
+                ]
+            )
             return ", ".join(args)
         if isinstance(op, MatMulOp):
             args.extend([op.input0, op.input1, op.output])
@@ -4690,6 +4811,7 @@ class CEmitter:
         | ClipOp
         | CastOp
         | QuantizeLinearOp
+        | QLinearMatMulOp
         | MatMulOp
         | EinsumOp
         | GemmOp
@@ -4752,6 +4874,7 @@ class CEmitter:
         | ClipOp
         | CastOp
         | QuantizeLinearOp
+        | QLinearMatMulOp
         | MatMulOp
         | EinsumOp
         | GemmOp
@@ -4917,6 +5040,47 @@ class CEmitter:
                 dtype=op.dtype,
                 input_dtype=op.input_dtype,
                 scale_dtype=op.scale_dtype,
+            )
+        if isinstance(op, QLinearMatMulOp):
+            return QLinearMatMulOp(
+                input0=temp_map.get(op.input0, op.input0),
+                input0_scale=temp_map.get(op.input0_scale, op.input0_scale),
+                input0_zero_point=temp_map.get(
+                    op.input0_zero_point, op.input0_zero_point
+                ),
+                input1=temp_map.get(op.input1, op.input1),
+                input1_scale=temp_map.get(op.input1_scale, op.input1_scale),
+                input1_zero_point=temp_map.get(
+                    op.input1_zero_point, op.input1_zero_point
+                ),
+                output_scale=temp_map.get(op.output_scale, op.output_scale),
+                output_zero_point=temp_map.get(
+                    op.output_zero_point, op.output_zero_point
+                ),
+                output=temp_map.get(op.output, op.output),
+                input0_shape=op.input0_shape,
+                input1_shape=op.input1_shape,
+                output_shape=op.output_shape,
+                batch_shape=op.batch_shape,
+                input0_batch_shape=op.input0_batch_shape,
+                input1_batch_shape=op.input1_batch_shape,
+                m=op.m,
+                n=op.n,
+                k=op.k,
+                left_vector=op.left_vector,
+                right_vector=op.right_vector,
+                input0_dtype=op.input0_dtype,
+                input1_dtype=op.input1_dtype,
+                dtype=op.dtype,
+                input0_scale_dtype=op.input0_scale_dtype,
+                input1_scale_dtype=op.input1_scale_dtype,
+                output_scale_dtype=op.output_scale_dtype,
+                input0_scale_shape=op.input0_scale_shape,
+                input1_scale_shape=op.input1_scale_shape,
+                output_scale_shape=op.output_scale_shape,
+                input0_zero_shape=op.input0_zero_shape,
+                input1_zero_shape=op.input1_zero_shape,
+                output_zero_shape=op.output_zero_shape,
             )
         if isinstance(op, GemmOp):
             return GemmOp(
@@ -5855,6 +6019,7 @@ class CEmitter:
         | ClipOp
         | CastOp
         | QuantizeLinearOp
+        | QLinearMatMulOp
         | MatMulOp
         | EinsumOp
         | GemmOp
@@ -5922,6 +6087,7 @@ class CEmitter:
         clip_template,
         cast_template,
         quantize_linear_template,
+        qlinear_matmul_template,
         matmul_template,
         einsum_template,
         gemm_template,
@@ -10025,6 +10191,187 @@ class CEmitter:
                 dim_args=dim_args,
             ).rstrip()
             return with_node_comment(rendered)
+        if isinstance(op, QLinearMatMulOp):
+            if scalar_registry is None:
+                raise CodegenError(
+                    "Scalar function registry is required for QLinearMatMul."
+                )
+            params = self._shared_param_map(
+                [
+                    ("input0", op.input0),
+                    ("input0_scale", op.input0_scale),
+                    ("input0_zero_point", op.input0_zero_point),
+                    ("input1", op.input1),
+                    ("input1_scale", op.input1_scale),
+                    ("input1_zero_point", op.input1_zero_point),
+                    ("output_scale", op.output_scale),
+                    ("output_zero_point", op.output_zero_point),
+                    ("output", op.output),
+                ]
+            )
+            output_shape = CEmitter._codegen_shape(op.output_shape)
+            output_loop_vars = CEmitter._loop_vars(output_shape)
+            output_index_expr = f"{params['output']}" + "".join(
+                f"[{var}]" for var in output_loop_vars
+            )
+            batch_rank = len(op.batch_shape)
+            batch_vars = output_loop_vars[:batch_rank]
+            if op.left_vector and op.right_vector:
+                row_var = None
+                col_var = None
+            elif op.left_vector:
+                row_var = None
+                col_var = output_loop_vars[-1]
+            elif op.right_vector:
+                row_var = output_loop_vars[-1]
+                col_var = None
+            else:
+                row_var = output_loop_vars[-2]
+                col_var = output_loop_vars[-1]
+            input0_index_expr, input1_index_expr = CEmitter._matmul_index_exprs(
+                op,
+                batch_vars,
+                row_var,
+                col_var,
+                batch_rank,
+                input0=params["input0"],
+                input1=params["input1"],
+            )
+            input0_suffix = self._param_array_suffix(op.input0_shape)
+            input1_suffix = self._param_array_suffix(op.input1_shape)
+            input0_scale_suffix = self._param_array_suffix(
+                op.input0_scale_shape
+            )
+            input1_scale_suffix = self._param_array_suffix(
+                op.input1_scale_shape
+            )
+            output_scale_suffix = self._param_array_suffix(
+                op.output_scale_shape
+            )
+            input0_zero_suffix = self._param_array_suffix(op.input0_zero_shape)
+            input1_zero_suffix = self._param_array_suffix(op.input1_zero_shape)
+            output_zero_suffix = self._param_array_suffix(op.output_zero_shape)
+            output_suffix = self._param_array_suffix(op.output_shape)
+            param_decls = self._build_param_decls(
+                [
+                    (
+                        params["input0"],
+                        op.input0_dtype.c_type,
+                        input0_suffix,
+                        True,
+                    ),
+                    (
+                        params["input0_scale"],
+                        op.input0_scale_dtype.c_type,
+                        input0_scale_suffix,
+                        True,
+                    ),
+                    (
+                        params["input0_zero_point"],
+                        op.input0_dtype.c_type,
+                        input0_zero_suffix,
+                        True,
+                    ),
+                    (
+                        params["input1"],
+                        op.input1_dtype.c_type,
+                        input1_suffix,
+                        True,
+                    ),
+                    (
+                        params["input1_scale"],
+                        op.input1_scale_dtype.c_type,
+                        input1_scale_suffix,
+                        True,
+                    ),
+                    (
+                        params["input1_zero_point"],
+                        op.input1_dtype.c_type,
+                        input1_zero_suffix,
+                        True,
+                    ),
+                    (
+                        params["output_scale"],
+                        op.output_scale_dtype.c_type,
+                        output_scale_suffix,
+                        True,
+                    ),
+                    (
+                        params["output_zero_point"],
+                        op.dtype.c_type,
+                        output_zero_suffix,
+                        True,
+                    ),
+                    (
+                        params["output"],
+                        op.dtype.c_type,
+                        output_suffix,
+                        False,
+                    ),
+                ]
+            )
+            compute_dtype = (
+                ScalarType.F64
+                if ScalarType.F64
+                in {
+                    op.input0_scale_dtype,
+                    op.input1_scale_dtype,
+                    op.output_scale_dtype,
+                }
+                else ScalarType.F32
+            )
+            compute_type = (
+                "double" if compute_dtype == ScalarType.F64 else "float"
+            )
+            max_fn = self._scalar_function_name(
+                ScalarFunction.MAXIMUM, compute_dtype, scalar_registry
+            )
+            min_fn = self._scalar_function_name(
+                ScalarFunction.MINIMUM, compute_dtype, scalar_registry
+            )
+            if max_fn is None or min_fn is None:
+                raise CodegenError(
+                    "Failed to resolve scalar min/max functions for QLinearMatMul."
+                )
+            round_fn = CEmitter._math_fn(
+                compute_dtype, "nearbyintf", "nearbyint"
+            )
+            scale_index = "0"
+            rendered = qlinear_matmul_template.render(
+                model_name=model.name,
+                op_name=op_name,
+                input0=params["input0"],
+                input1=params["input1"],
+                input0_scale=params["input0_scale"],
+                input0_zero_point=params["input0_zero_point"],
+                input1_scale=params["input1_scale"],
+                input1_zero_point=params["input1_zero_point"],
+                output_scale=params["output_scale"],
+                output_zero_point=params["output_zero_point"],
+                output=params["output"],
+                params=param_decls,
+                compute_type=compute_type,
+                output_c_type=op.dtype.c_type,
+                input0_index_expr=input0_index_expr,
+                input1_index_expr=input1_index_expr,
+                input0_scale_expr=f"{params['input0_scale']}[{scale_index}]",
+                input1_scale_expr=f"{params['input1_scale']}[{scale_index}]",
+                output_scale_expr=f"{params['output_scale']}[{scale_index}]",
+                input0_zero_expr=f"{params['input0_zero_point']}[{scale_index}]",
+                input1_zero_expr=f"{params['input1_zero_point']}[{scale_index}]",
+                output_zero_expr=f"{params['output_zero_point']}[{scale_index}]",
+                output_loop_vars=output_loop_vars,
+                output_loop_bounds=output_shape,
+                output_index_expr=output_index_expr,
+                k=op.k,
+                round_fn=round_fn,
+                min_literal=op.dtype.min_literal,
+                max_literal=op.dtype.max_literal,
+                min_fn=min_fn,
+                max_fn=max_fn,
+                dim_args=dim_args,
+            ).rstrip()
+            return with_node_comment(rendered)
         if isinstance(op, ClipOp):
             if scalar_registry is None:
                 raise CodegenError(
@@ -10677,6 +11024,8 @@ class CEmitter:
         | UnaryOp
         | ClipOp
         | CastOp
+        | QuantizeLinearOp
+        | QLinearMatMulOp
         | MatMulOp
         | EinsumOp
         | GemmOp
@@ -10739,6 +11088,8 @@ class CEmitter:
             return op.input_shape
         if isinstance(op, CastOp):
             return op.shape
+        if isinstance(op, QLinearMatMulOp):
+            return op.output_shape
         if isinstance(op, MatMulOp):
             return op.output_shape
         if isinstance(op, EinsumOp):

--- a/src/emx_onnx_cgen/compiler.py
+++ b/src/emx_onnx_cgen/compiler.py
@@ -56,6 +56,7 @@ from .codegen.c_emitter import (
     LoweredModel,
     ModelHeader,
     MatMulOp,
+    QLinearMatMulOp,
     MaxPoolOp,
     ReduceOp,
     ArgReduceOp,
@@ -135,6 +136,7 @@ from .lowering.reshape import lower_reshape
 from .lowering.resize import lower_resize
 from .lowering.grid_sample import lower_grid_sample
 from .lowering import quantize_linear as _quantize_linear  # noqa: F401
+from .lowering import qlinear_matmul as _qlinear_matmul  # noqa: F401
 from .lowering.slice import lower_slice
 from .lowering.squeeze import lower_squeeze
 from .lowering import depth_space as _depth_space  # noqa: F401
@@ -490,6 +492,7 @@ class Compiler:
             | ClipOp
             | CastOp
             | QuantizeLinearOp
+            | QLinearMatMulOp
             | MatMulOp
             | GemmOp
             | AttentionOp
@@ -544,6 +547,7 @@ class Compiler:
             | ClipOp
             | CastOp
             | QuantizeLinearOp
+            | QLinearMatMulOp
             | MatMulOp
             | GemmOp
             | AttentionOp

--- a/src/emx_onnx_cgen/lowering/qlinear_matmul.py
+++ b/src/emx_onnx_cgen/lowering/qlinear_matmul.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from shared.scalar_types import ScalarType
+
+from ..codegen.c_emitter import QLinearMatMulOp
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.model import Graph, Node
+from .common import value_dtype as _value_dtype
+from .common import value_shape as _value_shape
+from .registry import register_lowering
+
+
+@dataclass(frozen=True)
+class QLinearMatMulSpec:
+    input0_shape: tuple[int, ...]
+    input1_shape: tuple[int, ...]
+    output_shape: tuple[int, ...]
+    batch_shape: tuple[int, ...]
+    input0_batch_shape: tuple[int, ...]
+    input1_batch_shape: tuple[int, ...]
+    m: int
+    n: int
+    k: int
+    left_vector: bool
+    right_vector: bool
+
+
+def resolve_qlinear_matmul_spec(graph: Graph, node: Node) -> QLinearMatMulSpec:
+    if len(node.inputs) != 8 or len(node.outputs) != 1:
+        raise UnsupportedOpError(
+            "QLinearMatMul must have 8 inputs and 1 output"
+        )
+    input0_shape = _value_shape(graph, node.inputs[0], node)
+    input1_shape = _value_shape(graph, node.inputs[3], node)
+    if len(input0_shape) < 1 or len(input1_shape) < 1:
+        raise UnsupportedOpError(
+            "QLinearMatMul inputs must be at least 1D, "
+            f"got {input0_shape} x {input1_shape}"
+        )
+    left_vector = len(input0_shape) == 1
+    right_vector = len(input1_shape) == 1
+    input0_effective = (1, input0_shape[0]) if left_vector else input0_shape
+    input1_effective = (input1_shape[0], 1) if right_vector else input1_shape
+    m, k_left = input0_effective[-2], input0_effective[-1]
+    k_right, n = input1_effective[-2], input1_effective[-1]
+    if k_left != k_right:
+        raise ShapeInferenceError(
+            "QLinearMatMul inner dimensions must match, "
+            f"got {k_left} and {k_right}"
+        )
+    batch_shape, input0_batch_shape, input1_batch_shape = (
+        _broadcast_batch_shapes(
+            input0_effective[:-2], input1_effective[:-2], node
+        )
+    )
+    if left_vector and right_vector:
+        output_shape = batch_shape
+    elif left_vector:
+        output_shape = batch_shape + (n,)
+    elif right_vector:
+        output_shape = batch_shape + (m,)
+    else:
+        output_shape = batch_shape + (m, n)
+    expected_output_shape = _value_shape(graph, node.outputs[0], node)
+    if expected_output_shape != output_shape:
+        raise ShapeInferenceError(
+            "QLinearMatMul output shape must be "
+            f"{output_shape}, got {expected_output_shape}"
+        )
+    return QLinearMatMulSpec(
+        input0_shape=input0_shape,
+        input1_shape=input1_shape,
+        output_shape=output_shape,
+        batch_shape=batch_shape,
+        input0_batch_shape=input0_batch_shape,
+        input1_batch_shape=input1_batch_shape,
+        m=m,
+        n=n,
+        k=k_left,
+        left_vector=left_vector,
+        right_vector=right_vector,
+    )
+
+
+def _broadcast_batch_shapes(
+    left: tuple[int, ...], right: tuple[int, ...], node: Node
+) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+    max_rank = max(len(left), len(right))
+    left_padded = (1,) * (max_rank - len(left)) + left
+    right_padded = (1,) * (max_rank - len(right)) + right
+    broadcast_shape = []
+    for left_dim, right_dim in zip(left_padded, right_padded):
+        if not (left_dim == right_dim or left_dim == 1 or right_dim == 1):
+            raise ShapeInferenceError(
+                "QLinearMatMul batch dimensions must be broadcastable, "
+                f"got {left} x {right}"
+            )
+        broadcast_shape.append(max(left_dim, right_dim))
+    return tuple(broadcast_shape), left_padded, right_padded
+
+
+def _ensure_scalar_input(
+    graph: Graph, name: str, node: Node, label: str
+) -> tuple[int, ...]:
+    shape = _value_shape(graph, name, node)
+    if shape not in {(), (1,)}:
+        raise UnsupportedOpError(
+            f"QLinearMatMul {label} must be scalar, got shape {shape}"
+        )
+    return shape
+
+
+def _ensure_scale_dtype(dtype: ScalarType, label: str) -> None:
+    if not dtype.is_float:
+        raise UnsupportedOpError(
+            f"QLinearMatMul {label} must be float16/float/double"
+        )
+
+
+@register_lowering("QLinearMatMul")
+def lower_qlinear_matmul(graph: Graph, node: Node) -> QLinearMatMulOp:
+    spec = resolve_qlinear_matmul_spec(graph, node)
+    input0_dtype = _value_dtype(graph, node.inputs[0], node)
+    input1_dtype = _value_dtype(graph, node.inputs[3], node)
+    output_dtype = _value_dtype(graph, node.outputs[0], node)
+    if input0_dtype not in {ScalarType.U8, ScalarType.I8}:
+        raise UnsupportedOpError(
+            "QLinearMatMul supports uint8/int8 inputs only"
+        )
+    if input1_dtype not in {ScalarType.U8, ScalarType.I8}:
+        raise UnsupportedOpError(
+            "QLinearMatMul supports uint8/int8 inputs only"
+        )
+    if output_dtype not in {ScalarType.U8, ScalarType.I8}:
+        raise UnsupportedOpError(
+            "QLinearMatMul supports uint8/int8 outputs only"
+        )
+    input0_scale_dtype = _value_dtype(graph, node.inputs[1], node)
+    input1_scale_dtype = _value_dtype(graph, node.inputs[4], node)
+    output_scale_dtype = _value_dtype(graph, node.inputs[6], node)
+    _ensure_scale_dtype(input0_scale_dtype, "a_scale")
+    _ensure_scale_dtype(input1_scale_dtype, "b_scale")
+    _ensure_scale_dtype(output_scale_dtype, "y_scale")
+    input0_zero_dtype = _value_dtype(graph, node.inputs[2], node)
+    input1_zero_dtype = _value_dtype(graph, node.inputs[5], node)
+    output_zero_dtype = _value_dtype(graph, node.inputs[7], node)
+    if input0_zero_dtype != input0_dtype:
+        raise UnsupportedOpError(
+            "QLinearMatMul a_zero_point dtype must match a"
+        )
+    if input1_zero_dtype != input1_dtype:
+        raise UnsupportedOpError(
+            "QLinearMatMul b_zero_point dtype must match b"
+        )
+    if output_zero_dtype != output_dtype:
+        raise UnsupportedOpError(
+            "QLinearMatMul y_zero_point dtype must match y"
+        )
+    input0_scale_shape = _ensure_scalar_input(
+        graph, node.inputs[1], node, "a_scale"
+    )
+    input1_scale_shape = _ensure_scalar_input(
+        graph, node.inputs[4], node, "b_scale"
+    )
+    output_scale_shape = _ensure_scalar_input(
+        graph, node.inputs[6], node, "y_scale"
+    )
+    input0_zero_shape = _ensure_scalar_input(
+        graph, node.inputs[2], node, "a_zero_point"
+    )
+    input1_zero_shape = _ensure_scalar_input(
+        graph, node.inputs[5], node, "b_zero_point"
+    )
+    output_zero_shape = _ensure_scalar_input(
+        graph, node.inputs[7], node, "y_zero_point"
+    )
+    return QLinearMatMulOp(
+        input0=node.inputs[0],
+        input0_scale=node.inputs[1],
+        input0_zero_point=node.inputs[2],
+        input1=node.inputs[3],
+        input1_scale=node.inputs[4],
+        input1_zero_point=node.inputs[5],
+        output_scale=node.inputs[6],
+        output_zero_point=node.inputs[7],
+        output=node.outputs[0],
+        input0_shape=spec.input0_shape,
+        input1_shape=spec.input1_shape,
+        output_shape=spec.output_shape,
+        batch_shape=spec.batch_shape,
+        input0_batch_shape=spec.input0_batch_shape,
+        input1_batch_shape=spec.input1_batch_shape,
+        m=spec.m,
+        n=spec.n,
+        k=spec.k,
+        left_vector=spec.left_vector,
+        right_vector=spec.right_vector,
+        input0_dtype=input0_dtype,
+        input1_dtype=input1_dtype,
+        dtype=output_dtype,
+        input0_scale_dtype=input0_scale_dtype,
+        input1_scale_dtype=input1_scale_dtype,
+        output_scale_dtype=output_scale_dtype,
+        input0_scale_shape=input0_scale_shape,
+        input1_scale_shape=input1_scale_shape,
+        output_scale_shape=output_scale_shape,
+        input0_zero_shape=input0_zero_shape,
+        input1_zero_shape=input1_zero_shape,
+        output_zero_shape=output_zero_shape,
+    )

--- a/src/emx_onnx_cgen/runtime/evaluator.py
+++ b/src/emx_onnx_cgen/runtime/evaluator.py
@@ -49,6 +49,7 @@ from ..lowering.topk import lower_topk
 from ..lowering.lstm import ACTIVATION_KIND_BY_NAME, resolve_lstm_spec
 from ..lowering.lrn import resolve_lrn_spec
 from ..lowering.matmul import lower_matmul
+from ..lowering.qlinear_matmul import lower_qlinear_matmul
 from ..lowering.maxpool import resolve_maxpool_spec
 from ..lowering.reduce import (
     REDUCE_KIND_BY_OP,
@@ -1455,6 +1456,41 @@ def _eval_quantize_linear(evaluator: Evaluator, node: Node) -> None:
     evaluator.values[node.outputs[0]] = clipped.astype(
         spec.output_dtype.np_dtype, copy=False
     )
+
+
+@register_evaluator("QLinearMatMul")
+def _eval_qlinear_matmul(evaluator: Evaluator, node: Node) -> None:
+    op = lower_qlinear_matmul(evaluator.graph, node)
+    input0 = evaluator.values[op.input0]
+    input1 = evaluator.values[op.input1]
+    input0_scale = evaluator.values[op.input0_scale]
+    input1_scale = evaluator.values[op.input1_scale]
+    output_scale = evaluator.values[op.output_scale]
+    input0_zero_point = evaluator.values[op.input0_zero_point]
+    input1_zero_point = evaluator.values[op.input1_zero_point]
+    output_zero_point = evaluator.values[op.output_zero_point]
+
+    def _scalar_value(array: np.ndarray) -> float:
+        return float(np.asarray(array).reshape(-1)[0])
+
+    def _scalar_int(array: np.ndarray) -> int:
+        return int(np.asarray(array).reshape(-1)[0])
+
+    input0_zero = _scalar_int(input0_zero_point)
+    input1_zero = _scalar_int(input1_zero_point)
+    output_zero = _scalar_int(output_zero_point)
+    scale = _scalar_value(input0_scale) * _scalar_value(
+        input1_scale
+    ) / _scalar_value(output_scale)
+    acc = _apply_matmul(
+        input0.astype(np.int32) - input0_zero,
+        input1.astype(np.int32) - input1_zero,
+    )
+    scaled = acc.astype(np.float64) * scale + output_zero
+    rounded = np.rint(scaled)
+    info = np.iinfo(op.dtype.np_dtype)
+    clipped = np.clip(rounded, info.min, info.max)
+    evaluator.values[op.output] = clipped.astype(op.dtype.np_dtype)
 
 @register_evaluator("InstanceNormalization")
 def _eval_instance_normalization(evaluator: Evaluator, node: Node) -> None:

--- a/templates/qlinear_matmul_op.c.j2
+++ b/templates/qlinear_matmul_op.c.j2
@@ -1,0 +1,21 @@
+static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
+    const {{ compute_type }} scale = (({{ compute_type }}){{ input0_scale_expr }}) * (({{ compute_type }}){{ input1_scale_expr }}) / (({{ compute_type }}){{ output_scale_expr }});
+    const int32_t input0_zero = (int32_t){{ input0_zero_expr }};
+    const int32_t input1_zero = (int32_t){{ input1_zero_expr }};
+    const {{ compute_type }} output_zero = ({{ compute_type }}){{ output_zero_expr }};
+{% for idx in range(output_loop_vars | length) %}
+    {% for indent in range(loop.index0) %}    {% endfor %}for (idx_t {{ output_loop_vars[idx] }} = 0; {{ output_loop_vars[idx] }} < {{ output_loop_bounds[idx] }}; ++{{ output_loop_vars[idx] }}) {
+{% endfor %}
+        {% for indent in range(output_loop_vars | length) %}    {% endfor %}int32_t acc = 0;
+        {% for indent in range(output_loop_vars | length) %}    {% endfor %}for (idx_t k = 0; k < {{ k }}; ++k) {
+            {% for indent in range(output_loop_vars | length + 1) %}    {% endfor %}acc += ((int32_t){{ input0_index_expr }} - input0_zero) * ((int32_t){{ input1_index_expr }} - input1_zero);
+        {% for indent in range(output_loop_vars | length) %}    {% endfor %}}
+        {% for indent in range(output_loop_vars | length) %}    {% endfor %}{{ compute_type }} scaled = (({{ compute_type }})acc) * scale + output_zero;
+        {% for indent in range(output_loop_vars | length) %}    {% endfor %}{{ compute_type }} rounded = {{ round_fn }}(scaled);
+        {% for indent in range(output_loop_vars | length) %}    {% endfor %}rounded = {{ max_fn }}(rounded, ({{ compute_type }}){{ min_literal }});
+        {% for indent in range(output_loop_vars | length) %}    {% endfor %}rounded = {{ min_fn }}(rounded, ({{ compute_type }}){{ max_literal }});
+        {% for indent in range(output_loop_vars | length) %}    {% endfor %}{{ output_index_expr }} = ({{ output_c_type }})rounded;
+{% for idx in range(output_loop_vars | length) | reverse %}
+    {% for indent in range(loop.index0) %}    {% endfor %}}
+{% endfor %}
+}

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_qlinearmatmul_2D_uint8_float16__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_qlinearmatmul_2D_uint8_float16__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op QLinearMatMul",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_qlinearmatmul_2D_uint8_float16/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_qlinearmatmul_2D_uint8_float16/test_data_set_0",
   "operators": [
     "QLinearMatMul"


### PR DESCRIPTION
### Motivation
- The test suite reported an unsupported `QLinearMatMul` operator, so support for quantized MatMul is required to pass official ONNX node tests and enable quantized matmul codegen.
- Implement operator lowering, code generation, and runtime evaluation in a deterministic, validated way that follows existing pass/emit conventions.

### Description
- Add a dedicated lowering for `QLinearMatMul` with shape/dtype validation and scalar scale/zero_point checks in `src/emx_onnx_cgen/lowering/qlinear_matmul.py`. 
- Introduce a `QLinearMatMulOp` dataclass and wire it through the emitter in `src/emx_onnx_cgen/codegen/c_emitter.py`, including parameter mapping, call-sites, and codegen rendering logic. 
- Add a Jinja2 template `templates/qlinear_matmul_op.c.j2` that emits the quantized matmul inner loop (accumulate, scale, round, clamp) and register the template in the emitter. 
- Implement runtime evaluation for `QLinearMatMul` in `src/emx_onnx_cgen/runtime/evaluator.py` to support numpy-based verification; update compiler wiring (`compiler.py`) and public exports (`codegen/__init__.py`); update the failing expectation JSON and the fix prompt guidance for quantized ops. 

### Testing
- Ran the verification command `PYTHONPATH=src python -m emx_onnx_cgen.cli verify onnx-org/onnx/backend/test/data/node/test_qlinearmatmul_2D_uint8_float16/model.onnx --template-dir templates --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_qlinearmatmul_2D_uint8_float16/test_data_set_0`, which completed successfully with `OK (max ULP 0)`. 
- Measured execution time for the verification run as `real 0m1.557s`, and the CLI returned exit code `0` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6971fdfc59408325be7fe6fecf7f3f66)