### PR TITLE
cli: rename --large-temp-threshold-bytes to --large-temp-threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Options:
 - `--emit-testbench`: Emit a JSON-producing `main()` testbench for validation.
 - `--emit-data-file`: Emit constant data arrays into a companion `_data` C file.
 - `--large-weight-threshold`: Store weights larger than this element count in a binary file (default: `1048576`; set to `0` to disable).
-- `--large-temp-threshold-bytes`: Mark temporary buffers larger than this threshold as static (default: `1024`).
+- `--large-temp-threshold`: Mark temporary buffers larger than this threshold as static (default: `1024`).
 - `--no-restrict-arrays`: Disable `restrict` qualifiers on generated array parameters.
 
 ### `verify`
@@ -100,7 +100,7 @@ Options:
 - `--model-name`: Override the generated model name (default: model file stem).
 - `--cc`: Explicit C compiler command for building the testbench binary.
 - `--large-weight-threshold`: Store weights larger than this element count in a binary file (default: `1024`).
-- `--large-temp-threshold-bytes`: Mark temporary buffers larger than this threshold as static (default: `1024`).
+- `--large-temp-threshold`: Mark temporary buffers larger than this threshold as static (default: `1024`).
 - `--max-ulp`: Maximum allowed ULP distance for floating outputs (default: `100`).
 - `--runtime`: Runtime backend for verification (`onnxruntime` or `onnx-reference`, default: `onnx-reference`).
 - `--temp-dir`: Directory in which to create temporary verification files (default: system temp dir).

--- a/src/emx_onnx_cgen/cli.py
+++ b/src/emx_onnx_cgen/cli.py
@@ -171,9 +171,10 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     compile_parser.add_argument(
-        "--large-temp-threshold-bytes",
+        "--large-temp-threshold",
         type=int,
         default=1024,
+        dest="large_temp_threshold_bytes",
         help=(
             "Mark temporary buffers larger than this threshold as static "
             "(default: 1024)"
@@ -217,9 +218,10 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     verify_parser.add_argument(
-        "--large-temp-threshold-bytes",
+        "--large-temp-threshold",
         type=int,
         default=1024,
+        dest="large_temp_threshold_bytes",
         help=(
             "Mark temporary buffers larger than this threshold as static "
             "(default: 1024)"


### PR DESCRIPTION
### Motivation
- Rename the CLI flag to a shorter, clearer name so users pass `--large-temp-threshold` instead of `--large-temp-threshold-bytes` while preserving existing internal option behavior.

### Description
- Replace occurrences of `--large-temp-threshold-bytes` with `--large-temp-threshold` for both `compile` and `verify` subcommands in `src/emx_onnx_cgen/cli.py` and update the README accordingly, keeping the internal destination as `large_temp_threshold_bytes` to maintain backward-compatible variable usage.

### Testing
- Ran the targeted test suite with `pytest -q tests/test_cli.py` which completed successfully with `2 passed` in `8.84s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69749a212fe8832587df8515008bfda0)