### PR TITLE
cli: clarify temp dir deletion message to indicate --keep-temp-dir not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Options:
 - `--max-ulp`: Maximum allowed ULP distance for floating outputs (default: `100`).
 - `--runtime`: Runtime backend for verification (`onnxruntime` or `onnx-reference`, default: `onnx-reference`).
 - `--temp-dir`: Directory in which to create temporary verification files (default: system temp dir).
+- `--keep-temp-dir`: Keep the temporary verification directory instead of deleting it.
 
 How verification works:
 


### PR DESCRIPTION
### Motivation
- Make the verification cleanup log unambiguous by indicating when the temporary folder is being deleted because `--keep-temp-dir` was not set.

### Description
- Update `src/emx_onnx_cgen/cli.py` to annotate the deletion step message with the temp path and ` [--keep-temp-dir not set]` when the directory is removed.

### Testing
- Ran `pytest tests/test_cli.py` which passed (`2 passed`) in `4.51s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6974de59d6408325834bb4b4b62805af)