### PR TITLE
onnx_import: expand If to support sequence outputs and harden shape concretization (regen docs)

### DIFF
--- a/ONNX_ERRORS_HISTOGRAM.md
+++ b/ONNX_ERRORS_HISTOGRAM.md
@@ -21,12 +21,12 @@
 | Unsupported op SequenceMap | 6 | 17 |
 | Unsupported op StringSplit | 6 | 20 |
 | Unsupported op Col2Im | 5 | 18 |
-| Unsupported op If | 5 | 13, 20 |
 | Unsupported op StringConcat | 5 | 20 |
 | OptionalHasElement expects exactly one non-empty input. | 4 | 18 |
 | Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 4 | 25 |
 | Unsupported op AffineGrid | 4 | 20 |
 | Unsupported op DeformConv | 4 | 22 |
+| Unsupported op If | 4 | 20 |
 | Unsupported op LabelEncoder | 4 |  |
 | Unsupported op RNN | 4 | 22 |
 | Unsupported optional element type '*' for '*'. Hint: export the model with optional tensor inputs/outputs. | 4 | 16, 18 |
@@ -67,7 +67,6 @@
 | Error message | Opset | Count |
 | --- | --- | --- |
 | Out of tolerance | 9 | 1 |
-| Unsupported op If | 13 | 1 |
 | BatchNormalization must have 5 inputs and 1 output | 15 | 2 |
 | Unsupported optional element type '*' for '*'. Hint: export the model with optional tensor inputs/outputs. | 16 | 3 |
 | Unsupported op Loop | 17 | 6 |

--- a/ONNX_SUPPORT.md
+++ b/ONNX_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1481 / 1802 official ONNX files.
+Support 1482 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -755,7 +755,7 @@ Floating-point verification first ignores very small differences up to **1.0 × 
 | onnx-org/onnx/backend/test/data/node/test_identity_sequence/model.onnx | 25 | ❌ | Unsupported non-tensor value 'x' in op Identity. |
 | onnx-org/onnx/backend/test/data/node/test_if/model.onnx | 11 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_if_opt/model.onnx | 16 | ❌ | Unsupported optional element type 'sequence_type' for 'sequence'. Hint: export the model with optional tensor inputs/outputs. |
-| onnx-org/onnx/backend/test/data/node/test_if_seq/model.onnx | 13 | ❌ | Unsupported op If |
+| onnx-org/onnx/backend/test/data/node/test_if_seq/model.onnx | 13 | ✅ | OK (non-tensor outputs matched; max_abs_diff=0, max_ulp=0) |
 | onnx-org/onnx/backend/test/data/node/test_image_decoder_decode_bmp_rgb/model.onnx | 20 | ❌ | Unsupported op ImageDecoder |
 | onnx-org/onnx/backend/test/data/node/test_image_decoder_decode_jpeg2k_rgb/model.onnx | 20 | ❌ | Unsupported op ImageDecoder |
 | onnx-org/onnx/backend/test/data/node/test_image_decoder_decode_jpeg_bgr/model.onnx | 20 | ❌ | Unsupported op ImageDecoder |

--- a/src/emx_onnx_cgen/compiler.py
+++ b/src/emx_onnx_cgen/compiler.py
@@ -358,12 +358,13 @@ class Compiler:
         except Exception:
             return graph
 
-        shapes_by_name: dict[str, tuple[int, ...]] = {
-            name: tuple(int(dim) for dim in array.shape)
-            for name, array in zip(output_names, output_arrays)
-        }
+        shapes_by_name: dict[str, tuple[int, ...]] = {}
+        for name, array in zip(output_names, output_arrays):
+            if isinstance(array, np.ndarray):
+                shapes_by_name[name] = tuple(int(dim) for dim in array.shape)
         for name, array in self._options.testbench_inputs.items():
-            shapes_by_name[name] = tuple(int(dim) for dim in array.shape)
+            if isinstance(array, np.ndarray):
+                shapes_by_name[name] = tuple(int(dim) for dim in array.shape)
 
         def concretize_value(value: Value) -> Value:
             shape = shapes_by_name.get(value.name)

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_if_seq__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_if_seq__model.onnx.json
@@ -1,8 +1,9 @@
 {
-  "error": "Unsupported op If",
+  "error": "OK (non-tensor outputs matched; max_abs_diff=0, max_ulp=0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_if_seq model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "If"
   ],
-  "opset_version": 13
+  "opset_version": 13,
+  "generated_checksum": "cbf2935a4bb0b2d0d92f87b3c8f75e659a2de61d8b66e73125c148faa4607848"
 }


### PR DESCRIPTION
### Motivation
- Allow ONNX `If` nodes whose branches produce sequence-typed outputs via `SequenceConstruct` to be imported instead of rejected. 
- Avoid crashes during shape concretization when ORT returns non-tensor (non-ndarray) outputs by skipping shape reads for those values. 
- Keep generated documentation consistent with the updated importer behavior by refreshing support / histogram outputs.

### Description
- Add sequence-aware helpers and logic in the importer: `_is_sequence_output`, `_sequence_construct_inputs`, and extend `_expand_if_node` to produce element-wise `Where` nodes followed by a `SequenceConstruct` when both branches return compatible sequences (modified `src/emx_onnx_cgen/onnx_import.py`).
- Preserve existing tensor-output expansion to `Where` nodes and maintain deterministic naming/ordering for newly generated nodes (modified `src/emx_onnx_cgen/onnx_import.py`).
- Harden shape concretization to only read `.shape` from NumPy arrays returned by ONNX Runtime, ignoring non-ndarray results to prevent attribute errors (modified `src/emx_onnx_cgen/compiler.py`).
- Add a unit test that verifies `If` with `SequenceConstruct` branches expands to `Where` + `SequenceConstruct` (added `tests/test_onnx_import.py`) and update the golden expectation for the official ONNX case `test_if_seq` (updated `tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_if_seq__model.onnx.json`).
- Regenerate support documentation files to reflect the new support counts and histogram entries (`ONNX_SUPPORT.md`, `ONNX_ERRORS_HISTOGRAM.md`).

### Testing
- Ran `pytest -n auto -q --maxfail=10` (initial full run) which failed due to out-of-date generated docs; run duration was ~116.17s and showed 1 failing test before refs were updated. 
- Ran `UPDATE_REFS=1 pytest -n auto -q --maxfail=10 tests/test_official_onnx_files_docs.py` to refresh generated docs and the targeted test passed in ~5.81s. 
- Re-ran the full test suite with `pytest -n auto -q --maxfail=10` and observed success: `2221 passed, 1 skipped, 2 xfailed` in ~115.12s.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699a2c4c2ff88325bf183cd422669295)