### PR TITLE
tests: generalize extra verify args

### DIFF
--- a/ONNX_SUPPORT.md
+++ b/ONNX_SUPPORT.md
@@ -1031,7 +1031,7 @@ Floating-point verification first ignores very small differences up to **1.0 × 
 | onnx-org/onnx/backend/test/data/node/test_nllloss_NCd1d2d3_none_no_weight_negative_ii_expanded/model.onnx | 22 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_nllloss_NCd1d2d3_sum_weight_high_ii/model.onnx | 22 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_nllloss_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx | 22 | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_nllloss_NCd1d2d3d4d5_mean_weight/model.onnx | 22 | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_nllloss_NCd1d2d3d4d5_mean_weight/model.onnx | 22 | ✅ | OK (max ULP 0) (flags: --fp32-accumulation-strategy fp64) |
 | onnx-org/onnx/backend/test/data/node/test_nllloss_NCd1d2d3d4d5_mean_weight_expanded/model.onnx | 22 | ❌ | Out of tolerance (max ULP 357) |
 | onnx-org/onnx/backend/test/data/node/test_nllloss_NCd1d2d3d4d5_none_no_weight/model.onnx | 22 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_nllloss_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx | 22 | ✅ | OK (max ULP 0) |
@@ -1389,10 +1389,10 @@ Floating-point verification first ignores very small differences up to **1.0 × 
 | onnx-org/onnx/backend/test/data/node/test_sce_NCd1d2d3_sum_weight_high_ii_expanded/model.onnx | 13 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob/model.onnx | 13 | ✅ | OK (max ULP 2) |
 | onnx-org/onnx/backend/test/data/node/test_sce_NCd1d2d3_sum_weight_high_ii_log_prob_expanded/model.onnx | 13 | ✅ | OK (max ULP 2) |
-| onnx-org/onnx/backend/test/data/node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx | 13 | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx | 13 | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx | 13 | ✅ | OK (max ULP 2) |
-| onnx-org/onnx/backend/test/data/node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx | 13 | ✅ | OK (max ULP 3) |
+| onnx-org/onnx/backend/test/data/node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx | 13 | ✅ | OK (max ULP 0) (flags: --fp32-accumulation-strategy fp64) |
+| onnx-org/onnx/backend/test/data/node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx | 13 | ✅ | OK (max ULP 0) (flags: --fp32-accumulation-strategy fp64) |
+| onnx-org/onnx/backend/test/data/node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx | 13 | ✅ | OK (max ULP 2) (flags: --fp32-accumulation-strategy fp64) |
+| onnx-org/onnx/backend/test/data/node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx | 13 | ✅ | OK (max ULP 3) (flags: --fp32-accumulation-strategy fp64) |
 | onnx-org/onnx/backend/test/data/node/test_sce_NCd1d2d3d4d5_none_no_weight/model.onnx | 13 | ✅ | OK (max ULP 3) |
 | onnx-org/onnx/backend/test/data/node/test_sce_NCd1d2d3d4d5_none_no_weight_expanded/model.onnx | 13 | ✅ | OK (max ULP 3) |
 | onnx-org/onnx/backend/test/data/node/test_sce_NCd1d2d3d4d5_none_no_weight_log_prob/model.onnx | 13 | ✅ | OK (max ULP 3) |
@@ -1706,7 +1706,7 @@ Floating-point verification first ignores very small differences up to **1.0 × 
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv2d_strided/model.onnx | 6 | ✅ | OK (max ULP 9) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d/model.onnx | 6 | ✅ | OK (max ULP 4) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_dilated/model.onnx | 6 | ✅ | OK (max ULP 3) |
-| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_dilated_strided/model.onnx | 6 | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_dilated_strided/model.onnx | 6 | ✅ | OK (max ULP 0) (flags: --fp32-accumulation-strategy fp64) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_groups/model.onnx | 6 | ✅ | OK (max ULP 9) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_no_bias/model.onnx | 6 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_stride/model.onnx | 6 | ✅ | OK (max ULP 5) |

--- a/tests/test_official_onnx_files.py
+++ b/tests/test_official_onnx_files.py
@@ -19,13 +19,31 @@ LOCAL_ONNX_DATA_ROOT = (
 )
 ONNX_FILE_LIMIT = 5000
 _VERBOSE_FLAGS_REPORTED = False
-FP32_ACCUMULATION_FP64_MODELS = {
-    "onnx-org/onnx/backend/test/data/node/test_nllloss_NCd1d2d3d4d5_mean_weight/model.onnx",
-    "onnx-org/onnx/backend/test/data/node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx",
-    "onnx-org/onnx/backend/test/data/node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx",
-    "onnx-org/onnx/backend/test/data/node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx",
-    "onnx-org/onnx/backend/test/data/node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx",
-    "onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_dilated_strided/model.onnx",
+MODEL_EXTRA_VERIFY_ARGS = {
+    "onnx-org/onnx/backend/test/data/node/test_nllloss_NCd1d2d3d4d5_mean_weight/model.onnx": (
+        "--fp32-accumulation-strategy",
+        "fp64",
+    ),
+    "onnx-org/onnx/backend/test/data/node/test_sce_NCd1d2d3d4d5_mean_weight/model.onnx": (
+        "--fp32-accumulation-strategy",
+        "fp64",
+    ),
+    "onnx-org/onnx/backend/test/data/node/test_sce_NCd1d2d3d4d5_mean_weight_expanded/model.onnx": (
+        "--fp32-accumulation-strategy",
+        "fp64",
+    ),
+    "onnx-org/onnx/backend/test/data/node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob/model.onnx": (
+        "--fp32-accumulation-strategy",
+        "fp64",
+    ),
+    "onnx-org/onnx/backend/test/data/node/test_sce_NCd1d2d3d4d5_mean_weight_log_prob_expanded/model.onnx": (
+        "--fp32-accumulation-strategy",
+        "fp64",
+    ),
+    "onnx-org/onnx/backend/test/data/pytorch-converted/test_Conv3d_dilated_strided/model.onnx": (
+        "--fp32-accumulation-strategy",
+        "fp64",
+    ),
 }
 
 
@@ -392,13 +410,9 @@ def _run_expected_error_test(
                 test_data_argument,
             ]
         )
-    if repo_relative_path in FP32_ACCUMULATION_FP64_MODELS:
-        verify_args.extend(
-            [
-                "--fp32-accumulation-strategy",
-                "fp64",
-            ]
-        )
+    extra_args = MODEL_EXTRA_VERIFY_ARGS.get(repo_relative_path)
+    if extra_args:
+        verify_args.extend(extra_args)
 
     cli_result = cli.run_cli_command(verify_args)
 

--- a/tests/test_official_onnx_files_docs.py
+++ b/tests/test_official_onnx_files_docs.py
@@ -9,6 +9,7 @@ import pytest
 
 from test_official_onnx_files import (
     LOCAL_ONNX_DATA_ROOT,
+    MODEL_EXTRA_VERIFY_ARGS,
     OnnxFileExpectation,
     _load_expectation_for_repo_relative,
     _local_onnx_file_paths,
@@ -46,6 +47,10 @@ def _render_onnx_file_support_table(
             else ""
         )
         message = expectation.error.replace("\n", " ").strip()
+        extra_args = MODEL_EXTRA_VERIFY_ARGS.get(expectation.path)
+        if extra_args:
+            flag_text = " ".join(extra_args)
+            message = f"{message} (flags: {flag_text})".strip()
         lines.append(
             f"| {expectation.path} | {opset} | {supported} | {message} |"
         )


### PR DESCRIPTION
### Motivation

- Replace the hardcoded FP32-accumulation model set with a flexible per-model mapping so additional CLI flags can be attached to individual verification runs. 

### Description

- Replace `FP32_ACCUMULATION_FP64_MODELS` set with `MODEL_EXTRA_VERIFY_ARGS` mapping of repo-relative model paths to extra CLI args used by the verifier. 
- Append any mapped extra args to the `verify` invocation in `_run_expected_error_test` so per-model flags are honored at test/runtime verification. 
- Wire `MODEL_EXTRA_VERIFY_ARGS` into the docs-generator so the ONNX support table appends the flags to the existing Error cell text without adding a new table column. 
- Update `ONNX_SUPPORT.md` entries for the affected models to show the appended `(flags: ...)` note in-place.

### Testing

- No automated tests were executed as part of this change because it is a test-harness and documentation mapping update only. 
- The change is localized to test utilities and the generated markdown and does not alter compilation/runtime codepaths; run targeted `pytest` invocations (or `UPDATE_REFS=1 pytest ...`) when regenerating docs or validating behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697dfc5d2a9c83258ba737841bbca4f3)