### PR TITLE
onnx_import: add expansion for ai.onnx.preview.training::Gradient

### DIFF
--- a/ONNX_ERRORS_HISTOGRAM.md
+++ b/ONNX_ERRORS_HISTOGRAM.md
@@ -48,7 +48,6 @@
 | Unsupported op BitwiseNot | 2 | 18 |
 | Unsupported op BlackmanWindow | 2 | 17 |
 | Unsupported op Det | 2 | 22 |
-| Unsupported op Gradient | 2 | 12 |
 | Unsupported op HannWindow | 2 | 17 |
 | Unsupported op MaxUnpool | 2 | 22 |
 | Unsupported op STFT | 2 | 17 |
@@ -72,7 +71,6 @@
 | --- | --- | --- |
 | Out of tolerance | 9 | 1 |
 | Unsupported op SplitToSequence | 12 | 3 |
-| Unsupported op Gradient | 12 | 2 |
 | Dynamic dim for tensor '*' | 12 | 1 |
 | Testbench execution failed: exit code 1 | 13 | 1 |
 | Unsupported op If | 13 | 1 |

--- a/ONNX_SUPPORT.md
+++ b/ONNX_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1471 / 1802 official ONNX files.
+Support 1473 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -1793,8 +1793,8 @@ Floating-point verification first ignores very small differences up to **1.0 × 
 | onnx-org/onnx/backend/test/data/simple/test_expand_shape_model2/model.onnx | 9 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/simple/test_expand_shape_model3/model.onnx | 9 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/simple/test_expand_shape_model4/model.onnx | 9 | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/simple/test_gradient_of_add/model.onnx | 12 | ❌ | Unsupported op Gradient |
-| onnx-org/onnx/backend/test/data/simple/test_gradient_of_add_and_mul/model.onnx | 12 | ❌ | Unsupported op Gradient |
+| onnx-org/onnx/backend/test/data/simple/test_gradient_of_add/model.onnx | 12 | ✅ | OK (max ULP 0) |
+| onnx-org/onnx/backend/test/data/simple/test_gradient_of_add_and_mul/model.onnx | 12 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/simple/test_sequence_model1/model.onnx | 12 | ❌ | Dynamic dim for tensor 'out' |
 | onnx-org/onnx/backend/test/data/simple/test_sequence_model2/model.onnx | 12 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/simple/test_sequence_model3/model.onnx | 12 | ✅ | OK (max ULP 0) |

--- a/SUPPORT_OPS.md
+++ b/SUPPORT_OPS.md
@@ -2,7 +2,7 @@
 
 Operators are marked supported when they appear in an ONNX file with a successful verify result.
 
-Supported operators: 169 / 201
+Supported operators: 170 / 201
 
 | Operator | Supported |
 | --- | --- |
@@ -203,7 +203,7 @@ Supported operators: 169 / 201
 | ai.onnx.ml::TreeEnsemble | ❌ |
 | ai.onnx.preview.training::Adagrad | ✅ |
 | ai.onnx.preview.training::Adam | ❌ |
-| ai.onnx.preview.training::Gradient | ❌ |
+| ai.onnx.preview.training::Gradient | ✅ |
 | ai.onnx.preview.training::Momentum | ❌ |
 | com.microsoft::QLinearAdd | ❌ |
 | com.microsoft::QLinearMul | ✅ |

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__simple__test_gradient_of_add__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__simple__test_gradient_of_add__model.onnx.json
@@ -1,9 +1,10 @@
 {
-  "error": "Unsupported op Gradient",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/simple/test_gradient_of_add model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Add",
     "ai.onnx.preview.training::Gradient"
   ],
-  "opset_version": 12
+  "opset_version": 12,
+  "generated_checksum": "56995863e94d88461aad3462e3a74ca7b6c367756b32b9033b2b17c6075cfd11"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__simple__test_gradient_of_add_and_mul__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__simple__test_gradient_of_add_and_mul__model.onnx.json
@@ -1,10 +1,11 @@
 {
-  "error": "Unsupported op Gradient",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/simple/test_gradient_of_add_and_mul model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Add",
     "Mul",
     "ai.onnx.preview.training::Gradient"
   ],
-  "opset_version": 12
+  "opset_version": 12,
+  "generated_checksum": "422ca1a23cce8b555ba7492a94fbfe5d90b261d5b94a0466ec34e4dac49c6160"
 }


### PR DESCRIPTION
### Motivation
- Support ONNX training `Gradient` nodes by rewriting them into standard ONNX ops so the compiler pipeline can lower and verify these models without adding lowering/codegen for the training op.
- Ensure gradient seeds are correctly typed using available value info / initializer metadata to produce properly-typed seed initializers.
- Make the importer deterministic and keep downstream passes unchanged by eliminating `Gradient` nodes early in the import pipeline.

### Description
- Added a rewrite pass `_expand_gradient_nodes` in `src/emx_onnx_cgen/onnx_import.py` that expands `ai.onnx.preview.training::Gradient` into sequences of supported ops (`Add`/`Sub`/`Mul`/`Neg`/`Identity`) and per-Gradient typed seed initializers.  (See `_expand_gradient_nodes`.)
- Added helper `_tensor_elem_type_from_value_info` to resolve tensor element types from value info or initializers for constructing typed seed tensors.
- Hooked the expansion into `import_onnx()` so `Gradient` nodes are removed before shape inference/lowering, and added validation of `xs`/`y` attributes and supported forward-node patterns (single-output `Add`/`Sub`/`Mul`/`Identity`).
- Added importer unit tests in `tests/test_onnx_import.py` that exercise gradient-of-add and gradient-of-add-and-mul rewrites, and updated expected-error snapshots and support documentation files (`tests/expected_errors/*.json`, `SUPPORT_OPS.md`, `ONNX_SUPPORT.md`, `ONNX_ERRORS_HISTOGRAM.md`) to reflect the new support.

### Testing
- Ran targeted importer tests: `pytest -q tests/test_onnx_import.py -k gradient` (2 passed, 6 deselected, ~1.89s). 
- Updated official-file expectations and verified with `UPDATE_REFS=1 pytest -q tests/test_official_onnx_files.py -k "gradient_of_add"` (2 passed, ~4.68s) and `UPDATE_REFS=1 pytest -q tests/test_official_onnx_files_docs.py::test_official_onnx_file_support_doc` (1 passed, ~1.79s).
- Ran full test suite: `pytest -n auto -q --maxfail=10` which completed successfully (2212 passed, 1 skipped, 2 xfailed, ~129.5s).
- Verified CLI model verification for the two ONNX gradient examples via `PYTHONPATH=src python -m emx_onnx_cgen.cli verify ...` which returned OK for those models.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6999d7492cfc8325afea7e1539da08a0)