### PR TITLE
lowering: support Elu and LeakyRelu alpha and refresh verification refs

### DIFF
--- a/ONNX_ERRORS_HISTOGRAM.md
+++ b/ONNX_ERRORS_HISTOGRAM.md
@@ -31,9 +31,7 @@
 | Unsupported op DeformConv | 4 | 22 |
 | Unsupported op RNN | 4 | 22 |
 | Unsupported optional element type '*' for '*'. Hint: export the model with optional tensor inputs/outputs. | 4 | 16, 18 |
-| Elu only supports alpha=1.0 | 3 | 6, 22 |
 | HardSigmoid only supports alpha=0.2 | 3 | 22 |
-| LeakyRelu only supports alpha=0.01 | 3 | 6, 16 |
 | Unsupported op DynamicQuantizeLinear | 3 | 11 |
 | Unsupported op Loop | 3 | 11 |
 | Unsupported op Momentum | 3 |  |
@@ -81,8 +79,6 @@
 | Error message | Opset | Count |
 | --- | --- | --- |
 | Out of tolerance | 6 | 2 |
-| Elu only supports alpha=1.0 | 6 | 1 |
-| LeakyRelu only supports alpha=0.01 | 6 | 1 |
 | Unsupported op Scan | 8 | 1 |
 | Unsupported op TfIdfVectorizer | 9 | 7 |
 | Out of tolerance | 9 | 1 |
@@ -107,7 +103,6 @@
 | Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 13 | 2 |
 | BatchNormalization must have 5 inputs and 1 output | 15 | 2 |
 | Unsupported optional element type '*' for '*'. Hint: export the model with optional tensor inputs/outputs. | 16 | 3 |
-| LeakyRelu only supports alpha=0.01 | 16 | 2 |
 | Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 17 | 12 |
 | Unsupported op BlackmanWindow | 17 | 2 |
 | Unsupported op HannWindow | 17 | 2 |
@@ -139,7 +134,6 @@
 | Out of tolerance | 22 | 3 |
 | Unsupported op RandomUniformLike | 22 | 3 |
 | Unsupported op RoiAlign | 22 | 3 |
-| Elu only supports alpha=1.0 | 22 | 2 |
 | LpPool expects 2D kernel_shape | 22 | 2 |
 | LpPool supports auto_pad=NOTSET only | 22 | 2 |
 | Selu only supports alpha=1.6732632423543772 | 22 | 2 |

--- a/ONNX_SUPPORT.md
+++ b/ONNX_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1398 / 1802 official ONNX files.
+Support 1404 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -609,10 +609,10 @@ Floating-point verification first ignores very small differences up to **1.0 × 
 | onnx-org/onnx/backend/test/data/node/test_einsum_scalar/model.onnx | 12 | ❌ | Failed to build testbench. |
 | onnx-org/onnx/backend/test/data/node/test_einsum_sum/model.onnx | 12 | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/node/test_einsum_transpose/model.onnx | 12 | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_elu/model.onnx | 22 | ❌ | Elu only supports alpha=1.0 |
+| onnx-org/onnx/backend/test/data/node/test_elu/model.onnx | 22 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_elu_default/model.onnx | 22 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_elu_default_expanded_ver18/model.onnx | 18 | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_elu_example/model.onnx | 22 | ❌ | Elu only supports alpha=1.0 |
+| onnx-org/onnx/backend/test/data/node/test_elu_example/model.onnx | 22 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_elu_example_expanded_ver18/model.onnx | 18 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_elu_expanded_ver18/model.onnx | 18 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_equal/model.onnx | 19 | ✅ | OK (max ULP 0) |
@@ -835,10 +835,10 @@ Floating-point verification first ignores very small differences up to **1.0 × 
 | onnx-org/onnx/backend/test/data/node/test_layer_normalization_default_axis/model.onnx | 17 | ✅ | OK (max ULP 2) |
 | onnx-org/onnx/backend/test/data/node/test_layer_normalization_default_axis_expanded/model.onnx | 17 | ✅ | OK (max ULP 8) |
 | onnx-org/onnx/backend/test/data/node/test_layer_normalization_default_axis_expanded_ver18/model.onnx | 18 | ✅ | OK (max ULP 8) |
-| onnx-org/onnx/backend/test/data/node/test_leakyrelu/model.onnx | 16 | ❌ | LeakyRelu only supports alpha=0.01 |
+| onnx-org/onnx/backend/test/data/node/test_leakyrelu/model.onnx | 16 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_leakyrelu_default/model.onnx | 16 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_leakyrelu_default_expanded/model.onnx | 16 | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_leakyrelu_example/model.onnx | 16 | ❌ | LeakyRelu only supports alpha=0.01 |
+| onnx-org/onnx/backend/test/data/node/test_leakyrelu_example/model.onnx | 16 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_leakyrelu_example_expanded/model.onnx | 16 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_leakyrelu_expanded/model.onnx | 16 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_less/model.onnx | 13 | ✅ | OK (max ULP 0) |
@@ -1713,13 +1713,13 @@ Floating-point verification first ignores very small differences up to **1.0 × 
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_stride_padding/model.onnx | 6 | ✅ | OK (max ULP 7) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_ConvTranspose2d/model.onnx | 6 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_ConvTranspose2d_no_bias/model.onnx | 6 | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_ELU/model.onnx | 6 | ❌ | Elu only supports alpha=1.0 |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_ELU/model.onnx | 6 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_Embedding/model.onnx | 6 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_Embedding_sparse/model.onnx | 6 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_GLU/model.onnx | 6 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_GLU_dim/model.onnx | 6 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_LeakyReLU/model.onnx | 6 | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_LeakyReLU_with_negval/model.onnx | 6 | ❌ | LeakyRelu only supports alpha=0.01 |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_LeakyReLU_with_negval/model.onnx | 6 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_Linear/model.onnx | 6 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_Linear_no_bias/model.onnx | 6 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_LogSoftmax/model.onnx | 6 | ✅ | OK (max ULP 2) |

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_celu_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_celu_expanded__model.onnx.json
@@ -8,5 +8,5 @@
     "Mul"
   ],
   "opset_version": 12,
-  "generated_checksum": "280c4d2b3208d783acc7062e5cd03ec16b476fe18ceca044d7a0a8ea6f42c5cc"
+  "generated_checksum": "27348c0b5620c5aba5c681865ea109b11a6cdfc9d38d51363650a573de84c4a2"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_elu__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_elu__model.onnx.json
@@ -1,8 +1,9 @@
 {
-  "error": "Elu only supports alpha=1.0",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_elu model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Elu"
   ],
-  "opset_version": 22
+  "opset_version": 22,
+  "generated_checksum": "cca32b18677f67c6d649ade9f28b974fc2f678899ee60937a57f000e50857b53"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_elu_default__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_elu_default__model.onnx.json
@@ -5,5 +5,5 @@
     "Elu"
   ],
   "opset_version": 22,
-  "generated_checksum": "98e1514aa115a2119ad391d5e1979b191caf728cdcd92b3c5962bc32035eb278"
+  "generated_checksum": "83b8edec77aa2a8bf23d0291ccda5048cfc2792859aaa2adbac361e4e4793fee"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_elu_example__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_elu_example__model.onnx.json
@@ -1,8 +1,9 @@
 {
-  "error": "Elu only supports alpha=1.0",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_elu_example model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Elu"
   ],
-  "opset_version": 22
+  "opset_version": 22,
+  "generated_checksum": "d4516c00295bc8456c0f33ec6f5e414a52363853108184486f38eb1dd041e123"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_leakyrelu__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_leakyrelu__model.onnx.json
@@ -1,8 +1,9 @@
 {
-  "error": "LeakyRelu only supports alpha=0.01",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_leakyrelu model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "LeakyRelu"
   ],
-  "opset_version": 16
+  "opset_version": 16,
+  "generated_checksum": "566575722b41826e44ea8990987845c8d023c8d835178b34e60e657b431034a5"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_leakyrelu_default__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_leakyrelu_default__model.onnx.json
@@ -5,5 +5,5 @@
     "LeakyRelu"
   ],
   "opset_version": 16,
-  "generated_checksum": "592b83ba4147f48826a295bb8dae06c99be0272dfcb828a25bdde20f38d84408"
+  "generated_checksum": "84defe249af0ba9e1f49a658730b632ef1d71b823265005cd50c6e45195f3cd5"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_leakyrelu_example__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_leakyrelu_example__model.onnx.json
@@ -1,8 +1,9 @@
 {
-  "error": "LeakyRelu only supports alpha=0.01",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_leakyrelu_example model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "LeakyRelu"
   ],
-  "opset_version": 16
+  "opset_version": 16,
+  "generated_checksum": "a1184577f2e2d00039850b58dd9da2c638b33ebf55f11ff473074c9d6e6a784d"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_ELU__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_ELU__model.onnx.json
@@ -1,8 +1,9 @@
 {
-  "error": "Elu only supports alpha=1.0",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_ELU model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Elu"
   ],
-  "opset_version": 6
+  "opset_version": 6,
+  "generated_checksum": "d0303c70bfbd84bfe949ac3bac28989e6c79cee5c6f8960c216795c1caadb91b"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_LeakyReLU__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_LeakyReLU__model.onnx.json
@@ -5,5 +5,5 @@
     "LeakyRelu"
   ],
   "opset_version": 6,
-  "generated_checksum": "1894f11b56480ec87befa3cb51fbd12f157f7de9750dca036e735fa66d62c0f1"
+  "generated_checksum": "6c0ab6305336f00cafdaeca6f860d45740b5070ca325775cfa6a662c179d3c5d"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_LeakyReLU_with_negval__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-converted__test_LeakyReLU_with_negval__model.onnx.json
@@ -1,8 +1,9 @@
 {
-  "error": "LeakyRelu only supports alpha=0.01",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/pytorch-converted/test_LeakyReLU_with_negval model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "LeakyRelu"
   ],
-  "opset_version": 6
+  "opset_version": 6,
+  "generated_checksum": "e36310059d9259aa1934430509227276daad80d6eedb93c2dbe27bdf83624b5e"
 }


### PR DESCRIPTION
### Motivation
- Allow ONNX `Elu` and `LeakyRelu` nodes with non-default `alpha` attributes to be lowered instead of hard-failing, and propagate the numeric `alpha` to downstream codegen for correct runtime behavior.
- Keep attribute handling explicit and fail fast for unsupported attributes or non-numeric values to preserve clear error diagnostics.

### Description
- Add `lower_elu` and `lower_leaky_relu` in `src/emx_onnx_cgen/lowering/elementwise.py` that enforce 1 input / 1 output, require floating-point input types, whitelist only the `alpha` attribute, parse `alpha` to `float`, and return a `UnaryOp` with `params=(alpha,)` using `ScalarFunction.ELU` and `ScalarFunction.LEAKY_RELU` respectively.
- Emit `UnsupportedOpError` with actionable messages for invalid attribute names or non-numeric `alpha` values.
- Regenerate verification reference artifacts by updating `tests/expected_errors/*` baselines and refreshing `ONNX_SUPPORT.md` and `ONNX_ERRORS_HISTOGRAM.md` to reflect the new behavior and checksums.

### Testing
- Ran `UPDATE_REFS=1 pytest -n auto -q --maxfail=10` to regenerate references and run the test suite, which completed in ~242.61s (0:04:02) with `2156 passed, 1 skipped, 2 xfailed` and a single runtime warning.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697ba6ee70fc8325b46dc8918f016014)