### PR TITLE
codegen: extract reduce-like rendering helper and simplify emitter protocol

### DIFF
--- a/src/emx_onnx_cgen/ir/op_base.py
+++ b/src/emx_onnx_cgen/ir/op_base.py
@@ -11,16 +11,6 @@ from .op_context import OpContext
 
 
 class Emitter(Protocol):
-    def emit_elementwise_op(self, op: "ElementwiseOpBase", ctx: "EmitContext") -> str: ...
-
-    def emit_gather_like_op(self, op: "GatherLikeOpBase", ctx: "EmitContext") -> str: ...
-
-    def emit_shape_like_op(self, op: "ShapeLikeOpBase", ctx: "EmitContext") -> str: ...
-
-    def emit_variadic_like_op(self, op: "VariadicLikeOpBase", ctx: "EmitContext") -> str: ...
-
-    def emit_reduce_op(self, op: "ReduceOpBase", ctx: "EmitContext") -> str: ...
-
     def emit_generic_op(self, op: "OpBase", ctx: "EmitContext") -> str: ...
 
 
@@ -78,7 +68,7 @@ class ElementwiseOpBase(RenderableOpBase):
     """Elementwise ops should validate against OpContext and store no derived state."""
 
     def emit(self, emitter: Emitter, ctx: EmitContext) -> str:
-        return emitter.emit_elementwise_op(self, ctx)
+        return emitter.emit_generic_op(self, ctx)
 
     __io_outputs__ = ("output",)
 
@@ -170,7 +160,7 @@ class ElementwiseOpBase(RenderableOpBase):
 
 class GatherLikeOpBase(RenderableOpBase):
     def emit(self, emitter: Emitter, ctx: EmitContext) -> str:
-        return emitter.emit_gather_like_op(self, ctx)
+        return emitter.emit_generic_op(self, ctx)
 
     __io_inputs__ = ("data", "indices")
     __io_outputs__ = ("output",)
@@ -255,7 +245,7 @@ class GatherLikeOpBase(RenderableOpBase):
 
 class ShapeLikeOpBase(RenderableOpBase):
     def emit(self, emitter: Emitter, ctx: EmitContext) -> str:
-        return emitter.emit_shape_like_op(self, ctx)
+        return emitter.emit_generic_op(self, ctx)
 
     __io_inputs__ = ("input0", "input_shape")
     __io_outputs__ = ("output",)
@@ -365,7 +355,7 @@ class ShapeLikeOpBase(RenderableOpBase):
 
 class VariadicLikeOpBase(RenderableOpBase):
     def emit(self, emitter: Emitter, ctx: EmitContext) -> str:
-        return emitter.emit_variadic_like_op(self, ctx)
+        return emitter.emit_generic_op(self, ctx)
 
     __io_inputs__ = ("inputs",)
     __io_outputs__ = ("output",)
@@ -468,7 +458,7 @@ class VariadicLikeOpBase(RenderableOpBase):
 
 class ReduceOpBase(RenderableOpBase):
     def emit(self, emitter: Emitter, ctx: EmitContext) -> str:
-        return emitter.emit_reduce_op(self, ctx)
+        return emitter.emit_generic_op(self, ctx)
 
     __io_inputs__ = ("input0",)
     __io_outputs__ = ("output",)


### PR DESCRIPTION
### Motivation
- Continue refactor of the large `_render_op(...)` god-method by moving group-specific rendering logic into focused helpers to improve readability and make future op-group ownership easier.
- Reduce emitter surface area by routing all renderable ops through a single `emit_generic_op` path, keeping determinism and existing templates unchanged.

### Description
- Added `_render_reduce_like_op(...)` in `src/emx_onnx_cgen/codegen/c_emitter.py` that encapsulates rendering for `ReduceOp` (static axes), `ArgReduceOp`, `TopKOp`, and dynamic-axes `ReduceOp` using the existing templates and helpers; it returns `str | None` so the main renderer can early-delegate.
- Updated `_render_op(...)` to early-delegate to `_render_gather_like_op(...)` and the new `_render_reduce_like_op(...)`, returning the helper output (with node comment) when applicable, and otherwise continuing with the remaining per-op branches.
- Simplified emitter API in `src/emx_onnx_cgen/ir/op_base.py` by removing the specialized `emit_*` methods from the `Emitter` protocol and changing `RenderableOpBase` and all group bases (`ElementwiseOpBase`, `GatherLikeOpBase`, `ShapeLikeOpBase`, `VariadicLikeOpBase`, `ReduceOpBase`) to call `emit_generic_op` so the emitter only needs a single dispatch entry point.
- Preserved existing templates, formatting, and context helpers to avoid output drift; the refactor is behavioral-preserving (rendering expressions and templates reused).

### Testing
- Ran targeted reduce/topk tests: `pytest -n auto -q --maxfail=10 tests/test_ops.py -k "Reduce or TopK or ArgMax or ArgMin"` — `21 passed, 1 warning` in `12.17s`.
- Ran full suite: `pytest -n auto -q --maxfail=10` — `2170 passed, 1 skipped, 2 xfailed, 1 warning` in `320.65s (0:05:20)`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6988588363d4832598ffd4afa2c2cf0a)