### PR TITLE
runtime: silence pow/logsum warnings

### DIFF
--- a/src/emx_onnx_cgen/ops.py
+++ b/src/emx_onnx_cgen/ops.py
@@ -554,6 +554,9 @@ def unary_op_symbol(function: ScalarFunction, *, dtype: ScalarType) -> str | Non
 def apply_binary_op(
     op_spec: BinaryOpSpec, left: np.ndarray, right: np.ndarray
 ) -> np.ndarray:
+    if op_spec.apply is np.power:
+        with np.errstate(invalid="ignore", divide="ignore", over="ignore"):
+            return op_spec.apply(left, right)
     return op_spec.apply(left, right)
 
 

--- a/src/emx_onnx_cgen/runtime/evaluator.py
+++ b/src/emx_onnx_cgen/runtime/evaluator.py
@@ -2277,7 +2277,8 @@ def _eval_reduce(evaluator: Evaluator, node: Node) -> None:
     elif reduce_kind == "l2":
         result = np.sqrt(np.sum(value * value, axis=axes, keepdims=keepdims))
     elif reduce_kind == "logsum":
-        result = np.log(np.sum(value, axis=axes, keepdims=keepdims))
+        with np.errstate(invalid="ignore", divide="ignore"):
+            result = np.log(np.sum(value, axis=axes, keepdims=keepdims))
     elif reduce_kind == "logsumexp":
         result = np.log(np.sum(np.exp(value), axis=axes, keepdims=keepdims))
     elif reduce_kind == "sumsquare":


### PR DESCRIPTION
### Motivation
- Reduce noisy NumPy RuntimeWarnings emitted during evaluation of `Pow` and `ReduceLogSum` while preserving existing numeric behavior.

### Description
- Guard `np.power` calls in `apply_binary_op` with `np.errstate(invalid="ignore", divide="ignore", over="ignore")` in `src/emx_onnx_cgen/ops.py` to suppress spurious warnings.
- Wrap the `np.log(np.sum(...))` path for `logsum` in `src/emx_onnx_cgen/runtime/evaluator.py` with `np.errstate(invalid="ignore", divide="ignore")` to silence warnings from invalid/divide during reduction.

### Testing
- Ran targeted tests with `pytest -q tests/test_ops.py -k "Pow or ReduceLogSumAxis1"`, which returned `2 passed, 170 deselected` in `2.80s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697781275004832584346acab410881b)