### PR TITLE
cli: scope --model-base-dir to model and test-data paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ emx-onnx-cgen compile <model.onnx> <output.c> [options]
 
 Options:
 
+- `--model-base-dir`, `-B`: Base directory for resolving the model path (example: `emx-onnx-cgen compile --model-base-dir /data model.onnx out.c`).
 - `--model-name`: Override the generated model name (default: output file stem).
 - `--emit-testbench`: Emit a JSON-producing `main()` testbench for validation.
 - `--emit-data-file`: Emit constant data arrays into a companion `_data` C file.
@@ -97,6 +98,7 @@ emx-onnx-cgen verify <model.onnx> [options]
 
 Options:
 
+- `--model-base-dir`, `-B`: Base directory for resolving the model and test data paths (example: `emx-onnx-cgen verify --model-base-dir /data model.onnx --test-data-dir inputs`).
 - `--model-name`: Override the generated model name (default: model file stem).
 - `--cc`: Explicit C compiler command for building the testbench binary.
 - `--large-weight-threshold`: Store weights in a binary file once the cumulative byte size exceeds this threshold (default: `102400`).
@@ -147,4 +149,3 @@ See [`SUPPORT_OPS.md`](SUPPORT_OPS.md) for operator-level support derived from t
 ## Maintained by
 
 This project is maintained by [emmtrix](https://www.emmtrix.com).
-


### PR DESCRIPTION
### Motivation
- Narrow the previous general-purpose `--base-dir` behavior so only the model input and verification test-data paths are resolved against an explicit base directory.
- Avoid surprising rewrites of output/temp paths while keeping a reproducible way to reference input artifacts from a repository or data bundle.

### Description
- Renamed the CLI option from `--base-dir`/`-B` to `--model-base-dir`/`-B` and updated help text in `src/emx_onnx_cgen/cli.py` and `README.md`.
- Implemented scoped resolution in `_apply_base_dir` so only `model` and `test_data_dir` fields are resolved against the provided base dir and added a validation error message for an invalid base dir.
- Ensure parsed arguments are normalized early by invoking `_apply_base_dir` in both `run_cli_command` and `main` so programmatic and direct CLI entry points behave consistently.
- Updated unit tests in `tests/test_cli.py` to reflect the renamed option and to assert that `output` is not modified while `model` and `test_data_dir` are resolved.

### Testing
- Ran `pytest -q tests/test_cli.py`, which completed successfully with `6 passed` in `6.80s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69785528435483259be8558588d7c8e1)