### PR TITLE
refactor: introduce OpBase/GraphContext, registry-driven lowering, and op-driven emitter

### DIFF
--- a/src/emx_onnx_cgen/codegen/emitter.py
+++ b/src/emx_onnx_cgen/codegen/emitter.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .c_emitter import CEmitter
+
+__all__ = ["CEmitter"]

--- a/src/emx_onnx_cgen/compiler.py
+++ b/src/emx_onnx_cgen/compiler.py
@@ -12,170 +12,21 @@ from shared.scalar_types import ScalarType
 
 from .onnxruntime_utils import make_deterministic_session_options
 from .codegen.c_emitter import (
-    AttentionOp,
-    AveragePoolOp,
-    BatchNormOp,
-    LpNormalizationOp,
-    InstanceNormalizationOp,
-    GroupNormalizationOp,
-    LayerNormalizationOp,
-    MeanVarianceNormalizationOp,
-    RMSNormalizationOp,
-    BinaryOp,
-    MultiInputBinaryOp,
-    CastOp,
-    ClipOp,
     CEmitter,
     ConstTensor,
-    ConvOp,
-    ConvTransposeOp,
-    ConcatOp,
-    ConstantOfShapeOp,
-    CumSumOp,
-    GemmOp,
-    GatherOp,
-    GatherElementsOp,
-    GatherNDOp,
-    ScatterNDOp,
-    TensorScatterOp,
-    ExpandOp,
-    RangeOp,
-    OneHotOp,
-    LpPoolOp,
-    QuantizeLinearOp,
-    LrnOp,
-    LstmOp,
-    AdagradOp,
-    LogSoftmaxOp,
-    HardmaxOp,
-    NegativeLogLikelihoodLossOp,
-    NonZeroOp,
-    NonMaxSuppressionOp,
-    NodeInfo,
-    PadOp,
-    SplitOp,
-    SoftmaxCrossEntropyLossOp,
     LoweredModel,
     ModelHeader,
-    MatMulOp,
-    QLinearMatMulOp,
-    MaxPoolOp,
-    ReduceOp,
-    ArgReduceOp,
-    ReshapeOp,
-    ResizeOp,
-    GridSampleOp,
-    HardmaxOp,
-    SoftmaxOp,
-    ShapeOp,
-    SliceOp,
-    TransposeOp,
-    UnaryOp,
-    WhereOp,
+    NodeInfo,
 )
 from .dtypes import dtype_info
 from .errors import CodegenError, ShapeInferenceError, UnsupportedOpError
+from .ir.context import GraphContext
 from .ir.model import Graph, TensorType, Value
-from .lowering.attention import AttentionSpec, resolve_attention_spec
-from .lowering.average_pool import (
-    lower_average_pool,
-    lower_global_average_pool,
-)
-from .lowering import global_max_pool as _global_max_pool  # noqa: F401
-from .lowering.batch_normalization import lower_batch_normalization
-from .lowering.cast import lower_cast
-from .lowering.concat import lower_concat
-from .lowering.common import (
-    ensure_supported_dtype,
-    node_dtype,
-    shape_product,
-    value_dtype,
-    value_shape,
-)
-from .lowering.conv import ConvSpec, resolve_conv_spec
-from .lowering import conv_transpose as _conv_transpose  # noqa: F401
-from .lowering.constant_of_shape import lower_constant_of_shape
-from .lowering.dropout import lower_dropout
-from .lowering import cumsum as _cumsum  # noqa: F401
-from .lowering import einsum as _einsum  # noqa: F401
-from .lowering.flatten import lower_flatten
-from .lowering.gather import lower_gather
-from .lowering.gather_elements import lower_gather_elements
-from .lowering.gather_nd import lower_gather_nd
-from .lowering import scatter_nd as _scatter_nd  # noqa: F401
-from .lowering import tensor_scatter as _tensor_scatter  # noqa: F401
-from .lowering.gemm import resolve_gemm_spec, validate_gemm_bias_shape
-from .lowering.lrn import LrnSpec, resolve_lrn_spec
-from .lowering.logsoftmax import lower_logsoftmax
-from .lowering import hardmax as _hardmax  # noqa: F401
-from .lowering import adagrad as _adagrad  # noqa: F401
-from .lowering import group_normalization as _group_normalization  # noqa: F401
-from .lowering import instance_normalization as _instance_normalization  # noqa: F401
-from .lowering import layer_normalization as _layer_normalization  # noqa: F401
-from .lowering import lp_normalization as _lp_normalization  # noqa: F401
-from .lowering import lp_pool as _lp_pool  # noqa: F401
-from .lowering import mean_variance_normalization as _mean_variance_normalization  # noqa: F401
-from .lowering.negative_log_likelihood_loss import (
-    lower_negative_log_likelihood_loss,
-)
-from .lowering import nonzero as _nonzero  # noqa: F401
-from .lowering import non_max_suppression as _non_max_suppression  # noqa: F401
-from .lowering.expand import lower_expand
-from .lowering.range import lower_range
-from .lowering import one_hot as _one_hot  # noqa: F401
-from .lowering.split import lower_split
-from .lowering.softmax_cross_entropy_loss import (
-    lower_softmax_cross_entropy_loss,
-)
-from .lowering.matmul import lower_matmul
-from .lowering.maxpool import MaxPoolSpec, resolve_maxpool_spec
-from .lowering import pad as _pad  # noqa: F401
-from .lowering.reduce import (
-    REDUCE_KIND_BY_OP,
-    REDUCE_OUTPUTS_FLOAT_ONLY,
-)
-from .lowering import arg_reduce as _arg_reduce  # noqa: F401
-from .lowering import topk as _topk  # noqa: F401
-from .lowering.reshape import lower_reshape
-from .lowering.resize import lower_resize
-from .lowering.grid_sample import lower_grid_sample
-from .lowering import quantize_linear as _quantize_linear  # noqa: F401
-from .lowering import qlinear_matmul as _qlinear_matmul  # noqa: F401
-from .lowering.slice import lower_slice
-from .lowering.squeeze import lower_squeeze
-from .lowering import depth_space as _depth_space  # noqa: F401
-from .lowering import eye_like as _eye_like  # noqa: F401
-from .lowering import identity as _identity  # noqa: F401
-from .lowering import tile as _tile  # noqa: F401
-from .lowering import trilu as _trilu  # noqa: F401
-from .lowering.shape import lower_shape
-from .lowering.size import lower_size
-from .lowering.softmax import lower_softmax
-from .lowering.transpose import lower_transpose
-from .lowering.unsqueeze import lower_unsqueeze
-from .lowering.where import lower_where
-from .lowering.elementwise import (
-    lower_celu,
-    lower_clip,
-    lower_isinf,
-    lower_isnan,
-    lower_shrink,
-    lower_swish,
-)
-from .lowering import variadic as _variadic  # noqa: F401
-from .lowering import rms_normalization as _rms_normalization  # noqa: F401
-from .lowering import rotary_embedding as _rotary_embedding  # noqa: F401
-from .lowering.registry import get_lowering_registry, resolve_dispatch
+from .ir.op_base import OpBase
+from .lowering import load_lowering_registry
+from .lowering.common import ensure_supported_dtype, shape_product, value_dtype
+from .lowering.registry import get_lowering_registry
 from .onnx_import import import_onnx
-from .ops import (
-    BINARY_OP_TYPES,
-    COMPARE_FUNCTIONS,
-    UNARY_OP_TYPES,
-    binary_op_symbol,
-    unary_op_symbol,
-    validate_unary_attrs,
-)
-from shared.scalar_functions import ScalarFunction, ScalarFunctionError
 from .runtime.evaluator import Evaluator
 
 
@@ -212,6 +63,7 @@ class Compiler:
             large_temp_threshold_bytes=options.large_temp_threshold_bytes,
             large_weight_threshold=options.large_weight_threshold,
         )
+        load_lowering_registry()
 
     def compile(self, model: onnx.ModelProto) -> str:
         graph = import_onnx(model)
@@ -306,7 +158,8 @@ class Compiler:
         return collect(graph.inputs), collect(graph.outputs)
 
     def _lower_model(self, model: onnx.ModelProto, graph: Graph) -> LoweredModel:
-        constants = _lowered_constants(graph)
+        ctx = GraphContext(graph)
+        constants = _lowered_constants(ctx)
         self._validate_graph(graph)
         (
             input_names,
@@ -316,7 +169,7 @@ class Compiler:
             output_shapes,
             output_dtypes,
         ) = self._collect_io_specs(graph)
-        ops, node_infos = self._lower_nodes(graph)
+        ops, node_infos = self._lower_nodes(ctx)
         header = self._build_header(model, graph)
         return LoweredModel(
             name=self._options.model_name,
@@ -487,130 +340,16 @@ class Compiler:
         )
 
     def _lower_nodes(
-        self, graph: Graph
-    ) -> tuple[
-        list[
-            BinaryOp
-            | MultiInputBinaryOp
-            | UnaryOp
-            | ClipOp
-            | CastOp
-            | QuantizeLinearOp
-            | QLinearMatMulOp
-            | MatMulOp
-            | GemmOp
-            | AttentionOp
-            | ConvOp
-            | ConvTransposeOp
-            | AveragePoolOp
-            | LpPoolOp
-            | BatchNormOp
-            | LpNormalizationOp
-            | InstanceNormalizationOp
-            | GroupNormalizationOp
-            | LayerNormalizationOp
-            | MeanVarianceNormalizationOp
-            | RMSNormalizationOp
-            | LrnOp
-            | LstmOp
-            | AdagradOp
-            | SoftmaxOp
-            | LogSoftmaxOp
-            | HardmaxOp
-            | NegativeLogLikelihoodLossOp
-            | SoftmaxCrossEntropyLossOp
-            | MaxPoolOp
-            | ConcatOp
-            | GatherElementsOp
-            | GatherOp
-            | GatherNDOp
-            | ScatterNDOp
-            | TensorScatterOp
-            | TransposeOp
-            | ConstantOfShapeOp
-            | ReshapeOp
-            | SliceOp
-            | ResizeOp
-            | GridSampleOp
-            | ReduceOp
-            | ArgReduceOp
-            | ShapeOp
-            | PadOp
-            | NonZeroOp
-            | NonMaxSuppressionOp
-            | ExpandOp
-            | CumSumOp
-            | RangeOp
-            | OneHotOp
-            | SplitOp
-        ],
-        list[NodeInfo],
-    ]:
-        ops: list[
-            BinaryOp
-            | MultiInputBinaryOp
-            | UnaryOp
-            | ClipOp
-            | CastOp
-            | QuantizeLinearOp
-            | QLinearMatMulOp
-            | MatMulOp
-            | GemmOp
-            | AttentionOp
-            | ConvOp
-            | ConvTransposeOp
-            | AveragePoolOp
-            | LpPoolOp
-            | BatchNormOp
-            | LpNormalizationOp
-            | InstanceNormalizationOp
-            | GroupNormalizationOp
-            | LayerNormalizationOp
-            | MeanVarianceNormalizationOp
-            | RMSNormalizationOp
-            | LrnOp
-            | LstmOp
-            | SoftmaxOp
-            | LogSoftmaxOp
-            | HardmaxOp
-            | NegativeLogLikelihoodLossOp
-            | SoftmaxCrossEntropyLossOp
-            | MaxPoolOp
-            | ConcatOp
-            | GatherElementsOp
-            | GatherOp
-            | GatherNDOp
-            | ScatterNDOp
-            | TensorScatterOp
-            | TransposeOp
-            | ConstantOfShapeOp
-            | ReshapeOp
-            | SliceOp
-            | ResizeOp
-            | ReduceOp
-            | ArgReduceOp
-            | ShapeOp
-            | PadOp
-            | NonZeroOp
-            | NonMaxSuppressionOp
-            | ExpandOp
-            | CumSumOp
-            | RangeOp
-            | OneHotOp
-            | SplitOp
-            | WhereOp
-        ] = []
+        self, ctx: GraphContext
+    ) -> tuple[list[OpBase], list[NodeInfo]]:
+        ops: list[OpBase] = []
         node_infos: list[NodeInfo] = []
-        for node in graph.nodes:
-            lowering = resolve_dispatch(
-                node.op_type,
-                get_lowering_registry(),
-                binary_types=BINARY_OP_TYPES,
-                unary_types=UNARY_OP_TYPES,
-                binary_fallback=lambda: _lower_binary_unary,
-                unary_fallback=lambda: _lower_binary_unary,
-            )
-            ops.append(lowering(graph, node))
+        registry = get_lowering_registry()
+        for node in ctx.nodes:
+            lowering = registry.get(node.op_type)
+            if lowering is None:
+                raise UnsupportedOpError(f"Unsupported op {node.op_type}")
+            ops.append(lowering(ctx, node))
             node_infos.append(
                 NodeInfo(
                     op_type=node.op_type,
@@ -661,7 +400,7 @@ class Compiler:
         return evaluator.run(feeds)
 
 
-def _lowered_constants(graph: Graph) -> tuple[ConstTensor, ...]:
+def _lowered_constants(graph: Graph | GraphContext) -> tuple[ConstTensor, ...]:
     constants: list[ConstTensor] = []
     for initializer in graph.initializers:
         dtype = ensure_supported_dtype(initializer.type.dtype)
@@ -678,124 +417,3 @@ def _lowered_constants(graph: Graph) -> tuple[ConstTensor, ...]:
         )
     return tuple(constants)
 
-
-def _lower_binary_unary(graph: Graph, node: Node) -> BinaryOp | UnaryOp:
-    if node.op_type == "BitShift":
-        if len(node.inputs) != 2 or len(node.outputs) != 1:
-            raise UnsupportedOpError("BitShift must have 2 inputs and 1 output")
-        direction_attr = node.attrs.get("direction", "LEFT")
-        if isinstance(direction_attr, bytes):
-            direction = direction_attr.decode()
-        else:
-            direction = str(direction_attr)
-        if direction not in {"LEFT", "RIGHT"}:
-            raise UnsupportedOpError(
-                "BitShift direction must be LEFT or RIGHT"
-            )
-        op_dtype = node_dtype(graph, node, *node.inputs, *node.outputs)
-        if not op_dtype.is_integer:
-            raise UnsupportedOpError("BitShift expects integer inputs")
-        function = (
-            ScalarFunction.BITWISE_LEFT_SHIFT
-            if direction == "LEFT"
-            else ScalarFunction.BITWISE_RIGHT_SHIFT
-        )
-        op_spec = binary_op_symbol(function, node.attrs, dtype=op_dtype)
-        if op_spec is None:
-            raise UnsupportedOpError("Unsupported op BitShift")
-        input0_shape = value_shape(graph, node.inputs[0], node)
-        input1_shape = value_shape(graph, node.inputs[1], node)
-        output_shape = value_shape(graph, node.outputs[0], node)
-        return BinaryOp(
-            input0=node.inputs[0],
-            input1=node.inputs[1],
-            output=node.outputs[0],
-            function=function,
-            operator_kind=op_spec.kind,
-            input0_shape=input0_shape,
-            input1_shape=input1_shape,
-            shape=output_shape,
-            dtype=op_dtype,
-            input_dtype=op_dtype,
-        )
-    if node.op_type == "Mod":
-        fmod = int(node.attrs.get("fmod", 0))
-        if fmod not in {0, 1}:
-            raise UnsupportedOpError("Mod only supports fmod=0 or fmod=1")
-        function = (
-            ScalarFunction.FMOD if fmod == 1 else ScalarFunction.REMAINDER
-        )
-    else:
-        try:
-            function = ScalarFunction.from_onnx_op(node.op_type)
-        except ScalarFunctionError as exc:
-            raise UnsupportedOpError(
-                f"Unsupported op {node.op_type}"
-            ) from exc
-    validate_unary_attrs(node.op_type, node.attrs)
-    if function in COMPARE_FUNCTIONS:
-        input_dtype = node_dtype(graph, node, *node.inputs)
-        output_dtype = value_dtype(graph, node.outputs[0], node)
-        op_spec = binary_op_symbol(function, node.attrs, dtype=input_dtype)
-        if op_spec is None:
-            raise UnsupportedOpError(f"Unsupported op {node.op_type}")
-        if len(node.inputs) != 2 or len(node.outputs) != 1:
-            raise UnsupportedOpError(
-                f"{node.op_type} must have 2 inputs and 1 output"
-            )
-        if output_dtype != ScalarType.BOOL:
-            raise UnsupportedOpError(
-                f"{node.op_type} expects bool output, got {output_dtype.onnx_name}"
-            )
-        input0_shape = value_shape(graph, node.inputs[0], node)
-        input1_shape = value_shape(graph, node.inputs[1], node)
-        output_shape = value_shape(graph, node.outputs[0], node)
-        return BinaryOp(
-            input0=node.inputs[0],
-            input1=node.inputs[1],
-            output=node.outputs[0],
-            function=function,
-            operator_kind=op_spec.kind,
-            input0_shape=input0_shape,
-            input1_shape=input1_shape,
-            shape=output_shape,
-            dtype=output_dtype,
-            input_dtype=input_dtype,
-        )
-    op_dtype = node_dtype(graph, node, *node.inputs, *node.outputs)
-    op_spec = binary_op_symbol(function, node.attrs, dtype=op_dtype)
-    unary_symbol = unary_op_symbol(function, dtype=op_dtype)
-    if op_spec is None and unary_symbol is None:
-        raise UnsupportedOpError(f"Unsupported op {node.op_type}")
-    if op_spec is not None:
-        if len(node.inputs) != 2 or len(node.outputs) != 1:
-            raise UnsupportedOpError(
-                f"{node.op_type} must have 2 inputs and 1 output"
-            )
-        input0_shape = value_shape(graph, node.inputs[0], node)
-        input1_shape = value_shape(graph, node.inputs[1], node)
-        output_shape = value_shape(graph, node.outputs[0], node)
-        return BinaryOp(
-            input0=node.inputs[0],
-            input1=node.inputs[1],
-            output=node.outputs[0],
-            function=function,
-            operator_kind=op_spec.kind,
-            input0_shape=input0_shape,
-            input1_shape=input1_shape,
-            shape=output_shape,
-            dtype=op_dtype,
-            input_dtype=op_dtype,
-        )
-    if len(node.inputs) != 1 or len(node.outputs) != 1:
-        raise UnsupportedOpError(f"{node.op_type} must have 1 input and 1 output")
-    output_shape = value_shape(graph, node.outputs[0], node)
-    return UnaryOp(
-        input0=node.inputs[0],
-        output=node.outputs[0],
-        function=function,
-        shape=output_shape,
-        dtype=op_dtype,
-        input_dtype=op_dtype,
-        params=(),
-    )

--- a/src/emx_onnx_cgen/ir/context.py
+++ b/src/emx_onnx_cgen/ir/context.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from .model import Graph, Initializer, Node, Value
+from shared.scalar_types import ScalarType
+
+
+@dataclass
+class GraphContext:
+    graph: Graph
+    _dtype_cache: dict[str, ScalarType] = field(default_factory=dict)
+    _shape_cache: dict[str, tuple[int, ...]] = field(default_factory=dict)
+    _initializer_cache: dict[str, Initializer] = field(default_factory=dict)
+    _producer_cache: dict[str, Node] = field(default_factory=dict)
+
+    def find_value(self, name: str) -> Value:
+        return self.graph.find_value(name)
+
+    def dtype(self, name: str, node: Node | None = None) -> ScalarType:
+        if name in self._dtype_cache:
+            return self._dtype_cache[name]
+        try:
+            value = self.graph.find_value(name)
+        except KeyError as exc:
+            op_type = node.op_type if node is not None else "unknown"
+            raise ShapeInferenceError(
+                f"Missing dtype for value '{name}' in op {op_type}. "
+                "Hint: run ONNX shape inference or export with static shapes."
+            ) from exc
+        dtype = value.type.dtype
+        if not isinstance(dtype, ScalarType):
+            raise UnsupportedOpError(f"Unsupported dtype {dtype}")
+        self._dtype_cache[name] = dtype
+        return dtype
+
+    def shape(self, name: str, node: Node | None = None) -> tuple[int, ...]:
+        if name in self._shape_cache:
+            return self._shape_cache[name]
+        try:
+            value = self.graph.find_value(name)
+        except KeyError as exc:
+            op_type = node.op_type if node is not None else "unknown"
+            raise ShapeInferenceError(
+                f"Missing shape for value '{name}' in op {op_type}. "
+                "Hint: run ONNX shape inference or export with static shapes."
+            ) from exc
+        self._shape_cache[name] = value.type.shape
+        return value.type.shape
+
+    def initializer(self, name: str) -> Initializer | None:
+        if name in self._initializer_cache:
+            return self._initializer_cache[name]
+        for initializer in self.graph.initializers:
+            if initializer.name == name:
+                self._initializer_cache[name] = initializer
+                return initializer
+        return None
+
+    def producer(self, output_name: str) -> Node | None:
+        if output_name in self._producer_cache:
+            return self._producer_cache[output_name]
+        for node in self.graph.nodes:
+            if output_name in node.outputs:
+                self._producer_cache[output_name] = node
+                return node
+        return None
+
+    def opset_version(self, domain: str = "") -> int | None:
+        if domain in {"", "ai.onnx"}:
+            domains = {"", "ai.onnx"}
+        else:
+            domains = {domain}
+        for opset_domain, version in self.graph.opset_imports:
+            if opset_domain in domains:
+                return int(version)
+        return None
+
+    def __getattr__(self, name: str):
+        return getattr(self.graph, name)

--- a/src/emx_onnx_cgen/ir/op_base.py
+++ b/src/emx_onnx_cgen/ir/op_base.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Protocol
+
+from .context import GraphContext
+
+
+class Emitter(Protocol):
+    def render_op(self, op: "OpBase", ctx: "EmitContext") -> str:
+        ...
+
+
+@dataclass(frozen=True)
+class EmitContext:
+    op_index: int
+
+
+class OpBase(ABC):
+    inputs: tuple[str, ...]
+    outputs: tuple[str, ...]
+
+    def __getattr__(self, name: str) -> str:
+        if name == "kind":
+            return self.__class__.__name__
+        raise AttributeError(
+            f"'{self.__class__.__name__}' object has no attribute '{name}'"
+        )
+
+    def validate(self, ctx: GraphContext) -> None:
+        return None
+
+    def infer_types(self, ctx: GraphContext) -> None:
+        return None
+
+    def infer_shapes(self, ctx: GraphContext) -> None:
+        return None
+
+    @abstractmethod
+    def emit(self, emitter: Emitter, ctx: EmitContext) -> str:
+        raise NotImplementedError
+
+
+class RenderableOpBase(OpBase):
+    def emit(self, emitter: Emitter, ctx: EmitContext) -> str:
+        return emitter.render_op(self, ctx)
+
+
+class ElementwiseOpBase(RenderableOpBase):
+    pass
+
+
+class ReduceOpBase(RenderableOpBase):
+    pass
+
+
+class BroadcastingOpBase(RenderableOpBase):
+    pass
+
+
+class MatMulLikeOpBase(RenderableOpBase):
+    pass
+
+
+class GemmLikeOpBase(RenderableOpBase):
+    pass
+
+
+class ConvLikeOpBase(RenderableOpBase):
+    pass

--- a/src/emx_onnx_cgen/lowering/__init__.py
+++ b/src/emx_onnx_cgen/lowering/__init__.py
@@ -1,3 +1,81 @@
+from __future__ import annotations
+
+import importlib
+
 from .registry import get_lowering, register_lowering
 
-__all__ = ["get_lowering", "register_lowering"]
+_LOWERING_MODULES = [
+    "adagrad",
+    "arg_reduce",
+    "attention",
+    "average_pool",
+    "batch_normalization",
+    "cast",
+    "concat",
+    "constant_of_shape",
+    "conv",
+    "conv_transpose",
+    "cumsum",
+    "depth_space",
+    "dropout",
+    "einsum",
+    "elementwise",
+    "expand",
+    "eye_like",
+    "flatten",
+    "gather",
+    "gather_elements",
+    "gather_nd",
+    "gemm",
+    "global_max_pool",
+    "grid_sample",
+    "group_normalization",
+    "hardmax",
+    "identity",
+    "instance_normalization",
+    "layer_normalization",
+    "logsoftmax",
+    "lp_normalization",
+    "lp_pool",
+    "lrn",
+    "lstm",
+    "matmul",
+    "maxpool",
+    "mean_variance_normalization",
+    "negative_log_likelihood_loss",
+    "non_max_suppression",
+    "nonzero",
+    "one_hot",
+    "pad",
+    "qlinear_matmul",
+    "quantize_linear",
+    "range",
+    "reduce",
+    "reshape",
+    "resize",
+    "rms_normalization",
+    "rotary_embedding",
+    "scatter_nd",
+    "shape",
+    "size",
+    "slice",
+    "softmax",
+    "softmax_cross_entropy_loss",
+    "split",
+    "squeeze",
+    "tensor_scatter",
+    "tile",
+    "topk",
+    "transpose",
+    "trilu",
+    "unsqueeze",
+    "variadic",
+    "where",
+]
+
+
+def load_lowering_registry() -> None:
+    for module_name in _LOWERING_MODULES:
+        importlib.import_module(f"{__name__}.{module_name}")
+
+__all__ = ["get_lowering", "register_lowering", "load_lowering_registry"]

--- a/src/emx_onnx_cgen/lowering/registry.py
+++ b/src/emx_onnx_cgen/lowering/registry.py
@@ -3,32 +3,51 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from typing import TypeVar
 
+from ..ir.context import GraphContext
 from ..ir.model import Graph, Node
+from ..ir.op_base import OpBase
 from ..errors import UnsupportedOpError
 
 LoweredOp = TypeVar("LoweredOp")
 Handler = TypeVar("Handler")
 
-_LOWERING_REGISTRY: dict[str, Callable[[Graph, Node], object]] = {}
+_LOWERING_REGISTRY: dict[str, Callable[[Graph | GraphContext, Node], OpBase]] = {}
 
 
 def register_lowering(
     op_type: str,
 ) -> Callable[[Callable[[Graph, Node], LoweredOp]], Callable[[Graph, Node], LoweredOp]]:
     def decorator(
-        func: Callable[[Graph, Node], LoweredOp],
-    ) -> Callable[[Graph, Node], LoweredOp]:
+        func: Callable[[Graph | GraphContext, Node], LoweredOp],
+    ) -> Callable[[Graph | GraphContext, Node], LoweredOp]:
         _LOWERING_REGISTRY[op_type] = func
         return func
 
     return decorator
 
 
-def get_lowering(op_type: str) -> Callable[[Graph, Node], object] | None:
+def register_lowering_if_missing(
+    op_type: str,
+) -> Callable[[Callable[[Graph | GraphContext, Node], LoweredOp]], Callable[[Graph | GraphContext, Node], LoweredOp]]:
+    def decorator(
+        func: Callable[[Graph | GraphContext, Node], LoweredOp],
+    ) -> Callable[[Graph | GraphContext, Node], LoweredOp]:
+        if op_type not in _LOWERING_REGISTRY:
+            _LOWERING_REGISTRY[op_type] = func
+        return func
+
+    return decorator
+
+
+def get_lowering(
+    op_type: str,
+) -> Callable[[Graph | GraphContext, Node], OpBase] | None:
     return _LOWERING_REGISTRY.get(op_type)
 
 
-def get_lowering_registry() -> Mapping[str, Callable[[Graph, Node], object]]:
+def get_lowering_registry() -> Mapping[
+    str, Callable[[Graph | GraphContext, Node], OpBase]
+]:
     return _LOWERING_REGISTRY
 
 


### PR DESCRIPTION
### Motivation

- Replace the previous functional/union-based lowered-IR with a small OO hierarchy so lowered ops are polymorphic objects with a stable emit contract. 
- Centralize graph queries and caching behind a `GraphContext` service to avoid ad-hoc traversal logic in many lowerings. 
- Eliminate side-effect import lists and large switch/union dispatch by providing a lowering registry and loader so lowering discovery is explicit and modular. 

### Description

- Add an OO IR scaffold: `OpBase` + family bases (`ElementwiseOpBase`, `ReduceOpBase`, `BroadcastingOpBase`, `MatMulLikeOpBase`, `GemmLikeOpBase`, `ConvLikeOpBase`) and an `EmitContext` contract in `src/emx_onnx_cgen/ir/op_base.py`. 
- Add `GraphContext` in `src/emx_onnx_cgen/ir/context.py` that wraps a `Graph` and provides cached `dtype/shape/initializer/producer` queries and opset helpers; lowerings now use this `ctx` instead of ad-hoc lookups. 
- Convert emitter flow to be op-driven: `LoweredModel.ops` is now `tuple[OpBase, ...]`, ops implement `emit(emitter, ctx)` and call a thin `Emitter` service; `CEmitter` keeps a small `_EmitState` and exposes `render_op` used by ops (changes in `src/emx_onnx_cgen/codegen/c_emitter.py` and a thin `codegen/emitter.py` entry). 
- Simplify lowering discovery: `src/emx_onnx_cgen/lowering/__init__.py` provides `load_lowering_registry()` which imports lowering modules once; `registry.py` now stores handlers that return `OpBase` instances and exposes `register_lowering_if_missing` for safe defaults. 
- Migrate elementwise lowerings to the new scheme and register a default binary/unary lowering that is applied via the registry when appropriate (`src/emx_onnx_cgen/lowering/elementwise.py`), and update `lowering/common.py` helpers to accept either a `Graph` or `GraphContext`. 
- Update `compiler.py` to create a `GraphContext`, call the registry to build `OpBase` instances, and pass `LoweredModel` (with `OpBase` ops) to the emitter; removed the large union-typed signatures and side-effect imports in the compiler. 

### Testing

- Ran the full test-suite with `pytest -n auto -q`; result: all automated tests passed: `2151 passed, 1 skipped, 7 warnings` in 239.40s (~3:59). 
- Targeted iterations used the same `pytest` command to reproduce and fix issues during the refactor; final run above is green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69723af8abe08325bdeff6d2dfdb1e8a)