### PR TITLE
cli: remove unused error/success fields from CliResult

### DIFF
--- a/src/emx_onnx_cgen/cli.py
+++ b/src/emx_onnx_cgen/cli.py
@@ -38,8 +38,7 @@ LOGGER = logging.getLogger(__name__)
 class CliResult:
     exit_code: int
     command_line: str
-    error: str | None = None
-    success_message: str | None = None
+    result: str | None = None
     generated: str | None = None
     data_source: str | None = None
     operators: list[str] | None = None
@@ -176,8 +175,7 @@ def run_cli_command(
             return CliResult(
                 exit_code=0 if error is None else 1,
                 command_line=args.command_line,
-                error=error,
-                success_message=success_message,
+                result=error or success_message,
                 operators=operators,
                 opset_version=opset_version,
                 generated_checksum=generated_checksum,
@@ -189,12 +187,12 @@ def run_cli_command(
             return CliResult(
                 exit_code=1,
                 command_line=args.command_line,
-                error=error,
+                result=error,
             )
         return CliResult(
             exit_code=0,
             command_line=args.command_line,
-            success_message="",
+            result="",
             generated=generated,
             data_source=data_source,
         )
@@ -203,7 +201,7 @@ def run_cli_command(
         return CliResult(
             exit_code=1,
             command_line=args.command_line,
-            error=str(exc),
+            result=str(exc),
         )
 
 

--- a/tests/test_official_onnx_files.py
+++ b/tests/test_official_onnx_files.py
@@ -347,9 +347,9 @@ def _run_expected_error_test(
     cli_result = cli.run_cli_command(verify_args)
 
     if cli_result.exit_code != 0:
-        actual_error = cli_result.error or "ERROR UNKNOWN"
+        actual_error = cli_result.result or "ERROR UNKNOWN"
     else:
-        actual_error = cli_result.success_message or "OK UNKNOWN"
+        actual_error = cli_result.result or "OK UNKNOWN"
 
     if actual_error == "CHECKSUM":
         actual_error = expected_error


### PR DESCRIPTION
### Motivation
- Remove the redundant `error` and `success_message` fields from `CliResult` because the single `result` field is now the authoritative CLI outcome.

### Description
- Drop the `error` and `success_message` dataclass fields and update all `CliResult` construction sites in `run_cli_command` to populate only `result` (and other retained metadata) for verify/compile/exception paths.

### Testing
- Ran the targeted test `pytest -q tests/test_cli.py -k verify_operator_model` which passed (`1 passed, 1 deselected`) in 2.90s.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69771532aa548325af0ad54609846b7d)