### PR TITLE
ir: migrate NonZero/NonMaxSuppression derived state to OpContext

### DIFF
--- a/src/emx_onnx_cgen/lowering/non_max_suppression.py
+++ b/src/emx_onnx_cgen/lowering/non_max_suppression.py
@@ -1,36 +1,10 @@
 from __future__ import annotations
 
-from shared.scalar_types import ScalarType
-
 from ..ir.ops import NonMaxSuppressionOp
-from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..errors import UnsupportedOpError
 from ..ir.model import Graph, Node
-from ..lowering.common import optional_name, shape_product, value_dtype, value_shape
+from ..lowering.common import optional_name
 from .registry import register_lowering
-
-
-def _validate_scalar_input(
-    graph: Graph,
-    name: str,
-    node: Node,
-    *,
-    allowed_dtypes: set[ScalarType],
-    label: str,
-) -> tuple[ScalarType, tuple[int, ...]]:
-    dtype = value_dtype(graph, name, node)
-    if dtype not in allowed_dtypes:
-        allowed = ", ".join(sorted(d.onnx_name for d in allowed_dtypes))
-        raise UnsupportedOpError(
-            f"{node.op_type} {label} must be {allowed}, got {dtype.onnx_name}"
-        )
-    shape = value_shape(graph, name, node)
-    if shape not in {(), (1,)}:
-        total = shape_product(shape)
-        if total != 1:
-            raise ShapeInferenceError(
-                f"{node.op_type} {label} must be a scalar tensor, got shape {shape}"
-            )
-    return dtype, shape
 
 
 @register_lowering("NonMaxSuppression")
@@ -53,87 +27,7 @@ def lower_non_max_suppression(graph: Graph, node: Node) -> NonMaxSuppressionOp:
     score_threshold = optional_name(node.inputs, 4)
     output = node.outputs[0]
 
-    boxes_shape = value_shape(graph, boxes, node)
-    scores_shape = value_shape(graph, scores, node)
-    if len(boxes_shape) != 3 or boxes_shape[2] != 4:
-        raise ShapeInferenceError(
-            f"{node.op_type} boxes input must have shape "
-            f"[num_batches, num_boxes, 4], got {boxes_shape}"
-        )
-    if len(scores_shape) != 3:
-        raise ShapeInferenceError(
-            f"{node.op_type} scores input must have shape "
-            f"[num_batches, num_classes, num_boxes], got {scores_shape}"
-        )
-    if boxes_shape[0] != scores_shape[0]:
-        raise ShapeInferenceError(
-            f"{node.op_type} boxes/scores batch dims must match, "
-            f"got {boxes_shape[0]} and {scores_shape[0]}"
-        )
-    if boxes_shape[1] != scores_shape[2]:
-        raise ShapeInferenceError(
-            f"{node.op_type} boxes num_boxes dim {boxes_shape[1]} "
-            f"must match scores num_boxes dim {scores_shape[2]}"
-        )
-
-    boxes_dtype = value_dtype(graph, boxes, node)
-    scores_dtype = value_dtype(graph, scores, node)
-    if boxes_dtype != scores_dtype or not boxes_dtype.is_float:
-        raise UnsupportedOpError(
-            f"{node.op_type} boxes and scores must be the same float dtype, "
-            f"got {boxes_dtype.onnx_name} and {scores_dtype.onnx_name}"
-        )
-
-    max_output_dtype = None
-    max_output_shape = None
-    if max_output_boxes_per_class is not None:
-        max_output_dtype, max_output_shape = _validate_scalar_input(
-            graph,
-            max_output_boxes_per_class,
-            node,
-            allowed_dtypes={ScalarType.I32, ScalarType.I64},
-            label="max_output_boxes_per_class input",
-        )
-
-    iou_threshold_dtype = None
-    iou_threshold_shape = None
-    if iou_threshold is not None:
-        iou_threshold_dtype, iou_threshold_shape = _validate_scalar_input(
-            graph,
-            iou_threshold,
-            node,
-            allowed_dtypes={ScalarType.F32, ScalarType.F64},
-            label="iou_threshold input",
-        )
-
-    score_threshold_dtype = None
-    score_threshold_shape = None
-    if score_threshold is not None:
-        score_threshold_dtype, score_threshold_shape = _validate_scalar_input(
-            graph,
-            score_threshold,
-            node,
-            allowed_dtypes={ScalarType.F32, ScalarType.F64},
-            label="score_threshold input",
-        )
-
-    output_shape = value_shape(graph, output, node)
-    if len(output_shape) != 2 or output_shape[1] != 3:
-        raise ShapeInferenceError(
-            f"{node.op_type} output must have shape [num_selected, 3], "
-            f"got {output_shape}"
-        )
-    output_dtype = value_dtype(graph, output, node)
-    if output_dtype != ScalarType.I64:
-        raise UnsupportedOpError(
-            f"{node.op_type} output dtype must be int64"
-        )
-
     center_point_box = int(node.attrs.get("center_point_box", 0))
-    if center_point_box not in {0, 1}:
-        raise UnsupportedOpError(
-            f"{node.op_type} center_point_box must be 0 or 1, got {center_point_box}"
-        )
 
     return NonMaxSuppressionOp(
         boxes=boxes,
@@ -142,16 +36,5 @@ def lower_non_max_suppression(graph: Graph, node: Node) -> NonMaxSuppressionOp:
         iou_threshold=iou_threshold,
         score_threshold=score_threshold,
         output=output,
-        boxes_shape=boxes_shape,
-        scores_shape=scores_shape,
-        output_shape=output_shape,
         center_point_box=center_point_box,
-        boxes_dtype=boxes_dtype,
-        output_dtype=output_dtype,
-        max_output_dtype=max_output_dtype,
-        max_output_shape=max_output_shape,
-        iou_threshold_dtype=iou_threshold_dtype,
-        iou_threshold_shape=iou_threshold_shape,
-        score_threshold_dtype=score_threshold_dtype,
-        score_threshold_shape=score_threshold_shape,
     )

--- a/src/emx_onnx_cgen/lowering/nonzero.py
+++ b/src/emx_onnx_cgen/lowering/nonzero.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-from shared.scalar_types import ScalarType
-
 from ..ir.ops import NonZeroOp
-from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..errors import UnsupportedOpError
 from ..ir.model import Graph, Node
-from .common import value_dtype, value_shape
 from .registry import register_lowering
 
 
@@ -13,30 +10,7 @@ from .registry import register_lowering
 def lower_nonzero(graph: Graph, node: Node) -> NonZeroOp:
     if len(node.inputs) != 1 or len(node.outputs) != 1:
         raise UnsupportedOpError("NonZero must have 1 input and 1 output")
-    input_shape = value_shape(graph, node.inputs[0], node)
-    if len(input_shape) == 0:
-        raise UnsupportedOpError("NonZero does not support scalar inputs")
-    output_shape = value_shape(graph, node.outputs[0], node)
-    if len(output_shape) != 2:
-        raise ShapeInferenceError("NonZero output must be 2D")
-    if output_shape[0] != len(input_shape):
-        raise ShapeInferenceError(
-            "NonZero output shape must be "
-            f"({len(input_shape)}, N), got {output_shape}"
-        )
-    if output_shape[0] < 0 or output_shape[1] < 0:
-        raise ShapeInferenceError(
-            "NonZero output shape must be non-negative"
-        )
-    output_dtype = value_dtype(graph, node.outputs[0], node)
-    if output_dtype != ScalarType.I64:
-        raise UnsupportedOpError("NonZero output dtype must be int64")
-    input_dtype = value_dtype(graph, node.inputs[0], node)
     return NonZeroOp(
         input0=node.inputs[0],
         output=node.outputs[0],
-        input_shape=input_shape,
-        output_shape=output_shape,
-        dtype=output_dtype,
-        input_dtype=input_dtype,
     )


### PR DESCRIPTION
### Motivation

- Enforce OpBase invariant that ops are immutable and must not store derived/inferred state on the dataclass itself. 
- Move all derived shapes/dtypes/normalized attributes into `OpContext` to centralize inference state and make passes pure and deterministic. 
- Remove blocking stateful assumptions in codegen and lowering that prevented a clean pass-based design.

### Description

- Refactored `NonZeroOp` and `NonMaxSuppressionOp` to keep only canonical ONNX I/O (and true ONNX attributes like `center_point_box`) on the dataclass and removed all derived fields (shapes, dtypes, cached axes, etc.).
- Implemented validation and inference on the ops via `validate(ctx)`, `infer_types(ctx)`, and `infer_shapes(ctx)` so all derived values are stored/queried through `OpContext` (`set_shape`, `set_dtype`, `set_derived`, `require_derived`).
- Simplified the lowering implementations (`src/emx_onnx_cgen/lowering/nonzero.py`, `src/emx_onnx_cgen/lowering/non_max_suppression.py`) so they construct minimal immutable ops and defer inference to the standard pass order.
- Updated the C emitter (`src/emx_onnx_cgen/codegen/c_emitter.py`) to fetch shapes/dtypes/optional scalar shapes from the active `OpContext` during rendering (`_ctx_shape`, `_ctx_dtype`, `_derived`/_maybe_derived) and adjusted op-mapping/auxiliary helpers accordingly.
- Added/updated unit tests in `tests/test_ops.py` to verify that derived values live in `OpContext`, operator instances remain immutable after construction, and that codegen output remains stable for `NonZero` across compilation runs.
- Files changed: `src/emx_onnx_cgen/ir/ops/misc.py`, `src/emx_onnx_cgen/lowering/nonzero.py`, `src/emx_onnx_cgen/lowering/non_max_suppression.py`, `src/emx_onnx_cgen/codegen/c_emitter.py`, and `tests/test_ops.py`.

### Testing

- Ran targeted unit tests: `pytest -q tests/test_ops.py -k "codegen_emits_transform_logic or nonzero_codegen_output_is_stable or nonzero_inference_stores_values_in_context or nonzero_op_is_immutable_after_construction or non_max_suppression_inference_uses_context_only or nonzero_run_matches_numpy or nonzero_matches_onnxruntime"` which passed (7 passed, 176 deselected) in ~4.0s. 
- Verified formatting/compilation sanity with `python -m compileall -q src tests` which succeeded. 
- Additional focused checks (compiler/codegen render paths touched) were exercised indirectly by the tests to ensure emitted C behavior remains stable and unchanged for the covered cases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69875e44295083259c83950026e2d755)