### PR TITLE
batchnorm: implement training-mode support and running statistics

### DIFF
--- a/ONNX_ERRORS_HISTOGRAM.md
+++ b/ONNX_ERRORS_HISTOGRAM.md
@@ -36,7 +36,6 @@
 | Unsupported op RandomUniformLike | 3 | 22 |
 | Unsupported op RegexFullMatch | 3 | 20 |
 | Unsupported op RoiAlign | 3 | 22 |
-| BatchNormalization must have 5 inputs and 1 output | 2 | 15 |
 | Gelu only supports approximate=none | 2 | 20 |
 | LpPool expects 2D kernel_shape | 2 | 22 |
 | LpPool supports auto_pad=NOTSET only | 2 | 22 |
@@ -67,7 +66,6 @@
 | Error message | Opset | Count |
 | --- | --- | --- |
 | Out of tolerance | 9 | 1 |
-| BatchNormalization must have 5 inputs and 1 output | 15 | 2 |
 | Unsupported optional element type '*' for '*'. Hint: export the model with optional tensor inputs/outputs. | 16 | 3 |
 | Unsupported op Loop | 17 | 6 |
 | Unsupported op SequenceMap | 17 | 6 |

--- a/ONNX_SUPPORT.md
+++ b/ONNX_SUPPORT.md
@@ -1,6 +1,6 @@
 # Official ONNX file support
 
-Support 1482 / 1802 official ONNX files.
+Support 1484 / 1802 official ONNX files.
 
 ONNX version: 1.20.1
 
@@ -249,9 +249,9 @@ Floating-point verification first ignores very small differences up to **1.0 × 
 | onnx-org/onnx/backend/test/data/node/test_basic_deform_conv_with_padding/model.onnx | 22 | ❌ | Unsupported op DeformConv |
 | onnx-org/onnx/backend/test/data/node/test_basic_deform_conv_without_padding/model.onnx | 22 | ❌ | Unsupported op DeformConv |
 | onnx-org/onnx/backend/test/data/node/test_batchnorm_epsilon/model.onnx | 15 | ✅ | OK (max ULP 2) |
-| onnx-org/onnx/backend/test/data/node/test_batchnorm_epsilon_training_mode/model.onnx | 15 | ❌ | BatchNormalization must have 5 inputs and 1 output |
+| onnx-org/onnx/backend/test/data/node/test_batchnorm_epsilon_training_mode/model.onnx | 15 | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/node/test_batchnorm_example/model.onnx | 15 | ✅ | OK (max ULP 2) |
-| onnx-org/onnx/backend/test/data/node/test_batchnorm_example_training_mode/model.onnx | 15 | ❌ | BatchNormalization must have 5 inputs and 1 output |
+| onnx-org/onnx/backend/test/data/node/test_batchnorm_example_training_mode/model.onnx | 15 | ✅ | OK (max ULP 6) |
 | onnx-org/onnx/backend/test/data/node/test_bernoulli/model.onnx | 22 | ✅ | OK (non-deterministic output) |
 | onnx-org/onnx/backend/test/data/node/test_bernoulli_double/model.onnx | 22 | ✅ | OK (non-deterministic output) |
 | onnx-org/onnx/backend/test/data/node/test_bernoulli_double_expanded/model.onnx | 22 | ❌ | Unsupported op RandomUniformLike |

--- a/src/emx_onnx_cgen/ir/ops/nn.py
+++ b/src/emx_onnx_cgen/ir/ops/nn.py
@@ -845,16 +845,20 @@ class SoftmaxCrossEntropyLossOp(RenderableOpBase):
 @dataclass(frozen=True)
 class BatchNormOp(RenderableOpBase):
     __io_inputs__ = ("input0", "scale", "bias", "mean", "variance")
-    __io_outputs__ = ("output",)
+    __io_outputs__ = ("output", "running_mean", "running_variance")
     input0: str
     scale: str
     bias: str
     mean: str
     variance: str
     output: str
+    running_mean: str | None
+    running_variance: str | None
     shape: tuple[int, ...]
     channels: int
     epsilon: float
+    momentum: float
+    training_mode: bool
     dtype: ScalarType
 
 

--- a/src/emx_onnx_cgen/lowering/batch_normalization.py
+++ b/src/emx_onnx_cgen/lowering/batch_normalization.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from ..ir.ops import BatchNormOp
 from ..errors import ShapeInferenceError, UnsupportedOpError
 from ..ir.model import Graph, Node
+from ..ir.ops import BatchNormOp
+from .common import optional_name
 from .registry import register_lowering
 
 
@@ -13,6 +14,10 @@ class _BatchNormSpec:
     shape: tuple[int, ...]
     channels: int
     epsilon: float
+    momentum: float
+    training_mode: bool
+    running_mean: str | None
+    running_variance: str | None
 
 
 def _value_shape(graph: Graph, name: str, node: Node) -> tuple[int, ...]:
@@ -45,10 +50,10 @@ def _node_dtype(graph: Graph, node: Node, *names: str) -> str:
 
 
 def _resolve_batch_norm_spec(graph: Graph, node: Node) -> _BatchNormSpec:
-    if len(node.inputs) != 5 or len(node.outputs) != 1:
-        raise UnsupportedOpError(
-            "BatchNormalization must have 5 inputs and 1 output"
-        )
+    if len(node.inputs) != 5:
+        raise UnsupportedOpError("BatchNormalization must have exactly 5 inputs")
+    if len(node.outputs) < 1 or len(node.outputs) > 3:
+        raise UnsupportedOpError("BatchNormalization must have between 1 and 3 outputs")
     supported_attrs = {
         "epsilon",
         "is_test",
@@ -62,12 +67,22 @@ def _resolve_batch_norm_spec(graph: Graph, node: Node) -> _BatchNormSpec:
     if is_test != 1:
         raise UnsupportedOpError("BatchNormalization supports is_test=1 only")
     training_mode = int(node.attrs.get("training_mode", 0))
-    if training_mode != 0:
-        raise UnsupportedOpError("BatchNormalization supports training_mode=0 only")
+    if training_mode not in {0, 1}:
+        raise UnsupportedOpError("BatchNormalization training_mode must be 0 or 1")
+    if training_mode == 0 and len(node.outputs) != 1:
+        raise UnsupportedOpError(
+            "BatchNormalization requires exactly 1 output when training_mode=0"
+        )
+    if training_mode == 1 and len(node.outputs) != 3:
+        raise UnsupportedOpError(
+            "BatchNormalization requires exactly 3 outputs when training_mode=1"
+        )
     spatial = int(node.attrs.get("spatial", 1))
     if spatial != 1:
         raise UnsupportedOpError("BatchNormalization supports spatial=1 only")
     epsilon = float(node.attrs.get("epsilon", 1e-5))
+    momentum = float(node.attrs.get("momentum", 0.9))
+
     input_shape = _value_shape(graph, node.inputs[0], node)
     if len(input_shape) < 2:
         raise UnsupportedOpError(
@@ -81,27 +96,56 @@ def _resolve_batch_norm_spec(graph: Graph, node: Node) -> _BatchNormSpec:
                 "BatchNormalization parameter shape must be "
                 f"({channels},), got {shape}"
             )
+
     output_shape = _value_shape(graph, node.outputs[0], node)
     if output_shape != input_shape:
         raise ShapeInferenceError(
             "BatchNormalization output shape must match input shape, "
             f"got {output_shape}"
         )
+
+    running_mean = optional_name(node.outputs, 1)
+    running_variance = optional_name(node.outputs, 2)
+    if training_mode == 1:
+        assert running_mean is not None
+        assert running_variance is not None
+        mean_shape = _value_shape(graph, running_mean, node)
+        variance_shape = _value_shape(graph, running_variance, node)
+        if mean_shape != (channels,):
+            raise ShapeInferenceError(
+                "BatchNormalization running_mean shape must be "
+                f"({channels},), got {mean_shape}"
+            )
+        if variance_shape != (channels,):
+            raise ShapeInferenceError(
+                "BatchNormalization running_var shape must be "
+                f"({channels},), got {variance_shape}"
+            )
+
     return _BatchNormSpec(
         shape=input_shape,
         channels=channels,
         epsilon=epsilon,
+        momentum=momentum,
+        training_mode=training_mode == 1,
+        running_mean=running_mean,
+        running_variance=running_variance,
     )
 
 
 @register_lowering("BatchNormalization")
 def lower_batch_normalization(graph: Graph, node: Node) -> BatchNormOp:
-    op_dtype = _node_dtype(graph, node, *node.inputs, *node.outputs)
+    spec = _resolve_batch_norm_spec(graph, node)
+    output_names = [node.outputs[0]]
+    if spec.running_mean is not None:
+        output_names.append(spec.running_mean)
+    if spec.running_variance is not None:
+        output_names.append(spec.running_variance)
+    op_dtype = _node_dtype(graph, node, *node.inputs, *output_names)
     if not op_dtype.is_float:
         raise UnsupportedOpError(
             "BatchNormalization supports float16, float, and double inputs only"
         )
-    spec = _resolve_batch_norm_spec(graph, node)
     return BatchNormOp(
         input0=node.inputs[0],
         scale=node.inputs[1],
@@ -109,8 +153,12 @@ def lower_batch_normalization(graph: Graph, node: Node) -> BatchNormOp:
         mean=node.inputs[3],
         variance=node.inputs[4],
         output=node.outputs[0],
+        running_mean=spec.running_mean,
+        running_variance=spec.running_variance,
         shape=spec.shape,
         channels=spec.channels,
         epsilon=spec.epsilon,
+        momentum=spec.momentum,
+        training_mode=spec.training_mode,
         dtype=op_dtype,
     )

--- a/src/emx_onnx_cgen/templates/batch_norm_op.c.j2
+++ b/src/emx_onnx_cgen/templates/batch_norm_op.c.j2
@@ -1,4 +1,47 @@
 static inline void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
+{% if training_mode %}
+{{ c_type }} channel_mean[{{ channels }}];
+{{ c_type }} channel_var[{{ channels }}];
+{{ c_type }} inv_count = ({{ c_type }})1.0 / ({{ c_type }})({{ reduce_count_expr }});
+for (idx_t c = 0; c < {{ channels }}; ++c) {
+    channel_mean[c] = ({{ c_type }})0;
+    channel_var[c] = ({{ c_type }})0;
+}
+{% for dim in shape %}
+for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+{% endfor %}
+idx_t c = {{ loop_vars[1] }};
+channel_mean[c] += {{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %};
+{% for _ in shape %}
+}
+{% endfor %}
+for (idx_t c = 0; c < {{ channels }}; ++c) {
+    channel_mean[c] *= inv_count;
+}
+{% for dim in shape %}
+for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+{% endfor %}
+idx_t c = {{ loop_vars[1] }};
+{{ c_type }} centered = {{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %} - channel_mean[c];
+channel_var[c] += centered * centered;
+{% for _ in shape %}
+}
+{% endfor %}
+for (idx_t c = 0; c < {{ channels }}; ++c) {
+    channel_var[c] *= inv_count;
+    {{ running_mean }}[c] = {{ mean }}[c] * {{ momentum_literal }} + channel_mean[c] * {{ one_minus_momentum_literal }};
+    {{ running_variance }}[c] = {{ variance }}[c] * {{ momentum_literal }} + channel_var[c] * {{ one_minus_momentum_literal }};
+}
+{% for dim in shape %}
+for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
+{% endfor %}
+idx_t c = {{ loop_vars[1] }};
+{{ c_type }} denom = {{ sqrt_fn }}(channel_var[c] + {{ epsilon_literal }});
+{{ output }}{% for var in loop_vars %}[{{ var }}]{% endfor %} = ({{ input0 }}{% for var in loop_vars %}[{{ var }}]{% endfor %} - channel_mean[c]) / denom * {{ scale }}[c] + {{ bias }}[c];
+{% for _ in shape %}
+}
+{% endfor %}
+{% else %}
 {% for dim in shape %}
 for (idx_t {{ loop_vars[loop.index0] }} = 0; {{ loop_vars[loop.index0] }} < {{ dim }}; ++{{ loop_vars[loop.index0] }}) {
 {% endfor %}
@@ -8,4 +51,5 @@ idx_t c = {{ loop_vars[1] }};
 {% for _ in shape %}
 }
 {% endfor %}
+{% endif %}
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_batchnorm_epsilon_training_mode__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_batchnorm_epsilon_training_mode__model.onnx.json
@@ -1,8 +1,9 @@
 {
-  "error": "BatchNormalization must have 5 inputs and 1 output",
+  "error": "OK (max ULP 1)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_batchnorm_epsilon_training_mode model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "BatchNormalization"
   ],
-  "opset_version": 15
+  "opset_version": 15,
+  "generated_checksum": "2fd7cb81dcc00549b45c3064b1b49f7f3edce57c0e5d983da1d25569ef92e17b"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_batchnorm_example_training_mode__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_batchnorm_example_training_mode__model.onnx.json
@@ -1,8 +1,9 @@
 {
-  "error": "BatchNormalization must have 5 inputs and 1 output",
+  "error": "OK (max ULP 6)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_batchnorm_example_training_mode model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "BatchNormalization"
   ],
-  "opset_version": 15
+  "opset_version": 15,
+  "generated_checksum": "a4d7fbd7326ec13dd9a227379a3d4b67bd5e3e26742d7d1072b5a98a458b31de"
 }


### PR DESCRIPTION
### Motivation
- Implement BatchNormalization training-mode semantics per the ONNX operator spec so models with `training_mode=1` (3 outputs) are supported. 
- Surface clear, mode-specific validation errors and thread training parameters into the lowered IR so codegen can emit correct training behavior.

### Description
- Extend the IR `BatchNormOp` to include optional `running_mean`/`running_variance` outputs and `momentum`/`training_mode` fields. 
- Update lowering in `src/emx_onnx_cgen/lowering/batch_normalization.py` to validate input/output arity per-mode, verify running-stat shapes in training mode, and return a spec that includes `momentum` and `training_mode`. 
- Thread the new fields through the C emitter (`src/emx_onnx_cgen/codegen/c_emitter.py`) and update param mapping so templates receive `running_mean`, `running_variance`, `momentum`, `training_mode`, and a spatial reduce count expression. 
- Replace the batch-norm template with `src/emx_onnx_cgen/templates/batch_norm_op.c.j2` that emits a training branch to compute per-channel mean/variance, update running stats, and use current-batch stats for normalization, while keeping the original inference path. 
- Add an ORT-vs-generated-C test for training mode and update expected-error snapshots and ONNX support docs to mark the official training-mode BatchNorm models as supported.

### Testing
- Ran targeted C vs ORT tests: `pytest -q tests/test_ops.py::test_batchnorm_training_mode_matches_onnxruntime tests/test_ops.py::test_batchnorm_op_matches_onnxruntime` and they passed (2 tests, ~3.19s). 
- Ran official ONNX expected-error checks for the two training-mode BatchNorm models with `UPDATE_REFS=1 pytest -q tests/test_official_onnx_files.py::test_official_onnx_expected_errors -k "batchnorm_example_training_mode or batchnorm_epsilon_training_mode"` and both cases passed (2 tests, ~5.24s when run earlier). 
- Ran the full test suite with `pytest -n auto -q --maxfail=1` which completed successfully with `2222 passed, 1 skipped, 2 xfailed, 1 warning` in ~123.5s.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699ab82a7df883259142abbd0c4afce7)