### PR TITLE
Fix Compress testbench build, add lowering/codegen and refresh ONNX refs

### DIFF
--- a/ONNX_ERRORS_HISTOGRAM.md
+++ b/ONNX_ERRORS_HISTOGRAM.md
@@ -25,7 +25,6 @@
 | OptionalHasElement expects exactly one non-empty input. | 4 | 18 |
 | Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 4 | 25 |
 | Unsupported op AffineGrid | 4 | 20 |
-| Unsupported op Compress | 4 | 11 |
 | Unsupported op DeformConv | 4 | 22 |
 | Unsupported op LabelEncoder | 4 |  |
 | Unsupported op RNN | 4 | 22 |
@@ -72,7 +71,6 @@
 | Error message | Opset | Count |
 | --- | --- | --- |
 | Out of tolerance | 9 | 1 |
-| Unsupported op Compress | 11 | 4 |
 | Unsupported op DynamicQuantizeLinear | 11 | 3 |
 | Unsupported op Loop | 11 | 3 |
 | Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 11 | 2 |

--- a/ONNX_SUPPORT.md
+++ b/ONNX_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1451 / 1802 official ONNX files.
+Support 1455 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -502,10 +502,10 @@ Floating-point verification first ignores very small differences up to **1.0 × 
 | onnx-org/onnx/backend/test/data/node/test_col2im_dilations/model.onnx | 18 | ❌ | Unsupported op Col2Im |
 | onnx-org/onnx/backend/test/data/node/test_col2im_pads/model.onnx | 18 | ❌ | Unsupported op Col2Im |
 | onnx-org/onnx/backend/test/data/node/test_col2im_strides/model.onnx | 18 | ❌ | Unsupported op Col2Im |
-| onnx-org/onnx/backend/test/data/node/test_compress_0/model.onnx | 11 | ❌ | Unsupported op Compress |
-| onnx-org/onnx/backend/test/data/node/test_compress_1/model.onnx | 11 | ❌ | Unsupported op Compress |
-| onnx-org/onnx/backend/test/data/node/test_compress_default_axis/model.onnx | 11 | ❌ | Unsupported op Compress |
-| onnx-org/onnx/backend/test/data/node/test_compress_negative_axis/model.onnx | 11 | ❌ | Unsupported op Compress |
+| onnx-org/onnx/backend/test/data/node/test_compress_0/model.onnx | 11 | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_compress_1/model.onnx | 11 | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_compress_default_axis/model.onnx | 11 | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_compress_negative_axis/model.onnx | 11 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_concat_1d_axis_0/model.onnx | 13 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_concat_1d_axis_negative_1/model.onnx | 13 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_concat_2d_axis_0/model.onnx | 13 | ✅ | OK (max ULP 0) |

--- a/SUPPORT_OPS.md
+++ b/SUPPORT_OPS.md
@@ -2,7 +2,7 @@
 
 Operators are marked supported when they appear in an ONNX file with a successful verify result.
 
-Supported operators: 160 / 201
+Supported operators: 161 / 201
 
 | Operator | Supported |
 | --- | --- |
@@ -35,7 +35,7 @@ Supported operators: 160 / 201
 | CenterCropPad | ❌ |
 | Clip | ✅ |
 | Col2Im | ❌ |
-| Compress | ❌ |
+| Compress | ✅ |
 | Concat | ✅ |
 | ConcatFromSequence | ❌ |
 | Constant | ✅ |

--- a/src/emx_onnx_cgen/ir/ops/__init__.py
+++ b/src/emx_onnx_cgen/ir/ops/__init__.py
@@ -12,6 +12,7 @@ from .elementwise import (
 from .misc import (
     BernoulliOp,
     CastOp,
+    CompressOp,
     ConcatOp,
     ConstantOfShapeOp,
     CumSumOp,
@@ -93,6 +94,7 @@ __all__ = [
     "BernoulliOp",
     "BinaryOp",
     "CastOp",
+    "CompressOp",
     "ClipOp",
     "ConcatOp",
     "ConstantOfShapeOp",

--- a/src/emx_onnx_cgen/ir/ops/misc.py
+++ b/src/emx_onnx_cgen/ir/ops/misc.py
@@ -82,6 +82,16 @@ class ConcatOp(RenderableOpBase):
 
 
 @dataclass(frozen=True)
+class CompressOp(RenderableOpBase):
+    __io_inputs__ = ("data", "condition")
+    __io_outputs__ = ("output",)
+    data: str
+    condition: str
+    output: str
+    axis: int | None
+
+
+@dataclass(frozen=True)
 class GatherElementsOp(RenderableOpBase):
     __io_inputs__ = ("data", "indices")
     __io_outputs__ = ("output",)

--- a/src/emx_onnx_cgen/lowering/__init__.py
+++ b/src/emx_onnx_cgen/lowering/__init__.py
@@ -12,6 +12,7 @@ _LOWERING_MODULES = [
     "batch_normalization",
     "bernoulli",
     "cast",
+    "compress",
     "concat",
     "constant_of_shape",
     "conv",

--- a/src/emx_onnx_cgen/lowering/compress.py
+++ b/src/emx_onnx_cgen/lowering/compress.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from shared.scalar_types import ScalarType
+
+from ..errors import ShapeInferenceError, UnsupportedOpError
+from ..ir.context import GraphContext
+from ..ir.model import Graph, Node
+from ..ir.ops import CompressOp
+from ..lowering.common import value_dtype, value_shape
+from ..validation import normalize_axis
+from .registry import register_lowering
+
+
+@register_lowering("Compress")
+def lower_compress(graph: Graph, node: Node) -> CompressOp:
+    if len(node.inputs) != 2 or len(node.outputs) != 1:
+        raise UnsupportedOpError("Compress must have 2 inputs and 1 output")
+
+    data_name, condition_name = node.inputs
+    output_name = node.outputs[0]
+    data_shape = value_shape(graph, data_name, node)
+    condition_shape = value_shape(graph, condition_name, node)
+    output_shape = value_shape(graph, output_name, node)
+
+    if len(condition_shape) != 1:
+        raise ShapeInferenceError(
+            f"Compress condition must be rank 1, got shape {condition_shape}"
+        )
+
+    condition_dtype = value_dtype(graph, condition_name, node)
+    if condition_dtype != ScalarType.BOOL:
+        raise UnsupportedOpError(
+            "Compress condition must be bool, " f"got {condition_dtype.onnx_name}"
+        )
+
+    axis_attr = node.attrs.get("axis")
+    if axis_attr is None:
+        axis: int | None = None
+        data_element_count = 1
+        for dim in data_shape:
+            data_element_count *= dim
+        if condition_shape[0] > data_element_count:
+            raise ShapeInferenceError(
+                "Compress condition length must be <= flattened data length, "
+                f"got {condition_shape[0]} and {data_element_count}"
+            )
+        if len(output_shape) != 1:
+            raise ShapeInferenceError(
+                "Compress output must be rank 1 when axis is not provided, "
+                f"got {output_shape}"
+            )
+    else:
+        axis = normalize_axis(int(axis_attr), data_shape, node)
+        if condition_shape[0] > data_shape[axis]:
+            raise ShapeInferenceError(
+                f"Compress condition length must be <= axis dimension, got {condition_shape[0]} and {data_shape[axis]}"
+            )
+        if len(output_shape) != len(data_shape):
+            raise ShapeInferenceError(
+                "Compress output rank must match data rank when axis is set, "
+                f"got output shape {output_shape} and data shape {data_shape}"
+            )
+
+    if isinstance(graph, GraphContext):
+        graph.set_shape(output_name, output_shape)
+
+    return CompressOp(
+        data=data_name,
+        condition=condition_name,
+        output=output_name,
+        axis=axis,
+    )

--- a/src/emx_onnx_cgen/templates/compress_op.c.j2
+++ b/src/emx_onnx_cgen/templates/compress_op.c.j2
@@ -1,0 +1,35 @@
+static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
+{% if axis_is_none %}
+    idx_t out_index = 0;
+    for (idx_t cond_index = 0; cond_index < {{ condition_length }}; ++cond_index) {
+        if (!{{ condition }}[cond_index]) {
+            continue;
+        }
+        if (out_index < {{ output_size }}) {
+            {{ output }}[out_index] = ((const {{ c_type }}*){{ data }})[cond_index];
+            ++out_index;
+        }
+    }
+{% else %}
+    for (idx_t out_linear = 0; out_linear < {{ output_size }}; ++out_linear) {
+        idx_t remainder = out_linear;
+{% for dim in output_shape %}
+        idx_t {{ loop_vars[loop.index0] }} = remainder / {{ output_strides[loop.index0] }};
+        remainder = remainder % {{ output_strides[loop.index0] }};
+{% endfor %}
+        idx_t selected_data_axis = 0;
+        idx_t selected_count = 0;
+        for (idx_t cond_index = 0; cond_index < {{ condition_length }}; ++cond_index) {
+            if (!{{ condition }}[cond_index]) {
+                continue;
+            }
+            if (selected_count == {{ loop_vars[axis] }}) {
+                selected_data_axis = cond_index;
+                break;
+            }
+            ++selected_count;
+        }
+        {{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = {{ data }}{% for var in loop_vars %}[{% if loop.index0 == axis %}selected_data_axis{% else %}{{ var }}{% endif %}]{% endfor %};
+    }
+{% endif %}
+}

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_compress_0__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_compress_0__model.onnx.json
@@ -1,8 +1,9 @@
 {
-  "error": "Unsupported op Compress",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_compress_0 model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Compress"
   ],
-  "opset_version": 11
+  "opset_version": 11,
+  "generated_checksum": "efbb0983e7f6cf6ae103d46f3fc1a0b80775e61fc3b6c8c0eae8e1ccd2855fb8"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_compress_1__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_compress_1__model.onnx.json
@@ -1,8 +1,9 @@
 {
-  "error": "Unsupported op Compress",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_compress_1 model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Compress"
   ],
-  "opset_version": 11
+  "opset_version": 11,
+  "generated_checksum": "074ce6d0f290b0e5440dbb2746d0e77f3a2d06ae134c161fac844a9ab455f433"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_compress_default_axis__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_compress_default_axis__model.onnx.json
@@ -1,8 +1,9 @@
 {
-  "error": "Unsupported op Compress",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_compress_default_axis model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Compress"
   ],
-  "opset_version": 11
+  "opset_version": 11,
+  "generated_checksum": "930e21d4b1da3e25c5d8f7b6c7a073d348cd51a65b4d713d70d3c4688902d772"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_compress_negative_axis__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_compress_negative_axis__model.onnx.json
@@ -1,8 +1,9 @@
 {
-  "error": "Unsupported op Compress",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_compress_negative_axis model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Compress"
   ],
-  "opset_version": 11
+  "opset_version": 11,
+  "generated_checksum": "09b47e50ae9754c7fc34b9b4e77a4acd79933755e414968816d175dacf54c64f"
 }


### PR DESCRIPTION
### Motivation
- Add first-class support for the ONNX `Compress` operator so models using it can be lowered and compiled end-to-end.
- Fix a C template bug that caused testbench compilation to fail under `-Werror` (unused local and incorrect data indexing for flattened mode).
- Keep generated C deterministic and correctly typed by wiring the emitted dtype through the emitter into the template.

### Description
- Implemented the `Compress` IR op and exported it from `ir.ops` (`CompressOp` in `src/emx_onnx_cgen/ir/ops/misc.py`).
- Added lowering for `Compress` with input/output arity checks, condition-rank/dtype validation, axis normalization and shape constraints (`src/emx_onnx_cgen/lowering/compress.py`) and registered the module.
- Added template-driven codegen: `compress_op.c.j2` and emitter wiring in `CEmitter` to pass `c_type`, shapes/strides and render axis/default behavior (`src/emx_onnx_cgen/templates/compress_op.c.j2`, `src/emx_onnx_cgen/codegen/c_emitter.py`).
- Updated tests and repository metadata: new unit/integration tests in `tests/test_ops.py`, refreshed expected-error JSONs and ONNX support docs (`tests/expected_errors/*`, `ONNX_SUPPORT.md`, `SUPPORT_OPS.md`, `ONNX_ERRORS_HISTOGRAM.md`).

### Testing
- Ran targeted tests: `pytest -q tests/test_ops.py -k "compress"` (3 passed, 193 deselected) and these passed.
- Verified CLI end-to-end for official ONNX Compress cases via `cli.run_cli_command(...)` for the four official `Compress` models and all returned `OK (max ULP 0)`.
- Regenerated references and ran the broader suite: `UPDATE_REFS=1 pytest -n auto -q --maxfail=10` (2193 passed, 1 skipped, 2 xfailed; refs updated successfully).
- Ran linter/format checks: `ruff check` on modified emitter passed and `black` formatting applied where needed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69962d79814083259e637bc9377aac0a)