### PR TITLE
runtime: fix ConvTranspose accumulator dtype

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT.md
@@ -1,10 +1,6 @@
 # Official ONNX file support
 
-Support 1304 / 1802 official ONNX files.
-Support 1301 / 1802 official ONNX files.
-Support 1300 / 1802 official ONNX files.
-Support 1306 / 1802 official ONNX files.
-Support 1302 / 1802 official ONNX files.
+Support 1328 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -1713,8 +1709,8 @@ See [`OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`](OFFICIAL_ONNX_FILE_SUPPORT_HISTO
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_no_bias/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_stride/model.onnx | ✅ | OK (max ULP 12) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_stride_padding/model.onnx | ✅ | OK (max ULP 84) |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_ConvTranspose2d/model.onnx | ❌ | Out of tolerance (max ULP 112) |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_ConvTranspose2d_no_bias/model.onnx | ❌ | Out of tolerance (max ULP 128) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_ConvTranspose2d/model.onnx | ✅ | OK (max ULP 16) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_ConvTranspose2d_no_bias/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_ELU/model.onnx | ❌ | Elu only supports alpha=1.0 |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_Embedding/model.onnx | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_Embedding_sparse/model.onnx | ✅ | OK (max ULP 0) |

--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -2,23 +2,22 @@
 
 | Error message | Count | Histogram |
 | --- | --- | --- |
-| Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 36 | ██████████████████████████████ |
-| Out of tolerance | 34 | ████████████████████████████ |
-| Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ███████████████████████████ |
+| Out of tolerance | 37 | ██████████████████████████████ |
+| Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 36 | █████████████████████████████ |
+| Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ██████████████████████████ |
 | Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 22 | ██████████████████ |
-| Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 20 | █████████████████ |
+| Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 20 | ████████████████ |
 | Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 18 | ███████████████ |
 | Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 18 | ███████████████ |
 | Unsupported elem_type 21 (UINT4) for tensor '*'. | 17 | ██████████████ |
 | Unsupported elem_type 22 (INT4) for tensor '*'. | 17 | ██████████████ |
 | Unsupported elem_type 25 (UINT2) for tensor '*'. | 17 | ██████████████ |
 | Unsupported elem_type 26 (INT2) for tensor '*'. | 17 | ██████████████ |
-| Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 14 | ████████████ |
-| Unsupported op ImageDecoder | 9 | ████████ |
-| Dropout supports only the data input and 1 or 2 outputs | 8 | ███████ |
-| tuple index out of range | 8 | ███████ |
+| Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 14 | ███████████ |
+| Unsupported op ImageDecoder | 9 | ███████ |
+| Dropout supports only the data input and 1 or 2 outputs | 8 | ██████ |
+| tuple index out of range | 8 | ██████ |
 | Unsupported op TfIdfVectorizer | 7 | ██████ |
-| AveragePool has unsupported attributes | 6 | █████ |
 | Unsupported elem_type 16 (BFLOAT16) for tensor '*'. | 6 | █████ |
 | Unsupported op CenterCropPad | 6 | █████ |
 | Unsupported op DFT | 6 | █████ |
@@ -45,7 +44,6 @@
 | Unsupported op RandomUniformLike | 3 | ██ |
 | Unsupported op RoiAlign | 3 | ██ |
 | name '*' is not defined | 3 | ██ |
-| AveragePool supports ceil_mode=0 only | 2 | ██ |
 | BatchNormalization must have 5 inputs and 1 output | 2 | ██ |
 | Failed to build testbench. | 2 | ██ |
 | Gelu only supports approximate=none | 2 | ██ |

--- a/SUPPORT_OPS.md
+++ b/SUPPORT_OPS.md
@@ -2,8 +2,7 @@
 
 Operators are marked supported when they appear in an ONNX file with a successful verify result.
 
-Supported operators: 143 / 197
-Supported operators: 143 / 198
+Supported operators: 144 / 198
 
 | Operator | Supported |
 | --- | --- |

--- a/src/emx_onnx_cgen/runtime/evaluator.py
+++ b/src/emx_onnx_cgen/runtime/evaluator.py
@@ -2781,7 +2781,7 @@ def _apply_conv_transpose(
     pad_begin = spec.pads[: spec.spatial_rank]
     group_in_channels = spec.in_channels // spec.group
     group_out_channels = spec.out_channels // spec.group
-    acc_dtype = np.float32 if data.dtype == np.float16 else data.dtype
+    acc_dtype = np.float32 if data.dtype == np.float16 else data.dtype.type
     for n in range(spec.batch):
         for g in range(spec.group):
             oc_base = g * group_out_channels

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_convtranspose_1d__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_convtranspose_1d__model.onnx.json
@@ -5,5 +5,5 @@
     "ConvTranspose"
   ],
   "opset_version": 22,
-  "generated_checksum": "fd858e9ee80e18e5f9f3094c72004edb601ba86e9bcd762ae5a1dae29dc06ca4"
+  "generated_checksum": "55a4ecc11be7aeef8ace3a7ede3b8a4a4e01670426690d2bac7c49db5417e5e6"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_convtranspose_3d__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_convtranspose_3d__model.onnx.json
@@ -5,5 +5,5 @@
     "ConvTranspose"
   ],
   "opset_version": 22,
-  "generated_checksum": "0b4874bb70930c76e520d270d7c23f20ee6445171ec40ab34bf35dc814900149"
+  "generated_checksum": "6f21131dd755a88d5893e2c7198756ce46d6ccd2f2dec0a6372d2b93b11e3fa2"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_convtranspose__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_convtranspose__model.onnx.json
@@ -5,5 +5,5 @@
     "ConvTranspose"
   ],
   "opset_version": 22,
-  "generated_checksum": "fa249b79ab84d902c25e1f0c207400b0fdf0454e409c17f2b1cd8519e14e26b9"
+  "generated_checksum": "276281b5d992393aef9356e825afe673b9f8e607fa4b390641c50505a0d21392"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_convtranspose_autopad_same__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_convtranspose_autopad_same__model.onnx.json
@@ -5,5 +5,5 @@
     "ConvTranspose"
   ],
   "opset_version": 22,
-  "generated_checksum": "96bf461aab477bef5e3b28235bb143b51a0327052d67106cdf586bea83432a53"
+  "generated_checksum": "3af9e5e3585c147a775fb067595ec20a9c8d35fd30a42a153a3d64ab2a9ea64a"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_convtranspose_dilations__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_convtranspose_dilations__model.onnx.json
@@ -5,5 +5,5 @@
     "ConvTranspose"
   ],
   "opset_version": 22,
-  "generated_checksum": "2ed408a99e92ba6a35a3ef0665115deebfb073278dc14dfee60be82cd45acae5"
+  "generated_checksum": "bc09b4bdb2c958371040c2e4f329bc21b2bbc8394e81d7cec2e60ed07b30b666"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_convtranspose_group_2__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_convtranspose_group_2__model.onnx.json
@@ -5,5 +5,5 @@
     "ConvTranspose"
   ],
   "opset_version": 22,
-  "generated_checksum": "add0298f8bbfa45793f496d32abd9bad13f9fb092ee940c0d647372d080fd16f"
+  "generated_checksum": "3245928ea509fca599d5ce44b2071f031e91e25a8419c1cc875839f5618d1295"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_convtranspose_group_2_image_3__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_convtranspose_group_2_image_3__model.onnx.json
@@ -5,5 +5,5 @@
     "ConvTranspose"
   ],
   "opset_version": 22,
-  "generated_checksum": "30741f7e432df548e96be9be62d0a65624083cc9ab76119e73f1cac81e578cd3"
+  "generated_checksum": "b01ca96138472dc39f18ee79a9fac2d4b887c3ff0e3d3511f677423dc071cf65"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_convtranspose_kernel_shape__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_convtranspose_kernel_shape__model.onnx.json
@@ -5,5 +5,5 @@
     "ConvTranspose"
   ],
   "opset_version": 22,
-  "generated_checksum": "db7a5028e6efc13aadd5fbd767bae28f874fa08ef68033e466dd555cea3cb68c"
+  "generated_checksum": "2792d084d901a070f9d800b0f7e1fbda068c57980e05beb6917e5441e48fa29f"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_convtranspose_pad__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_convtranspose_pad__model.onnx.json
@@ -5,5 +5,5 @@
     "ConvTranspose"
   ],
   "opset_version": 22,
-  "generated_checksum": "2f0f61747bad988607399f0ae05c63aa31b0fa210eec03785fff078f746ec89c"
+  "generated_checksum": "7ed6d8ffc49dc97fc51ea122dfe01f7a20ad00e9995b8a00c63faa741d76cc87"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_convtranspose_pads__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_convtranspose_pads__model.onnx.json
@@ -5,5 +5,5 @@
     "ConvTranspose"
   ],
   "opset_version": 22,
-  "generated_checksum": "574be0b9dbea58fb5972f6ce4d0f08b8e3ee003869b11759a56f927f1abdbb7c"
+  "generated_checksum": "d48eba6c49b4de36822d70071b9cbb6d51d64b511109c6bd76d27ea59e7f4c54"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_ConvTranspose2d_no_bias__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_ConvTranspose2d_no_bias__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Out of tolerance (max ULP 128)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify onnx-org/onnx/backend/test/data/pytorch-converted/test_ConvTranspose2d_no_bias/model.onnx --test-data-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_ConvTranspose2d_no_bias/test_data_set_0",
   "operators": [
     "ConvTranspose"
   ],
   "opset_version": 6,
-  "generated_checksum": "d4cb3e8732082c41b9278ab1b73d723c3fa9e16ea5b2da2437ad54d87f7ee301"
+  "generated_checksum": "4a62b66fa60d60563d8be1f730618db6c3181d2af1c1db51e983a5359ba7b2eb"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-operator__test_operator_convtranspose__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-operator__test_operator_convtranspose__model.onnx.json
@@ -5,5 +5,5 @@
     "ConvTranspose"
   ],
   "opset_version": 6,
-  "generated_checksum": "b7fb5b9955336ccd0ef156b584ae74502303710a4efad00b5f09acda53cb4b5a"
+  "generated_checksum": "11d032d500872f5fd161c1099c176b51150059e1597462d14047587af74331e5"
 }


### PR DESCRIPTION
### Motivation
- Resolve a TypeError in the ConvTranspose runtime evaluator where the accumulator was initialized using a non-callable numpy dtype object, causing a failing test during evaluation.

### Description
- Change accumulator dtype selection in `src/emx_onnx_cgen/runtime/evaluator.py` to use `data.dtype.type` so `acc_dtype` is a callable type (e.g. `np.float32`).
- Regenerate ONNX support summaries and updated expected-error/golden references produced by the `UPDATE_REFS=1` test run, touching `OFFICIAL_ONNX_FILE_SUPPORT.md`, `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md`, `SUPPORT_OPS.md`, and several files under `tests/expected_errors/`.

### Testing
- Ran the full test command `UPDATE_REFS=1 pytest -n auto -q --maxfail=10`, which completed in approximately 160.06s and resulted in `2152 passed, 1 skipped, 2 warnings` (all tests passing after the fix).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6977745dbb688325821e68bf99966857)