### PR TITLE
tests: refresh refs after Clip fix

### DIFF
--- a/ONNX_ERRORS_HISTOGRAM.md
+++ b/ONNX_ERRORS_HISTOGRAM.md
@@ -15,7 +15,7 @@
 | Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 14 | 25 |
 | Unsupported op ImageDecoder | 9 | 20 |
 | Dropout supports only the data input and 1 or 2 outputs | 8 | 22 |
-| Out of tolerance | 8 | 6, 9, 19, 22 |
+| Out of tolerance | 7 | 9, 19, 22 |
 | Unsupported op TfIdfVectorizer | 7 | 9 |
 | Unsupported elem_type 16 (BFLOAT16) for tensor '*'. | 6 | 25 |
 | Unsupported op CenterCropPad | 6 | 18 |
@@ -78,7 +78,6 @@
 
 | Error message | Opset | Count |
 | --- | --- | --- |
-| Out of tolerance | 6 | 1 |
 | Unsupported op Scan | 8 | 1 |
 | Unsupported op TfIdfVectorizer | 9 | 7 |
 | Out of tolerance | 9 | 1 |

--- a/ONNX_SUPPORT.md
+++ b/ONNX_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1404 / 1802 official ONNX files.
+Support 1405 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -1762,7 +1762,7 @@ Floating-point verification first ignores very small differences up to **1.0 × 
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_addmm/model.onnx | 6 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_basic/model.onnx | 6 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_chunk/model.onnx | 6 | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_clip/model.onnx | 6 | ❌ | Out of tolerance (max ULP 17525756) |
+| onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_clip/model.onnx | 6 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_concat2/model.onnx | 6 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_conv/model.onnx | 6 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_convtranspose/model.onnx | 6 | ✅ | OK (max ULP 0) |

--- a/src/emx_onnx_cgen/codegen/c_emitter.py
+++ b/src/emx_onnx_cgen/codegen/c_emitter.py
@@ -1096,6 +1096,8 @@ class CEmitter:
                 input_min=self._map_optional_name(name_map, op.input_min),
                 input_max=self._map_optional_name(name_map, op.input_max),
                 output=name_map.get(op.output, op.output),
+                min_value=op.min_value,
+                max_value=op.max_value,
             )
         if isinstance(op, CastOp):
             return CastOp(
@@ -4272,6 +4274,8 @@ class CEmitter:
                 if op.input_max is not None
                 else None,
                 output=temp_map.get(op.output, op.output),
+                min_value=op.min_value,
+                max_value=op.max_value,
             )
         if isinstance(op, MatMulOp):
             return MatMulOp(
@@ -10808,7 +10812,11 @@ class CEmitter:
                     loop_vars,
                 )
                 if op.input_min is not None
-                else output_dtype.min_literal
+                else (
+                    CEmitter._format_literal(output_dtype, op.min_value)
+                    if op.min_value is not None
+                    else output_dtype.min_literal
+                )
             )
             max_expr = (
                 CEmitter._broadcast_index_expr(
@@ -10818,7 +10826,11 @@ class CEmitter:
                     loop_vars,
                 )
                 if op.input_max is not None
-                else output_dtype.max_literal
+                else (
+                    CEmitter._format_literal(output_dtype, op.max_value)
+                    if op.max_value is not None
+                    else output_dtype.max_literal
+                )
             )
             input_suffix = self._param_array_suffix(
                 input_shape, _dim_names_for(op.input0)

--- a/src/emx_onnx_cgen/ir/ops/elementwise.py
+++ b/src/emx_onnx_cgen/ir/ops/elementwise.py
@@ -220,6 +220,8 @@ class ClipOp(ElementwiseOpBase):
     input_min: str | None
     input_max: str | None
     output: str
+    min_value: float | None = None
+    max_value: float | None = None
 
     def _elementwise_inputs(self) -> tuple[str, ...]:
         inputs = [self.input0]

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-operator__test_operator_clip__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-operator__test_operator_clip__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Out of tolerance (max ULP 17525756)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/pytorch-operator/test_operator_clip model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Clip"
   ],
   "opset_version": 6,
-  "generated_checksum": "b45f3e101621411b494ade4d47c982e7429bc18d92809027920cba82a29a612e"
+  "generated_checksum": "dd5f162ba9dd3ad8357baf62d2e5233681ec946dbcc24bf11c01f0395db341de"
 }


### PR DESCRIPTION
### Motivation
- The Clip lowering fix now preserves literal `min`/`max` bounds for legacy opsets, which changed verification outcomes for the Clip test and requires reference updates.

### Description
- Regenerated golden refs and support artifacts to reflect the Clip fix, updating `tests/expected_errors/onnx-org__onnx__backend__test__data__pytorch-operator__test_operator_clip__model.onnx.json` with a passing status and new checksum.
- Updated `ONNX_SUPPORT.md` to increment the supported-file count and mark the Clip model as `OK (max ULP 0)`. 
- Updated `ONNX_ERRORS_HISTOGRAM.md` to adjust the error histogram counts impacted by the ref refresh.

### Testing
- Ran `UPDATE_REFS=1 pytest -n auto -q --maxfail=10`, which completed in ~153.31s (0:02:33) with `2157 passed, 1 skipped, 2 xfailed, 1 warning` and overall success.
- Verified the Clip model via the recorded command line now reports `OK (max ULP 0)` and the expected-error JSON was updated accordingly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697e06e7685483259fb830d37ed281d0)