### PR TITLE
docs: sort per-opset histogram ascending (opset ↑, count ↓)

### DIFF
--- a/ONNX_ERRORS_HISTOGRAM.md
+++ b/ONNX_ERRORS_HISTOGRAM.md
@@ -76,6 +76,95 @@
 | Unsupported op QLinearConv | 1 | 10 |
 | Unsupported op Upsample | 1 | 9 |
 
+## Error frequency by opset
+
+| Error message | Opset | Count |
+| --- | --- | --- |
+| Out of tolerance | 6 | 2 |
+| Elu only supports alpha=1.0 | 6 | 1 |
+| LeakyRelu only supports alpha=0.01 | 6 | 1 |
+| Unsupported op Scan | 8 | 1 |
+| Unsupported op TfIdfVectorizer | 9 | 7 |
+| Out of tolerance | 9 | 1 |
+| Unsupported op Scan | 9 | 1 |
+| Unsupported op Upsample | 9 | 1 |
+| Unsupported elem_type 8 (STRING) for tensor '*'. | 10 | 12 |
+| Unsupported op ConvInteger | 10 | 2 |
+| Unsupported op ReverseSequence | 10 | 2 |
+| Unsupported op Scatter | 10 | 2 |
+| Unsupported op MatMulInteger | 10 | 1 |
+| Unsupported op QLinearConv | 10 | 1 |
+| Unsupported op Unique | 11 | 6 |
+| Unsupported op Compress | 11 | 4 |
+| Unsupported op DynamicQuantizeLinear | 11 | 3 |
+| Unsupported op Loop | 11 | 3 |
+| Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 11 | 2 |
+| Unsupported op If | 11 | 1 |
+| Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 12 | 7 |
+| Failed to build testbench. | 12 | 2 |
+| Unsupported op Gradient | 12 | 2 |
+| Dynamic dim for tensor '*' | 12 | 1 |
+| Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 13 | 2 |
+| BatchNormalization must have 5 inputs and 1 output | 15 | 2 |
+| Unsupported optional element type '*' for '*'. Hint: export the model with optional tensor inputs/outputs. | 16 | 3 |
+| LeakyRelu only supports alpha=0.01 | 16 | 2 |
+| Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 17 | 12 |
+| Unsupported op BlackmanWindow | 17 | 2 |
+| Unsupported op HannWindow | 17 | 2 |
+| Unsupported op STFT | 17 | 2 |
+| Unsupported op MelWeightMatrix | 17 | 1 |
+| Unsupported op CenterCropPad | 18 | 6 |
+| Unsupported op ScatterElements | 18 | 6 |
+| Unsupported op Col2Im | 18 | 5 |
+| OptionalHasElement expects exactly one non-empty input. | 18 | 4 |
+| Unsupported op BitwiseNot | 18 | 2 |
+| Unsupported op OptionalGetElement | 18 | 2 |
+| Unsupported optional element type '*' for '*'. Hint: export the model with optional tensor inputs/outputs. | 18 | 1 |
+| Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 18 | 1 |
+| Unsupported op DFT | 19 | 3 |
+| Out of tolerance | 19 | 2 |
+| Unsupported elem_type 8 (STRING) for tensor '*'. | 19 | 2 |
+| Unsupported elem_type 8 (STRING) for tensor '*'. | 20 | 14 |
+| Unsupported op ImageDecoder | 20 | 9 |
+| Unsupported op AffineGrid | 20 | 4 |
+| Unsupported op If | 20 | 4 |
+| Unsupported op DFT | 20 | 3 |
+| Gelu only supports approximate=none | 20 | 2 |
+| ReduceMax does not support dtype bool | 20 | 1 |
+| ReduceMin does not support dtype bool | 20 | 1 |
+| Dropout supports only the data input and 1 or 2 outputs | 22 | 8 |
+| Unsupported op DeformConv | 22 | 4 |
+| Unsupported op RNN | 22 | 4 |
+| HardSigmoid only supports alpha=0.2 | 22 | 3 |
+| Out of tolerance | 22 | 3 |
+| Unsupported op RandomUniformLike | 22 | 3 |
+| Unsupported op RoiAlign | 22 | 3 |
+| Elu only supports alpha=1.0 | 22 | 2 |
+| LpPool expects 2D kernel_shape | 22 | 2 |
+| LpPool supports auto_pad=NOTSET only | 22 | 2 |
+| Selu only supports alpha=1.6732632423543772 | 22 | 2 |
+| ThresholdedRelu only supports alpha=1.0 | 22 | 2 |
+| Unsupported op Det | 22 | 2 |
+| Unsupported op MaxUnpool | 22 | 2 |
+| ConvTranspose output shape must be fully defined and non-negative | 22 | 1 |
+| Dropout mask output is not supported | 22 | 1 |
+| Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 24 | 3 |
+| Pad value input must be a scalar | 24 | 1 |
+| Unsupported elem_type 17 (FLOAT8E4M3FN) for tensor '*'. | 25 | 22 |
+| Unsupported elem_type 19 (FLOAT8E5M2) for tensor '*'. | 25 | 20 |
+| Unsupported elem_type 18 (FLOAT8E4M3FNUZ) for tensor '*'. | 25 | 18 |
+| Unsupported elem_type 20 (FLOAT8E5M2FNUZ) for tensor '*'. | 25 | 18 |
+| Unsupported elem_type 21 (UINT4) for tensor '*'. | 25 | 17 |
+| Unsupported elem_type 22 (INT4) for tensor '*'. | 25 | 17 |
+| Unsupported elem_type 25 (UINT2) for tensor '*'. | 25 | 17 |
+| Unsupported elem_type 26 (INT2) for tensor '*'. | 25 | 17 |
+| Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 25 | 14 |
+| Unsupported elem_type 16 (BFLOAT16) for tensor '*'. | 25 | 6 |
+| Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 25 | 4 |
+| QuantizeLinear block_size is not supported | 25 | 2 |
+| Graph must contain at least one node | 25 | 1 |
+| Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 25 | 1 |
+
 ## Local ONNX file support histogram
 
 ### Error frequency
@@ -85,3 +174,10 @@
 | Unsupported LSTM direction b'*' | 2 | 11 |
 | Unsupported op QLinearAdd | 2 |  |
 | Gemm bias input must be broadcastable to output shape, got (2,) vs (2, 4) | 1 | 12 |
+
+## Error frequency by opset
+
+| Error message | Opset | Count |
+| --- | --- | --- |
+| Unsupported LSTM direction b'*' | 11 | 2 |
+| Gemm bias input must be broadcastable to output shape, got (2,) vs (2, 4) | 12 | 1 |


### PR DESCRIPTION
### Motivation
- Make the per-opset error breakdown easier to scan by ordering rows by opset ascending and then by count descending as requested (`Opset aufsteigend, count absteigend`).

### Description
- Change the per-opset sort key in `_render_error_histogram_markdown` to `key=lambda item: (item[0][1], -item[1], item[0][0])` to sort by opset ascending then count descending in `tests/test_official_onnx_files_docs.py`.
- Add `error_opset_pairs` and the per-opset table rendering to `_render_error_histogram_markdown` so a secondary opset-specific histogram is emitted when opset data is present.
- Add helper `_next_heading` to compute the opset-table heading level relative to the provided `title` so headings render consistently.
- Regenerate `ONNX_ERRORS_HISTOGRAM.md` to reflect the new ordering in the per-opset breakdown.

### Testing
- Ran the histogram regeneration snippet with `PYTHONPATH=src:tests python - <<'PY' ...` which wrote `ONNX_ERRORS_HISTOGRAM.md` and completed successfully.
- No `pytest` test suite was executed for this documentation/formatting change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697ba28bc9a88325afc78ce7e020132a)