### PR TITLE
build: add PyPI project URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,11 @@ readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"
 dynamic = ["version"]
 
+[project.urls]
+Homepage = "https://github.com/emmtrix/emx-onnx-cgen"
+Repository = "https://github.com/emmtrix/emx-onnx-cgen"
+Issues = "https://github.com/emmtrix/emx-onnx-cgen/issues"
+
 [project.scripts]
 emx-onnx-cgen = "emx_onnx_cgen.cli:main"
 


### PR DESCRIPTION
### Motivation
- Add project URL metadata to `pyproject.toml` so PyPI and other tools can link to the repository, homepage, and issue tracker.

### Description
- Add a `[project.urls]` section to `pyproject.toml` with `Homepage`, `Repository`, and `Issues` entries pointing to `https://github.com/emmtrix/emx-onnx-cgen`.

### Testing
- No automated tests were run because this is a metadata-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6981c7a3a06883259dc5e0e9c6526670)