### PR TITLE
ci: fetch tags for release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
### Motivation
- Ensure the release workflow fetches full git history and tags so `setuptools_scm` can resolve the release tag (e.g. `v0.4.1`) and avoid publishing `*.dev0` versions to PyPI.

### Description
- Add `with: fetch-depth: 0` to the `actions/checkout@v4` step in `.github/workflows/release.yml` so tags are available during the build.

### Testing
- No automated tests were run because this change only updates the CI release workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6981f6e0fa6083259f8d1432804e1010)