### PR TITLE
tests: skip checksums for UPDATE_REFS 2/3

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -121,6 +121,8 @@ export DISABLE_CHECKSUM=1
 ```
 
 When `UPDATE_REFS=1` is set, expected checksums may still be passed if present.
+Set `UPDATE_REFS=2` to skip checksum usage for tests that are already expected
+to fail (non-OK expectations), or `UPDATE_REFS=3` to skip checksums entirely.
 
 ### Full suite
 


### PR DESCRIPTION
### Motivation

- Allow finer control over expected checksum usage when regenerating expectations with `UPDATE_REFS` so failing tests or all tests can skip the checksum check during verification.

### Description

- Add `_update_refs_mode`, `_is_failure_expectation`, and `_should_use_expected_checksum` helpers in `tests/test_official_onnx_files.py` and use them to decide whether to pass `--expected-checksum` to the verifier. 
- Change `_run_expected_error_test` to call ` _should_use_expected_checksum(expectation)` instead of the previous unconditional check. 
- Document the new modes in `DEVELOPMENT.md`, describing `UPDATE_REFS=2` (skip checksums for non-OK expectations) and `UPDATE_REFS=3` (skip checksums entirely).

### Testing

- Ran the targeted test module with `pytest -q tests/test_official_onnx_files.py -n auto`, which completed successfully: `1876 passed in 175.13s`.
- No other automated tests were modified or required for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69774eecde688325bdf446299947778a)