### PR TITLE
build: drop local version metadata for releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,4 @@ where = ["src"]
 
 [tool.setuptools_scm]
 write_to = "src/emx_onnx_cgen/_version.py"
+local_scheme = "no-local-version"


### PR DESCRIPTION
### Motivation
- Prevent PyPI release failures by omitting local version metadata from generated package versions so published distributions are PEP 440 compatible.

### Description
- Add `local_scheme = "no-local-version"` to `pyproject.toml` under `[tool.setuptools_scm]` to instruct `setuptools_scm` to omit local version segments.

### Testing
- No automated tests were run since this is a configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6981f2884b288325abcb81ef87324094)