### PR TITLE
cli: avoid absolute compiler path in verify compile command

### DIFF
--- a/src/emx_onnx_cgen/cli.py
+++ b/src/emx_onnx_cgen/cli.py
@@ -538,9 +538,8 @@ def _resolve_compiler(cc: str | None, prefer_ccache: bool = False) -> list[str] 
     if env_cc:
         return resolve_tokens(shlex.split(env_cc))
     for candidate in ("cc", "gcc", "clang"):
-        resolved = shutil.which(candidate)
-        if resolved:
-            return maybe_prefix_ccache([resolved])
+        if shutil.which(candidate):
+            return maybe_prefix_ccache([candidate])
     return None
 
 


### PR DESCRIPTION
### Motivation
- When the verifier reports the compile command it should show the discovered compiler token (e.g. `gcc`) instead of the absolute executable path so outputs are cleaner and not platform-specific.

### Description
- Modify `_resolve_compiler` in `src/emx_onnx_cgen/cli.py` to return the discovered compiler token (`cc`/`gcc`/`clang`) rather than the absolute path resolved by `shutil.which` when falling back to PATH discovery.

### Testing
- Ran `pytest -n auto -q tests/test_cli.py`, which completed successfully with `2 passed` in ~6.08s.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69774a51725883258cb59c278d22526c)