### PR TITLE
codegen: read testbench inputs elementwise

### DIFF
--- a/src/emx_onnx_cgen/templates/testbench.c.j2
+++ b/src/emx_onnx_cgen/templates/testbench.c.j2
@@ -39,7 +39,15 @@ static const {{ input.c_type }} {{ input.constant_name }}[] = {
 {% endif %}
 {% endfor %}
 
-int main(void) {
+int main(int argc, char **argv) {
+    FILE *input_file = NULL;
+    if (argc > 1) {
+        input_file = fopen(argv[1], "rb");
+        if (!input_file) {
+            fprintf(stderr, "Failed to open input file: %s\n", argv[1]);
+            return 1;
+        }
+    }
 {% for dim in dim_args %}
     int {{ dim.name }} = {{ dim.value }};
 {% endfor %}
@@ -59,9 +67,18 @@ int main(void) {
 {% endfor %}
 {% endif %}
 {% else %}
-{% if input.rank == 0 %}
-    {{ input.name }} = {{ input.random_expr }};
-{% else %}
+    if (input_file) {
+{% for depth in range(input.rank) %}
+    for (idx_t {{ input.loop_vars[depth] }} = 0; {{ input.loop_vars[depth] }} < {{ input.shape[depth] }}; ++{{ input.loop_vars[depth] }}) {
+{% endfor %}
+        if (fread(&{{ input.name }}{{ input.array_index_expr }}, sizeof({{ input.c_type }}), 1, input_file) != 1) {
+            fprintf(stderr, "Failed to read input {{ input.json_name }}\n");
+            return 1;
+        }
+{% for depth in range(input.rank - 1, -1, -1) %}
+    }
+{% endfor %}
+    } else {
 {% for depth in range(input.rank) %}
     for (idx_t {{ input.loop_vars[depth] }} = 0; {{ input.loop_vars[depth] }} < {{ input.shape[depth] }}; ++{{ input.loop_vars[depth] }}) {
 {% endfor %}
@@ -69,9 +86,12 @@ int main(void) {
 {% for depth in range(input.rank - 1, -1, -1) %}
     }
 {% endfor %}
-{% endif %}
+    }
 {% endif %}
 {% endfor %}
+    if (input_file) {
+        fclose(input_file);
+    }
 
 {% for output in outputs %}
     {{ output.c_type }} {{ output.name }}{{ output.array_suffix }};

--- a/tests/golden/add_model_testbench.c
+++ b/tests/golden/add_model_testbench.c
@@ -84,23 +84,60 @@ static float rng_next_float(void) {
 
 
 
-int main(void) {
+int main(int argc, char **argv) {
+    FILE *input_file = NULL;
+    if (argc > 1) {
+        input_file = fopen(argv[1], "rb");
+        if (!input_file) {
+            fprintf(stderr, "Failed to open input file: %s\n", argv[1]);
+            return 1;
+        }
+    }
 
     float a[2][3][4];
-    for (idx_t i0 = 0; i0 < 2; ++i0) {
-        for (idx_t i1 = 0; i1 < 3; ++i1) {
-            for (idx_t i2 = 0; i2 < 4; ++i2) {
-                a[i0][i1][i2] = rng_next_float();
+    if (input_file) {
+        for (idx_t i0 = 0; i0 < 2; ++i0) {
+            for (idx_t i1 = 0; i1 < 3; ++i1) {
+                for (idx_t i2 = 0; i2 < 4; ++i2) {
+                    if (fread(&a[i0][i1][i2], sizeof(float), 1, input_file) != 1) {
+                        fprintf(stderr, "Failed to read input a\n");
+                        return 1;
+                    }
+                }
+            }
+        }
+    } else {
+        for (idx_t i0 = 0; i0 < 2; ++i0) {
+            for (idx_t i1 = 0; i1 < 3; ++i1) {
+                for (idx_t i2 = 0; i2 < 4; ++i2) {
+                    a[i0][i1][i2] = rng_next_float();
+                }
             }
         }
     }
     float b[2][3][4];
-    for (idx_t i0 = 0; i0 < 2; ++i0) {
-        for (idx_t i1 = 0; i1 < 3; ++i1) {
-            for (idx_t i2 = 0; i2 < 4; ++i2) {
-                b[i0][i1][i2] = rng_next_float();
+    if (input_file) {
+        for (idx_t i0 = 0; i0 < 2; ++i0) {
+            for (idx_t i1 = 0; i1 < 3; ++i1) {
+                for (idx_t i2 = 0; i2 < 4; ++i2) {
+                    if (fread(&b[i0][i1][i2], sizeof(float), 1, input_file) != 1) {
+                        fprintf(stderr, "Failed to read input b\n");
+                        return 1;
+                    }
+                }
             }
         }
+    } else {
+        for (idx_t i0 = 0; i0 < 2; ++i0) {
+            for (idx_t i1 = 0; i1 < 3; ++i1) {
+                for (idx_t i2 = 0; i2 < 4; ++i2) {
+                    b[i0][i1][i2] = rng_next_float();
+                }
+            }
+        }
+    }
+    if (input_file) {
+        fclose(input_file);
     }
 
     float out[2][3][4];

--- a/tests/golden/large_weight_model_testbench.c
+++ b/tests/golden/large_weight_model_testbench.c
@@ -111,13 +111,35 @@ static float rng_next_float(void) {
 
 
 
-int main(void) {
+int main(int argc, char **argv) {
+    FILE *input_file = NULL;
+    if (argc > 1) {
+        input_file = fopen(argv[1], "rb");
+        if (!input_file) {
+            fprintf(stderr, "Failed to open input file: %s\n", argv[1]);
+            return 1;
+        }
+    }
 
     float in0[2][3];
-    for (idx_t i0 = 0; i0 < 2; ++i0) {
-        for (idx_t i1 = 0; i1 < 3; ++i1) {
-            in0[i0][i1] = rng_next_float();
+    if (input_file) {
+        for (idx_t i0 = 0; i0 < 2; ++i0) {
+            for (idx_t i1 = 0; i1 < 3; ++i1) {
+                if (fread(&in0[i0][i1], sizeof(float), 1, input_file) != 1) {
+                    fprintf(stderr, "Failed to read input in0\n");
+                    return 1;
+                }
+            }
         }
+    } else {
+        for (idx_t i0 = 0; i0 < 2; ++i0) {
+            for (idx_t i1 = 0; i1 < 3; ++i1) {
+                in0[i0][i1] = rng_next_float();
+            }
+        }
+    }
+    if (input_file) {
+        fclose(input_file);
     }
 
     float out[2][3];


### PR DESCRIPTION
### Motivation
- Enable deterministic testbench runs by allowing input tensors to be loaded from a binary file rather than always using RNG values.
- Implement the reviewer request to perform `fread` per element (matching how weights are loaded) to avoid block reads and ensure consistent I/O semantics.
- Preserve previous RNG fallback when no input file is provided.

### Description
- Change the testbench template to `int main(int argc, char **argv)` and open `argv[1]` as a binary `FILE *` when provided.
- For each input tensor, emit nested loops over its shape and call `fread(&<elem>, sizeof(<ctype>), 1, input_file)` per element, returning an error on I/O failure.
- Preserve the random-fill fallback (`rng_next_*`) when no input file is supplied and close the file after reading.
- Refresh golden outputs to reflect the elementwise read behavior in `tests/golden/*_testbench.c`.

### Testing
- Ran the targeted golden tests with reference refresh: `UPDATE_REFS=1 pytest -n auto -q tests/test_golden.py::test_codegen_golden_large_weight_loader tests/test_golden.py::test_codegen_includes_testbench`, which passed (2 passed) in ~4.88s.
- Updated golden fixtures to match the new emitted testbench code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69766f44573c832589d6581f7ab53b7a)