### PR TITLE
docs/cli: document fp16/fp32 accumulation flags and add fp16 CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Options:
 - `--large-weight-threshold`: Store weights in a binary file once the cumulative byte size exceeds this threshold (default: `102400`; set to `0` to disable).
 - `--large-temp-threshold`: Mark temporary buffers larger than this threshold as static (default: `1024`).
 - `--no-restrict-arrays`: Disable `restrict` qualifiers on generated array parameters.
+- `--fp32-accumulation-strategy`: Accumulation strategy for float32 inputs (`simple` uses float32, `fp64` uses double; default: `fp64`).
+- `--fp16-accumulation-strategy`: Accumulation strategy for float16 inputs (`simple` uses float16, `fp32` uses float; default: `fp32`).
 
 ### `verify`
 
@@ -111,6 +113,8 @@ Options:
 - `--temp-dir-root`: Root directory in which to create a temporary verification directory (default: system temp dir).
 - `--temp-dir`: Exact directory to use for temporary verification files (default: create a temporary directory).
 - `--keep-temp-dir`: Keep the temporary verification directory instead of deleting it.
+- `--fp32-accumulation-strategy`: Accumulation strategy for float32 inputs (`simple` uses float32, `fp64` uses double; default: `fp64`).
+- `--fp16-accumulation-strategy`: Accumulation strategy for float16 inputs (`simple` uses float16, `fp32` uses float; default: `fp32`).
 
 How verification works:
 

--- a/src/emx_onnx_cgen/cli.py
+++ b/src/emx_onnx_cgen/cli.py
@@ -353,6 +353,19 @@ def _build_parser() -> argparse.ArgumentParser:
             ),
         )
 
+    def add_fp16_accumulation_strategy_flag(
+        subparser: argparse.ArgumentParser,
+    ) -> None:
+        subparser.add_argument(
+            "--fp16-accumulation-strategy",
+            choices=("simple", "fp32"),
+            default="fp32",
+            help=(
+                "Accumulation strategy for float16 inputs "
+                "(simple uses float16, fp32 uses float; default: fp32)"
+            ),
+        )
+
     compile_parser = subparsers.add_parser(
         "compile", help="Compile an ONNX model into C source"
     )
@@ -428,6 +441,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     add_restrict_flags(compile_parser)
     add_fp32_accumulation_strategy_flag(compile_parser)
+    add_fp16_accumulation_strategy_flag(compile_parser)
 
     verify_parser = subparsers.add_parser(
         "verify",
@@ -553,6 +567,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     add_restrict_flags(verify_parser)
     add_fp32_accumulation_strategy_flag(verify_parser)
+    add_fp16_accumulation_strategy_flag(verify_parser)
     return parser
 
 
@@ -665,6 +680,7 @@ def _compile_model(
             model_checksum=model_checksum,
             restrict_arrays=args.restrict_arrays,
             fp32_accumulation_strategy=args.fp32_accumulation_strategy,
+            fp16_accumulation_strategy=args.fp16_accumulation_strategy,
             truncate_weights_after=args.truncate_weights_after,
             large_temp_threshold_bytes=args.large_temp_threshold_bytes,
             large_weight_threshold=args.large_weight_threshold,
@@ -872,6 +888,7 @@ def _verify_model(
             model_checksum=model_checksum,
             restrict_arrays=args.restrict_arrays,
             fp32_accumulation_strategy=args.fp32_accumulation_strategy,
+            fp16_accumulation_strategy=args.fp16_accumulation_strategy,
             truncate_weights_after=args.truncate_weights_after,
             large_temp_threshold_bytes=args.large_temp_threshold_bytes,
             large_weight_threshold=args.large_weight_threshold,

--- a/src/emx_onnx_cgen/compiler.py
+++ b/src/emx_onnx_cgen/compiler.py
@@ -41,6 +41,7 @@ class CompilerOptions:
     model_checksum: str | None = None
     restrict_arrays: bool = True
     fp32_accumulation_strategy: str = "fp64"
+    fp16_accumulation_strategy: str = "fp32"
     testbench_inputs: Mapping[str, np.ndarray] | None = None
     testbench_optional_inputs: Mapping[str, bool] | None = None
     truncate_weights_after: int | None = None
@@ -72,6 +73,7 @@ class Compiler:
             options.template_dir,
             restrict_arrays=options.restrict_arrays,
             fp32_accumulation_strategy=options.fp32_accumulation_strategy,
+            fp16_accumulation_strategy=options.fp16_accumulation_strategy,
             truncate_weights_after=options.truncate_weights_after,
             large_temp_threshold_bytes=options.large_temp_threshold_bytes,
             large_weight_threshold=options.large_weight_threshold,


### PR DESCRIPTION
### Motivation
- Expose and document a configurable accumulation strategy for `fp16` inputs analogous to the existing `fp32` option so accumulation precision can be controlled for ops like `Conv`.
- Centralize accumulation-dtype logic to avoid duplicated ad-hoc selection scattered in codegen.
- Update user-facing CLI docs so both accumulation flags are described for `compile` and `verify`.

### Description
- Add a new CLI helper `add_fp16_accumulation_strategy_flag` and wire the `--fp16-accumulation-strategy` flag into both `compile` and `verify` parsers in `src/emx_onnx_cgen/cli.py`.
- Extend `CompilerOptions` with `fp16_accumulation_strategy` and propagate it through `Compiler` into `CEmitter` in `src/emx_onnx_cgen/compiler.py` and `src/emx_onnx_cgen/codegen/c_emitter.py`.
- Validate and store the new option in `CEmitter` and introduce `CEmitter._accumulation_dtype(dtype: ScalarType)` to centralize accumulation-type selection for `F16`/`F32`/other types, and replace the duplicated Conv accumulation logic to call this helper.
- Document both `--fp32-accumulation-strategy` and `--fp16-accumulation-strategy` in `README.md` under the `compile` and `verify` CLI options.

### Testing
- No automated tests were executed for this change (documentation and CLI wiring only); manual validation was limited to ensuring the CLI options parse and propagate without runtime errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697d1daecfa083258504c57310cb5367)