### PR TITLE
codegen: add -Werror to verify compile and fix EyeLike/Adagrad call signatures

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1170 / 1802 official ONNX files.
+Support 1171 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -23,7 +23,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_acosh/model.onnx | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/node/test_acosh_example/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_adagrad/model.onnx | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_adagrad_multiple/model.onnx | ❌ | Out of tolerance (max ULP 1074139703) |
+| onnx-org/onnx/backend/test/data/node/test_adagrad_multiple/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_adam/model.onnx | ❌ | Unsupported op Adam |
 | onnx-org/onnx/backend/test/data/node/test_adam_multiple/model.onnx | ❌ | Unsupported op Adam |
 | onnx-org/onnx/backend/test/data/node/test_add/model.onnx | ✅ | OK (max ULP 0) |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -7,7 +7,7 @@
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | █████████████████████████ |
 | Test data input count does not match model inputs: 1 vs 3. | 27 | █████████████████████ |
 | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 22 | █████████████████ |
-| Out of tolerance | 21 | █████████████████ |
+| Out of tolerance | 20 | ████████████████ |
 | Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 20 | ████████████████ |
 | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 18 | ██████████████ |
 | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 18 | ██████████████ |

--- a/src/emx_onnx_cgen/cli.py
+++ b/src/emx_onnx_cgen/cli.py
@@ -459,6 +459,7 @@ def _verify_model(
                 *compiler_cmd,
                 "-std=c99",
                 "-O2",
+                "-Werror",
                 str(c_path),
                 "-o",
                 str(exe_path),

--- a/src/emx_onnx_cgen/codegen/c_emitter.py
+++ b/src/emx_onnx_cgen/codegen/c_emitter.py
@@ -3498,17 +3498,18 @@ class CEmitter:
             args.extend(call_parts)
             return ", ".join(args)
         if isinstance(op, AdagradOp):
-            args.extend(
-                [
-                    op.rate,
-                    op.timestep,
-                    *op.inputs,
-                    *op.gradients,
-                    *op.accumulators,
-                    *op.outputs,
-                    *op.accumulator_outputs,
-                ]
-            )
+            args.append(op.rate)
+            args.append(op.timestep)
+            for index in range(len(op.inputs)):
+                args.extend(
+                    [
+                        op.inputs[index],
+                        op.gradients[index],
+                        op.accumulators[index],
+                        op.outputs[index],
+                        op.accumulator_outputs[index],
+                    ]
+                )
             return ", ".join(args)
         if isinstance(op, (SoftmaxOp, LogSoftmaxOp, HardmaxOp)):
             args.extend([op.input0, op.output])
@@ -7823,6 +7824,7 @@ class CEmitter:
             ).rstrip()
             return with_node_comment(rendered)
         if isinstance(op, EyeLikeOp):
+            input_c_type = op.input_dtype.c_type
             params = self._shared_param_map(
                 [("input0", op.input0), ("output", op.output)]
             )
@@ -7836,7 +7838,7 @@ class CEmitter:
             batch_size = CEmitter._element_count(batch_dims or (1,))
             param_decls = self._build_param_decls(
                 [
-                    (params["input0"], c_type, input_suffix, True),
+                    (params["input0"], input_c_type, input_suffix, True),
                     (params["output"], c_type, output_suffix, False),
                 ]
             )

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_adagrad_multiple__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_adagrad_multiple__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Out of tolerance (max ULP 1074139703)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_adagrad_multiple/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_adagrad_multiple/test_data_set_0",
   "operators": [
     "ai.onnx.preview.training::Adagrad"


### PR DESCRIPTION
### Motivation

- Enforce that generated C code is warning-free during `verify` by treating warnings as errors at compile time with `-Werror` so regressions are caught early. 
- Resolve build failures introduced by `-Werror` where generated calls had incorrect parameter types/order causing incompatible-pointer or const-qualifier warnings. 

### Description

- Add `-Werror` to the verify compile command in `src/emx_onnx_cgen/cli.py` so the compile command includes `-Werror` alongside `-std=c99 -O2`.
- Use the original input dtype for the `EyeLike` input parameter in `src/emx_onnx_cgen/codegen/c_emitter.py` by using `op.input_dtype.c_type` when declaring the input parameter to avoid incompatible-pointer warnings in generated code.
- Fix the `Adagrad` op call argument ordering in `src/emx_onnx_cgen/codegen/c_emitter.py` so the call builds arguments per-tensor in the same order as the generated function signature, avoiding discarded-qualifier and ordering mismatches.
- Update the golden expectation file for `test_adagrad_multiple` at `tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_adagrad_multiple__model.onnx.json` and refresh `OFFICIAL_ONNX_FILE_SUPPORT.md` and `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md` to reflect the new verification result.

### Testing

- Ran targeted verification via `PYTHONPATH=src python -m emx_onnx_cgen.cli verify <model> --cc cc` to reproduce `-Werror` build failures and confirm fixes, which showed the problematic models now produce `OK` instead of build errors. 
- Executed the full test suite with references updated using `UPDATE_REFS=1 pytest -n auto -q --maxfail=10`, which completed successfully with all tests passing; final run result: `2151 passed, 1 skipped, 7 warnings` in approximately `6m03s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69739924cff48325be14af5a2d27ea7e)