### PR TITLE
cli: split verify temp directory options

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ Options:
 - `--large-temp-threshold`: Mark temporary buffers larger than this threshold as static (default: `1024`).
 - `--max-ulp`: Maximum allowed ULP distance for floating outputs (default: `100`).
 - `--runtime`: Runtime backend for verification (`onnxruntime` or `onnx-reference`, default: `onnx-reference`).
-- `--temp-dir`: Directory in which to create temporary verification files (default: system temp dir).
+- `--temp-dir-root`: Root directory in which to create a temporary verification directory (default: system temp dir).
+- `--temp-dir`: Exact directory to use for temporary verification files (default: create a temporary directory).
 - `--keep-temp-dir`: Keep the temporary verification directory instead of deleting it.
 
 How verification works:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,7 +36,7 @@ def _run_cli_verify(model: onnx.ModelProto) -> None:
                 "emx_onnx_cgen",
                 "verify",
                 str(model_path),
-                "--temp-dir",
+                "--temp-dir-root",
                 str(temp_dir),
             ],
             check=True,


### PR DESCRIPTION
### Motivation
- Give callers fine-grained control over verification temp locations by separating the notion of a root for temporary directories from an explicit temp directory to use. 
- Avoid ambiguous behavior where a single `--temp-dir` flag served both as a root and as the exact temp directory. 
- Make cleanup behavior clearer when an explicit directory is created or when `--keep-temp-dir` is used.

### Description
- Add a new CLI option `--temp-dir-root` while keeping `--temp-dir` as the explicit directory option, and update the `verify` parser help text in `src/emx_onnx_cgen/cli.py` and `README.md`.
- Enforce mutual exclusion between `--temp-dir-root` and `--temp-dir` and validate that supplied paths are directories in `_verify_model`.
- When `--temp-dir` is provided, use it as the exact temp directory and create it if missing; if the directory was created by the tool it will be deleted unless `--keep-temp-dir` is set.
- Preserve existing behavior for creating a temporary directory under a provided `--temp-dir-root` and for `--keep-temp-dir` (keeps the folder when a temporary one was used).
- Update the CLI test to pass `--temp-dir-root` and adjust cleanup/creation logic in `tests/test_cli.py`.

### Testing
- Ran the focused CLI tests: `pytest tests/test_cli.py -q`, which passed: `2 passed in 4.55s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6974e8eab664832580c88312c9fb02f9)