### PR TITLE
onnx_import: inline expandable Loop subgraphs and add Loop→Range lowering; refresh refs

### DIFF
--- a/ONNX_ERRORS_HISTOGRAM.md
+++ b/ONNX_ERRORS_HISTOGRAM.md
@@ -17,8 +17,8 @@
 | Unsupported op CenterCropPad | 6 | 18 |
 | Unsupported op DFT | 6 | 19, 20 |
 | Unsupported op If | 6 | 11, 13, 20 |
+| Unsupported op Loop | 6 | 17 |
 | Unsupported op ScatterElements | 6 | 18 |
-| Unsupported op SequenceLength | 6 | 17 |
 | Unsupported op SequenceMap | 6 | 17 |
 | Unsupported op SplitToSequence | 6 | 12, 24 |
 | Unsupported op StringSplit | 6 | 20 |
@@ -29,21 +29,21 @@
 | Unsupported op AffineGrid | 4 | 20 |
 | Unsupported op DeformConv | 4 | 22 |
 | Unsupported op LabelEncoder | 4 |  |
-| Unsupported op Loop | 4 | 11, 13 |
 | Unsupported op RNN | 4 | 22 |
 | Unsupported op SequenceConstruct | 4 | 12 |
-| Unsupported optional element type '*' for '*'. Hint: export the model with optional tensor inputs/outputs. | 4 | 16, 18 |
 | HardSigmoid only supports alpha=0.2 | 3 | 22 |
 | Unsupported op Momentum | 3 |  |
 | Unsupported op OptionalGetElement | 3 | 18 |
 | Unsupported op RandomUniformLike | 3 | 22 |
 | Unsupported op RegexFullMatch | 3 | 20 |
 | Unsupported op RoiAlign | 3 | 22 |
+| Unsupported optional element type '*' for '*'. Hint: export the model with optional tensor inputs/outputs. | 3 | 16, 18 |
 | BatchNormalization must have 5 inputs and 1 output | 2 | 15 |
 | Failed to build testbench. | 2 | 12 |
 | Gelu only supports approximate=none | 2 | 20 |
 | LpPool expects 2D kernel_shape | 2 | 22 |
 | LpPool supports auto_pad=NOTSET only | 2 | 22 |
+| ONNX shape inference failed | 2 | 13, 16 |
 | QuantizeLinear block_size is not supported | 2 | 25 |
 | Selu only supports alpha=1.6732632423543772 | 2 | 22 |
 | ThresholdedRelu only supports alpha=1.0 | 2 | 22 |
@@ -74,19 +74,19 @@
 | Error message | Opset | Count |
 | --- | --- | --- |
 | Out of tolerance | 9 | 1 |
-| Unsupported op Loop | 11 | 3 |
 | Unsupported op If | 11 | 1 |
 | Unsupported op SequenceConstruct | 12 | 4 |
 | Unsupported op SplitToSequence | 12 | 3 |
 | Failed to build testbench. | 12 | 2 |
 | Unsupported op Gradient | 12 | 2 |
 | Dynamic dim for tensor '*' | 12 | 1 |
+| ONNX shape inference failed | 13 | 1 |
 | Testbench execution failed: exit code 1 | 13 | 1 |
 | Unsupported op If | 13 | 1 |
-| Unsupported op Loop | 13 | 1 |
 | BatchNormalization must have 5 inputs and 1 output | 15 | 2 |
-| Unsupported optional element type '*' for '*'. Hint: export the model with optional tensor inputs/outputs. | 16 | 3 |
-| Unsupported op SequenceLength | 17 | 6 |
+| Unsupported optional element type '*' for '*'. Hint: export the model with optional tensor inputs/outputs. | 16 | 2 |
+| ONNX shape inference failed | 16 | 1 |
+| Unsupported op Loop | 17 | 6 |
 | Unsupported op SequenceMap | 17 | 6 |
 | Unsupported op BlackmanWindow | 17 | 2 |
 | Unsupported op HannWindow | 17 | 2 |

--- a/ONNX_SUPPORT.md
+++ b/ONNX_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1460 / 1802 official ONNX files.
+Support 1463 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -888,9 +888,9 @@ Floating-point verification first ignores very small differences up to **1.0 × 
 | onnx-org/onnx/backend/test/data/node/test_logsoftmax_negative_axis/model.onnx | 13 | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/node/test_logsoftmax_negative_axis_expanded/model.onnx | 13 | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/node/test_logsoftmax_negative_axis_expanded_ver18/model.onnx | 18 | ✅ | OK (max ULP 1) |
-| onnx-org/onnx/backend/test/data/node/test_loop11/model.onnx | 11 | ❌ | Unsupported op Loop |
-| onnx-org/onnx/backend/test/data/node/test_loop13_seq/model.onnx | 13 | ❌ | Unsupported op Loop |
-| onnx-org/onnx/backend/test/data/node/test_loop16_seq_none/model.onnx | 16 | ❌ | Unsupported optional element type 'sequence_type' for 'opt_seq'. Hint: export the model with optional tensor inputs/outputs. |
+| onnx-org/onnx/backend/test/data/node/test_loop11/model.onnx | 11 | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_loop13_seq/model.onnx | 13 | ❌ | ONNX shape inference failed |
+| onnx-org/onnx/backend/test/data/node/test_loop16_seq_none/model.onnx | 16 | ❌ | ONNX shape inference failed |
 | onnx-org/onnx/backend/test/data/node/test_lpnormalization_default/model.onnx | 22 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_lppool_1d_default/model.onnx | 22 | ❌ | LpPool expects 2D kernel_shape |
 | onnx-org/onnx/backend/test/data/node/test_lppool_2d_default/model.onnx | 22 | ✅ | OK (max ULP 0) |
@@ -1110,9 +1110,9 @@ Floating-point verification first ignores very small differences up to **1.0 × 
 | onnx-org/onnx/backend/test/data/node/test_quantizelinear_uint2/model.onnx | 25 | ❌ | Unsupported elem_type 25 (UINT2) for tensor 'y_zero_point'. |
 | onnx-org/onnx/backend/test/data/node/test_quantizelinear_uint4/model.onnx | 25 | ❌ | Unsupported elem_type 21 (UINT4) for tensor 'y_zero_point'. |
 | onnx-org/onnx/backend/test/data/node/test_range_float_type_positive_delta/model.onnx | 11 | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_range_float_type_positive_delta_expanded/model.onnx | 11 | ❌ | Unsupported op Loop |
+| onnx-org/onnx/backend/test/data/node/test_range_float_type_positive_delta_expanded/model.onnx | 11 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_range_int32_type_negative_delta/model.onnx | 11 | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_range_int32_type_negative_delta_expanded/model.onnx | 11 | ❌ | Unsupported op Loop |
+| onnx-org/onnx/backend/test/data/node/test_range_int32_type_negative_delta_expanded/model.onnx | 11 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_reciprocal/model.onnx | 13 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_reciprocal_example/model.onnx | 13 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_reduce_l1_default_axes_keepdims_example/model.onnx | 18 | ✅ | OK (max ULP 0) |
@@ -1454,17 +1454,17 @@ Floating-point verification first ignores very small differences up to **1.0 × 
 | onnx-org/onnx/backend/test/data/node/test_sequence_insert_at_back/model.onnx | 11 | ✅ | OK (non-tensor outputs matched) |
 | onnx-org/onnx/backend/test/data/node/test_sequence_insert_at_front/model.onnx | 11 | ✅ | OK (non-tensor outputs matched) |
 | onnx-org/onnx/backend/test/data/node/test_sequence_map_add_1_sequence_1_tensor/model.onnx | 17 | ❌ | Unsupported op SequenceMap |
-| onnx-org/onnx/backend/test/data/node/test_sequence_map_add_1_sequence_1_tensor_expanded/model.onnx | 17 | ❌ | Unsupported op SequenceLength |
+| onnx-org/onnx/backend/test/data/node/test_sequence_map_add_1_sequence_1_tensor_expanded/model.onnx | 17 | ❌ | Unsupported op Loop |
 | onnx-org/onnx/backend/test/data/node/test_sequence_map_add_2_sequences/model.onnx | 17 | ❌ | Unsupported op SequenceMap |
-| onnx-org/onnx/backend/test/data/node/test_sequence_map_add_2_sequences_expanded/model.onnx | 17 | ❌ | Unsupported op SequenceLength |
+| onnx-org/onnx/backend/test/data/node/test_sequence_map_add_2_sequences_expanded/model.onnx | 17 | ❌ | Unsupported op Loop |
 | onnx-org/onnx/backend/test/data/node/test_sequence_map_extract_shapes/model.onnx | 17 | ❌ | Unsupported op SequenceMap |
-| onnx-org/onnx/backend/test/data/node/test_sequence_map_extract_shapes_expanded/model.onnx | 17 | ❌ | Unsupported op SequenceLength |
+| onnx-org/onnx/backend/test/data/node/test_sequence_map_extract_shapes_expanded/model.onnx | 17 | ❌ | Unsupported op Loop |
 | onnx-org/onnx/backend/test/data/node/test_sequence_map_identity_1_sequence/model.onnx | 17 | ❌ | Unsupported op SequenceMap |
 | onnx-org/onnx/backend/test/data/node/test_sequence_map_identity_1_sequence_1_tensor/model.onnx | 17 | ❌ | Unsupported op SequenceMap |
-| onnx-org/onnx/backend/test/data/node/test_sequence_map_identity_1_sequence_1_tensor_expanded/model.onnx | 17 | ❌ | Unsupported op SequenceLength |
-| onnx-org/onnx/backend/test/data/node/test_sequence_map_identity_1_sequence_expanded/model.onnx | 17 | ❌ | Unsupported op SequenceLength |
+| onnx-org/onnx/backend/test/data/node/test_sequence_map_identity_1_sequence_1_tensor_expanded/model.onnx | 17 | ❌ | Unsupported op Loop |
+| onnx-org/onnx/backend/test/data/node/test_sequence_map_identity_1_sequence_expanded/model.onnx | 17 | ❌ | Unsupported op Loop |
 | onnx-org/onnx/backend/test/data/node/test_sequence_map_identity_2_sequences/model.onnx | 17 | ❌ | Unsupported op SequenceMap |
-| onnx-org/onnx/backend/test/data/node/test_sequence_map_identity_2_sequences_expanded/model.onnx | 17 | ❌ | Unsupported op SequenceLength |
+| onnx-org/onnx/backend/test/data/node/test_sequence_map_identity_2_sequences_expanded/model.onnx | 17 | ❌ | Unsupported op Loop |
 | onnx-org/onnx/backend/test/data/node/test_shape/model.onnx | 25 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_shape_clip_end/model.onnx | 25 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_shape_clip_start/model.onnx | 25 | ✅ | OK (max ULP 0) |

--- a/SUPPORT_OPS.md
+++ b/SUPPORT_OPS.md
@@ -2,7 +2,7 @@
 
 Operators are marked supported when they appear in an ONNX file with a successful verify result.
 
-Supported operators: 163 / 201
+Supported operators: 164 / 201
 
 | Operator | Supported |
 | --- | --- |
@@ -94,7 +94,7 @@ Supported operators: 163 / 201
 | LessOrEqual | ✅ |
 | Log | ✅ |
 | LogSoftmax | ✅ |
-| Loop | ❌ |
+| Loop | ✅ |
 | LpNormalization | ✅ |
 | LpPool | ✅ |
 | MatMul | ✅ |

--- a/src/emx_onnx_cgen/lowering/__init__.py
+++ b/src/emx_onnx_cgen/lowering/__init__.py
@@ -42,6 +42,7 @@ _LOWERING_MODULES = [
     "instance_normalization",
     "layer_normalization",
     "logsoftmax",
+    "loop",
     "lp_normalization",
     "lp_pool",
     "lrn",

--- a/src/emx_onnx_cgen/lowering/loop.py
+++ b/src/emx_onnx_cgen/lowering/loop.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from onnx import GraphProto, NodeProto
+
+from ..errors import UnsupportedOpError
+from ..ir.model import Graph, Node
+from ..ir.ops import RangeOp
+from .registry import register_lowering
+
+
+def _body_node_by_output(body: GraphProto) -> dict[str, NodeProto]:
+    mapping: dict[str, NodeProto] = {}
+    for node in body.node:
+        for output in node.output:
+            if output:
+                mapping[output] = node
+    return mapping
+
+
+def _match_range_loop(node: Node) -> tuple[str, str] | None:
+    if len(node.inputs) != 3 or len(node.outputs) != 2:
+        return None
+    body = node.attrs.get("body")
+    if not isinstance(body, GraphProto):
+        return None
+    if len(body.input) != 3 or len(body.output) != 3:
+        return None
+
+    iter_name = body.input[0].name
+    cond_name = body.input[1].name
+    prev_name = body.input[2].name
+    cond_out_name = body.output[0].name
+    carry_out_name = body.output[1].name
+    scan_out_name = body.output[2].name
+
+    producers = _body_node_by_output(body)
+
+    cond_producer = producers.get(cond_out_name)
+    if (
+        cond_producer is None
+        or cond_producer.op_type != "Identity"
+        or tuple(cond_producer.input) != (cond_name,)
+    ):
+        return None
+
+    carry_producer = producers.get(carry_out_name)
+    if (
+        carry_producer is None
+        or carry_producer.op_type != "Add"
+        or len(carry_producer.input) != 2
+    ):
+        return None
+    add_lhs, add_rhs = tuple(carry_producer.input)
+    if add_lhs == prev_name:
+        delta_name = add_rhs
+    elif add_rhs == prev_name:
+        delta_name = add_lhs
+    else:
+        return None
+    if not delta_name or delta_name == iter_name:
+        return None
+
+    scan_producer = producers.get(scan_out_name)
+    if (
+        scan_producer is None
+        or scan_producer.op_type != "Identity"
+        or tuple(scan_producer.input) != (prev_name,)
+    ):
+        return None
+
+    if len(body.node) != 3:
+        return None
+
+    return node.inputs[2], delta_name
+
+
+@register_lowering("Loop")
+def lower_loop(graph: Graph, node: Node) -> RangeOp:
+    matched = _match_range_loop(node)
+    if matched is None:
+        raise UnsupportedOpError("Unsupported op Loop")
+    start_name, delta_name = matched
+    return RangeOp(
+        start=start_name,
+        # This Loop form represents a trip-count-driven range where the
+        # generated Range kernel only needs start/delta and fixed output length.
+        # Reusing start for limit keeps parameter dtypes consistent.
+        limit=start_name,
+        delta=delta_name,
+        output=node.outputs[1],
+    )

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_loop11__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_loop11__model.onnx.json
@@ -1,8 +1,9 @@
 {
-  "error": "Unsupported op Loop",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_loop11 model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Loop"
   ],
-  "opset_version": 11
+  "opset_version": 11,
+  "generated_checksum": "bc4dc231cf1c58f650cff7b5e5fd7f04650b1af2964ac9bc237af90bc22cf12c"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_loop13_seq__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_loop13_seq__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op Loop",
+  "error": "ONNX shape inference failed",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_loop13_seq model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Loop"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_loop16_seq_none__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_loop16_seq_none__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported optional element type 'sequence_type' for 'opt_seq'. Hint: export the model with optional tensor inputs/outputs.",
+  "error": "ONNX shape inference failed",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_loop16_seq_none model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Loop"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_range_float_type_positive_delta_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_range_float_type_positive_delta_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op Loop",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_range_float_type_positive_delta_expanded model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Sub",
@@ -9,5 +9,6 @@
     "Relu",
     "Loop"
   ],
-  "opset_version": 11
+  "opset_version": 11,
+  "generated_checksum": "be31c87f6c0d7dc3aab4114a9215c37cf0733f1dc6401cb25633d524326f6d6b"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_range_int32_type_negative_delta_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_range_int32_type_negative_delta_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op Loop",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_range_int32_type_negative_delta_expanded model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Sub",
@@ -9,5 +9,6 @@
     "Relu",
     "Loop"
   ],
-  "opset_version": 11
+  "opset_version": 11,
+  "generated_checksum": "880b3ce9eedce826c53aa7786b357243a5830caf46318db75b439a6390df4150"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_sequence_map_add_1_sequence_1_tensor_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_sequence_map_add_1_sequence_1_tensor_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op SequenceLength",
+  "error": "Unsupported op Loop",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_sequence_map_add_1_sequence_1_tensor_expanded model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "SequenceLength",

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_sequence_map_add_2_sequences_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_sequence_map_add_2_sequences_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op SequenceLength",
+  "error": "Unsupported op Loop",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_sequence_map_add_2_sequences_expanded model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "SequenceLength",

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_sequence_map_extract_shapes_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_sequence_map_extract_shapes_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op SequenceLength",
+  "error": "Unsupported op Loop",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_sequence_map_extract_shapes_expanded model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "SequenceLength",

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_sequence_map_identity_1_sequence_1_tensor_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_sequence_map_identity_1_sequence_1_tensor_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op SequenceLength",
+  "error": "Unsupported op Loop",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_sequence_map_identity_1_sequence_1_tensor_expanded model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "SequenceLength",

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_sequence_map_identity_1_sequence_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_sequence_map_identity_1_sequence_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op SequenceLength",
+  "error": "Unsupported op Loop",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_sequence_map_identity_1_sequence_expanded model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "SequenceLength",

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_sequence_map_identity_2_sequences_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_sequence_map_identity_2_sequences_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op SequenceLength",
+  "error": "Unsupported op Loop",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_sequence_map_identity_2_sequences_expanded model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "SequenceLength",


### PR DESCRIPTION
### Motivation
- Support additional official ONNX Loop testcases by handling Loop subgraphs that can be inlined when the iteration count is statically derivable. 
- Provide a safe, narrowly-scoped lowering from the specific trip-count-driven Loop pattern to a `RangeOp` to enable downstream lowering/codegen instead of treating the Loop as unsupported. 
- Keep import/shape-inference resilient when an expansion pass rewrites graph structure so reference expectations can be refreshed deterministically.

### Description
- Add a Loop lowering module `src/emx_onnx_cgen/lowering/loop.py` that matches a canonical trip-count-driven Loop body (cond passthrough, carry updated by `Add(prev, delta)`, scan-out `Identity`) and lowers it to `RangeOp` via `register_lowering("Loop")`.
- Extend `src/emx_onnx_cgen/onnx_import.py` with `_expand_loop_nodes()` that inlines Loop bodies into plain ONNX nodes when a static iteration count can be inferred from scan output shape or a 1-D Constant in the body, materializes a typed per-iteration `Constant` counter, and normalizes 2-input `Unsqueeze` forms with constant axes to the attribute form.
- Adjust the import pipeline to call loop expansion (`import_onnx` now runs `_expand_scan_nodes` and `_expand_loop_nodes`) and avoid failing shape inference immediately if an expansion occurred.
- Register the new lowering module in the lowering registry and refresh reference artifacts and support summaries (`ONNX_SUPPORT.md`, `ONNX_ERRORS_HISTOGRAM.md`, `SUPPORT_OPS.md` and multiple `tests/expected_errors/*.json`).

### Testing
- Ran full reference refresh with `UPDATE_REFS=1 pytest -n auto -q --maxfail=10`, which completed successfully: `2198 passed, 1 skipped, 2 xfailed` in ~91s.
- Ran targeted official-file checks: `pytest -n auto -q --maxfail=10 tests/test_official_onnx_files.py -k 'loop11 or loop13_seq or sequence_map_identity_1_sequence_expanded'` which passed (`3 passed` in ~4.5s), and additional targeted runs for `loop11`/`loop13_seq` also passed in ~4–5s.
- Ran the model verification command `PYTHONPATH=src python -m emx_onnx_cgen.cli verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_loop11 model.onnx --test-data-dir test_data_set_0`, which succeeded (the expected error entry for `test_loop11` was updated to `OK`).
- Noted remaining tracked failures: some SequenceMap/Loop variants remain expected as failures (kept in `tests/expected_errors/`), e.g. `test_loop13_seq` / `test_loop16_seq_none` remain recorded with `ONNX shape inference failed` in expectations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699752858f3c83258d56fd9126372a05)