### PR TITLE
ci: add linux release pipeline

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build-linux-bundle:
     runs-on: ubuntu-latest
+    container:
+      image: quay.io/pypa/manylinux_2_28_x86_64
     permissions:
       contents: write
     steps:
@@ -14,10 +16,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          cache: pip
+        run: |
+          echo "/opt/python/cp311-cp311/bin" >> "$GITHUB_PATH"
+          python --version
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
### Motivation
- Provide a Linux release workflow to produce a PyInstaller bundle and upload a Linux release asset in parity with the existing Windows release.

### Description
- Add `.github/workflows/linux-release.yml` which triggers on `release` published and runs on `ubuntu-latest` to set up Python 3.11, install dependencies and `pyinstaller`, build the bundle with `pyinstaller --clean --noconfirm --onedir --name emx-onnx-cgen --paths src src/emx_onnx_cgen/cli.py`, package it as `emx-onnx-cgen-linux-amd64.tar.gz`, and upload the asset using `softprops/action-gh-release@v2`.

### Testing
- Ran `pytest -n auto -q`, which completed with `2151 passed, 1 skipped, 7 warnings` in `216.38s` (0:03:36).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69731987eda883259e6450d7da25a836)