### PR TITLE
build: declare runtime dependencies in pyproject and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,14 @@ Install the package directly from PyPI (recommended):
 pip install emx-onnx-cgen
 ```
 
+Required at runtime (both `compile` and `verify`):
+
+- `onnx`
+- `numpy`
+
 Optional for verification and tests:
 
 - `onnxruntime`
-- `numpy`
 - A C compiler (`cc`, `gcc`, `clang` or via `--cc`)
 
 ## Quickstart

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,15 @@ description = "emmtrix ONNX-to-C Code Generator"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"
 dynamic = ["version"]
+dependencies = [
+    "numpy",
+    "onnx",
+]
+
+[project.optional-dependencies]
+verify = [
+    "onnxruntime",
+]
 
 [project.urls]
 Homepage = "https://github.com/emmtrix/emx-onnx-cgen"


### PR DESCRIPTION
### Motivation
- Ensure the CLI runtime requirements are explicit and packaged so `compile` and `verify` work when installed from PyPI by declaring `onnx` and `numpy` as required dependencies. 

### Description
- Add `dependencies = ["numpy", "onnx"]` and an optional `verify` extra containing `onnxruntime` to `pyproject.toml`, and update `README.md` with a `Required at runtime` section listing `onnx` and `numpy` while cleaning up the verification section. 

### Testing
- No automated tests were run because this is a packaging/metadata and documentation change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6982277d6d9c8325b9eb380cdba263dd)