### PR TITLE
tests: refresh reference outputs

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1172 / 1802 official ONNX files.
+Support 1291 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -12,8 +12,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/light/light_densenet121.onnx | ❌ | Out of tolerance (max ULP 50389) |
 | onnx-org/onnx/backend/test/data/light/light_inception_v1.onnx | ❌ | Out of tolerance (max ULP 981668463) |
 | onnx-org/onnx/backend/test/data/light/light_inception_v2.onnx | ✅ | OK (max ULP 1) |
-| onnx-org/onnx/backend/test/data/light/light_resnet50.onnx | ❌ | 'gpu_0_data_0' |
-| onnx-org/onnx/backend/test/data/light/light_shufflenet.onnx | ❌ | 'gpu_0_data_0' |
+| onnx-org/onnx/backend/test/data/light/light_resnet50.onnx | ❌ | Out of tolerance (max ULP 539) |
+| onnx-org/onnx/backend/test/data/light/light_shufflenet.onnx | ✅ | OK (max ULP 10) |
 | onnx-org/onnx/backend/test/data/light/light_squeezenet.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/light/light_vgg19.onnx | ❌ | Out of tolerance (max ULP 981668463) |
 | onnx-org/onnx/backend/test/data/light/light_zfnet512.onnx | ❌ | Out of tolerance (max ULP 981668463) |
@@ -90,13 +90,13 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_argmin_no_keepdims_example_select_last_index/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_argmin_no_keepdims_random/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_argmin_no_keepdims_random_select_last_index/model.onnx | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_asin/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_asin/model.onnx | ✅ | OK (max ULP 2) |
 | onnx-org/onnx/backend/test/data/node/test_asin_example/model.onnx | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_asinh/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_asinh/model.onnx | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/node/test_asinh_example/model.onnx | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_atan/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_atan/model.onnx | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/node/test_atan_example/model.onnx | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_atanh/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_atanh/model.onnx | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/node/test_atanh_example/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d/model.onnx | ✅ | OK (max ULP 2) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_attn_mask/model.onnx | ✅ | OK (max ULP 2) |
@@ -135,15 +135,15 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_transpose_verification/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_transpose_verification_expanded/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present/model.onnx | ✅ | OK (max ULP 4) |
-| onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_expanded/model.onnx | ✅ | OK (max ULP 5) |
+| onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_expanded/model.onnx | ✅ | OK (max ULP 4) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_qk_matmul/model.onnx | ✅ | OK (max ULP 4) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_qk_matmul_bias/model.onnx | ✅ | OK (max ULP 4) |
-| onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_qk_matmul_bias_expanded/model.onnx | ✅ | OK (max ULP 5) |
-| onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_qk_matmul_expanded/model.onnx | ✅ | OK (max ULP 5) |
+| onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_qk_matmul_bias_expanded/model.onnx | ✅ | OK (max ULP 4) |
+| onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_qk_matmul_expanded/model.onnx | ✅ | OK (max ULP 4) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_qk_matmul_softcap/model.onnx | ✅ | OK (max ULP 3) |
-| onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded/model.onnx | ✅ | OK (max ULP 3) |
+| onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded/model.onnx | ✅ | OK (max ULP 4) |
 | onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_qk_matmul_softmax/model.onnx | ✅ | OK (max ULP 5) |
-| onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded/model.onnx | ✅ | OK (max ULP 5) |
+| onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded/model.onnx | ✅ | OK (max ULP 4) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d/model.onnx | ✅ | OK (max ULP 3) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_attn_mask/model.onnx | ✅ | OK (max ULP 4) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_attn_mask_3d/model.onnx | ✅ | OK (max ULP 4) |
@@ -174,7 +174,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_diff_heads_sizes_softcap/model.onnx | ✅ | OK (max ULP 3) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_diff_heads_sizes_softcap_expanded/model.onnx | ✅ | OK (max ULP 5) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_diff_heads_with_past_and_present/model.onnx | ✅ | OK (max ULP 3) |
-| onnx-org/onnx/backend/test/data/node/test_attention_4d_diff_heads_with_past_and_present_expanded/model.onnx | ✅ | OK (max ULP 6) |
+| onnx-org/onnx/backend/test/data/node/test_attention_4d_diff_heads_with_past_and_present_expanded/model.onnx | ✅ | OK (max ULP 5) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_diff_heads_with_past_and_present_mask3d/model.onnx | ✅ | OK (max ULP 4) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_diff_heads_with_past_and_present_mask3d_expanded/model.onnx | ✅ | OK (max ULP 4) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_diff_heads_with_past_and_present_mask4d/model.onnx | ✅ | OK (max ULP 4) |
@@ -193,7 +193,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_gqa_softcap/model.onnx | ✅ | OK (max ULP 2) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_gqa_softcap_expanded/model.onnx | ✅ | OK (max ULP 3) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_gqa_with_past_and_present/model.onnx | ✅ | OK (max ULP 4) |
-| onnx-org/onnx/backend/test/data/node/test_attention_4d_gqa_with_past_and_present_expanded/model.onnx | ✅ | OK (max ULP 5) |
+| onnx-org/onnx/backend/test/data/node/test_attention_4d_gqa_with_past_and_present_expanded/model.onnx | ✅ | OK (max ULP 7) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_gqa_with_past_and_present_fp16/model.onnx | ✅ | OK (max ULP 4) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_gqa_with_past_and_present_fp16_expanded/model.onnx | ✅ | OK (max ULP 4) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_scaled/model.onnx | ✅ | OK (max ULP 2) |
@@ -206,12 +206,12 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias/model.onnx | ✅ | OK (max ULP 4) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask/model.onnx | ✅ | OK (max ULP 4) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal/model.onnx | ✅ | OK (max ULP 4) |
-| onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal_expanded/model.onnx | ✅ | OK (max ULP 4) |
-| onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_expanded/model.onnx | ✅ | OK (max ULP 5) |
+| onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal_expanded/model.onnx | ✅ | OK (max ULP 6) |
+| onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_expanded/model.onnx | ✅ | OK (max ULP 7) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask/model.onnx | ✅ | OK (max ULP 4) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal/model.onnx | ✅ | OK (max ULP 3) |
-| onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal_expanded/model.onnx | ✅ | OK (max ULP 3) |
-| onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_expanded/model.onnx | ✅ | OK (max ULP 4) |
+| onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal_expanded/model.onnx | ✅ | OK (max ULP 4) |
+| onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_expanded/model.onnx | ✅ | OK (max ULP 5) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_expanded/model.onnx | ✅ | OK (max ULP 4) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_expanded/model.onnx | ✅ | OK (max ULP 4) |
 | onnx-org/onnx/backend/test/data/node/test_attention_4d_with_qk_matmul/model.onnx | ✅ | OK (max ULP 3) |
@@ -542,8 +542,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_convtranspose_pads/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_cos/model.onnx | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/node/test_cos_example/model.onnx | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_cosh/model.onnx | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_cosh_example/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_cosh/model.onnx | ✅ | OK (max ULP 2) |
+| onnx-org/onnx/backend/test/data/node/test_cosh_example/model.onnx | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/node/test_cumsum_1d/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_cumsum_1d_exclusive/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_cumsum_1d_int32_exclusive/model.onnx | ✅ | OK (max ULP 0) |
@@ -774,7 +774,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_l1normalization_axis_0/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_l1normalization_axis_1/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_l1normalization_axis_last/model.onnx | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_l2normalization_axis_0/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_l2normalization_axis_0/model.onnx | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/node/test_l2normalization_axis_1/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_layer_normalization_2d_axis0/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_layer_normalization_2d_axis0_expanded/model.onnx | ✅ | OK (max ULP 0) |
@@ -899,7 +899,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_lppool_2d_strides/model.onnx | ✅ | OK (max ULP 2) |
 | onnx-org/onnx/backend/test/data/node/test_lppool_3d_default/model.onnx | ❌ | LpPool expects 2D kernel_shape |
 | onnx-org/onnx/backend/test/data/node/test_lrn/model.onnx | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_lrn_default/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_lrn_default/model.onnx | ✅ | OK (max ULP 2) |
 | onnx-org/onnx/backend/test/data/node/test_lstm_batchwise/model.onnx | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/node/test_lstm_defaults/model.onnx | ✅ | OK (max ULP 2) |
 | onnx-org/onnx/backend/test/data/node/test_lstm_with_initial_bias/model.onnx | ✅ | OK (max ULP 1) |
@@ -1069,7 +1069,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_or_bcast4v2d/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_or_bcast4v3d/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_or_bcast4v4d/model.onnx | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_pow/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_pow/model.onnx | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/node/test_pow_bcast_array/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_pow_bcast_scalar/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_pow_example/model.onnx | ✅ | OK (max ULP 0) |
@@ -1486,7 +1486,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_simple_rnn_with_initial_bias/model.onnx | ❌ | Unsupported op RNN |
 | onnx-org/onnx/backend/test/data/node/test_sin/model.onnx | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/node/test_sin_example/model.onnx | ✅ | OK (max ULP 1) |
-| onnx-org/onnx/backend/test/data/node/test_sinh/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_sinh/model.onnx | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/node/test_sinh_example/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_size/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_size_example/model.onnx | ✅ | OK (max ULP 0) |
@@ -1585,7 +1585,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_sum_two_inputs/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_swish/model.onnx | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/node/test_swish_expanded/model.onnx | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_tan/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_tan/model.onnx | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/node/test_tan_example/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_tanh/model.onnx | ✅ | OK (max ULP 2) |
 | onnx-org/onnx/backend/test/data/node/test_tanh_example/model.onnx | ✅ | OK (max ULP 0) |
@@ -1665,61 +1665,61 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_xor2d/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_xor3d/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_xor4d/model.onnx | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_xor_bcast3v1d/model.onnx | ❌ | Xor expects identical input/output shapes |
-| onnx-org/onnx/backend/test/data/node/test_xor_bcast3v2d/model.onnx | ❌ | Xor expects identical input/output shapes |
-| onnx-org/onnx/backend/test/data/node/test_xor_bcast4v2d/model.onnx | ❌ | Xor expects identical input/output shapes |
-| onnx-org/onnx/backend/test/data/node/test_xor_bcast4v3d/model.onnx | ❌ | Xor expects identical input/output shapes |
-| onnx-org/onnx/backend/test/data/node/test_xor_bcast4v4d/model.onnx | ❌ | Xor expects identical input/output shapes |
+| onnx-org/onnx/backend/test/data/node/test_xor_bcast3v1d/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_xor_bcast3v2d/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_xor_bcast4v2d/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_xor_bcast4v3d/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_xor_bcast4v4d/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_AvgPool1d/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_AvgPool1d_stride/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_AvgPool2d/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_AvgPool2d_stride/model.onnx | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_AvgPool3d/model.onnx | ❌ | AveragePool expects 2D kernel_shape |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_AvgPool3d_stride/model.onnx | ❌ | AveragePool expects 2D kernel_shape |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_AvgPool3d_stride1_pad0_gpu_input/model.onnx | ❌ | AveragePool expects 2D kernel_shape |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_BatchNorm1d_3d_input_eval/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 5. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_BatchNorm2d_eval/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 5. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_BatchNorm2d_momentum_eval/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 5. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_BatchNorm3d_eval/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 5. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_BatchNorm3d_momentum_eval/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 5. |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_AvgPool3d/model.onnx | ✅ | OK (max ULP 16) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_AvgPool3d_stride/model.onnx | ✅ | OK (max ULP 30) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_AvgPool3d_stride1_pad0_gpu_input/model.onnx | ✅ | OK (max ULP 19) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_BatchNorm1d_3d_input_eval/model.onnx | ✅ | OK (max ULP 1) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_BatchNorm2d_eval/model.onnx | ✅ | OK (max ULP 1) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_BatchNorm2d_momentum_eval/model.onnx | ✅ | OK (max ULP 1) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_BatchNorm3d_eval/model.onnx | ✅ | OK (max ULP 2) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_BatchNorm3d_momentum_eval/model.onnx | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_ConstantPad2d/model.onnx | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_dilated/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_groups/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_pad1/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_pad1size1/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_pad2/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_pad2size1/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_stride/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_depthwise/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_depthwise_padded/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_depthwise_strided/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_depthwise_with_multiplier/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_dilated/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_groups/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_groups_thnn/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_no_bias/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 2. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_padding/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_strided/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_dilated/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_dilated_strided/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_groups/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_no_bias/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 2. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_stride/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_stride_padding/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_ConvTranspose2d/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_ConvTranspose2d_no_bias/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 2. |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d/model.onnx | ❌ | Out of tolerance (max ULP 208) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_dilated/model.onnx | ✅ | OK (max ULP 64) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_groups/model.onnx | ✅ | OK (max ULP 3) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_pad1/model.onnx | ❌ | Out of tolerance (max ULP 117) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_pad1size1/model.onnx | ✅ | OK (max ULP 6) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_pad2/model.onnx | ✅ | OK (max ULP 64) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_pad2size1/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_stride/model.onnx | ✅ | OK (max ULP 24) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d/model.onnx | ❌ | Out of tolerance (max ULP 320) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_depthwise/model.onnx | ❌ | Out of tolerance (max ULP 480) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_depthwise_padded/model.onnx | ❌ | Out of tolerance (max ULP 128) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_depthwise_strided/model.onnx | ✅ | OK (max ULP 16) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_depthwise_with_multiplier/model.onnx | ✅ | OK (max ULP 56) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_dilated/model.onnx | ✅ | OK (max ULP 24) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_groups/model.onnx | ❌ | Out of tolerance (max ULP 640) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_groups_thnn/model.onnx | ❌ | Out of tolerance (max ULP 528) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_no_bias/model.onnx | ❌ | Out of tolerance (max ULP 1021) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_padding/model.onnx | ✅ | OK (max ULP 56) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_strided/model.onnx | ❌ | Out of tolerance (max ULP 168) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d/model.onnx | ✅ | OK (max ULP 27) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_dilated/model.onnx | ❌ | Out of tolerance (max ULP 168) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_dilated_strided/model.onnx | ❌ | Out of tolerance (max ULP 448) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_groups/model.onnx | ❌ | Out of tolerance (max ULP 256) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_no_bias/model.onnx | ✅ | OK (max ULP 38) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_stride/model.onnx | ✅ | OK (max ULP 8) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_stride_padding/model.onnx | ✅ | OK (max ULP 84) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_ConvTranspose2d/model.onnx | ❌ | Out of tolerance (max ULP 112) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_ConvTranspose2d_no_bias/model.onnx | ❌ | Out of tolerance (max ULP 128) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_ELU/model.onnx | ❌ | Elu only supports alpha=1.0 |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Embedding/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 2. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Embedding_sparse/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 2. |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Embedding/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Embedding_sparse/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_GLU/model.onnx | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_GLU_dim/model.onnx | ✅ | OK (max ULP 2) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_LeakyReLU/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_LeakyReLU_with_negval/model.onnx | ❌ | LeakyRelu only supports alpha=0.01 |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Linear/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Linear_no_bias/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 2. |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Linear/model.onnx | ✅ | OK (max ULP 12) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Linear_no_bias/model.onnx | ✅ | OK (max ULP 62) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_LogSoftmax/model.onnx | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_MaxPool1d/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_MaxPool1d_stride/model.onnx | ✅ | OK (max ULP 0) |
@@ -1729,12 +1729,12 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_MaxPool3d/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_MaxPool3d_stride/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_MaxPool3d_stride_padding/model.onnx | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_PReLU_1d/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 2. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_PReLU_1d_multiparam/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 2. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_PReLU_2d/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 2. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_PReLU_2d_multiparam/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 2. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_PReLU_3d/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 2. |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_PReLU_3d_multiparam/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 2. |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_PReLU_1d/model.onnx | ❌ | Missing output 2 in testbench data |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_PReLU_1d_multiparam/model.onnx | ❌ | Broadcasting mismatch for shapes: (2, 3, 4), (3,) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_PReLU_2d/model.onnx | ❌ | Missing output 2 in testbench data |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_PReLU_2d_multiparam/model.onnx | ❌ | Broadcasting mismatch for shapes: (2, 3, 4, 5), (3,) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_PReLU_3d/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_PReLU_3d_multiparam/model.onnx | ❌ | Broadcasting mismatch for shapes: (2, 3, 4, 5, 6), (3,) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_PixelShuffle/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_PoissonNLLLLoss_no_reduce/model.onnx | ✅ | OK (max ULP 4) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_ReLU/model.onnx | ✅ | OK (max ULP 0) |
@@ -1762,8 +1762,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_chunk/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_clip/model.onnx | ❌ | Out of tolerance (max ULP 17525756) |
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_concat2/model.onnx | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_conv/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 2. |
-| onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_convtranspose/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 2. |
+| onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_conv/model.onnx | ❌ | Failed to build testbench. |
+| onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_convtranspose/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_exp/model.onnx | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_flatten/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_index/model.onnx | ✅ | OK (max ULP 0) |
@@ -1771,11 +1771,11 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_maxpool/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_min/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_mm/model.onnx | ✅ | OK (max ULP 1) |
-| onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_non_float_params/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 2. |
+| onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_non_float_params/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_pad/model.onnx | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_params/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 2. |
+| onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_params/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_permute2/model.onnx | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_pow/model.onnx | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_pow/model.onnx | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_reduced_mean/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_reduced_mean_keepdim/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_reduced_sum/model.onnx | ✅ | OK (max ULP 0) |
@@ -1784,7 +1784,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_repeat_dim_overflow/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_selu/model.onnx | ✅ | OK (max ULP 15) |
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_sqrt/model.onnx | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_symbolic_override/model.onnx | ❌ | Test data input count does not match model inputs: 1 vs 3. |
+| onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_symbolic_override/model.onnx | ❌ | Out of tolerance (max ULP 5380) |
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_symbolic_override_nested/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_view/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/simple/test_expand_shape_model1/model.onnx | ✅ | OK (max ULP 0) |
@@ -1862,10 +1862,10 @@ Support 54 / 74 local ONNX files.
 | test_matmul_2x3x3x4_1x4x5/model.onnx | ✅ | OK (max ULP 1) |
 | test_matmul_2x3x4_4/model.onnx | ✅ | OK (max ULP 1) |
 | test_matmul_2x3x4_4x5/model.onnx | ✅ | OK (max ULP 1) |
-| test_matmul_2x3x4x5_5/model.onnx | ✅ | OK (max ULP 2) |
-| test_matmul_3_2x3x4/model.onnx | ✅ | OK (max ULP 0) |
+| test_matmul_2x3x4x5_5/model.onnx | ✅ | OK (max ULP 1) |
+| test_matmul_3_2x3x4/model.onnx | ✅ | OK (max ULP 1) |
 | test_matmul_3_3/model.onnx | ✅ | OK (max ULP 0) |
-| test_matmul_3_3x4/model.onnx | ✅ | OK (max ULP 0) |
+| test_matmul_3_3x4/model.onnx | ✅ | OK (max ULP 1) |
 | test_matmul_3x4_2x4x5/model.onnx | ✅ | OK (max ULP 1) |
 | test_matmul_3x4_4/model.onnx | ✅ | OK (max ULP 0) |
 | test_matmul_4x5x2x3_4x5x3x4/model.onnx | ✅ | OK (max ULP 2) |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -2,22 +2,18 @@
 
 | Error message | Count | Histogram |
 | --- | --- | --- |
-| Missing output 1 in testbench data | 38 | ██████████████████████████████ |
-| Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 33 | ██████████████████████████ |
+| Out of tolerance | 38 | ██████████████████████████████ |
+| Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 36 | ████████████████████████████ |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | █████████████████████████ |
-| Test data input count does not match model inputs: 1 vs 3. | 27 | █████████████████████ |
 | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 22 | █████████████████ |
 | Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 20 | ████████████████ |
-| Out of tolerance | 19 | ███████████████ |
 | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 18 | ██████████████ |
 | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 18 | ██████████████ |
-| Test data input count does not match model inputs: 1 vs 2. | 17 | █████████████ |
 | Unsupported elem_type 21 (UINT4) for tensor '*'. | 17 | █████████████ |
 | Unsupported elem_type 22 (INT4) for tensor '*'. | 17 | █████████████ |
 | Unsupported elem_type 25 (UINT2) for tensor '*'. | 17 | █████████████ |
 | Unsupported elem_type 26 (INT2) for tensor '*'. | 17 | █████████████ |
 | Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 14 | ███████████ |
-| Missing output 2 in testbench data | 12 | █████████ |
 | Unsupported op ImageDecoder | 9 | ███████ |
 | '*' object has no attribute '*' | 8 | ██████ |
 | Dropout supports only the data input and 1 or 2 outputs | 8 | ██████ |
@@ -29,35 +25,29 @@
 | Unsupported op DFT | 6 | █████ |
 | Unsupported op ScatterElements | 6 | █████ |
 | Unsupported op Unique | 6 | █████ |
-| And expects identical input/output shapes | 5 | █████ |
-| AveragePool expects 2D kernel_shape | 5 | █████ |
-| Iteration of zero-sized operands is not enabled | 5 | █████ |
-| Or expects identical input/output shapes | 5 | █████ |
-| Test data input count does not match model inputs: 1 vs 5. | 5 | █████ |
-| Unsupported op Col2Im | 5 | █████ |
-| Unsupported op DequantizeLinear | 5 | █████ |
-| Unsupported op If | 5 | █████ |
-| Xor expects identical input/output shapes | 5 | █████ |
-| Sum expects identical input/output shapes | 4 | ████ |
-| Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 4 | ████ |
-| Unsupported op AffineGrid | 4 | ████ |
-| Unsupported op Compress | 4 | ████ |
-| Unsupported op DeformConv | 4 | ████ |
-| Unsupported op GRU | 4 | ████ |
-| Unsupported op OptionalHasElement | 4 | ████ |
-| Unsupported op RNN | 4 | ████ |
-| AveragePool supports auto_pad=NOTSET only | 3 | ███ |
-| Elu only supports alpha=1.0 | 3 | ███ |
-| HardSigmoid only supports alpha=0.2 | 3 | ███ |
-| LeakyRelu only supports alpha=0.01 | 3 | ███ |
-| Min expects identical input/output shapes | 3 | ███ |
-| Unsupported op Bernoulli | 3 | ███ |
-| Unsupported op DynamicQuantizeLinear | 3 | ███ |
-| Unsupported op Loop | 3 | ███ |
-| Unsupported op Momentum | 3 | ███ |
-| Unsupported op RandomUniformLike | 3 | ███ |
-| Unsupported op RoiAlign | 3 | ███ |
-| name '*' is not defined | 3 | ███ |
+| Iteration of zero-sized operands is not enabled | 5 | ████ |
+| Unsupported op Col2Im | 5 | ████ |
+| Unsupported op DequantizeLinear | 5 | ████ |
+| Unsupported op If | 5 | ████ |
+| Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 4 | ███ |
+| Unsupported op AffineGrid | 4 | ███ |
+| Unsupported op Compress | 4 | ███ |
+| Unsupported op DeformConv | 4 | ███ |
+| Unsupported op GRU | 4 | ███ |
+| Unsupported op OptionalHasElement | 4 | ███ |
+| Unsupported op RNN | 4 | ███ |
+| AveragePool supports auto_pad=NOTSET only | 3 | ██ |
+| Elu only supports alpha=1.0 | 3 | ██ |
+| Failed to build testbench. | 3 | ██ |
+| HardSigmoid only supports alpha=0.2 | 3 | ██ |
+| LeakyRelu only supports alpha=0.01 | 3 | ██ |
+| Unsupported op Bernoulli | 3 | ██ |
+| Unsupported op DynamicQuantizeLinear | 3 | ██ |
+| Unsupported op Loop | 3 | ██ |
+| Unsupported op Momentum | 3 | ██ |
+| Unsupported op RandomUniformLike | 3 | ██ |
+| Unsupported op RoiAlign | 3 | ██ |
+| name '*' is not defined | 3 | ██ |
 | 
 Arrays are not equal
 
@@ -70,11 +60,10 @@ Max relative difference among violations: 5.4
        [  1, -75,  20]], dtype=int8) | 2 | ██ |
 | AveragePool supports ceil_mode=0 only | 2 | ██ |
 | BatchNormalization must have 5 inputs and 1 output | 2 | ██ |
-| Failed to build testbench. | 2 | ██ |
 | Gelu only supports approximate=none | 2 | ██ |
 | LpPool expects 2D kernel_shape | 2 | ██ |
 | LpPool supports auto_pad=NOTSET only | 2 | ██ |
-| Missing output 6 in testbench data | 2 | ██ |
+| Missing output 2 in testbench data | 2 | ██ |
 | Pow expects matching dtypes, got float, int32 | 2 | ██ |
 | Pow expects matching dtypes, got float, int64 | 2 | ██ |
 | QuantizeLinear block_size is not supported | 2 | ██ |
@@ -137,6 +126,7 @@ Max relative difference among violations: 0.10344828
  DESIRED: array([[[ -86,  116,  119],
         [ 115,   39, -121]],
 ... | 1 | █ |
+| AveragePool supports 2D/3D inputs only | 1 | █ |
 | Broadcasting mismatch for shapes: (2, 3, 4), (3,) | 1 | █ |
 | Broadcasting mismatch for shapes: (2, 3, 4, 5), (3,) | 1 | █ |
 | Broadcasting mismatch for shapes: (2, 3, 4, 5, 6), (3,) | 1 | █ |

--- a/SUPPORT_OPS.md
+++ b/SUPPORT_OPS.md
@@ -2,7 +2,7 @@
 
 Operators are marked supported when they appear in an ONNX file with a successful verify result.
 
-Supported operators: 141 / 197
+Supported operators: 140 / 197
 
 | Operator | Supported |
 | --- | --- |

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__light__light_resnet50.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__light__light_resnet50.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Out of tolerance (max ULP 553)",
+  "error": "Out of tolerance (max ULP 539)",
   "command_line": "verify onnx-org/onnx/backend/test/data/light/light_resnet50.onnx --cc /usr/bin/cc",
   "operators": [
     "ConstantOfShape",
@@ -14,5 +14,5 @@
     "Softmax"
   ],
   "opset_version": 9,
-  "generated_checksum": "bad30cc231f71ddd57443422b985b308341e047dc218b99e612cd9163fcbd03c"
+  "generated_checksum": "e7d496a4f6cb47a2ee08a6bce7e927ca8a38c75e05bdaee3306547bad66b2723"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__light__light_shufflenet.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__light__light_shufflenet.onnx.json
@@ -16,5 +16,5 @@
     "Softmax"
   ],
   "opset_version": 9,
-  "generated_checksum": "852d1f4fa2bdacf4406db9d5f12c231af7019b0f7dc31399e3b9238b4c47b8e3"
+  "generated_checksum": "09dfbd5a26c4470c7531bd18744faddd647604032b313459136fd0f8f881344f"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_acos__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_acos__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 0)",
+  "error": "OK (max ULP 1)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_acos/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_acos/test_data_set_0",
   "operators": [
     "Acos"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_acosh__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_acosh__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 0)",
+  "error": "OK (max ULP 1)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_acosh/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_acosh/test_data_set_0",
   "operators": [
     "Acosh"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_asin__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_asin__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 0)",
+  "error": "OK (max ULP 2)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_asin/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_asin/test_data_set_0",
   "operators": [
     "Asin"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_asinh__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_asinh__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 0)",
+  "error": "OK (max ULP 1)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_asinh/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_asinh/test_data_set_0",
   "operators": [
     "Asinh"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_atan__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_atan__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 0)",
+  "error": "OK (max ULP 1)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_atan/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_atan/test_data_set_0",
   "operators": [
     "Atan"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_atanh__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_atanh__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 0)",
+  "error": "OK (max ULP 1)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_atanh/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_atanh/test_data_set_0",
   "operators": [
     "Atanh"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_with_past_and_present_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_with_past_and_present_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 5)",
+  "error": "OK (max ULP 4)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_expanded/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_expanded/test_data_set_0",
   "operators": [
     "Shape",

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_with_past_and_present_qk_matmul_bias_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_with_past_and_present_qk_matmul_bias_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 5)",
+  "error": "OK (max ULP 4)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_qk_matmul_bias_expanded/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_qk_matmul_bias_expanded/test_data_set_0",
   "operators": [
     "Shape",

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_with_past_and_present_qk_matmul_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_with_past_and_present_qk_matmul_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 5)",
+  "error": "OK (max ULP 4)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_qk_matmul_expanded/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_qk_matmul_expanded/test_data_set_0",
   "operators": [
     "Shape",

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 3)",
+  "error": "OK (max ULP 4)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded/test_data_set_0",
   "operators": [
     "Shape",

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 5)",
+  "error": "OK (max ULP 4)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded/test_data_set_0",
   "operators": [
     "Shape",

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_diff_heads_with_past_and_present_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_diff_heads_with_past_and_present_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 6)",
+  "error": "OK (max ULP 5)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_attention_4d_diff_heads_with_past_and_present_expanded/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_attention_4d_diff_heads_with_past_and_present_expanded/test_data_set_0",
   "operators": [
     "Shape",

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_gqa_with_past_and_present_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_gqa_with_past_and_present_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 5)",
+  "error": "OK (max ULP 7)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_attention_4d_gqa_with_past_and_present_expanded/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_attention_4d_gqa_with_past_and_present_expanded/test_data_set_0",
   "operators": [
     "Shape",

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 4)",
+  "error": "OK (max ULP 6)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal_expanded/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal_expanded/test_data_set_0",
   "operators": [
     "Shape",

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 5)",
+  "error": "OK (max ULP 7)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_expanded/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_expanded/test_data_set_0",
   "operators": [
     "Shape",

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 3)",
+  "error": "OK (max ULP 4)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal_expanded/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal_expanded/test_data_set_0",
   "operators": [
     "Shape",

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 4)",
+  "error": "OK (max ULP 5)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_expanded/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_expanded/test_data_set_0",
   "operators": [
     "Shape",

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cosh__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cosh__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 0)",
+  "error": "OK (max ULP 2)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_cosh/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_cosh/test_data_set_0",
   "operators": [
     "Cosh"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cosh_example__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_cosh_example__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 0)",
+  "error": "OK (max ULP 1)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_cosh_example/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_cosh_example/test_data_set_0",
   "operators": [
     "Cosh"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_l2normalization_axis_0__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_l2normalization_axis_0__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 0)",
+  "error": "OK (max ULP 1)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_l2normalization_axis_0/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_l2normalization_axis_0/test_data_set_0",
   "operators": [
     "LpNormalization"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_lrn_default__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_lrn_default__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 0)",
+  "error": "OK (max ULP 2)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_lrn_default/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_lrn_default/test_data_set_0",
   "operators": [
     "LRN"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_pow__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_pow__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 0)",
+  "error": "OK (max ULP 1)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_pow/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_pow/test_data_set_0",
   "operators": [
     "Pow"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_sinh__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_sinh__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 0)",
+  "error": "OK (max ULP 1)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_sinh/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_sinh/test_data_set_0",
   "operators": [
     "Sinh"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_tan__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_tan__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 0)",
+  "error": "OK (max ULP 1)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_tan/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/node/test_tan/test_data_set_0",
   "operators": [
     "Tan"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_AvgPool3d__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_AvgPool3d__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 1 in testbench data",
+  "error": "OK (max ULP 16)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_AvgPool3d/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_AvgPool3d/test_data_set_0",
   "operators": [
     "AveragePool"
   ],
   "opset_version": 6,
-  "generated_checksum": "80f43627f6434cfb356f0eb64e938d94403a282b8fb69a0e189cfe293a964b84"
+  "generated_checksum": "d226bb2b100537a8042fb8bc5fbfddade72abe6f2f404354091e35cdd33eeb9b"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_AvgPool3d_stride1_pad0_gpu_input__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_AvgPool3d_stride1_pad0_gpu_input__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 1 in testbench data",
+  "error": "OK (max ULP 19)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_AvgPool3d_stride1_pad0_gpu_input/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_AvgPool3d_stride1_pad0_gpu_input/test_data_set_0",
   "operators": [
     "AveragePool"
   ],
   "opset_version": 6,
-  "generated_checksum": "8f33daa77375cf6e1ad3359425fca466dbf5bcf977a5dfe75bf89085b4fc3376"
+  "generated_checksum": "6a280b2001afe025d753e0388654cf647587a57da1fa10d07961db8ff57f365a"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_AvgPool3d_stride__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_AvgPool3d_stride__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 1 in testbench data",
+  "error": "OK (max ULP 30)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_AvgPool3d_stride/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_AvgPool3d_stride/test_data_set_0",
   "operators": [
     "AveragePool"
   ],
   "opset_version": 6,
-  "generated_checksum": "6099d360aaf4d086d07d5a49f0b4ea5d56e73b949b06daa209137dc59ce18088"
+  "generated_checksum": "5419961f85bf581238ee3cbab17ccbc6f120dc4be13766f12b91071011b81055"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_BatchNorm1d_3d_input_eval__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_BatchNorm1d_3d_input_eval__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 5 in testbench data",
+  "error": "OK (max ULP 1)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_BatchNorm1d_3d_input_eval/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_BatchNorm1d_3d_input_eval/test_data_set_0",
   "operators": [
     "BatchNormalization"
   ],
   "opset_version": 6,
-  "generated_checksum": "a924c4857fc9e5b5ce6d0c6c7c229484d94489f169c57e6365b7e92771a72ed0"
+  "generated_checksum": "797cdcf761ddfbbdaa8680862d074dd85ea60a20707171f69b2ab084023faa86"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_BatchNorm2d_eval__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_BatchNorm2d_eval__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 5 in testbench data",
+  "error": "OK (max ULP 1)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_BatchNorm2d_eval/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_BatchNorm2d_eval/test_data_set_0",
   "operators": [
     "BatchNormalization"
   ],
   "opset_version": 6,
-  "generated_checksum": "e8195fca297a20ad67dac6c54f194b56b0402371f49e891f09a3529576da318c"
+  "generated_checksum": "fa98ad657af143d546466101357840b5e253a9a9518875729372da26a7d5d080"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_BatchNorm2d_momentum_eval__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_BatchNorm2d_momentum_eval__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 5 in testbench data",
+  "error": "OK (max ULP 1)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_BatchNorm2d_momentum_eval/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_BatchNorm2d_momentum_eval/test_data_set_0",
   "operators": [
     "BatchNormalization"
   ],
   "opset_version": 6,
-  "generated_checksum": "4f665cc879017f1fbef5d5df9442ba04939f2df0cbdc4cc9d3b007b353e67e96"
+  "generated_checksum": "e948ef1766927410cf5151ad07485c89e259891fb276ab1a36ba393da8594eae"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_BatchNorm3d_eval__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_BatchNorm3d_eval__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 5 in testbench data",
+  "error": "OK (max ULP 2)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_BatchNorm3d_eval/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_BatchNorm3d_eval/test_data_set_0",
   "operators": [
     "BatchNormalization"
   ],
   "opset_version": 6,
-  "generated_checksum": "87a8217926e118b39375dccdead6d08cf7ba79fda3f2e0722d710e9b7e98a91d"
+  "generated_checksum": "70dad11f035fe24eabb9287f97a3448f9ca8c5096430a7b4792e353bc5602b6a"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_BatchNorm3d_momentum_eval__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_BatchNorm3d_momentum_eval__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 5 in testbench data",
+  "error": "OK (max ULP 1)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_BatchNorm3d_momentum_eval/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_BatchNorm3d_momentum_eval/test_data_set_0",
   "operators": [
     "BatchNormalization"
   ],
   "opset_version": 6,
-  "generated_checksum": "ccd8f95755f50d49407effa32e40e60b13173fa2f2d680c9bcf149bd45390b3c"
+  "generated_checksum": "d8891cef844c573e1df485c3d57ec668d6755eb8e51868572d1fc751989ccf05"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv1d__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv1d__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "Out of tolerance (max ULP 208)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "553474bf42d549693a0cee32a4de2d7e03dab56d127ff8589e742ee0c5333269"
+  "generated_checksum": "a07450e9ef8905ef4764a8fa5f9cfbeafd228865aa9dc945a30ca55a0713268d"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv1d_dilated__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv1d_dilated__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "OK (max ULP 64)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_dilated/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_dilated/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "832c88e97a8d4deb20623a8b63ad52d3be44b66254f80094778a071667e35f3a"
+  "generated_checksum": "20b13b8171502f9ef9e44710fa31556d40a357bfbf91b2e1ffec73845d8a8991"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv1d_groups__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv1d_groups__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "OK (max ULP 3)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_groups/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_groups/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "5777e1d9ba582c55325f9563f0653bbbdb572454e310581afcd686dd970a63f6"
+  "generated_checksum": "e96f032166d4b52668224c141d7ed8377dce49bf03921bfc72151f82865abe44"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv1d_pad1__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv1d_pad1__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "Out of tolerance (max ULP 117)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_pad1/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_pad1/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "55eeac717ecb97d56e06ddeb0f798136977b320556cd3cfd10701aa8ba19b40d"
+  "generated_checksum": "b2235fb3944aa22e8f6fa0736dc244d7eea9d51846acfccdbd4f0689abf62651"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv1d_pad1size1__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv1d_pad1size1__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "OK (max ULP 6)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_pad1size1/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_pad1size1/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "0dbedd6f4ffa6b469cccd0511347d018d97323c6db3ae09446f2fabc6bc4e45e"
+  "generated_checksum": "71b1170c6990854782ad1a69a550357df0c80da4a92c7ed8ebea410223a0910d"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv1d_pad2__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv1d_pad2__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "OK (max ULP 64)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_pad2/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_pad2/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "bbe20ece92ee154c015cc5aed2109f24ad9fbc106481f3a971e6b2a3ffe1357e"
+  "generated_checksum": "b65a736247b81b34dcebfc0d2920155eebe9f08802e673339b4cc45e625b09da"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv1d_pad2size1__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv1d_pad2size1__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_pad2size1/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_pad2size1/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "bcad4b51da51242929fe408d098b927ab67d6e2052acb8540bb6ac7e0e30ba4c"
+  "generated_checksum": "c79ff76081d192c76914b0bd35f5003dfc5123ba1f81f13b747cb856b2ef89b4"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv1d_stride__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv1d_stride__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "OK (max ULP 24)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_stride/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv1d_stride/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "f312326499b6cb7557675eeda23a94ce146f14e15f9c9ee6a7857d21fa556893"
+  "generated_checksum": "fae52a874ab2a1dbff0d8d8375f1aea8110130aea0d21ff3aaffbcaca2ddcd04"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv2d__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv2d__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "Out of tolerance (max ULP 320)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "b4f8d751dba7bcf8d767d9f52e5225f7cf6cb9b6ba41030160973f8c2522eaea"
+  "generated_checksum": "7b805943abedb8a78dc75e046c9108935a766948b786153f351ddd18cbfeb73a"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv2d_depthwise__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv2d_depthwise__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "Out of tolerance (max ULP 480)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_depthwise/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_depthwise/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "d5655479fdda989701169d366ec8209f179c549460c5d087e32c255b1ecc336f"
+  "generated_checksum": "4e12b254fcf0a58f634bc388ad6d863c06e771268c28b0524116feefbefeb5b2"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv2d_depthwise_padded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv2d_depthwise_padded__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "Out of tolerance (max ULP 128)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_depthwise_padded/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_depthwise_padded/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "ef4c3f3ec9a7643a4b8e1f1ccdda9c2f96541abf24404862d48828984ec0013a"
+  "generated_checksum": "41b4007584006811cb9b969e7ad50a37abb408b241d6aae316f613497cd9d62b"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv2d_depthwise_strided__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv2d_depthwise_strided__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "OK (max ULP 16)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_depthwise_strided/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_depthwise_strided/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "66385233f2d59ecfacde12a32043cbe363e846af3d7a67bde284c5dfcb6c19a3"
+  "generated_checksum": "c4c47034a04eb0cf6207929cd78465edd27d243c681afa299610336245526632"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv2d_depthwise_with_multiplier__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv2d_depthwise_with_multiplier__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "OK (max ULP 56)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_depthwise_with_multiplier/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_depthwise_with_multiplier/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "218dc0df9351cd5b93050e98ce58fc8400dc1d101c700d560ac20cc77d937712"
+  "generated_checksum": "e058477807b0f20e57c7a9eb9fe644c04b4f4b2a4d7f6666cf09e861741a56a2"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv2d_dilated__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv2d_dilated__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "OK (max ULP 24)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_dilated/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_dilated/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "e33bb76af97c7b2700417eae74ff780ab4adef6ece6c05ab3dd7b8b54e7d7b15"
+  "generated_checksum": "32977f8279887ae8dd32f575528018e4517492b2706bb3ffb2c4dfbffaf756fb"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv2d_groups__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv2d_groups__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "Out of tolerance (max ULP 640)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_groups/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_groups/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "a7cffcec35173e468d0889b6ea23db072b6e44de912286883ed5d7bc615bc9b4"
+  "generated_checksum": "9246ccd612dac9da1ef1190b3ed5381aa885c33b925c67c735f4446ef1aa0428"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv2d_groups_thnn__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv2d_groups_thnn__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "Out of tolerance (max ULP 528)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_groups_thnn/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_groups_thnn/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "b7ce1cddf0249708447d8437a8dbcf14ab29198845207fea9c4be99e0eb54e84"
+  "generated_checksum": "a69bca6d3f85c9a536be7dcd8825a7918d3ead325fb39b3e99c557ce15adb03b"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv2d_no_bias__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv2d_no_bias__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 2 in testbench data",
+  "error": "Out of tolerance (max ULP 1021)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_no_bias/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_no_bias/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "2473185bbb26d0a51ebd03410d989fdadb11d7a9e880567846c761d3ac44f1dc"
+  "generated_checksum": "c173d90948df99fe750bc6fce1a26210896e5a38e2c236043a1625b688458189"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv2d_padding__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv2d_padding__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "OK (max ULP 56)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_padding/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_padding/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "7b41c27bc4cfc588513cb950a1d3713988bf6862d471c8846b13885fdc271136"
+  "generated_checksum": "b4a028a4f6c210d457b795a67c763747ff41a0da3953e0a7dc593259b4f67e63"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv2d_strided__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv2d_strided__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "Out of tolerance (max ULP 168)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_strided/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_strided/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "28e72156db6332f4536a7a3ccca2f363ca267cf126466a13568c87f5165eaae2"
+  "generated_checksum": "89af0669f5ccc42ef5bb626b485be3a607f1d78f61507a2fe24600280a64e67f"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv3d__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv3d__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "OK (max ULP 27)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "627e8ea55c18f72c4f28527239e7cf547c922465b12f06e1cc95a553884fd72e"
+  "generated_checksum": "649b48df868c779af711909d000b50665496ece4ba89d1931f38a9d715ae3cd4"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv3d_dilated__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv3d_dilated__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "Out of tolerance (max ULP 168)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_dilated/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_dilated/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "6ce5a4fcf738dbe69c38dcd826ca9625b63062e9d533f0e8fe40d62ff877aa6e"
+  "generated_checksum": "b91124a063f2cf91e6d176bb17257984e5879c5d642e49f9a975f8b8343d0a9e"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv3d_dilated_strided__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv3d_dilated_strided__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "Out of tolerance (max ULP 448)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_dilated_strided/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_dilated_strided/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "ffda60ca368d44a725887744f9aaa5de664b4dedb21213704c626473ec9dd7dc"
+  "generated_checksum": "fbbabd24c62557e8f19c4dd42b0a9d712de20f97c8eeb284c76dadbe1b048171"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv3d_groups__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv3d_groups__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "Out of tolerance (max ULP 256)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_groups/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_groups/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "a1e93f1c1a0976e808761bd2137905736eec0fc5e3836207f88dcc91938bca40"
+  "generated_checksum": "80a93f3248a4347cfaba3be8204523f853337378f8ebb1e6e84c5fb3a5fa2036"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv3d_no_bias__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv3d_no_bias__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 2 in testbench data",
+  "error": "OK (max ULP 38)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_no_bias/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_no_bias/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "482eee5ff90a185fee0972ca90e044ba70be820d98479cce68f1193e4b2f2b25"
+  "generated_checksum": "b2eedb22dbc6fb8a9272c56f10bdfd25f98c8d4dbbdca67fd772af4467c9c030"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv3d_stride__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv3d_stride__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "OK (max ULP 8)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_stride/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_stride/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "e210860a7c058203a5ddbec52f1d8907aa328890bdde95446e747b0b21921c22"
+  "generated_checksum": "08c803e716f096442050ff07ef256ba1dac6a0016e73dabf96bc59984814acdd"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv3d_stride_padding__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Conv3d_stride_padding__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "OK (max ULP 84)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_stride_padding/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_stride_padding/test_data_set_0",
   "operators": [
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "2534932f8102e46ba821a2b8789c8882c073c36c00c7b0b139246b980e499bea"
+  "generated_checksum": "456d5db95fcdf9f4e065547637a5b7a3ea2f33904790f78a996206bc14954858"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_ConvTranspose2d__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_ConvTranspose2d__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "Out of tolerance (max ULP 112)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_ConvTranspose2d/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_ConvTranspose2d/test_data_set_0",
   "operators": [
     "ConvTranspose"
   ],
   "opset_version": 6,
-  "generated_checksum": "d646625d0daad104fa5d3f62d9b43172731e174aecfb2853cb9f103198ffbbcd"
+  "generated_checksum": "0cfbb1c956d89528812f4bc5c7db1a61f6c4151cc595224d1780ef351d38b479"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_ConvTranspose2d_no_bias__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_ConvTranspose2d_no_bias__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 2 in testbench data",
+  "error": "Out of tolerance (max ULP 128)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_ConvTranspose2d_no_bias/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_ConvTranspose2d_no_bias/test_data_set_0",
   "operators": [
     "ConvTranspose"
   ],
   "opset_version": 6,
-  "generated_checksum": "9af8bc46c657f50928add1841d10b9a42a4e1cb552cbe3f7ad0fe32e39cd4bff"
+  "generated_checksum": "c713c4c9c583d80fe852ebc0b77b92118ef74b53cb3d69dbf1bab7a00f8e8328"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Embedding__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Embedding__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 2 in testbench data",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Embedding/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Embedding/test_data_set_0",
   "operators": [
     "Gather"
   ],
   "opset_version": 6,
-  "generated_checksum": "b3fdd94bf5d9d53992cb61e9f7c14656806e659ee4c4ec1e5b4e537d6c0d9872"
+  "generated_checksum": "60ce5b3dc10fc740e4db9b12135e683073cfc7bdaa3efb73fc9f3e2ffb0ab3b0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Embedding_sparse__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Embedding_sparse__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 2 in testbench data",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Embedding_sparse/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Embedding_sparse/test_data_set_0",
   "operators": [
     "Gather"
   ],
   "opset_version": 6,
-  "generated_checksum": "442704657ed6b42a80d67d24c4b7aa3c61aff44af697067c1ab133fcbf3a1700"
+  "generated_checksum": "66f4d458dca95eb6e254fbe619270aa6c3db67cf18d9055860059b483d13cf6a"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Linear__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Linear__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "OK (max ULP 12)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Linear/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Linear/test_data_set_0",
   "operators": [
     "Gemm"
   ],
   "opset_version": 6,
-  "generated_checksum": "193e68ba1553480adbb99516b6f53088572ccbebb2827433ca9f029fc2117d9b"
+  "generated_checksum": "a0b5efcd6d841c3c93d019b601457337758422349e2464d4c2f1dca2f157626f"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Linear_no_bias__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_Linear_no_bias__model.onnx.json
@@ -1,10 +1,10 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "OK (max ULP 62)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_Linear_no_bias/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_Linear_no_bias/test_data_set_0",
   "operators": [
     "Transpose",
     "MatMul"
   ],
   "opset_version": 6,
-  "generated_checksum": "1ff2dc153afbe3dc0742ba05be9095710016aedf984107b7e9840cef01dfff5f"
+  "generated_checksum": "0d83020c5a1b3f676177ac7d0d2087896938388ca8ffcb9ca9c310d66703f219"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_PReLU_1d__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_PReLU_1d__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 2 in testbench data",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_PReLU_1d/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_PReLU_1d/test_data_set_0",
   "operators": [
     "PRelu"
   ],
   "opset_version": 6,
-  "generated_checksum": "3714f18fa829ba5612420af2d63c3a32c519e1334f12aee584f79e52959a8acd"
+  "generated_checksum": "6741f0c8b42dba086dfd4ee48a64b28096c46b3525e64f53e649fb46cbb67191"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_PReLU_2d__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_PReLU_2d__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 2 in testbench data",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_PReLU_2d/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_PReLU_2d/test_data_set_0",
   "operators": [
     "PRelu"
   ],
   "opset_version": 6,
-  "generated_checksum": "22ca557bdecd4236397499b32ebd8ab1cfac650cbb1c8506d9ef722b4bf497df"
+  "generated_checksum": "305873fba14b6a1b06afa6cb42d97f84ccd03f35f62b28f7c0b4f304175a97f0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_PReLU_3d__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_PReLU_3d__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 2 in testbench data",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_PReLU_3d/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_PReLU_3d/test_data_set_0",
   "operators": [
     "PRelu"
   ],
   "opset_version": 6,
-  "generated_checksum": "3da7e4c6c7372579151cbadb784bbc80390bffbed8b1826dac630429e95eeb4c"
+  "generated_checksum": "99456b84a1a1b1392a8dd898b04408765847a4400f35f840bef8d5632a9f6baf"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-operator__test_operator_conv__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-operator__test_operator_conv__model.onnx.json
@@ -5,5 +5,5 @@
     "Conv"
   ],
   "opset_version": 6,
-  "generated_checksum": "dd7ecdc7539853199d15e2d87496036936f547254e670343523f7ef5404d5458"
+  "generated_checksum": "8d9437ab100eccc5ffc6f4f3fe9cd63a4469405fc90c786b6a6262b1b46c4028"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-operator__test_operator_convtranspose__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-operator__test_operator_convtranspose__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 2 in testbench data",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_convtranspose/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_convtranspose/test_data_set_0",
   "operators": [
     "ConvTranspose"
   ],
   "opset_version": 6,
-  "generated_checksum": "f9a10c4c4b6bc80c84d20ad88b146ae50178f38fbbace459a5e9c8199d938fd9"
+  "generated_checksum": "cd30f8ebc82a63e2c9d060c4a4b340d1271f5a5e7f8ed00e9bd2a8acd522d67f"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-operator__test_operator_non_float_params__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-operator__test_operator_non_float_params__model.onnx.json
@@ -1,10 +1,10 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_non_float_params/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_non_float_params/test_data_set_0",
   "operators": [
     "Add",
     "Mul"
   ],
   "opset_version": 6,
-  "generated_checksum": "94139cd554b71e5734806d447ff703829c190d39df0a12c5b090050c29ff5dec"
+  "generated_checksum": "b175a792b706a1aa2dd8f46f60e4b80c40eb816295c3ea0a81347cddebd450ff"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-operator__test_operator_params__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-operator__test_operator_params__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Missing output 6 in testbench data",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_params/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_params/test_data_set_0",
   "operators": [
     "Add",
@@ -9,5 +9,5 @@
     "Neg"
   ],
   "opset_version": 6,
-  "generated_checksum": "6fdc620c93914279c98add0f0dad17334f26f025d12b4f588801580cb1fd83a9"
+  "generated_checksum": "bc59ddd307c5b904e9d8b64c82fad1e04396bd0928438cfb409a7b745b33b8a8"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-operator__test_operator_pow__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-operator__test_operator_pow__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 0)",
+  "error": "OK (max ULP 1)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_pow/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_pow/test_data_set_0",
   "operators": [
     "Pow"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-operator__test_operator_symbolic_override__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-operator__test_operator_symbolic_override__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Missing output 3 in testbench data",
+  "error": "Out of tolerance (max ULP 5380)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_symbolic_override/model.onnx --cc /usr/bin/cc --test-data-dir onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_symbolic_override/test_data_set_0",
   "operators": [
     "InstanceNormalization"
   ],
   "opset_version": 6,
-  "generated_checksum": "ae6eccca2678fef3f8f329eedcb41e068f9e676a23ff635b1d05180ae27375c3"
+  "generated_checksum": "a6001721d04495402e89acd6a91802d1ee29584b8c135f8b29176f19a61dcde9"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-operator__test_operator_symbolic_override_nested__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-operator__test_operator_symbolic_override_nested__model.onnx.json
@@ -6,5 +6,5 @@
     "Neg"
   ],
   "opset_version": 6,
-  "generated_checksum": "ae00ce5dff924786a4b5e1c96019ec5b80e45196f5c0f4cc32e5aa234746a3f2"
+  "generated_checksum": "201e5cafc3334c878e6b3bf648e91ed2b0ec24dbdddb131fa07ecd66a477444e"
 }

--- a/tests/expected_errors/onnx2c-org__test__local_ops__test_matmul_2x3x4x5_5__model.onnx.json
+++ b/tests/expected_errors/onnx2c-org__test__local_ops__test_matmul_2x3x4x5_5__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 2)",
+  "error": "OK (max ULP 1)",
   "command_line": "verify onnx2c-org/test/local_ops/test_matmul_2x3x4x5_5/model.onnx --cc /usr/bin/cc --test-data-dir onnx2c-org/test/local_ops/test_matmul_2x3x4x5_5/test_data_set_0",
   "operators": [
     "MatMul"

--- a/tests/expected_errors/onnx2c-org__test__local_ops__test_matmul_3_2x3x4__model.onnx.json
+++ b/tests/expected_errors/onnx2c-org__test__local_ops__test_matmul_3_2x3x4__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 0)",
+  "error": "OK (max ULP 1)",
   "command_line": "verify onnx2c-org/test/local_ops/test_matmul_3_2x3x4/model.onnx --cc /usr/bin/cc --test-data-dir onnx2c-org/test/local_ops/test_matmul_3_2x3x4/test_data_set_0",
   "operators": [
     "MatMul"

--- a/tests/expected_errors/onnx2c-org__test__local_ops__test_matmul_3_3x4__model.onnx.json
+++ b/tests/expected_errors/onnx2c-org__test__local_ops__test_matmul_3_3x4__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "OK (max ULP 0)",
+  "error": "OK (max ULP 1)",
   "command_line": "verify onnx2c-org/test/local_ops/test_matmul_3_3x4/model.onnx --cc /usr/bin/cc --test-data-dir onnx2c-org/test/local_ops/test_matmul_3_3x4/test_data_set_0",
   "operators": [
     "MatMul"


### PR DESCRIPTION
### Motivation
- Keep golden references and documentation in sync with latest verification run after regenerating expectations for official ONNX files and local test models.
- Ensure `OFFICIAL_ONNX_FILE_SUPPORT.md`, the error histogram, and operator support summary reflect current verification outcomes.
- Capture updated checksums and ULP/error messages for many ONNX backend, PyTorch-converted, and onnx2c test models so CI remains deterministic.

### Description
- Regenerated reference artifacts and updated `OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`, and `SUPPORT_OPS.md` to reflect new verification results and counts.
- Updated numerous `tests/expected_errors/*.json` snapshots with revised `error` strings, `generated_checksum` values, and ULP metrics for ONNX backend, PyTorch-converted, and onnx2c test models (many files under `tests/expected_errors/` were modified).
- Adjusted supported operator tally from the verification run (summary numbers in `SUPPORT_OPS.md`).
- Staged and committed the refreshed reference files (82 files changed in the update commit).

### Testing
- Ran the reference refresh and full test verification with `UPDATE_REFS=1 pytest -n auto -q --maxfail=10` which completed successfully in about `232.25s`.
- Result: `2151 passed, 1 skipped, 7 warnings` indicating the updated references match current test outputs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69742a6102bc83259ccc132d1ea8c97a)