### PR TITLE
tests: fix broken QLinearConv test model helper

### DIFF
--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -2100,6 +2100,17 @@ def _make_qlinearconv_model(
         [input_info],
         [output],
         initializer=initializers,
+    )
+    model = helper.make_model(
+        graph,
+        producer_name="onnx2c",
+        opset_imports=[helper.make_operatorsetid("", 10)],
+    )
+    model.ir_version = 7
+    onnx.checker.check_model(model)
+    return model
+
+
 def _make_matmulinteger_model() -> onnx.ModelProto:
     input_info = helper.make_tensor_value_info("in0", TensorProto.UINT8, [2, 3])
     weight_values = np.arange(12, dtype=np.uint8).reshape(3, 4)


### PR DESCRIPTION
### Motivation
- A missing closing/model-construction block in the `_make_qlinearconv_model` test helper caused a `SyntaxError` during pytest collection and prevented several test modules from running.

### Description
- Restore the missing `make_graph` closing parenthesis and complete the model construction by adding `helper.make_model(...)` for the QLinearConv helper in `tests/test_ops.py`.
- Set `model.ir_version = 7`, run `onnx.checker.check_model(model)`, and `return model` from the helper.

### Testing
- Ran targeted tests with `pytest -q tests/test_ops.py -k 'qlinearconv or matmulinteger'` which passed (`3 passed, 188 deselected`) in ~2.77s.
- Ran the broader test selection with `pytest -q tests/test_ops.py tests/test_cli.py tests/test_golden_ops.py` which passed (`251 passed, 1 skipped, 2 xfailed, 1 warning`) in ~66.64s.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698ed98a0c4883258c42fca565084cb6)