### PR TITLE
codegen: use original ops for include collection and robustify variadic/shape/dtype inference

### DIFF
--- a/src/emx_onnx_cgen/ir/op_base.py
+++ b/src/emx_onnx_cgen/ir/op_base.py
@@ -88,7 +88,10 @@ class ElementwiseOpBase(RenderableOpBase):
             raise UnsupportedOpError(
                 f"{self.kind} expects matching input dtypes, got {dtype_names}"
             )
-        output_dtype = ctx.dtype(self._elementwise_output())
+        try:
+            output_dtype = ctx.dtype(self._elementwise_output())
+        except ShapeInferenceError:
+            return None
         if self._elementwise_compare():
             if output_dtype != ScalarType.BOOL:
                 raise UnsupportedOpError(
@@ -107,7 +110,25 @@ class ElementwiseOpBase(RenderableOpBase):
         output_name = self._elementwise_output()
         for name in input_names:
             ctx.dtype(name)
-        ctx.dtype(output_name)
+        desired_dtype = (
+            ScalarType.BOOL if self._elementwise_compare() else None
+        )
+        if desired_dtype is None:
+            data_inputs = self._elementwise_data_inputs()
+            if data_inputs:
+                desired_dtype = ctx.dtype(data_inputs[0])
+        try:
+            output_dtype = ctx.dtype(output_name)
+        except ShapeInferenceError:
+            if desired_dtype is not None:
+                ctx.set_dtype(output_name, desired_dtype)
+                return None
+            raise
+        if desired_dtype is not None and output_dtype != desired_dtype:
+            raise UnsupportedOpError(
+                f"{self.kind} expects output dtype {desired_dtype.onnx_name}, "
+                f"got {output_dtype.onnx_name}"
+            )
 
     def infer_shapes(self, ctx: OpContext) -> None:
         input_names = self._elementwise_inputs()
@@ -119,6 +140,295 @@ class ElementwiseOpBase(RenderableOpBase):
             output_shape = BroadcastingOpBase.broadcast_shapes(*input_shapes)
         ctx.set_shape(output_name, output_shape)
         return None
+
+
+class GatherLikeOpBase(RenderableOpBase):
+    def _gather_data(self) -> str:
+        raise NotImplementedError
+
+    def _gather_indices(self) -> str:
+        raise NotImplementedError
+
+    def _gather_output(self) -> str:
+        raise NotImplementedError
+
+    def _gather_axis(self) -> int:
+        raise NotImplementedError
+
+    def _gather_mode(self) -> str:
+        raise NotImplementedError
+
+    def validate(self, ctx: OpContext) -> None:
+        indices_dtype = ctx.dtype(self._gather_indices())
+        if indices_dtype not in {ScalarType.I64, ScalarType.I32}:
+            raise UnsupportedOpError(
+                f"{self.kind} indices must be int32 or int64, "
+                f"got {indices_dtype.onnx_name}"
+            )
+        data_shape = ctx.shape(self._gather_data())
+        if self._gather_mode() in {"gather", "gather_elements"}:
+            if not data_shape:
+                raise ShapeInferenceError(
+                    f"{self.kind} does not support scalar inputs"
+                )
+            axis = self._gather_axis()
+            if axis < 0:
+                axis += len(data_shape)
+            if axis < 0 or axis >= len(data_shape):
+                raise ShapeInferenceError(
+                    f"{self.kind} axis {axis} is out of range for rank "
+                    f"{len(data_shape)}"
+                )
+        return None
+
+    def infer_types(self, ctx: OpContext) -> None:
+        data_dtype = ctx.dtype(self._gather_data())
+        try:
+            output_dtype = ctx.dtype(self._gather_output())
+        except ShapeInferenceError:
+            ctx.set_dtype(self._gather_output(), data_dtype)
+            output_dtype = data_dtype
+        if output_dtype != data_dtype:
+            raise UnsupportedOpError(
+                f"{self.kind} expects output dtype {data_dtype.onnx_name}, "
+                f"got {output_dtype.onnx_name}"
+            )
+
+    def infer_shapes(self, ctx: OpContext) -> None:
+        data_shape = ctx.shape(self._gather_data())
+        indices_shape = ctx.shape(self._gather_indices())
+        axis = self._gather_axis()
+        if axis < 0:
+            axis += len(data_shape)
+        if axis < 0 or axis >= len(data_shape):
+            raise ShapeInferenceError(
+                f"{self.kind} axis {axis} is out of range for rank "
+                f"{len(data_shape)}"
+            )
+        if self._gather_mode() == "gather":
+            output_shape = (
+                data_shape[:axis] + indices_shape + data_shape[axis + 1 :]
+            )
+        else:
+            raise UnsupportedOpError(
+                f"{self.kind} does not support gather mode "
+                f"{self._gather_mode()}"
+            )
+        try:
+            expected = ctx.shape(self._gather_output())
+        except ShapeInferenceError:
+            expected = None
+        if expected is not None and expected != output_shape:
+            raise ShapeInferenceError(
+                f"{self.kind} output shape must be {output_shape}, got {expected}"
+            )
+        ctx.set_shape(self._gather_output(), output_shape)
+        ctx.set_derived(self, "axis", axis)
+
+
+class ShapeLikeOpBase(RenderableOpBase):
+    def _shape_data(self) -> str:
+        raise NotImplementedError
+
+    def _shape_output(self) -> str:
+        raise NotImplementedError
+
+    def _shape_spec(self, ctx: OpContext) -> tuple[int, ...]:
+        raise NotImplementedError
+
+    def _shape_mode(self) -> str:
+        raise NotImplementedError
+
+    def _shape_derived(
+        self,
+        ctx: OpContext,
+        *,
+        data_shape: tuple[int, ...],
+        target_shape: tuple[int, ...],
+        output_shape: tuple[int, ...],
+    ) -> None:
+        return None
+
+    @staticmethod
+    def _validate_static_dims(shape: tuple[int, ...], kind: str) -> None:
+        if any(dim < 0 for dim in shape):
+            raise ShapeInferenceError(
+                f"{kind} does not support dynamic dims"
+            )
+
+    @staticmethod
+    def _broadcast_shape(
+        input_shape: tuple[int, ...],
+        target_shape: tuple[int, ...],
+        *,
+        kind: str,
+    ) -> tuple[int, ...]:
+        ShapeLikeOpBase._validate_static_dims(input_shape, kind)
+        ShapeLikeOpBase._validate_static_dims(target_shape, kind)
+        output_rank = max(len(input_shape), len(target_shape))
+        input_padded = (1,) * (output_rank - len(input_shape)) + input_shape
+        target_padded = (1,) * (output_rank - len(target_shape)) + target_shape
+        result: list[int] = []
+        for input_dim, target_dim in zip(input_padded, target_padded):
+            if input_dim == 1:
+                result.append(target_dim)
+            elif target_dim == 1:
+                result.append(input_dim)
+            elif input_dim == target_dim:
+                result.append(input_dim)
+            else:
+                raise ShapeInferenceError(
+                    f"{kind} input shape {input_shape} is not "
+                    f"broadcastable to {target_shape}"
+                )
+        return tuple(result)
+
+    def validate(self, ctx: OpContext) -> None:
+        data_shape = ctx.shape(self._shape_data())
+        target_shape = self._shape_spec(ctx)
+        if self._shape_mode() == "expand":
+            self._broadcast_shape(
+                data_shape, target_shape, kind=self.kind
+            )
+        return None
+
+    def infer_types(self, ctx: OpContext) -> None:
+        input_dtype = ctx.dtype(self._shape_data())
+        try:
+            output_dtype = ctx.dtype(self._shape_output())
+        except ShapeInferenceError:
+            ctx.set_dtype(self._shape_output(), input_dtype)
+            output_dtype = input_dtype
+        if output_dtype != input_dtype:
+            raise UnsupportedOpError(
+                f"{self.kind} expects output dtype {input_dtype.onnx_name}, "
+                f"got {output_dtype.onnx_name}"
+            )
+
+    def infer_shapes(self, ctx: OpContext) -> None:
+        data_shape = ctx.shape(self._shape_data())
+        target_shape = self._shape_spec(ctx)
+        if self._shape_mode() == "expand":
+            output_shape = self._broadcast_shape(
+                data_shape, target_shape, kind=self.kind
+            )
+        else:
+            output_shape = target_shape
+        try:
+            expected = ctx.shape(self._shape_output())
+        except ShapeInferenceError:
+            expected = None
+        if expected is not None and expected != output_shape:
+            raise ShapeInferenceError(
+                f"{self.kind} output shape must be {output_shape}, got {expected}"
+            )
+        ctx.set_shape(self._shape_output(), output_shape)
+        self._shape_derived(
+            ctx,
+            data_shape=data_shape,
+            target_shape=target_shape,
+            output_shape=output_shape,
+        )
+
+
+class VariadicLikeOpBase(RenderableOpBase):
+    def _variadic_inputs(self) -> tuple[str, ...]:
+        raise NotImplementedError
+
+    def _variadic_output(self) -> str:
+        raise NotImplementedError
+
+    def _variadic_kind(self) -> str:
+        return self.kind
+
+    def _variadic_min_inputs(self) -> int:
+        return 2
+
+    def _variadic_max_inputs(self) -> int | None:
+        return None
+
+    def _variadic_compare(self) -> bool:
+        return False
+
+    def _variadic_supports_dtype(self, dtype: ScalarType) -> bool:
+        return True
+
+    def validate(self, ctx: OpContext) -> None:
+        inputs = self._variadic_inputs()
+        if any(not name for name in inputs):
+            raise UnsupportedOpError(
+                f"{self._variadic_kind()} input must be provided"
+            )
+        min_inputs = self._variadic_min_inputs()
+        max_inputs = self._variadic_max_inputs()
+        if len(inputs) < min_inputs:
+            raise UnsupportedOpError(
+                f"{self._variadic_kind()} must have at least {min_inputs} inputs"
+            )
+        if max_inputs is not None and len(inputs) != max_inputs:
+            raise UnsupportedOpError(
+                f"{self._variadic_kind()} must have exactly {max_inputs} inputs"
+            )
+        input_dtypes = tuple(ctx.dtype(name) for name in inputs)
+        if any(dtype != input_dtypes[0] for dtype in input_dtypes[1:]):
+            dtype_names = ", ".join(
+                dtype.onnx_name for dtype in input_dtypes
+            )
+            raise UnsupportedOpError(
+                f"{self._variadic_kind()} expects matching input dtypes, "
+                f"got {dtype_names}"
+            )
+        try:
+            output_dtype = ctx.dtype(self._variadic_output())
+        except ShapeInferenceError:
+            output_dtype = None
+        if output_dtype is not None:
+            if self._variadic_compare():
+                if output_dtype != ScalarType.BOOL:
+                    raise UnsupportedOpError(
+                        f"{self._variadic_kind()} expects bool output, "
+                        f"got {output_dtype.onnx_name}"
+                    )
+            elif output_dtype != input_dtypes[0]:
+                raise UnsupportedOpError(
+                    f"{self._variadic_kind()} expects output dtype "
+                    f"{input_dtypes[0].onnx_name}, got {output_dtype.onnx_name}"
+                )
+        if not self._variadic_supports_dtype(input_dtypes[0]):
+            raise UnsupportedOpError(
+                f"{self._variadic_kind()} does not support dtype "
+                f"{input_dtypes[0].onnx_name}"
+            )
+        return None
+
+    def infer_types(self, ctx: OpContext) -> None:
+        for name in self._variadic_inputs():
+            ctx.dtype(name)
+        try:
+            ctx.dtype(self._variadic_output())
+        except ShapeInferenceError:
+            ctx.set_dtype(
+                self._variadic_output(),
+                ctx.dtype(self._variadic_inputs()[0]),
+            )
+
+    def infer_shapes(self, ctx: OpContext) -> None:
+        input_shapes = tuple(ctx.shape(name) for name in self._variadic_inputs())
+        output_shape = BroadcastingOpBase.broadcast_shapes(*input_shapes)
+        for shape in input_shapes:
+            if shape != output_shape:
+                raise UnsupportedOpError(
+                    f"{self._variadic_kind()} expects identical input/output shapes"
+                )
+        try:
+            expected = ctx.shape(self._variadic_output())
+        except ShapeInferenceError:
+            expected = None
+        if expected is not None and expected != output_shape:
+            raise UnsupportedOpError(
+                f"{self._variadic_kind()} expects identical input/output shapes"
+            )
+        ctx.set_shape(self._variadic_output(), output_shape)
 
 
 class ReduceOpBase(RenderableOpBase):

--- a/src/emx_onnx_cgen/ir/ops/__init__.py
+++ b/src/emx_onnx_cgen/ir/ops/__init__.py
@@ -1,4 +1,12 @@
-from .elementwise import BinaryOp, ClipOp, IdentityOp, MultiInputBinaryOp, UnaryOp, WhereOp
+from .elementwise import (
+    BinaryOp,
+    ClipOp,
+    IdentityOp,
+    MultiInputBinaryOp,
+    UnaryOp,
+    VariadicOp,
+    WhereOp,
+)
 from .misc import (
     CastOp,
     ConcatOp,
@@ -126,5 +134,6 @@ __all__ = [
     "TransposeOp",
     "TriluOp",
     "UnaryOp",
+    "VariadicOp",
     "WhereOp",
 ]

--- a/src/emx_onnx_cgen/lowering/expand.py
+++ b/src/emx_onnx_cgen/lowering/expand.py
@@ -1,151 +1,17 @@
 from __future__ import annotations
 
-import numpy as np
-
-from shared.scalar_types import ScalarType
-
+from ..errors import UnsupportedOpError
+from ..ir.model import Graph, Node
 from ..ir.ops import ExpandOp
-from ..errors import ShapeInferenceError, UnsupportedOpError
-from ..ir.model import Graph, Initializer, Node
-from ..lowering.common import value_dtype, value_shape
 from .registry import register_lowering
-
-
-def _find_initializer(graph: Graph, name: str) -> Initializer | None:
-    for initializer in graph.initializers:
-        if initializer.name == name:
-            return initializer
-    return None
-
-
-def _read_shape_values(graph: Graph, name: str, node: Node) -> list[int] | None:
-    initializer = _find_initializer(graph, name)
-    if initializer is None:
-        return None
-    if initializer.type.dtype not in {ScalarType.I64, ScalarType.I32}:
-        raise UnsupportedOpError(
-            f"{node.op_type} shape input must be int64 or int32"
-        )
-    if len(initializer.type.shape) != 1:
-        raise UnsupportedOpError(
-            f"{node.op_type} shape input must be a 1D tensor"
-        )
-    values = np.array(initializer.data, dtype=np.int64).reshape(-1)
-    if values.size == 0:
-        raise ShapeInferenceError(
-            f"{node.op_type} shape input cannot be empty"
-        )
-    return [int(value) for value in values]
-
-
-def _validate_shape_input(graph: Graph, name: str, node: Node) -> None:
-    dtype = value_dtype(graph, name, node)
-    if dtype not in {ScalarType.I64, ScalarType.I32}:
-        raise UnsupportedOpError(
-            f"{node.op_type} shape input must be int64 or int32"
-        )
-    shape = value_shape(graph, name, node)
-    if len(shape) != 1:
-        raise UnsupportedOpError(
-            f"{node.op_type} shape input must be a 1D tensor"
-        )
-    if shape[0] <= 0:
-        raise ShapeInferenceError(
-            f"{node.op_type} shape input cannot be empty"
-        )
-
-
-def _validate_static_dims(shape: tuple[int, ...], node: Node) -> None:
-    if any(dim < 0 for dim in shape):
-        raise ShapeInferenceError(
-            f"{node.op_type} does not support dynamic dims"
-        )
-
-
-def _broadcast_shape(
-    input_shape: tuple[int, ...], shape_values: list[int], node: Node
-) -> tuple[int, ...]:
-    _validate_static_dims(input_shape, node)
-    for dim in shape_values:
-        if dim < 0:
-            raise ShapeInferenceError(
-                f"{node.op_type} does not support dynamic dims"
-            )
-    output_rank = max(len(input_shape), len(shape_values))
-    input_padded = (1,) * (output_rank - len(input_shape)) + input_shape
-    shape_padded = (1,) * (output_rank - len(shape_values)) + tuple(shape_values)
-    result: list[int] = []
-    for input_dim, shape_dim in zip(input_padded, shape_padded):
-        if input_dim == 1:
-            result.append(shape_dim)
-        elif shape_dim == 1:
-            result.append(input_dim)
-        elif input_dim == shape_dim:
-            result.append(input_dim)
-        else:
-            raise ShapeInferenceError(
-                f"{node.op_type} input shape {input_shape} is not "
-                f"broadcastable to {shape_values}"
-            )
-    return tuple(result)
-
-
-def _compute_strides(shape: tuple[int, ...]) -> tuple[int, ...]:
-    strides: list[int] = []
-    stride = 1
-    for dim in reversed(shape):
-        strides.append(stride)
-        stride *= dim
-    return tuple(reversed(strides))
 
 
 @register_lowering("Expand")
 def lower_expand(graph: Graph, node: Node) -> ExpandOp:
     if len(node.inputs) != 2 or len(node.outputs) != 1:
         raise UnsupportedOpError("Expand must have 2 inputs and 1 output")
-    input_shape = value_shape(graph, node.inputs[0], node)
-    output_shape = value_shape(graph, node.outputs[0], node)
-    input_dtype = value_dtype(graph, node.inputs[0], node)
-    output_dtype = value_dtype(graph, node.outputs[0], node)
-    if input_dtype != output_dtype:
-        raise UnsupportedOpError(
-            f"{node.op_type} expects matching input/output dtypes, "
-            f"got {input_dtype} and {output_dtype}"
-        )
-    shape_values = _read_shape_values(graph, node.inputs[1], node)
-    if shape_values is not None:
-        expected_output_shape = _broadcast_shape(input_shape, shape_values, node)
-        _validate_static_dims(expected_output_shape, node)
-        if output_shape and output_shape != expected_output_shape:
-            raise ShapeInferenceError(
-                f"{node.op_type} output shape must be {expected_output_shape}, "
-                f"got {output_shape}"
-            )
-    else:
-        _validate_shape_input(graph, node.inputs[1], node)
-        if not output_shape:
-            raise ShapeInferenceError(
-                f"{node.op_type} output shape must be specified"
-            )
-        expected_output_shape = _broadcast_shape(
-            input_shape, list(output_shape), node
-        )
-        if expected_output_shape != output_shape:
-            raise ShapeInferenceError(
-                f"{node.op_type} output shape must be {expected_output_shape}, "
-                f"got {output_shape}"
-            )
-    input_shape_padded = (
-        (1,) * (len(expected_output_shape) - len(input_shape)) + input_shape
-    )
-    input_strides = _compute_strides(input_shape_padded)
     return ExpandOp(
         input0=node.inputs[0],
+        input_shape=node.inputs[1],
         output=node.outputs[0],
-        input_shape=input_shape,
-        output_shape=expected_output_shape,
-        input_shape_padded=input_shape_padded,
-        input_strides=input_strides,
-        dtype=input_dtype,
-        input_dtype=input_dtype,
     )

--- a/src/emx_onnx_cgen/lowering/gather.py
+++ b/src/emx_onnx_cgen/lowering/gather.py
@@ -1,13 +1,8 @@
 from __future__ import annotations
 
-from shared.scalar_types import ScalarType
-
 from ..ir.ops import GatherOp
-from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..errors import UnsupportedOpError
 from ..ir.model import Graph, Node
-from ..validation import normalize_axis
-from .common import value_dtype as _value_dtype
-from .common import value_shape as _value_shape
 from .registry import register_lowering
 
 
@@ -16,33 +11,9 @@ def lower_gather(graph: Graph, node: Node) -> GatherOp:
     if len(node.inputs) != 2 or len(node.outputs) != 1:
         raise UnsupportedOpError("Gather must have 2 inputs and 1 output")
     data_name, indices_name = node.inputs
-    data_shape = _value_shape(graph, data_name, node)
-    indices_shape = _value_shape(graph, indices_name, node)
-    output_shape = _value_shape(graph, node.outputs[0], node)
-    axis = normalize_axis(int(node.attrs.get("axis", 0)), data_shape, node)
-    expected_output_shape = (
-        data_shape[:axis] + indices_shape + data_shape[axis + 1 :]
-    )
-    if output_shape != expected_output_shape:
-        raise ShapeInferenceError(
-            "Gather output shape must be "
-            f"{expected_output_shape}, got {output_shape}"
-        )
-    op_dtype = _value_dtype(graph, data_name, node)
-    indices_dtype = _value_dtype(graph, indices_name, node)
-    if indices_dtype not in {ScalarType.I64, ScalarType.I32}:
-        raise UnsupportedOpError(
-            "Gather indices must be int32 or int64, "
-            f"got {indices_dtype.onnx_name}"
-        )
     return GatherOp(
         data=data_name,
         indices=indices_name,
         output=node.outputs[0],
-        axis=axis,
-        data_shape=data_shape,
-        indices_shape=indices_shape,
-        output_shape=output_shape,
-        dtype=op_dtype,
-        indices_dtype=indices_dtype,
+        axis=int(node.attrs.get("axis", 0)),
     )


### PR DESCRIPTION
### Motivation

- Avoid spurious errors and incorrect include/dtype lookups caused by using sanitized/resolved op names during emission. 
- Preserve original variadic operator identity so emitted messages and operator handling reflect the original ONNX op type. 
- Make type/shape inference tolerant to ordering and missing derived values so lowering and codegen can be thinner and ordering-independent. 
- Ensure runtime constant evaluators (e.g., `Expand`) use the same `OpContext`-derived shapes/dtypes as the compiler pipeline.

### Description

- Emit/include collection now traverses the `original_model` ops instead of resolved/sanitized ops so includes and dtype collection use original value names. (file: `src/emx_onnx_cgen/codegen/c_emitter.py`)
- Introduced new op base helpers to centralize and harden validation/inference: `VariadicLikeOpBase`, `GatherLikeOpBase`, and `ShapeLikeOpBase`, plus related helpers such as `_compute_strides`. (file: `src/emx_onnx_cgen/ir/op_base.py`, `src/emx_onnx_cgen/ir/ops/*.py`, `src/emx_onnx_cgen/ir/ops/elementwise.py`, `src/emx_onnx_cgen/ir/ops/misc.py`)
- Converted variadic/multi-input elementwise ops to carry original op identity (`VariadicOp.op_type`) and to rely on the new base behavior for sensible dtype/shape seeding and validation. (files: `src/emx_onnx_cgen/ir/ops/elementwise.py`, `src/emx_onnx_cgen/lowering/variadic.py`)
- Lowerings updated to carry operand names (not fully-resolved shapes) and to record seeds for `OpContext` where outputs are derived (notably `Expand`, `Gather`, and variadic ops). (files: `src/emx_onnx_cgen/lowering/expand.py`, `src/emx_onnx_cgen/lowering/gather.py`, `src/emx_onnx_cgen/lowering/variadic.py`)
- Compiler now seeds the `OpContext` for ops whose outputs are inferred (e.g., variadic/`Gather`/`Expand`) so later `validate`/`infer_types`/`infer_shapes` can rely on correct dtype information. (file: `src/emx_onnx_cgen/compiler.py`)
- Code generation now resolves shapes/dtypes via `OpContext` helpers (`_ctx_shape`, `_ctx_dtype`, `_op_output_dtype`) and uses derived values when rendering kernels (many spots in `c_emitter.py`). (file: `src/emx_onnx_cgen/codegen/c_emitter.py`)
- Runtime evaluator for `Expand` now runs `validate` → `infer_types` → `infer_shapes` with an `OpContext` to compute the runtime output shape used during constant evaluation. (file: `src/emx_onnx_cgen/runtime/evaluator.py`)

### Testing

- Ran the full test-suite with `pytest -n auto -q`; result: `2151 passed, 1 skipped, 7 warnings` in ~312.4s (~5:12), showing the earlier failing official-ONNX expectation mismatches are resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6972d5e097908325ac4c45d48172bf51)