### PR TITLE
QuantizeLinear: round scaled values before adding zero_point and refresh refs

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1300 / 1802 official ONNX files.
+Support 1302 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -595,7 +595,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_dropout_default_ratio/model.onnx | ❌ | Dropout supports only the data input and 1 or 2 outputs |
 | onnx-org/onnx/backend/test/data/node/test_dropout_random_old/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_dynamicquantizelinear/model.onnx | ❌ | Unsupported op DynamicQuantizeLinear |
-| onnx-org/onnx/backend/test/data/node/test_dynamicquantizelinear_expanded/model.onnx | ❌ | Arrays are not equal  Mismatched elements: 1 / 6 (16.7%) Max absolute difference among violations: 1 Max relative difference among violations: 0.00558659  ACTUAL: array([153, 255,   0,  26, 221, 178], dtype=uint8)  DESIRED: array([153, 255,   0,  26, 221, 179], dtype=uint8) |
+| onnx-org/onnx/backend/test/data/node/test_dynamicquantizelinear_expanded/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_dynamicquantizelinear_max_adjusted/model.onnx | ❌ | Unsupported op DynamicQuantizeLinear |
 | onnx-org/onnx/backend/test/data/node/test_dynamicquantizelinear_max_adjusted_expanded/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_dynamicquantizelinear_min_adjusted/model.onnx | ❌ | Unsupported op DynamicQuantizeLinear |
@@ -1104,7 +1104,7 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/node/test_quantizelinear_int16/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_quantizelinear_int2/model.onnx | ❌ | Unsupported elem_type 26 (INT2) for tensor 'y_zero_point'. |
 | onnx-org/onnx/backend/test/data/node/test_quantizelinear_int4/model.onnx | ❌ | Unsupported elem_type 22 (INT4) for tensor 'y_zero_point'. |
-| onnx-org/onnx/backend/test/data/node/test_quantizelinear_uint16/model.onnx | ❌ | Arrays are not equal  Mismatched elements: 2 / 12 (16.7%) Max absolute difference among violations: 1 Max relative difference among violations: 3.05203723e-05  ACTUAL: array([32767, 32703, 32768, 32766, 32768, 32766, 32769, 32765, 65535,            0, 65535,     0], dtype=uint16)  DESIRED: array([32767, 32703, 32769, 32765, 32768, 32766, 32769, 32765, 65535,            0, 65535,     0], dtype=uint16) |
+| onnx-org/onnx/backend/test/data/node/test_quantizelinear_uint16/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_quantizelinear_uint2/model.onnx | ❌ | Unsupported elem_type 25 (UINT2) for tensor 'y_zero_point'. |
 | onnx-org/onnx/backend/test/data/node/test_quantizelinear_uint4/model.onnx | ❌ | Unsupported elem_type 21 (UINT4) for tensor 'y_zero_point'. |
 | onnx-org/onnx/backend/test/data/node/test_range_float_type_positive_delta/model.onnx | ✅ | OK (max ULP 0) |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -86,24 +86,6 @@ Max relative difference among violations: 5.4
 | 
 Arrays are not equal
 
-Mismatched elements: 1 / 6 (16.7%)
-Max absolute difference among violations: 1
-Max relative difference among violations: 0.00558659
- ACTUAL: array([153, 255,   0,  26, 221, 178], dtype=uint8)
- DESIRED: array([153, 255,   0,  26, 221, 179], dtype=uint8) | 1 | █ |
-| 
-Arrays are not equal
-
-Mismatched elements: 2 / 12 (16.7%)
-Max absolute difference among violations: 1
-Max relative difference among violations: 3.05203723e-05
- ACTUAL: array([32767, 32703, 32768, 32766, 32768, 32766, 32769, 32765, 65535,
-           0, 65535,     0], dtype=uint16)
- DESIRED: array([32767, 32703, 32769, 32765, 32768, 32766, 32769, 32765, 65535,
-           0, 65535,     0], dtype=uint16) | 1 | █ |
-| 
-Arrays are not equal
-
 Mismatched elements: 4 / 12 (33.3%)
 Max absolute difference among violations: 11
 Max relative difference among violations: 0.09401709

--- a/src/emx_onnx_cgen/runtime/evaluator.py
+++ b/src/emx_onnx_cgen/runtime/evaluator.py
@@ -1700,14 +1700,13 @@ def _eval_quantize_linear(evaluator: Evaluator, node: Node) -> None:
     else:
         zero_point = evaluator.values[zero_point_name]
     if spec.axis is None:
-        scaled = data / scale + zero_point
+        scaled = data / scale
+        rounded = np.rint(scaled) + np.asarray(zero_point)
     else:
         shape = [1] * data.ndim
         shape[spec.axis] = scale.shape[0]
-        scaled = data / scale.reshape(shape) + np.asarray(zero_point).reshape(
-            shape
-        )
-    rounded = np.rint(scaled)
+        scaled = data / scale.reshape(shape)
+        rounded = np.rint(scaled) + np.asarray(zero_point).reshape(shape)
     info = np.iinfo(spec.output_dtype.np_dtype)
     clipped = np.clip(rounded, info.min, info.max)
     evaluator.values[node.outputs[0]] = clipped.astype(

--- a/src/emx_onnx_cgen/templates/quantize_linear_op.c.j2
+++ b/src/emx_onnx_cgen/templates/quantize_linear_op.c.j2
@@ -2,8 +2,8 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
 {% for dim in shape %}
 for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
-    {{ compute_type }} scaled = (({{ compute_type }}){{ input_expr }} / ({{ compute_type }}){{ scale_expr }}) + ({{ compute_type }}){{ zero_expr }};
-    {{ compute_type }} rounded = {{ round_fn }}(scaled);
+    {{ compute_type }} scaled = (({{ compute_type }}){{ input_expr }} / ({{ compute_type }}){{ scale_expr }});
+    {{ compute_type }} rounded = {{ round_fn }}(scaled) + ({{ compute_type }}){{ zero_expr }};
     rounded = {{ max_fn }}(rounded, ({{ compute_type }}){{ min_literal }});
     rounded = {{ min_fn }}(rounded, ({{ compute_type }}){{ max_literal }});
     {{ output_expr }} = ({{ output_c_type }})rounded;

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_dynamicquantizelinear_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_dynamicquantizelinear_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "\nArrays are not equal\n\nMismatched elements: 1 / 6 (16.7%)\nMax absolute difference among violations: 1\nMax relative difference among violations: 0.00558659\n ACTUAL: array([153, 255,   0,  26, 221, 178], dtype=uint8)\n DESIRED: array([153, 255,   0,  26, 221, 179], dtype=uint8)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_dynamicquantizelinear_expanded/model.onnx --test-data-dir onnx-org/onnx/backend/test/data/node/test_dynamicquantizelinear_expanded/test_data_set_0",
   "operators": [
     "Constant",
@@ -16,5 +16,5 @@
     "QuantizeLinear"
   ],
   "opset_version": 11,
-  "generated_checksum": "d36048fa9fded7395bcbce9bc453653b835db7a773cdad2ee23b96b71f4d7f28"
+  "generated_checksum": "4c2d1f34b42356623979e39cfa60d33e4cca49512bdbb3c47e5ad5b214a81609"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_dynamicquantizelinear_max_adjusted_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_dynamicquantizelinear_max_adjusted_expanded__model.onnx.json
@@ -16,5 +16,5 @@
     "QuantizeLinear"
   ],
   "opset_version": 11,
-  "generated_checksum": "0c58979377650ba17005b90c7bf9deaea3cd267044f52a2fc009cdebac0f9abd"
+  "generated_checksum": "fc467c6fc5c53414ba0c9aa15d8047a22f560bb921cfc1244910bb58066ece19"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_dynamicquantizelinear_min_adjusted_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_dynamicquantizelinear_min_adjusted_expanded__model.onnx.json
@@ -16,5 +16,5 @@
     "QuantizeLinear"
   ],
   "opset_version": 11,
-  "generated_checksum": "e82e4a0c7fa5b3f0aab5fe1c2541a0e53a2e23a503e327c0da6538c2374cc88b"
+  "generated_checksum": "ec0cca8318704a4c9d15de2f417ff89a5ceda93a84f9e0e867d980124ab51750"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_quantizelinear__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_quantizelinear__model.onnx.json
@@ -5,5 +5,5 @@
     "QuantizeLinear"
   ],
   "opset_version": 25,
-  "generated_checksum": "d2fa79afbc082b54efb9d6c7b6adcbba6e329ef2f4ef7a29a0ccaeb74a75d7b8"
+  "generated_checksum": "b4572891004e42d52e6310381e6c32e626c78703965a0ff0059f6bcc5786e1d3"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_quantizelinear_axis__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_quantizelinear_axis__model.onnx.json
@@ -5,5 +5,5 @@
     "QuantizeLinear"
   ],
   "opset_version": 25,
-  "generated_checksum": "23748356c9476b9a0d6d415f415eabeadad9c7b502b6358125552b634dd5cee0"
+  "generated_checksum": "5ee09b9d4461037259d15c1d1df3990c196ec4a5572c30ba4f3324d8bd9d4ce4"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_quantizelinear_int16__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_quantizelinear_int16__model.onnx.json
@@ -5,5 +5,5 @@
     "QuantizeLinear"
   ],
   "opset_version": 25,
-  "generated_checksum": "ab98d7705a1c879a3d1504b5e4528d3455f160611cf183a2d2bd9a0e73f3b2d4"
+  "generated_checksum": "7ae62d6c86296169ea572775fb0df9d6cea275a06784325fe3c8052d98deb5b0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_quantizelinear_uint16__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_quantizelinear_uint16__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "\nArrays are not equal\n\nMismatched elements: 2 / 12 (16.7%)\nMax absolute difference among violations: 1\nMax relative difference among violations: 3.05203723e-05\n ACTUAL: array([32767, 32703, 32768, 32766, 32768, 32766, 32769, 32765, 65535,\n           0, 65535,     0], dtype=uint16)\n DESIRED: array([32767, 32703, 32769, 32765, 32768, 32766, 32769, 32765, 65535,\n           0, 65535,     0], dtype=uint16)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/node/test_quantizelinear_uint16/model.onnx --test-data-dir onnx-org/onnx/backend/test/data/node/test_quantizelinear_uint16/test_data_set_0",
   "operators": [
     "QuantizeLinear"
   ],
   "opset_version": 25,
-  "generated_checksum": "b5c7f6242b44c249d96b7e0b2e725d7036403b924032b98a5554cbcdaff3f5b3"
+  "generated_checksum": "9013bcd582a4a7b0a75aa9b63440049818f8080dd676a02335f2c3c80ef21d6f"
 }


### PR DESCRIPTION
### Motivation
- Ensure QuantizeLinear matches ONNX semantics by performing rounding on the scaled float values before adding the integer `zero_point`, which fixes off-by-one discrepancies for integer outputs like `uint16`.
- Maintain deterministic, correct codegen and runtime behavior by updating both the evaluator and the emitted C template consistently.

### Description
- Change runtime evaluator `QuantizeLinear` to compute `scaled = data / scale`, then `rounded = rint(scaled) + zero_point` with proper broadcasting handling, before clipping and casting in `src/emx_onnx_cgen/runtime/evaluator.py`.
- Update the C emission template `src/emx_onnx_cgen/templates/quantize_linear_op.c.j2` to perform rounding on the scaled value and then add the `zero_point` in generated code.
- Refresh ONNX verification reference artifacts in `tests/expected_errors/*.json` for affected Quantize/DynamicQuantizeLinear tests and update `OFFICIAL_ONNX_FILE_SUPPORT.md` and `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md` to reflect the new passing status.

### Testing
- Ran the repository test suite with updated references using `UPDATE_REFS=1 pytest -n auto -q --maxfail=10`, which completed in 241.58s and resulted in `2152 passed, 1 skipped, 2 warnings` (success).
- Verified the specific ONNX model `onnx-org/onnx/backend/test/data/node/test_quantizelinear_uint16/model.onnx` as part of the reference update and recorded an OK result in the refreshed expected JSON.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6977499640588325bf65faf82078b029)