### PR TITLE
onnx_import: lower simple If branches into Where

### DIFF
--- a/ONNX_ERRORS_HISTOGRAM.md
+++ b/ONNX_ERRORS_HISTOGRAM.md
@@ -16,15 +16,14 @@
 | Out of tolerance | 7 | 9, 19, 22 |
 | Unsupported op CenterCropPad | 6 | 18 |
 | Unsupported op DFT | 6 | 19, 20 |
-| Unsupported op If | 6 | 11, 13, 20 |
 | Unsupported op ScatterElements | 6 | 18 |
 | Unsupported op SequenceLength | 6 | 17 |
 | Unsupported op SequenceMap | 6 | 17 |
 | Unsupported op SplitToSequence | 6 | 12, 24 |
 | Unsupported op StringSplit | 6 | 20 |
 | Unsupported op Col2Im | 5 | 18 |
+| Unsupported op If | 5 | 13, 20 |
 | Unsupported op StringConcat | 5 | 20 |
-| Failed to build testbench. | 4 | 11, 12 |
 | OptionalHasElement expects exactly one non-empty input. | 4 | 18 |
 | Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 4 | 25 |
 | Unsupported op AffineGrid | 4 | 20 |
@@ -40,6 +39,7 @@
 | Unsupported op RegexFullMatch | 3 | 20 |
 | Unsupported op RoiAlign | 3 | 22 |
 | BatchNormalization must have 5 inputs and 1 output | 2 | 15 |
+| Failed to build testbench. | 2 | 12 |
 | Gelu only supports approximate=none | 2 | 20 |
 | LpPool expects 2D kernel_shape | 2 | 22 |
 | LpPool supports auto_pad=NOTSET only | 2 | 22 |
@@ -73,8 +73,6 @@
 | Error message | Opset | Count |
 | --- | --- | --- |
 | Out of tolerance | 9 | 1 |
-| Failed to build testbench. | 11 | 2 |
-| Unsupported op If | 11 | 1 |
 | Unsupported op SequenceConstruct | 12 | 4 |
 | Unsupported op SplitToSequence | 12 | 3 |
 | Failed to build testbench. | 12 | 2 |

--- a/ONNX_SUPPORT.md
+++ b/ONNX_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1462 / 1802 official ONNX files.
+Support 1465 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -753,7 +753,7 @@ Floating-point verification first ignores very small differences up to **1.0 × 
 | onnx-org/onnx/backend/test/data/node/test_identity/model.onnx | 25 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_identity_opt/model.onnx | 16 | ❌ | Unsupported optional element type 'sequence_type' for 'opt_in'. Hint: export the model with optional tensor inputs/outputs. |
 | onnx-org/onnx/backend/test/data/node/test_identity_sequence/model.onnx | 25 | ❌ | Unsupported non-tensor value 'x' in op Identity. |
-| onnx-org/onnx/backend/test/data/node/test_if/model.onnx | 11 | ❌ | Unsupported op If |
+| onnx-org/onnx/backend/test/data/node/test_if/model.onnx | 11 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_if_opt/model.onnx | 16 | ❌ | Unsupported optional element type 'sequence_type' for 'sequence'. Hint: export the model with optional tensor inputs/outputs. |
 | onnx-org/onnx/backend/test/data/node/test_if_seq/model.onnx | 13 | ❌ | Unsupported op If |
 | onnx-org/onnx/backend/test/data/node/test_image_decoder_decode_bmp_rgb/model.onnx | 20 | ❌ | Unsupported op ImageDecoder |
@@ -1110,9 +1110,9 @@ Floating-point verification first ignores very small differences up to **1.0 × 
 | onnx-org/onnx/backend/test/data/node/test_quantizelinear_uint2/model.onnx | 25 | ❌ | Unsupported elem_type 25 (UINT2) for tensor 'y_zero_point'. |
 | onnx-org/onnx/backend/test/data/node/test_quantizelinear_uint4/model.onnx | 25 | ❌ | Unsupported elem_type 21 (UINT4) for tensor 'y_zero_point'. |
 | onnx-org/onnx/backend/test/data/node/test_range_float_type_positive_delta/model.onnx | 11 | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_range_float_type_positive_delta_expanded/model.onnx | 11 | ❌ | Failed to build testbench. |
+| onnx-org/onnx/backend/test/data/node/test_range_float_type_positive_delta_expanded/model.onnx | 11 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_range_int32_type_negative_delta/model.onnx | 11 | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_range_int32_type_negative_delta_expanded/model.onnx | 11 | ❌ | Failed to build testbench. |
+| onnx-org/onnx/backend/test/data/node/test_range_int32_type_negative_delta_expanded/model.onnx | 11 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_reciprocal/model.onnx | 13 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_reciprocal_example/model.onnx | 13 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_reduce_l1_default_axes_keepdims_example/model.onnx | 18 | ✅ | OK (max ULP 0) |

--- a/SUPPORT_OPS.md
+++ b/SUPPORT_OPS.md
@@ -2,7 +2,7 @@
 
 Operators are marked supported when they appear in an ONNX file with a successful verify result.
 
-Supported operators: 164 / 201
+Supported operators: 165 / 201
 
 | Operator | Supported |
 | --- | --- |
@@ -81,7 +81,7 @@ Supported operators: 164 / 201
 | HardSwish | ✅ |
 | Hardmax | ✅ |
 | Identity | ✅ |
-| If | ❌ |
+| If | ✅ |
 | ImageDecoder | ❌ |
 | InstanceNormalization | ✅ |
 | IsInf | ✅ |

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_if__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_if__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op If",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_if model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "If"


### PR DESCRIPTION
### Motivation
- Add import-time support for ONNX `If` nodes whose branches produce tensor outputs so models using simple conditionals can be handled by the pipeline.
- Prefer a conservative, deterministic transformation that preserves semantics by inlining branch subgraphs only when safe.
- Hoist any branch constants into initializers so downstream passes treat branch outputs like normal tensors.

### Description
- Implemented an `If` expansion pass in `src/emx_onnx_cgen/onnx_import.py` with helpers `_if_graph_attrs`, `_is_tensor_output`, `_inline_if_branch`, `_expand_if_node`, and `_expand_if_nodes` that inline eligible `then_branch`/`else_branch` graphs and replace the `If` with `Where` selection nodes.
- Wired the new expansion into `import_onnx()` so it runs during model import (in addition to the existing `Scan` expansion).
- Added a unit test `test_import_if_with_tensor_branches_expands_to_where` in `tests/test_onnx_import.py` that verifies branch constants are hoisted and the `If` is replaced by a `Where` node.
- Updated the official expected result for the `test_if` model and regenerated support docs (`tests/expected_errors/.../test_if__model.onnx.json`, `ONNX_SUPPORT.md`, `SUPPORT_OPS.md`, `ONNX_ERRORS_HISTOGRAM.md`) to reflect that this form of `If` is now supported.

### Testing
- Ran `pytest -q tests/test_onnx_import.py` and observed `6 passed` (full module run: 6 passed in 0.60s). 
- Ran the CLI verification for the ONNX `test_if` model with `PYTHONPATH=src python -m emx_onnx_cgen.cli verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_if model.onnx --test-data-dir test_data_set_0` and it exited successfully (OK). 
- Regenerated support references with `UPDATE_REFS=1 pytest -q tests/test_official_onnx_files_docs.py::test_official_onnx_file_support_doc` which passed (`1 passed` in ~1.22s).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6998c2158cb48325aead1a5756aacb53)