### PR TITLE
codegen: fix LoopRange temp allocation for opset11 range testbench

### DIFF
--- a/src/emx_onnx_cgen/codegen/c_emitter.py
+++ b/src/emx_onnx_cgen/codegen/c_emitter.py
@@ -11414,6 +11414,7 @@ class CEmitter:
             | ExpandOp
             | CumSumOp
             | RangeOp
+            | LoopRangeOp
             | HammingWindowOp
             | OneHotOp
             | SplitOp
@@ -12035,6 +12036,11 @@ class CEmitter:
             )
         if isinstance(op, LoopSequenceInsertOp):
             return ((op.output_sequence, op.elem_shape, op.elem_dtype),)
+        if isinstance(op, LoopRangeOp):
+            return (
+                (op.final, self._ctx_shape(op.final), self._ctx_dtype(op.final)),
+                (op.output, self._ctx_shape(op.output), self._ctx_dtype(op.output)),
+            )
         return (
             (
                 op.output,

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_range_float_type_positive_delta_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_range_float_type_positive_delta_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_range_float_type_positive_delta_expanded model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Sub",
@@ -10,5 +10,5 @@
     "Loop"
   ],
   "opset_version": 11,
-  "generated_checksum": "f5b1cf913f99afef39e686d8f185d678b16283e9b4e3c86f50c1dff3e12634c3"
+  "generated_checksum": "4d5934c92f452b8af4be8356aad511b4b939791ffd7ecc469ebbc5a3640ad038"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_range_int32_type_negative_delta_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_range_int32_type_negative_delta_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_range_int32_type_negative_delta_expanded model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Sub",
@@ -10,5 +10,5 @@
     "Loop"
   ],
   "opset_version": 11,
-  "generated_checksum": "0e7d78030f7aaf03a9813337519e4f2c27f577f5b740997787b293fabaee73df"
+  "generated_checksum": "6ae8904e070524498607fa15aa358f8a1402039e2ca934c8bd74e852357d526d"
 }


### PR DESCRIPTION
### Motivation
- Expanded `Range` models lowered to a `Loop` body produce a loop-carried `final` value that was not reported as an op output, causing the emitter to skip allocating a temp buffer and yielding an undeclared symbol at testbench compile time (manifested as "Failed to build testbench." for two opset-11 official Range cases). 

### Description
- Update `CEmitter._op_outputs` to return both `final` and `output` for `LoopRangeOp` so the temporary buffer for the hidden loop-carried final value is allocated. 
- Add `LoopRangeOp` to the emitter output logic where needed so codegen correctly recognizes its outputs. 
- Refresh two expected-official test result JSONs under `tests/expected_errors/` to reflect successful verification and updated checksums for the opset-11 Range cases.

### Testing
- Running the CLI verification for the two failing official cases returned success (`exit_code=0`, `OK (max ULP 0)`) after the change. 
- `UPDATE_REFS=1 pytest -n auto -q tests/test_official_onnx_files.py::test_official_onnx_expected_errors -k 'range_int32_type_negative_delta_expanded or range_float_type_positive_delta_expanded'` passed (2 passed, 7.69s). 
- The non-update `pytest` run of the same scoped test passed (2 passed, 7.03s). 
- Targeted unit tests `tests/test_ops.py::test_range_matches_onnxruntime` and `tests/test_ops.py::test_range_run_matches_numpy` passed (2 passed, 5.59s).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69985bc7b0948325b186e338dec51d38)