### PR TITLE
deps/docs: declare Jinja2 dependency and document it in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Required at runtime (both `compile` and `verify`):
 
 - `onnx`
 - `numpy`
+- `jinja2`
 
 Optional for verification and tests:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.10"
 dynamic = ["version"]
 license = { file = "LICENSE" }
 dependencies = [
+    "jinja2",
     "numpy",
     "onnx",
 ]


### PR DESCRIPTION
### Motivation
- The codebase emits Jinja2-based templates during code generation, so `jinja2` must be declared as a runtime dependency and documented for users.

### Description
- Added `"jinja2"` to the `[project].dependencies` list in `pyproject.toml` and added a `- jinja2` entry to the `Installation` section of `README.md` to document the requirement.

### Testing
- No automated tests were run because this change only updates dependency metadata and documentation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69822b944f4083259d3bb0077b4b805c)