### PR TITLE
codegen: fix scalar Einsum output indexing and refresh ONNX support docs

### DIFF
--- a/ONNX_ERRORS_HISTOGRAM.md
+++ b/ONNX_ERRORS_HISTOGRAM.md
@@ -38,7 +38,6 @@
 | Unsupported op RegexFullMatch | 3 | 20 |
 | Unsupported op RoiAlign | 3 | 22 |
 | BatchNormalization must have 5 inputs and 1 output | 2 | 15 |
-| Failed to build testbench. | 2 | 12 |
 | Gelu only supports approximate=none | 2 | 20 |
 | LpPool expects 2D kernel_shape | 2 | 22 |
 | LpPool supports auto_pad=NOTSET only | 2 | 22 |
@@ -73,7 +72,6 @@
 | --- | --- | --- |
 | Out of tolerance | 9 | 1 |
 | Unsupported op SplitToSequence | 12 | 3 |
-| Failed to build testbench. | 12 | 2 |
 | Unsupported op Gradient | 12 | 2 |
 | Dynamic dim for tensor '*' | 12 | 1 |
 | Testbench execution failed: exit code 1 | 13 | 1 |

--- a/ONNX_SUPPORT.md
+++ b/ONNX_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1469 / 1802 official ONNX files.
+Support 1471 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -605,8 +605,8 @@ Floating-point verification first ignores very small differences up to **1.0 × 
 | onnx-org/onnx/backend/test/data/node/test_edge_pad/model.onnx | 25 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_einsum_batch_diagonal/model.onnx | 12 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_einsum_batch_matmul/model.onnx | 12 | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_einsum_inner_prod/model.onnx | 12 | ❌ | Failed to build testbench. |
-| onnx-org/onnx/backend/test/data/node/test_einsum_scalar/model.onnx | 12 | ❌ | Failed to build testbench. |
+| onnx-org/onnx/backend/test/data/node/test_einsum_inner_prod/model.onnx | 12 | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/node/test_einsum_scalar/model.onnx | 12 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_einsum_sum/model.onnx | 12 | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/node/test_einsum_transpose/model.onnx | 12 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_elu/model.onnx | 22 | ✅ | OK (max ULP 0) |

--- a/src/emx_onnx_cgen/codegen/c_emitter.py
+++ b/src/emx_onnx_cgen/codegen/c_emitter.py
@@ -6221,7 +6221,7 @@ class CEmitter:
             output_dim_names = _dim_names_for(op.output)
             output_shape = CEmitter._shape_dim_exprs(op.output_shape, output_dim_names)
             output_loop_vars = CEmitter._loop_vars(op.output_shape)
-            if output_loop_vars:
+            if op.output_shape:
                 output_expr = f"{params['output']}" + "".join(
                     f"[{var}]" for var in output_loop_vars
                 )

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_einsum_inner_prod__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_einsum_inner_prod__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_einsum_inner_prod model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Einsum"
   ],
   "opset_version": 12,
-  "generated_checksum": "ac9e7f4e5fef2247f25bd4354a4a70d8ffd299c1b4a079c9f9193c5ff4bf50bb"
+  "generated_checksum": "26e6bb3a1bc60f6245e4312fec0bcd9e08e9ee0c6d27747c86cfa53a962f7558"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_einsum_scalar__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_einsum_scalar__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Failed to build testbench.",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_einsum_scalar model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Einsum"
   ],
   "opset_version": 12,
-  "generated_checksum": "a06d80a9778b3d7195f75f2008bb52c73cbef7e7d50e86a1ee99ec0a672f4212"
+  "generated_checksum": "921749d4874f324e47143d33580e3953a2451bf2ce07533d5b0440632bbea9b1"
 }


### PR DESCRIPTION
### Motivation

- Scalar Einsum lowering emitted output indexing using loop variables for rank-0 outputs, causing invalid C code and testbench build failures for some Einsum models. 
- Expected-error snapshots and the generated ONNX support documentation became stale after the fix and needed regeneration to keep test expectations consistent.

### Description

- Change Einsum output indexing in `src/emx_onnx_cgen/codegen/c_emitter.py` to decide between `output[...]` and `output[0]` based on the explicit presence of `op.output_shape` instead of relying on loop-variable lists. 
- Update the expected results for the two affected models (`tests/expected_errors/...test_einsum_scalar...` and `...test_einsum_inner_prod...`) to show successful verification and new checksums. 
- Regenerate the ONNX support snapshots `ONNX_SUPPORT.md` and `ONNX_ERRORS_HISTOGRAM.md` to reflect the updated support totals and error histogram after the fix.

### Testing

- Ran the full test suite with `pytest -n auto -q --maxfail=10`, which completed successfully with `2210 passed, 1 skipped, 2 xfailed` in ~116.9s. 
- Refreshed the generated docs with `UPDATE_REFS=1 pytest -q tests/test_official_onnx_files_docs.py::test_official_onnx_file_support_doc -n auto --maxfail=1`, which passed in ~5.65s, and the non-update variant `pytest -q ...` also passed in ~5.39s. 
- The two previously failing Einsum cases now match verification expectations (`OK (max ULP 0)`) as reflected in the updated `tests/expected_errors` JSON files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6999a87de4d483259f1ddd58cbe4b7da)