### PR TITLE
ci: add Windows release bundle workflow

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -1,0 +1,40 @@
+name: windows-release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-windows-bundle:
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-ci.txt
+          python -m pip install pyinstaller
+          python -m pip install .
+
+      - name: Build PyInstaller bundle
+        run: |
+          pyinstaller --clean --noconfirm --onedir --name emx-onnx-cgen -m emx_onnx_cgen.cli
+
+      - name: Zip bundle
+        run: |
+          Compress-Archive -Path dist/emx-onnx-cgen/* -DestinationPath emx-onnx-cgen-windows-amd64.zip
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: emx-onnx-cgen-windows-amd64.zip


### PR DESCRIPTION
### Motivation
- Provide a CI workflow that builds a Windows PyInstaller `--onedir` bundle on release and attaches it as a GitHub Release asset.

### Description
- Add `.github/workflows/windows-release.yml` which triggers on a published release and runs on `windows-latest` with `contents: write` permission.
- The workflow checks out the repo, sets up Python, installs `requirements-ci.txt`, `pyinstaller`, and the package, then builds a PyInstaller onedir bundle using `pyinstaller --clean --noconfirm --onedir --name emx-onnx-cgen -m emx_onnx_cgen.cli`.
- The built `dist/emx-onnx-cgen` directory is compressed to `emx-onnx-cgen-windows-amd64.zip` using `Compress-Archive`, and the ZIP is uploaded to the release via `softprops/action-gh-release@v2`.

### Testing
- Ran `pytest -q` which reported `76 passed in 196.36s (0:03:16)`; the test run was then interrupted via `KeyboardInterrupt` during teardown/command return but all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6972dbb754a48325aa55765d5db8e2ce)