### PR TITLE
docs: remove histogram column from OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md

### DIFF
--- a/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
+++ b/OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md
@@ -1,87 +1,87 @@
 # Error frequency
 
-| Error message | Count | Histogram |
-| --- | --- | --- |
-| Unsupported elem_type 8 (STRING) for tensor '*'. | 32 | ██████████████████████████████ |
-| Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 28 | ██████████████████████████ |
-| Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 22 | █████████████████████ |
-| Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 20 | ███████████████████ |
-| Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 18 | █████████████████ |
-| Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 18 | █████████████████ |
-| Unsupported elem_type 21 (UINT4) for tensor '*'. | 17 | ████████████████ |
-| Unsupported elem_type 22 (INT4) for tensor '*'. | 17 | ████████████████ |
-| Unsupported elem_type 25 (UINT2) for tensor '*'. | 17 | ████████████████ |
-| Unsupported elem_type 26 (INT2) for tensor '*'. | 17 | ████████████████ |
-| Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 14 | █████████████ |
-| Unsupported op ImageDecoder | 9 | ████████ |
-| Dropout supports only the data input and 1 or 2 outputs | 8 | ████████ |
-| Out of tolerance | 8 | ████████ |
-| Unsupported op TfIdfVectorizer | 7 | ███████ |
-| Unsupported elem_type 16 (BFLOAT16) for tensor '*'. | 6 | ██████ |
-| Unsupported op CenterCropPad | 6 | ██████ |
-| Unsupported op DFT | 6 | ██████ |
-| Unsupported op ScatterElements | 6 | ██████ |
-| Unsupported op Unique | 6 | ██████ |
-| Unsupported op Col2Im | 5 | █████ |
-| Unsupported op If | 5 | █████ |
-| OptionalHasElement expects exactly one non-empty input. | 4 | ████ |
-| Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 4 | ████ |
-| Unsupported op AffineGrid | 4 | ████ |
-| Unsupported op Compress | 4 | ████ |
-| Unsupported op DeformConv | 4 | ████ |
-| Unsupported op RNN | 4 | ████ |
-| Unsupported optional element type '*' for '*'. Hint: export the model with optional tensor inputs/outputs. | 4 | ████ |
-| Elu only supports alpha=1.0 | 3 | ███ |
-| HardSigmoid only supports alpha=0.2 | 3 | ███ |
-| LeakyRelu only supports alpha=0.01 | 3 | ███ |
-| Unsupported op DynamicQuantizeLinear | 3 | ███ |
-| Unsupported op Loop | 3 | ███ |
-| Unsupported op Momentum | 3 | ███ |
-| Unsupported op RandomUniformLike | 3 | ███ |
-| Unsupported op RoiAlign | 3 | ███ |
-| name '*' is not defined | 3 | ███ |
-| BatchNormalization must have 5 inputs and 1 output | 2 | ██ |
-| Failed to build testbench. | 2 | ██ |
-| Gelu only supports approximate=none | 2 | ██ |
-| LpPool expects 2D kernel_shape | 2 | ██ |
-| LpPool supports auto_pad=NOTSET only | 2 | ██ |
-| QuantizeLinear block_size is not supported | 2 | ██ |
-| Selu only supports alpha=1.6732632423543772 | 2 | ██ |
-| ThresholdedRelu only supports alpha=1.0 | 2 | ██ |
-| Unsupported op Adam | 2 | ██ |
-| Unsupported op BitwiseNot | 2 | ██ |
-| Unsupported op BlackmanWindow | 2 | ██ |
-| Unsupported op ConvInteger | 2 | ██ |
-| Unsupported op Det | 2 | ██ |
-| Unsupported op Gradient | 2 | ██ |
-| Unsupported op HannWindow | 2 | ██ |
-| Unsupported op MaxUnpool | 2 | ██ |
-| Unsupported op OptionalGetElement | 2 | ██ |
-| Unsupported op ReverseSequence | 2 | ██ |
-| Unsupported op STFT | 2 | ██ |
-| Unsupported op Scan | 2 | ██ |
-| Unsupported op Scatter | 2 | ██ |
-| Unsupported op TreeEnsemble | 2 | ██ |
-| ConvTranspose output shape must be fully defined and non-negative | 1 | █ |
-| Dropout mask output is not supported | 1 | █ |
-| Dynamic dim for tensor '*' | 1 | █ |
-| Graph must contain at least one node | 1 | █ |
-| Pad value input must be a scalar | 1 | █ |
-| ReduceMax does not support dtype bool | 1 | █ |
-| ReduceMin does not support dtype bool | 1 | █ |
-| Unsupported op ArrayFeatureExtractor | 1 | █ |
-| Unsupported op Binarizer | 1 | █ |
-| Unsupported op MatMulInteger | 1 | █ |
-| Unsupported op MelWeightMatrix | 1 | █ |
-| Unsupported op QLinearConv | 1 | █ |
-| Unsupported op Upsample | 1 | █ |
+| Error message | Count |
+| --- | --- |
+| Unsupported elem_type 8 (STRING) for tensor '*'. | 32 |
+| Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 28 |
+| Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 22 |
+| Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 20 |
+| Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 18 |
+| Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 18 |
+| Unsupported elem_type 21 (UINT4) for tensor '*'. | 17 |
+| Unsupported elem_type 22 (INT4) for tensor '*'. | 17 |
+| Unsupported elem_type 25 (UINT2) for tensor '*'. | 17 |
+| Unsupported elem_type 26 (INT2) for tensor '*'. | 17 |
+| Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 14 |
+| Unsupported op ImageDecoder | 9 |
+| Dropout supports only the data input and 1 or 2 outputs | 8 |
+| Out of tolerance | 8 |
+| Unsupported op TfIdfVectorizer | 7 |
+| Unsupported elem_type 16 (BFLOAT16) for tensor '*'. | 6 |
+| Unsupported op CenterCropPad | 6 |
+| Unsupported op DFT | 6 |
+| Unsupported op ScatterElements | 6 |
+| Unsupported op Unique | 6 |
+| Unsupported op Col2Im | 5 |
+| Unsupported op If | 5 |
+| OptionalHasElement expects exactly one non-empty input. | 4 |
+| Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 4 |
+| Unsupported op AffineGrid | 4 |
+| Unsupported op Compress | 4 |
+| Unsupported op DeformConv | 4 |
+| Unsupported op RNN | 4 |
+| Unsupported optional element type '*' for '*'. Hint: export the model with optional tensor inputs/outputs. | 4 |
+| Elu only supports alpha=1.0 | 3 |
+| HardSigmoid only supports alpha=0.2 | 3 |
+| LeakyRelu only supports alpha=0.01 | 3 |
+| Unsupported op DynamicQuantizeLinear | 3 |
+| Unsupported op Loop | 3 |
+| Unsupported op Momentum | 3 |
+| Unsupported op RandomUniformLike | 3 |
+| Unsupported op RoiAlign | 3 |
+| name '*' is not defined | 3 |
+| BatchNormalization must have 5 inputs and 1 output | 2 |
+| Failed to build testbench. | 2 |
+| Gelu only supports approximate=none | 2 |
+| LpPool expects 2D kernel_shape | 2 |
+| LpPool supports auto_pad=NOTSET only | 2 |
+| QuantizeLinear block_size is not supported | 2 |
+| Selu only supports alpha=1.6732632423543772 | 2 |
+| ThresholdedRelu only supports alpha=1.0 | 2 |
+| Unsupported op Adam | 2 |
+| Unsupported op BitwiseNot | 2 |
+| Unsupported op BlackmanWindow | 2 |
+| Unsupported op ConvInteger | 2 |
+| Unsupported op Det | 2 |
+| Unsupported op Gradient | 2 |
+| Unsupported op HannWindow | 2 |
+| Unsupported op MaxUnpool | 2 |
+| Unsupported op OptionalGetElement | 2 |
+| Unsupported op ReverseSequence | 2 |
+| Unsupported op STFT | 2 |
+| Unsupported op Scan | 2 |
+| Unsupported op Scatter | 2 |
+| Unsupported op TreeEnsemble | 2 |
+| ConvTranspose output shape must be fully defined and non-negative | 1 |
+| Dropout mask output is not supported | 1 |
+| Dynamic dim for tensor '*' | 1 |
+| Graph must contain at least one node | 1 |
+| Pad value input must be a scalar | 1 |
+| ReduceMax does not support dtype bool | 1 |
+| ReduceMin does not support dtype bool | 1 |
+| Unsupported op ArrayFeatureExtractor | 1 |
+| Unsupported op Binarizer | 1 |
+| Unsupported op MatMulInteger | 1 |
+| Unsupported op MelWeightMatrix | 1 |
+| Unsupported op QLinearConv | 1 |
+| Unsupported op Upsample | 1 |
 
 ## Local ONNX file support histogram
 
 ### Error frequency
 
-| Error message | Count | Histogram |
-| --- | --- | --- |
-| Unsupported LSTM direction b'*' | 2 | ██████████████████████████████ |
-| Unsupported op QLinearAdd | 2 | ██████████████████████████████ |
-| Gemm bias input must be broadcastable to output shape, got (2,) vs (2, 4) | 1 | ███████████████ |
+| Error message | Count |
+| --- | --- |
+| Unsupported LSTM direction b'*' | 2 |
+| Unsupported op QLinearAdd | 2 |
+| Gemm bias input must be broadcastable to output shape, got (2,) vs (2, 4) | 1 |


### PR DESCRIPTION
### Motivation
- Simplify the error-frequency documentation by removing the ASCII "Histogram" column from the tables to improve readability and downstream rendering.

### Description
- Updated `OFFICIAL_ONNX_FILE_SUPPORT_HISTOGRAM.md` to remove the "Histogram" column and its contents from both the main "Error frequency" table and the "Local ONNX file support histogram" table, preserving the "Error message" and "Count" columns.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697b911517548325a3a424c8526c6db3)