### PR TITLE
codegen: add forward declaration for generated weight loader helper

### DIFF
--- a/src/emx_onnx_cgen/codegen/c_emitter.py
+++ b/src/emx_onnx_cgen/codegen/c_emitter.py
@@ -11504,12 +11504,16 @@ class CEmitter:
     def _emit_weight_loader(
         self, model: LoweredModel, large_constants: tuple[ConstTensor, ...]
     ) -> str:
-        lines = [f"_Bool {model.name}_load(const char *path) {{"]
+        lines = []
         if not large_constants:
+            lines.append(f"_Bool {model.name}_load(const char *path) {{")
             lines.append("    (void)path;")
             lines.append("    return 1;")
             lines.append("}")
             return _format_c_indentation("\n".join(lines))
+        lines.append(f"static _Bool {model.name}_load_file(FILE *file);")
+        lines.append("")
+        lines.append(f"_Bool {model.name}_load(const char *path) {{")
         lines.append("    FILE *file = fopen(path, \"rb\");")
         lines.append("    if (!file) {")
         lines.append("        return 0;")

--- a/tests/golden/large_weight_model_testbench.c
+++ b/tests/golden/large_weight_model_testbench.c
@@ -66,6 +66,8 @@ static inline void node0_add(const float input0[2][3], const float input1[2][3],
     }
 }
 
+static _Bool large_weight_model_load_file(FILE *file);
+
 _Bool large_weight_model_load(const char *path) {
     FILE *file = fopen(path, "rb");
     if (!file) {


### PR DESCRIPTION
### Motivation
- Avoid implicit C declarations and potential compile errors when the generated `_load_file` helper is defined after the public `model_load` function by emitting an explicit forward declaration.

### Description
- Emit a `static _Bool <model>_load_file(FILE *file);` forward declaration from the C emitter and adjust the `model_load` emission so the helper can be defined later; update the large-weight golden C test file to include the new forward declaration.

### Testing
- Ran the targeted golden test `pytest tests/test_golden.py::test_codegen_golden_large_weight_loader -q` which passed (`1 passed in 2.51s`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6974af02bfb08325b67b6b075e1bf680)