### PR TITLE
codegen: fix dynamic Slice bounds for out-of-range starts

### DIFF
--- a/ONNX_ERRORS_HISTOGRAM.md
+++ b/ONNX_ERRORS_HISTOGRAM.md
@@ -57,7 +57,6 @@
 | Pad value input must be a scalar | 1 | 24 |
 | ReduceMax does not support dtype bool | 1 | 20 |
 | ReduceMin does not support dtype bool | 1 | 20 |
-| Testbench execution failed: exit code 1 | 1 | 13 |
 | Unsupported non-tensor value '*' in op Identity. | 1 | 25 |
 | Unsupported op ArrayFeatureExtractor | 1 |  |
 | Unsupported op Binarizer | 1 |  |
@@ -68,7 +67,6 @@
 | Error message | Opset | Count |
 | --- | --- | --- |
 | Out of tolerance | 9 | 1 |
-| Testbench execution failed: exit code 1 | 13 | 1 |
 | Unsupported op If | 13 | 1 |
 | BatchNormalization must have 5 inputs and 1 output | 15 | 2 |
 | Unsupported optional element type '*' for '*'. Hint: export the model with optional tensor inputs/outputs. | 16 | 3 |

--- a/ONNX_SUPPORT.md
+++ b/ONNX_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1480 / 1802 official ONNX files.
+Support 1481 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -1499,7 +1499,7 @@ Floating-point verification first ignores very small differences up to **1.0 × 
 | onnx-org/onnx/backend/test/data/node/test_slice_neg/model.onnx | 13 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_slice_neg_steps/model.onnx | 13 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_slice_negative_axes/model.onnx | 13 | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_slice_start_out_of_bounds/model.onnx | 13 | ❌ | Testbench execution failed: exit code 1 |
+| onnx-org/onnx/backend/test/data/node/test_slice_start_out_of_bounds/model.onnx | 13 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_softmax_axis_0/model.onnx | 13 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_softmax_axis_0_expanded/model.onnx | 13 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_softmax_axis_0_expanded_ver18/model.onnx | 18 | ✅ | OK (max ULP 0) |

--- a/src/emx_onnx_cgen/templates/slice_op_dynamic.c.j2
+++ b/src/emx_onnx_cgen/templates/slice_op_dynamic.c.j2
@@ -1,11 +1,14 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
     const idx_t input_rank = {{ input_rank }};
     const idx_t input_dims[] = { {% for dim in input_shape %}{{ dim }}{% if not loop.last %}, {% endif %}{% endfor %} };
+    const idx_t output_dims[] = { {% for dim in output_shape %}{{ dim }}{% if not loop.last %}, {% endif %}{% endfor %} };
     idx_t start_indices[{{ input_rank }}];
     idx_t step_values[{{ input_rank }}];
+    idx_t slice_limits[{{ input_rank }}];
     for (idx_t idx = 0; idx < input_rank; ++idx) {
         start_indices[idx] = 0;
         step_values[idx] = 1;
+        slice_limits[idx] = output_dims[idx];
     }
     for (idx_t i = 0; i < {{ starts_len }}; ++i) {
 {% if axes_input %}
@@ -57,11 +60,23 @@ static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
                 end_value = dim - 1;
             }
         }
+        idx_t slice_length = 0;
+        if (step_value > 0) {
+            if (end_value > start_value) {
+                slice_length = (end_value - start_value + step_value - 1) / step_value;
+            }
+        } else if (start_value > end_value) {
+            idx_t step_abs = -step_value;
+            slice_length = (start_value - end_value + step_abs - 1) / step_abs;
+        }
+        if (slice_length < slice_limits[axis]) {
+            slice_limits[axis] = slice_length;
+        }
         start_indices[axis] = start_value;
         step_values[axis] = step_value;
     }
 {% for dim in output_shape %}
-    for (idx_t {{ output_loop_vars[loop.index0] }} = 0; {{ output_loop_vars[loop.index0] }} < {{ dim }}; ++{{ output_loop_vars[loop.index0] }}) {
+    for (idx_t {{ output_loop_vars[loop.index0] }} = 0; {{ output_loop_vars[loop.index0] }} < slice_limits[{{ loop.index0 }}]; ++{{ output_loop_vars[loop.index0] }}) {
 {% endfor %}
         {{ output }}{% for var in output_loop_vars %}[{{ var }}]{% endfor %} = {{ input0 }}{% for var in output_loop_vars %}[start_indices[{{ loop.index0 }}] + ({{ var }} * step_values[{{ loop.index0 }}])]{% endfor %};
 {% for _ in output_shape %}

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_slice_start_out_of_bounds__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_slice_start_out_of_bounds__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Testbench execution failed: exit code 1",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_slice_start_out_of_bounds model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Slice"
   ],
   "opset_version": 13,
-  "generated_checksum": "c22ffd73e4a889f91028d4b8df8789dadcea5dff7f9a72f9eca685577f9b0a71"
+  "generated_checksum": "f881e5546ad2bf718905d061c29dbc0a9d5d40aa0fb5f1f69eac9e2a7323db9e"
 }


### PR DESCRIPTION
### Motivation

- Prevent runtime out-of-bounds reads when compiling ONNX `Slice` nodes whose logical output dimension may be zero but the emitted C array is concretized (e.g., the official `test_slice_start_out_of_bounds` case). 
- Preserve correct semantics for slices with positive and negative `steps` while keeping loop bounds safe at runtime.

### Description

- Updated the dynamic `Slice` codegen template `src/emx_onnx_cgen/templates/slice_op_dynamic.c.j2` to compute `output_dims` and per-axis `slice_limits`, initialize them from the logical output, compute a runtime `slice_length` for each axis (handling positive and negative `steps`), clamp `slice_limits[axis]`, and use `slice_limits` as the loop bounds instead of the raw output dims. 
- This prevents reading past the concrete C array when ONNX semantics produce a zero-length logical dimension. 
- Updated the expected result for `onnx-org/onnx/backend/test/data/node/test_slice_start_out_of_bounds/model.onnx` in `tests/expected_errors/...test_slice_start_out_of_bounds__model.onnx.json` to `OK (max ULP 0)` and recorded the new `generated_checksum`. 
- Regenerated support documentation entries (`ONNX_SUPPORT.md`, `ONNX_ERRORS_HISTOGRAM.md`) to reflect the now-passing official model.

### Testing

- Ran targeted official-file tests: `pytest -q tests/test_official_onnx_files.py -k 'slice_start_out_of_bounds or slice_neg_steps'` and both relevant cases passed. 
- Updated docs references with `UPDATE_REFS=1 pytest -q tests/test_official_onnx_files_docs.py::test_official_onnx_file_support_doc`, which passed.
- Ran the full test suite: `pytest -n auto -q --maxfail=10`, which completed successfully with `2220 passed, 1 skipped, 2 xfailed, 1 warning` in approximately `123.05s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699a25d4369c8325bebfa60c50d0a91d)