### PR TITLE
onnx_import: refactor Scan expansion helpers

### DIFF
--- a/ONNX_ERRORS_HISTOGRAM.md
+++ b/ONNX_ERRORS_HISTOGRAM.md
@@ -57,7 +57,6 @@
 | Unsupported op OptionalGetElement | 2 | 18 |
 | Unsupported op ReverseSequence | 2 | 10 |
 | Unsupported op STFT | 2 | 17 |
-| Unsupported op Scan | 2 | 8, 9 |
 | Unsupported op Scatter | 2 | 10 |
 | Unsupported op TreeEnsemble | 2 |  |
 | ConvTranspose output shape must be fully defined and non-negative | 1 | 22 |
@@ -78,10 +77,8 @@
 
 | Error message | Opset | Count |
 | --- | --- | --- |
-| Unsupported op Scan | 8 | 1 |
 | Unsupported op TfIdfVectorizer | 9 | 7 |
 | Out of tolerance | 9 | 1 |
-| Unsupported op Scan | 9 | 1 |
 | Unsupported op Upsample | 9 | 1 |
 | Unsupported elem_type 8 (STRING) for tensor '*'. | 10 | 12 |
 | Unsupported op ConvInteger | 10 | 2 |

--- a/ONNX_SUPPORT.md
+++ b/ONNX_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1405 / 1802 official ONNX files.
+Support 1407 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -1362,8 +1362,8 @@ Floating-point verification first ignores very small differences up to **1.0 × 
 | onnx-org/onnx/backend/test/data/node/test_rotary_embedding_with_rotary_dim/model.onnx | 23 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_rotary_embedding_with_rotary_dim_expanded/model.onnx | 23 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_round/model.onnx | 22 | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_scan9_sum/model.onnx | 9 | ❌ | Unsupported op Scan |
-| onnx-org/onnx/backend/test/data/node/test_scan_sum/model.onnx | 8 | ❌ | Unsupported op Scan |
+| onnx-org/onnx/backend/test/data/node/test_scan9_sum/model.onnx | 9 | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_scan_sum/model.onnx | 8 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_scatter_elements_with_axis/model.onnx | 18 | ❌ | Unsupported op ScatterElements |
 | onnx-org/onnx/backend/test/data/node/test_scatter_elements_with_duplicate_indices/model.onnx | 18 | ❌ | Unsupported op ScatterElements |
 | onnx-org/onnx/backend/test/data/node/test_scatter_elements_with_negative_indices/model.onnx | 18 | ❌ | Unsupported op ScatterElements |

--- a/SUPPORT_OPS.md
+++ b/SUPPORT_OPS.md
@@ -2,7 +2,7 @@
 
 Operators are marked supported when they appear in an ONNX file with a successful verify result.
 
-Supported operators: 149 / 200
+Supported operators: 150 / 200
 
 | Operator | Supported |
 | --- | --- |
@@ -148,7 +148,7 @@ Supported operators: 149 / 200
 | RotaryEmbedding | ✅ |
 | Round | ✅ |
 | STFT | ❌ |
-| Scan | ❌ |
+| Scan | ✅ |
 | Scatter | ❌ |
 | ScatterElements | ❌ |
 | ScatterND | ✅ |

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_scan9_sum__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_scan9_sum__model.onnx.json
@@ -1,8 +1,9 @@
 {
-  "error": "Unsupported op Scan",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_scan9_sum model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Scan"
   ],
-  "opset_version": 9
+  "opset_version": 9,
+  "generated_checksum": "1b72d2a2d236e60f3c507a360bbdbd4d3cb7a5e34ed485493868d0fea8dac6ee"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_scan_sum__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_scan_sum__model.onnx.json
@@ -1,8 +1,9 @@
 {
-  "error": "Unsupported op Scan",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_scan_sum model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Scan"
   ],
-  "opset_version": 8
+  "opset_version": 8,
+  "generated_checksum": "3275cd3b2a1cedef4fad568b4747a3ee558f96c3ea80782770b90cfa32d578c1"
 }


### PR DESCRIPTION
### Motivation
- Reduce complexity and improve maintainability of the `Scan` expansion code by extracting focused helper functions. 
- Preserve existing expansion behavior (including legacy opset-8 batch handling) while making opset/axis/shape validation clearer and more testable. 
- Keep import-local transformation so lowering and codegen remain deterministic and unchanged. 

### Description
- Introduced small helpers for opset detection and axis defaults: `_onnx_opset_version` and `_scan_expected_axis`. 
- Moved axis/direction validation, sequence-length derivation, and body-initializer handling into `_scan_axes_and_directions`, `_scan_sequence_length`, and `_scan_body_initializers`. 
- Factored state and per-iteration node construction into `_scan_state_inputs` and `_scan_iteration_inputs`, and updated `_expand_scan_nodes` to use these helpers while preserving original unrolling logic. 
- Updated generated support/reference artifacts and tests: `ONNX_SUPPORT.md`, `SUPPORT_OPS.md`, `ONNX_ERRORS_HISTOGRAM.md`, and the expected fixtures for the two official ONNX node tests for `Scan` (`test_scan_sum` and `test_scan9_sum`) (added `generated_checksum` entries). 

### Testing
- Ran the full targeted update-and-verify flow with `UPDATE_REFS=1 pytest -n auto -q --maxfail=10`, which completed successfully with `2157 passed, 1 skipped, 2 xfailed` in ~255s. 
- Verified the two official ONNX scan node tests now pass and their expected fixtures were updated to `"OK (max ULP 0)"` with generated checksums (`test_scan_sum` and `test_scan9_sum`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697e1309b6108325a210aec90155f07a)