### PR TITLE
ci: force setuptools_scm version from tag in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -25,6 +27,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install build
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            export SETUPTOOLS_SCM_PRETEND_VERSION="${GITHUB_REF_NAME#v}"
+          fi
           python -m build
 
       - name: Publish to PyPI


### PR DESCRIPTION
### Motivation
- Ensure release builds publish the exact git tag-derived version instead of a `*.dev0` fallback by making `setuptools_scm` use the tag value. 
- Make tags and full git history available during the build so version resolution is deterministic.

### Description
- Update `.github/workflows/release.yml` to export `SETUPTOOLS_SCM_PRETEND_VERSION` (stripping a leading `v`) when `GITHUB_REF_TYPE` is `tag` before running `python -m build`.
- Ensure the checkout step fetches full history/tags by setting `fetch-depth: 0` so `setuptools_scm` can read tags reliably.

### Testing
- No automated tests were run because this change only modifies the CI release workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6981f6e0fa6083259f8d1432804e1010)