### PR TITLE
ir: align emit migration with group-base ownership

### DIFF
--- a/src/emx_onnx_cgen/codegen/c_emitter.py
+++ b/src/emx_onnx_cgen/codegen/c_emitter.py
@@ -5106,6 +5106,24 @@ class CEmitter:
         )
 
     def render_op(self, op: OpBase, ctx: EmitContext) -> str:
+        return op.emit(self, ctx)
+
+    def emit_elementwise_op(self, op: ElementwiseOpBase, ctx: EmitContext) -> str:
+        return self.emit_generic_op(op, ctx)
+
+    def emit_gather_like_op(self, op: RenderableOpBase, ctx: EmitContext) -> str:
+        return self.emit_generic_op(op, ctx)
+
+    def emit_shape_like_op(self, op: RenderableOpBase, ctx: EmitContext) -> str:
+        return self.emit_generic_op(op, ctx)
+
+    def emit_variadic_like_op(self, op: RenderableOpBase, ctx: EmitContext) -> str:
+        return self.emit_generic_op(op, ctx)
+
+    def emit_reduce_op(self, op: ReduceOpBase, ctx: EmitContext) -> str:
+        return self.emit_generic_op(op, ctx)
+
+    def emit_generic_op(self, op: OpBase, ctx: EmitContext) -> str:
         if self._emit_state is None:
             raise CodegenError("Emitter state not initialized")
         state = self._emit_state

--- a/src/emx_onnx_cgen/ir/op_base.py
+++ b/src/emx_onnx_cgen/ir/op_base.py
@@ -11,7 +11,17 @@ from .op_context import OpContext
 
 
 class Emitter(Protocol):
-    def render_op(self, op: "OpBase", ctx: "EmitContext") -> str: ...
+    def emit_elementwise_op(self, op: "ElementwiseOpBase", ctx: "EmitContext") -> str: ...
+
+    def emit_gather_like_op(self, op: "GatherLikeOpBase", ctx: "EmitContext") -> str: ...
+
+    def emit_shape_like_op(self, op: "ShapeLikeOpBase", ctx: "EmitContext") -> str: ...
+
+    def emit_variadic_like_op(self, op: "VariadicLikeOpBase", ctx: "EmitContext") -> str: ...
+
+    def emit_reduce_op(self, op: "ReduceOpBase", ctx: "EmitContext") -> str: ...
+
+    def emit_generic_op(self, op: "OpBase", ctx: "EmitContext") -> str: ...
 
 
 @dataclass(frozen=True)
@@ -58,11 +68,14 @@ class OpBase(ABC):
 
 class RenderableOpBase(OpBase):
     def emit(self, emitter: Emitter, ctx: EmitContext) -> str:
-        return emitter.render_op(self, ctx)
+        return emitter.emit_generic_op(self, ctx)
 
 
 class ElementwiseOpBase(RenderableOpBase):
     """Elementwise ops should validate against OpContext and store no derived state."""
+
+    def emit(self, emitter: Emitter, ctx: EmitContext) -> str:
+        return emitter.emit_elementwise_op(self, ctx)
 
     __io_outputs__ = ("output",)
 
@@ -153,6 +166,9 @@ class ElementwiseOpBase(RenderableOpBase):
 
 
 class GatherLikeOpBase(RenderableOpBase):
+    def emit(self, emitter: Emitter, ctx: EmitContext) -> str:
+        return emitter.emit_gather_like_op(self, ctx)
+
     __io_inputs__ = ("data", "indices")
     __io_outputs__ = ("output",)
 
@@ -235,6 +251,9 @@ class GatherLikeOpBase(RenderableOpBase):
 
 
 class ShapeLikeOpBase(RenderableOpBase):
+    def emit(self, emitter: Emitter, ctx: EmitContext) -> str:
+        return emitter.emit_shape_like_op(self, ctx)
+
     __io_inputs__ = ("input0", "input_shape")
     __io_outputs__ = ("output",)
 
@@ -339,6 +358,9 @@ class ShapeLikeOpBase(RenderableOpBase):
 
 
 class VariadicLikeOpBase(RenderableOpBase):
+    def emit(self, emitter: Emitter, ctx: EmitContext) -> str:
+        return emitter.emit_variadic_like_op(self, ctx)
+
     __io_inputs__ = ("inputs",)
     __io_outputs__ = ("output",)
 
@@ -439,6 +461,9 @@ class VariadicLikeOpBase(RenderableOpBase):
 
 
 class ReduceOpBase(RenderableOpBase):
+    def emit(self, emitter: Emitter, ctx: EmitContext) -> str:
+        return emitter.emit_reduce_op(self, ctx)
+
     __io_inputs__ = ("input0",)
     __io_outputs__ = ("output",)
 

--- a/src/emx_onnx_cgen/ir/ops/misc.py
+++ b/src/emx_onnx_cgen/ir/ops/misc.py
@@ -9,6 +9,8 @@ from shared.scalar_types import ScalarType
 from ...errors import ShapeInferenceError, UnsupportedOpError
 from ..op_base import (
     BroadcastingOpBase,
+    EmitContext,
+    Emitter,
     GatherLikeOpBase,
     RenderableOpBase,
     ShapeLikeOpBase,
@@ -427,6 +429,9 @@ class ConstantOfShapeOp(RenderableOpBase):
     dtype: ScalarType
     input_dtype: ScalarType
 
+    def emit(self, emitter: Emitter, ctx: EmitContext) -> str:
+        return emitter.emit_generic_op(self, ctx)
+
 
 @dataclass(frozen=True)
 class ShapeOp(RenderableOpBase):
@@ -440,9 +445,15 @@ class ShapeOp(RenderableOpBase):
     dtype: ScalarType
     input_dtype: ScalarType
 
+    def emit(self, emitter: Emitter, ctx: EmitContext) -> str:
+        return emitter.emit_generic_op(self, ctx)
+
 
 @dataclass(frozen=True)
 class SizeOp(RenderableOpBase):
+    def emit(self, emitter: Emitter, ctx: EmitContext) -> str:
+        return emitter.emit_generic_op(self, ctx)
+
     __io_inputs__ = ("input0",)
     __io_outputs__ = ("output",)
     input0: str
@@ -460,6 +471,9 @@ class OptionalHasElementOp(RenderableOpBase):
     __io_outputs__ = ("output",)
     input0: str
     output: str
+
+    def emit(self, emitter: Emitter, ctx: EmitContext) -> str:
+        return emitter.emit_generic_op(self, ctx)
 
     def validate(self, ctx: OpContext) -> None:
         value = ctx.graph.find_value(self.input0)
@@ -507,6 +521,9 @@ class NonZeroOp(RenderableOpBase):
     __io_outputs__ = ("output",)
     input0: str
     output: str
+
+    def emit(self, emitter: Emitter, ctx: EmitContext) -> str:
+        return emitter.emit_generic_op(self, ctx)
 
     def validate(self, ctx: OpContext) -> None:
         if len(ctx.shape(self.input0)) == 0:


### PR DESCRIPTION
### Motivation
- Reduce duplicated per-op `emit()` boilerplate and keep emission ownership at operator-group base classes to preserve group-level codegen consistency.
- Simplify imports and restore the intended gradual migration where group bases are responsible for dispatching C emission.

### Description
- Added explicit `Emitter` protocol hooks (`emit_elementwise_op`, `emit_gather_like_op`, `emit_shape_like_op`, `emit_variadic_like_op`, `emit_reduce_op`, `emit_generic_op`) and updated `RenderableOpBase` to call `emit_generic_op` by default.
- Implemented group-level `emit()` overrides on `ElementwiseOpBase`, `GatherLikeOpBase`, `ShapeLikeOpBase`, `VariadicLikeOpBase`, and `ReduceOpBase` to dispatch to the corresponding `Emitter` hooks.
- Updated `CEmitter.render_op` to call `op.emit(self, ctx)` and added `CEmitter.emit_*` methods that delegate to the existing `emit_generic_op` implementation.
- Removed redundant concrete `emit()` implementations from elementwise and reduce op modules and cleaned unused imports, and restored explicit generic `emit()` on a few misc ops (`ConstantOfShapeOp`, `ShapeOp`, `SizeOp`, `OptionalHasElementOp`, `NonZeroOp`).

### Testing
- Ran `python -m compileall -q src` which completed without syntax errors.
- Ran the full test suite `pytest -n auto -q --maxfail=10` which passed with `2170 passed, 1 skipped, 2 xfailed` and 1 warning in ~131.31s.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6987aff3ebf0832594cc1ee78b200a8c)