### PR TITLE
refactor: centralize shape/dtype in OpContext and remove derived fields from ops; tighten depth/space test

### DIFF
--- a/src/emx_onnx_cgen/ir/ops/misc.py
+++ b/src/emx_onnx_cgen/ir/ops/misc.py
@@ -51,11 +51,7 @@ class QuantizeLinearOp(RenderableOpBase):
     scale: str
     zero_point: str | None
     output: str
-    input_shape: tuple[int, ...]
     axis: int | None
-    dtype: ScalarType
-    input_dtype: ScalarType
-    scale_dtype: ScalarType
 
 
 @dataclass(frozen=True)
@@ -66,12 +62,8 @@ class DequantizeLinearOp(RenderableOpBase):
     scale: str
     zero_point: str | None
     output: str
-    input_shape: tuple[int, ...]
     axis: int | None
     block_size: int | None
-    dtype: ScalarType
-    input_dtype: ScalarType
-    scale_dtype: ScalarType
 
 
 @dataclass(frozen=True)
@@ -216,15 +208,9 @@ class TriluOp(RenderableOpBase):
     __io_outputs__ = ("output",)
     input0: str
     output: str
-    input_shape: tuple[int, ...]
-    output_shape: tuple[int, ...]
     upper: bool
     k_value: int
     k_input: str | None
-    k_input_shape: tuple[int, ...] | None
-    k_input_dtype: ScalarType | None
-    dtype: ScalarType
-    input_dtype: ScalarType
 
     def call_args(self) -> tuple[str, ...]:
         args = [self.input0, self.output]
@@ -239,12 +225,7 @@ class TileOp(RenderableOpBase):
     __io_outputs__ = ("output",)
     input0: str
     output: str
-    input_shape: tuple[int, ...]
-    output_shape: tuple[int, ...]
     repeats: tuple[int, ...]
-    input_strides: tuple[int, ...]
-    dtype: ScalarType
-    input_dtype: ScalarType
 
 
 @dataclass(frozen=True)
@@ -280,12 +261,8 @@ class DepthToSpaceOp(RenderableOpBase):
     __io_outputs__ = ("output",)
     input0: str
     output: str
-    input_shape: tuple[int, ...]
-    output_shape: tuple[int, ...]
     blocksize: int
     mode: str
-    dtype: ScalarType
-    input_dtype: ScalarType
 
 
 @dataclass(frozen=True)
@@ -294,11 +271,7 @@ class SpaceToDepthOp(RenderableOpBase):
     __io_outputs__ = ("output",)
     input0: str
     output: str
-    input_shape: tuple[int, ...]
-    output_shape: tuple[int, ...]
     blocksize: int
-    dtype: ScalarType
-    input_dtype: ScalarType
 
 
 @dataclass(frozen=True)
@@ -700,12 +673,8 @@ class CumSumOp(RenderableOpBase):
     __io_outputs__ = ("output",)
     input0: str
     axis_input: str | None
-    axis_input_dtype: ScalarType | None
     axis: int | None
     output: str
-    input_shape: tuple[int, ...]
-    dtype: ScalarType
-    input_dtype: ScalarType
     exclusive: bool
     reverse: bool
 
@@ -738,13 +707,6 @@ class OneHotOp(RenderableOpBase):
     values: str
     output: str
     axis: int
-    indices_shape: tuple[int, ...]
-    values_shape: tuple[int, ...]
-    output_shape: tuple[int, ...]
-    depth_dim: int
-    dtype: ScalarType
-    indices_dtype: ScalarType
-    depth_dtype: ScalarType
 
 
 @dataclass(frozen=True)
@@ -753,10 +715,6 @@ class TfIdfVectorizerOp(RenderableOpBase):
     __io_outputs__ = ("output",)
     input0: str
     output: str
-    input_shape: tuple[int, ...]
-    output_shape: tuple[int, ...]
-    input_dtype: ScalarType
-    output_dtype: ScalarType
     min_gram_length: int
     max_gram_length: int
     max_skip_count: int
@@ -773,8 +731,6 @@ class StringNormalizerOp(RenderableOpBase):
     __io_outputs__ = ("output",)
     input0: str
     output: str
-    input_shape: tuple[int, ...]
-    output_shape: tuple[int, ...]
     case_change_action: str
     is_case_sensitive: bool
     stopwords: tuple[str, ...]
@@ -786,9 +742,5 @@ class SplitOp(RenderableOpBase):
     __io_outputs__ = ("outputs",)
     input0: str
     outputs: tuple[str, ...]
-    input_shape: tuple[int, ...]
-    output_shapes: tuple[tuple[int, ...], ...]
     axis: int
     split_sizes: tuple[int, ...]
-    dtype: ScalarType
-    input_dtype: ScalarType

--- a/src/emx_onnx_cgen/lowering/cumsum.py
+++ b/src/emx_onnx_cgen/lowering/cumsum.py
@@ -81,7 +81,6 @@ def lower_cumsum(graph: Graph, node: Node) -> CumSumOp:
     axis_initializer = _find_initializer(graph, axis_name)
     axis_value = None
     axis_input = None
-    axis_input_dtype = None
     if axis_initializer is not None:
         axis_value = normalize_axis(
             _read_axis_initializer(axis_initializer, node),
@@ -107,12 +106,8 @@ def lower_cumsum(graph: Graph, node: Node) -> CumSumOp:
     return CumSumOp(
         input0=input_name,
         axis_input=axis_input,
-        axis_input_dtype=axis_input_dtype,
         axis=axis_value,
         output=node.outputs[0],
-        input_shape=input_shape,
-        dtype=input_dtype,
-        input_dtype=input_dtype,
         exclusive=bool(exclusive),
         reverse=bool(reverse),
     )

--- a/src/emx_onnx_cgen/lowering/depth_space.py
+++ b/src/emx_onnx_cgen/lowering/depth_space.py
@@ -62,12 +62,8 @@ def lower_depth_to_space(graph: Graph, node: Node) -> DepthToSpaceOp:
     return DepthToSpaceOp(
         input0=node.inputs[0],
         output=node.outputs[0],
-        input_shape=input_shape,
-        output_shape=output_shape,
         blocksize=blocksize,
         mode=mode,
-        dtype=output_dtype,
-        input_dtype=input_dtype,
     )
 
 
@@ -106,9 +102,5 @@ def lower_space_to_depth(graph: Graph, node: Node) -> SpaceToDepthOp:
     return SpaceToDepthOp(
         input0=node.inputs[0],
         output=node.outputs[0],
-        input_shape=input_shape,
-        output_shape=output_shape,
         blocksize=blocksize,
-        dtype=output_dtype,
-        input_dtype=input_dtype,
     )

--- a/src/emx_onnx_cgen/lowering/dequantize_linear.py
+++ b/src/emx_onnx_cgen/lowering/dequantize_linear.py
@@ -119,10 +119,6 @@ def lower_dequantize_linear(graph: Graph, node: Node) -> DequantizeLinearOp:
         scale=node.inputs[1],
         zero_point=zero_point_name,
         output=node.outputs[0],
-        input_shape=spec.input_shape,
         axis=spec.axis,
         block_size=spec.block_size,
-        dtype=output_dtype,
-        input_dtype=input_dtype,
-        scale_dtype=scale_dtype,
     )

--- a/src/emx_onnx_cgen/lowering/one_hot.py
+++ b/src/emx_onnx_cgen/lowering/one_hot.py
@@ -110,11 +110,4 @@ def lower_onehot(graph: Graph, node: Node) -> OneHotOp:
         values=values_name,
         output=node.outputs[0],
         axis=axis,
-        indices_shape=indices_shape,
-        values_shape=values_shape,
-        output_shape=output_shape,
-        depth_dim=depth_dim,
-        dtype=values_dtype,
-        indices_dtype=indices_dtype,
-        depth_dtype=depth_dtype,
     )

--- a/src/emx_onnx_cgen/lowering/quantize_linear.py
+++ b/src/emx_onnx_cgen/lowering/quantize_linear.py
@@ -118,9 +118,5 @@ def lower_quantize_linear(graph: Graph, node: Node) -> QuantizeLinearOp:
         scale=node.inputs[1],
         zero_point=optional_name(node.inputs, 2),
         output=node.outputs[0],
-        input_shape=spec.input_shape,
         axis=spec.axis,
-        dtype=spec.output_dtype,
-        input_dtype=op_dtype,
-        scale_dtype=scale_dtype,
     )

--- a/src/emx_onnx_cgen/lowering/split.py
+++ b/src/emx_onnx_cgen/lowering/split.py
@@ -175,10 +175,6 @@ def lower_split(graph: Graph, node: Node) -> SplitOp:
     return SplitOp(
         input0=input_name,
         outputs=tuple(node.outputs),
-        input_shape=input_shape,
-        output_shapes=tuple(computed_shapes),
         axis=axis,
         split_sizes=tuple(split_sizes),
-        dtype=input_dtype,
-        input_dtype=input_dtype,
     )

--- a/src/emx_onnx_cgen/lowering/string_normalizer.py
+++ b/src/emx_onnx_cgen/lowering/string_normalizer.py
@@ -79,8 +79,6 @@ def lower_string_normalizer(graph: Graph, node: Node) -> StringNormalizerOp:
     return StringNormalizerOp(
         input0=input_name,
         output=output_name,
-        input_shape=input_shape,
-        output_shape=output_shape,
         case_change_action=case_change_action,
         is_case_sensitive=bool(int(node.attrs.get("is_case_sensitive", 0))),
         stopwords=_decode_stopwords(node.attrs.get("stopwords")),

--- a/src/emx_onnx_cgen/lowering/tfidf_vectorizer.py
+++ b/src/emx_onnx_cgen/lowering/tfidf_vectorizer.py
@@ -184,10 +184,6 @@ def lower_tfidf_vectorizer(graph: Graph, node: Node) -> TfIdfVectorizerOp:
     return TfIdfVectorizerOp(
         input0=input_name,
         output=output_name,
-        input_shape=input_shape,
-        output_shape=output_shape,
-        input_dtype=input_dtype,
-        output_dtype=output_dtype,
         min_gram_length=min_gram_length,
         max_gram_length=max_gram_length,
         max_skip_count=max_skip_count,

--- a/src/emx_onnx_cgen/lowering/tile.py
+++ b/src/emx_onnx_cgen/lowering/tile.py
@@ -109,10 +109,5 @@ def lower_tile(graph: Graph, node: Node) -> TileOp:
     return TileOp(
         input0=node.inputs[0],
         output=node.outputs[0],
-        input_shape=input_shape,
-        output_shape=expected_shape,
         repeats=repeats,
-        input_strides=_compute_strides(input_shape),
-        dtype=output_dtype,
-        input_dtype=input_dtype,
     )

--- a/src/emx_onnx_cgen/lowering/trilu.py
+++ b/src/emx_onnx_cgen/lowering/trilu.py
@@ -58,8 +58,6 @@ def lower_trilu(graph: Graph, node: Node) -> TriluOp:
     k_input = optional_name(node.inputs, 1)
     k_value = 0
     k_input_name = None
-    k_input_shape = None
-    k_input_dtype = None
     if k_input:
         k_initializer = _find_initializer(graph, k_input)
         if k_initializer is not None:
@@ -72,18 +70,10 @@ def lower_trilu(graph: Graph, node: Node) -> TriluOp:
             if k_dtype != ScalarType.I64:
                 raise UnsupportedOpError("Trilu k input must be int64")
             k_input_name = k_input
-            k_input_shape = k_shape
-            k_input_dtype = k_dtype
     return TriluOp(
         input0=input_name,
         output=node.outputs[0],
-        input_shape=input_shape,
-        output_shape=output_shape,
         upper=upper,
         k_value=k_value,
         k_input=k_input_name,
-        k_input_shape=k_input_shape,
-        k_input_dtype=k_input_dtype,
-        dtype=output_dtype,
-        input_dtype=input_dtype,
     )


### PR DESCRIPTION
### Motivation
- Centralize shape and dtype resolution in the `OpContext`/codegen path instead of embedding derived or remappable metadata on op dataclasses to avoid drift and hidden state. 
- Make code generation deterministic and less brittle by querying shapes/dtypes at emission time and removing duplicated/derived fields from IR ops.
- Strengthen the depth/space regression test to lock the dataclass surface exactly and catch accidental reintroductions of derived fields.

### Description
- Removed many derived `*_shape` and `*_dtype` fields from multiple op dataclasses in `src/emx_onnx_cgen/ir/ops/misc.py` (e.g., `QuantizeLinearOp`, `DequantizeLinearOp`, `TriluOp`, `TileOp`, `DepthToSpaceOp`, `SpaceToDepthOp`, `OneHotOp`, `TfIdfVectorizerOp`, `StringNormalizerOp`, `SplitOp`, `CumSumOp`, etc.).
- Updated lowering functions in `src/emx_onnx_cgen/lowering/*` to stop attaching shape/dtype fields to ops (lowerers now return ops with only explicit ONNX attributes and IO names). 
- Refactored `CEmitter` (`src/emx_onnx_cgen/codegen/c_emitter.py`) to query shapes and dtypes from the emission context via `self._ctx_shape(...)` and `self._ctx_dtype(...)` instead of using removed op fields, and adjusted template parameter suffixes, loop vars, and index computations accordingly. 
- Adjusted various codegen helpers and dtype/shape resolution sites to use `model.op_context` or `_ctx_*` helpers (including fixes for `Split`, `Tile`, `Trilu`, `DepthToSpace`, `SpaceToDepth`, `OneHot`, `QuantizeLinear`, `DequantizeLinear`, `TfIdfVectorizer`, `StringNormalizer`, `CumSum`, and others). 
- Tightened the regression test in `tests/test_ops.py` by importing `fields` from `dataclasses` and asserting the exact set of dataclass field names for lowered `DepthToSpace` and `SpaceToDepth` ops via `dataclasses.fields(...)` instead of ad-hoc `hasattr` checks.

### Testing
- Ran `pytest -q tests/test_ops.py -k "depth_space_ops_keep_only_explicit_attrs or onehot_axis_normalization" --maxfail=1`, which passed: `2 passed, 182 deselected` in ~3.67s. 
- Ran `pytest -q tests/test_ops.py -k "DepthToSpace or SpaceToDepth" --maxfail=1`, which passed: `4 passed, 180 deselected` in ~1.69s. 
- Ran `pytest -q tests/test_golden_ops.py -k "depth_to_space or space_to_depth" --maxfail=1`, which passed: `2 passed, 52 deselected` in ~3.72s.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6989e0a61ff08325aa714dcf536d875d)