### PR TITLE
tools: simplify PyInstaller build script

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build PyInstaller bundle
         run: |
-          python -m PyInstaller --clean --noconfirm --onedir --name emx-onnx-cgen --paths src src/emx_onnx_cgen/cli.py
+          bash tools/pyinstaller_build.sh
 
       - name: Package bundle
         run: |

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Build PyInstaller bundle
         run: |
-          pyinstaller --clean --noconfirm --onedir --name emx-onnx-cgen --paths src src/emx_onnx_cgen/cli.py
+          bash tools/pyinstaller_build.sh
 
       - name: Zip bundle
         run: |

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -27,3 +27,4 @@ onnxoptimizer>=0.3.13
 ruff>=0.6.0
 black>=24.0.0
 setuptools_scm[toml]>=7.0
+pyinstaller

--- a/tools/pyinstaller_build.sh
+++ b/tools/pyinstaller_build.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cli_path="${repo_root}/src/emx_onnx_cgen/cli.py"
+
+command=(
+  python -m PyInstaller
+  --clean
+  --noconfirm
+  --onedir
+  --name emx-onnx-cgen
+  --paths src
+  "${cli_path}"
+)
+
+command+=("$@")
+
+"${command[@]}"

--- a/tools/pyinstaller_test.sh
+++ b/tools/pyinstaller_test.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! python -m PyInstaller --version >/dev/null 2>&1; then
+  echo "PyInstaller is not available. Install it in the active environment to run this test." >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+dist_dir="${tmp_dir}/dist"
+build_dir="${tmp_dir}/build"
+spec_dir="${tmp_dir}/spec"
+
+bash "${repo_root}/tools/pyinstaller_build.sh" \
+  --distpath "${dist_dir}" \
+  --workpath "${build_dir}" \
+  --specpath "${spec_dir}"
+
+"${dist_dir}/emx-onnx-cgen/emx-onnx-cgen" --help >/dev/null
+
+echo "PyInstaller build succeeded."


### PR DESCRIPTION
### Motivation
- Make the PyInstaller helper simpler and more flexible by forwarding any caller-provided arguments directly to the PyInstaller invocation.

### Description
- Replace manual `--distpath`/`--workpath`/`--specpath` parsing with a simple `command+=("$@")` so all passed parameters are appended unchanged.
- Preserve the default invocation (`python -m PyInstaller --clean --noconfirm --onedir --name emx-onnx-cgen --paths src <cli>`) and keep `repo_root`/`cli_path` resolution.

### Testing
- Ran the smoke script `tools/pyinstaller_test.sh`, which exited with status 1 because `PyInstaller` is not installed in the environment and therefore the build test could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6973406c93dc8325a429acb5a2ea4917)