### PR TITLE
verify: feed binary testbench inputs and stop inlining input arrays

### DIFF
--- a/src/emx_onnx_cgen/compiler.py
+++ b/src/emx_onnx_cgen/compiler.py
@@ -308,7 +308,6 @@ class Compiler:
                 "Testbench inputs include unknown inputs: "
                 + ", ".join(unknown_inputs)
             )
-        resolved: dict[str, tuple[float | int | bool, ...]] = {}
         for name, values in self._options.testbench_inputs.items():
             if not isinstance(values, np.ndarray):
                 raise CodegenError(
@@ -325,9 +324,7 @@ class Compiler:
                     "Testbench input "
                     f"{name} has {array.size} elements, expected {expected_count}"
                 )
-            array = array.reshape(expected_shape)
-            resolved[name] = tuple(array.ravel().tolist())
-        return resolved
+        return None
 
     def _concretize_graph_shapes(
         self, model: onnx.ModelProto, graph: Graph

--- a/src/emx_onnx_cgen/templates/testbench.c.j2
+++ b/src/emx_onnx_cgen/templates/testbench.c.j2
@@ -39,7 +39,15 @@ static const {{ input.c_type }} {{ input.constant_name }}[] = {
 {% endif %}
 {% endfor %}
 
-int main(void) {
+int main(int argc, char **argv) {
+    FILE *input_file = NULL;
+    if (argc > 1) {
+        input_file = fopen(argv[1], "rb");
+        if (!input_file) {
+            fprintf(stderr, "Failed to open input file: %s\n", argv[1]);
+            return 1;
+        }
+    }
 {% for dim in dim_args %}
     int {{ dim.name }} = {{ dim.value }};
 {% endfor %}
@@ -59,9 +67,18 @@ int main(void) {
 {% endfor %}
 {% endif %}
 {% else %}
-{% if input.rank == 0 %}
-    {{ input.name }} = {{ input.random_expr }};
-{% else %}
+    if (input_file) {
+{% for depth in range(input.rank) %}
+    for (idx_t {{ input.loop_vars[depth] }} = 0; {{ input.loop_vars[depth] }} < {{ input.shape[depth] }}; ++{{ input.loop_vars[depth] }}) {
+{% endfor %}
+        if (fread(&{{ input.name }}{{ input.array_index_expr }}, sizeof({{ input.c_type }}), 1, input_file) != 1) {
+            fprintf(stderr, "Failed to read input {{ input.json_name }}\n");
+            return 1;
+        }
+{% for depth in range(input.rank - 1, -1, -1) %}
+    }
+{% endfor %}
+    } else {
 {% for depth in range(input.rank) %}
     for (idx_t {{ input.loop_vars[depth] }} = 0; {{ input.loop_vars[depth] }} < {{ input.shape[depth] }}; ++{{ input.loop_vars[depth] }}) {
 {% endfor %}
@@ -69,9 +86,12 @@ int main(void) {
 {% for depth in range(input.rank - 1, -1, -1) %}
     }
 {% endfor %}
-{% endif %}
+    }
 {% endif %}
 {% endfor %}
+    if (input_file) {
+        fclose(input_file);
+    }
 
 {% for output in outputs %}
     {{ output.c_type }} {{ output.name }}{{ output.array_suffix }};

--- a/tests/golden/add_model_testbench.c
+++ b/tests/golden/add_model_testbench.c
@@ -84,23 +84,60 @@ static float rng_next_float(void) {
 
 
 
-int main(void) {
+int main(int argc, char **argv) {
+    FILE *input_file = NULL;
+    if (argc > 1) {
+        input_file = fopen(argv[1], "rb");
+        if (!input_file) {
+            fprintf(stderr, "Failed to open input file: %s\n", argv[1]);
+            return 1;
+        }
+    }
 
     float a[2][3][4];
-    for (idx_t i0 = 0; i0 < 2; ++i0) {
-        for (idx_t i1 = 0; i1 < 3; ++i1) {
-            for (idx_t i2 = 0; i2 < 4; ++i2) {
-                a[i0][i1][i2] = rng_next_float();
+    if (input_file) {
+        for (idx_t i0 = 0; i0 < 2; ++i0) {
+            for (idx_t i1 = 0; i1 < 3; ++i1) {
+                for (idx_t i2 = 0; i2 < 4; ++i2) {
+                    if (fread(&a[i0][i1][i2], sizeof(float), 1, input_file) != 1) {
+                        fprintf(stderr, "Failed to read input a\n");
+                        return 1;
+                    }
+                }
+            }
+        }
+    } else {
+        for (idx_t i0 = 0; i0 < 2; ++i0) {
+            for (idx_t i1 = 0; i1 < 3; ++i1) {
+                for (idx_t i2 = 0; i2 < 4; ++i2) {
+                    a[i0][i1][i2] = rng_next_float();
+                }
             }
         }
     }
     float b[2][3][4];
-    for (idx_t i0 = 0; i0 < 2; ++i0) {
-        for (idx_t i1 = 0; i1 < 3; ++i1) {
-            for (idx_t i2 = 0; i2 < 4; ++i2) {
-                b[i0][i1][i2] = rng_next_float();
+    if (input_file) {
+        for (idx_t i0 = 0; i0 < 2; ++i0) {
+            for (idx_t i1 = 0; i1 < 3; ++i1) {
+                for (idx_t i2 = 0; i2 < 4; ++i2) {
+                    if (fread(&b[i0][i1][i2], sizeof(float), 1, input_file) != 1) {
+                        fprintf(stderr, "Failed to read input b\n");
+                        return 1;
+                    }
+                }
             }
         }
+    } else {
+        for (idx_t i0 = 0; i0 < 2; ++i0) {
+            for (idx_t i1 = 0; i1 < 3; ++i1) {
+                for (idx_t i2 = 0; i2 < 4; ++i2) {
+                    b[i0][i1][i2] = rng_next_float();
+                }
+            }
+        }
+    }
+    if (input_file) {
+        fclose(input_file);
     }
 
     float out[2][3][4];

--- a/tests/golden/large_weight_model_testbench.c
+++ b/tests/golden/large_weight_model_testbench.c
@@ -111,13 +111,35 @@ static float rng_next_float(void) {
 
 
 
-int main(void) {
+int main(int argc, char **argv) {
+    FILE *input_file = NULL;
+    if (argc > 1) {
+        input_file = fopen(argv[1], "rb");
+        if (!input_file) {
+            fprintf(stderr, "Failed to open input file: %s\n", argv[1]);
+            return 1;
+        }
+    }
 
     float in0[2][3];
-    for (idx_t i0 = 0; i0 < 2; ++i0) {
-        for (idx_t i1 = 0; i1 < 3; ++i1) {
-            in0[i0][i1] = rng_next_float();
+    if (input_file) {
+        for (idx_t i0 = 0; i0 < 2; ++i0) {
+            for (idx_t i1 = 0; i1 < 3; ++i1) {
+                if (fread(&in0[i0][i1], sizeof(float), 1, input_file) != 1) {
+                    fprintf(stderr, "Failed to read input in0\n");
+                    return 1;
+                }
+            }
         }
+    } else {
+        for (idx_t i0 = 0; i0 < 2; ++i0) {
+            for (idx_t i1 = 0; i1 < 3; ++i1) {
+                in0[i0][i1] = rng_next_float();
+            }
+        }
+    }
+    if (input_file) {
+        fclose(input_file);
     }
 
     float out[2][3];


### PR DESCRIPTION
### Motivation

- Make verification deterministic by feeding testbench inputs via a binary file instead of embedding them into generated C sources.
- Avoid embedding non-random input data in emitted code so verification uses the same input path as external tooling and stays consistent with weight loading semantics.
- Ensure the C testbench reads inputs elementwise (matching weight loads) and falls back to RNG when no input file is provided.

### Description

- Stop producing inlined testbench input arrays by changing `Compiler._resolve_testbench_inputs` to not return resolved constant arrays so codegen no longer emits static input data.
- Write provided testbench inputs to a binary file inside the verification temporary folder in `_verify_model` (CLI), and pass the binary path as an argument to the generated testbench executable.
- Update the testbench template (`testbench.c.j2`) to accept `argc/argv`, open the provided file, `fread` each element into the input tensors, and fall back to RNG when no file is supplied; the file is closed after reading.
- Update tests to supply inputs via binary files and update assertions to ensure input data is not embedded in generated C (changes in `tests/test_endtoend_features.py` and `tests/test_ops.py`).

### Testing

- Ran targeted verification tests with: `pytest -n auto -q tests/test_endtoend_features.py::test_testbench_accepts_constant_inputs tests/test_ops.py::test_operator_c_testbench_matches_onnxruntime`, which completed successfully with all tests passing (40 passed) and 1 warning in ~6.94s.
- Confirmed the modified tests that write binary input files pass locally and that generated C no longer contains `static const ... _testbench_data` in the constant-input case.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69766f44573c832589d6581f7ab53b7a)