### PR TITLE
onnx-import: support optional sequence value types and refresh expectations

### DIFF
--- a/ONNX_ERRORS_HISTOGRAM.md
+++ b/ONNX_ERRORS_HISTOGRAM.md
@@ -14,25 +14,24 @@
 | Unsupported op ImageDecoder | 9 | 20 |
 | Dropout supports only the data input and 1 or 2 outputs | 8 | 22 |
 | Out of tolerance | 7 | 9, 19, 22 |
+| Unsupported op Loop | 7 | 16, 17 |
 | Unsupported op CenterCropPad | 6 | 18 |
 | Unsupported op DFT | 6 | 19, 20 |
-| Unsupported op Loop | 6 | 17 |
 | Unsupported op ScatterElements | 6 | 18 |
 | Unsupported op SequenceMap | 6 | 17 |
 | Unsupported op StringSplit | 6 | 20 |
 | Unsupported op Col2Im | 5 | 18 |
+| Unsupported op If | 5 | 16, 20 |
 | Unsupported op StringConcat | 5 | 20 |
 | OptionalHasElement expects exactly one non-empty input. | 4 | 18 |
 | Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 4 | 25 |
 | Unsupported op AffineGrid | 4 | 20 |
 | Unsupported op DeformConv | 4 | 22 |
-| Unsupported op If | 4 | 20 |
 | Unsupported op LabelEncoder | 4 |  |
+| Unsupported op OptionalGetElement | 4 | 18 |
 | Unsupported op RNN | 4 | 22 |
-| Unsupported optional element type '*' for '*'. Hint: export the model with optional tensor inputs/outputs. | 4 | 16, 18 |
 | HardSigmoid only supports alpha=0.2 | 3 | 22 |
 | Unsupported op Momentum | 3 |  |
-| Unsupported op OptionalGetElement | 3 | 18 |
 | Unsupported op RandomUniformLike | 3 | 22 |
 | Unsupported op RegexFullMatch | 3 | 20 |
 | Unsupported op RoiAlign | 3 | 22 |
@@ -42,6 +41,7 @@
 | QuantizeLinear block_size is not supported | 2 | 25 |
 | Selu only supports alpha=1.6732632423543772 | 2 | 22 |
 | ThresholdedRelu only supports alpha=1.0 | 2 | 22 |
+| Unsupported non-tensor value '*' in op Identity. | 2 | 16, 25 |
 | Unsupported op Adam | 2 |  |
 | Unsupported op BitwiseNot | 2 | 18 |
 | Unsupported op BlackmanWindow | 2 | 17 |
@@ -56,7 +56,6 @@
 | Pad value input must be a scalar | 1 | 24 |
 | ReduceMax does not support dtype bool | 1 | 20 |
 | ReduceMin does not support dtype bool | 1 | 20 |
-| Unsupported non-tensor value '*' in op Identity. | 1 | 25 |
 | Unsupported op ArrayFeatureExtractor | 1 |  |
 | Unsupported op Binarizer | 1 |  |
 | Unsupported op MelWeightMatrix | 1 | 17 |
@@ -66,7 +65,9 @@
 | Error message | Opset | Count |
 | --- | --- | --- |
 | Out of tolerance | 9 | 1 |
-| Unsupported optional element type '*' for '*'. Hint: export the model with optional tensor inputs/outputs. | 16 | 3 |
+| Unsupported non-tensor value '*' in op Identity. | 16 | 1 |
+| Unsupported op If | 16 | 1 |
+| Unsupported op Loop | 16 | 1 |
 | Unsupported op Loop | 17 | 6 |
 | Unsupported op SequenceMap | 17 | 6 |
 | Unsupported op BlackmanWindow | 17 | 2 |
@@ -77,9 +78,8 @@
 | Unsupported op ScatterElements | 18 | 6 |
 | Unsupported op Col2Im | 18 | 5 |
 | OptionalHasElement expects exactly one non-empty input. | 18 | 4 |
-| Unsupported op OptionalGetElement | 18 | 3 |
+| Unsupported op OptionalGetElement | 18 | 4 |
 | Unsupported op BitwiseNot | 18 | 2 |
-| Unsupported optional element type '*' for '*'. Hint: export the model with optional tensor inputs/outputs. | 18 | 1 |
 | Unsupported op DFT | 19 | 3 |
 | Out of tolerance | 19 | 2 |
 | Unsupported op ImageDecoder | 20 | 9 |

--- a/ONNX_SUPPORT.md
+++ b/ONNX_SUPPORT.md
@@ -751,10 +751,10 @@ Floating-point verification first ignores very small differences up to **1.0 × 
 | onnx-org/onnx/backend/test/data/node/test_hardswish/model.onnx | 22 | ✅ | OK (max ULP 2) |
 | onnx-org/onnx/backend/test/data/node/test_hardswish_expanded/model.onnx | 22 | ❌ | HardSigmoid only supports alpha=0.2 |
 | onnx-org/onnx/backend/test/data/node/test_identity/model.onnx | 25 | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_identity_opt/model.onnx | 16 | ❌ | Unsupported optional element type 'sequence_type' for 'opt_in'. Hint: export the model with optional tensor inputs/outputs. |
+| onnx-org/onnx/backend/test/data/node/test_identity_opt/model.onnx | 16 | ❌ | Unsupported non-tensor value 'opt_in' in op Identity. |
 | onnx-org/onnx/backend/test/data/node/test_identity_sequence/model.onnx | 25 | ❌ | Unsupported non-tensor value 'x' in op Identity. |
 | onnx-org/onnx/backend/test/data/node/test_if/model.onnx | 11 | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_if_opt/model.onnx | 16 | ❌ | Unsupported optional element type 'sequence_type' for 'sequence'. Hint: export the model with optional tensor inputs/outputs. |
+| onnx-org/onnx/backend/test/data/node/test_if_opt/model.onnx | 16 | ❌ | Unsupported op If |
 | onnx-org/onnx/backend/test/data/node/test_if_seq/model.onnx | 13 | ✅ | OK (non-tensor outputs matched; max_abs_diff=0, max_ulp=0) |
 | onnx-org/onnx/backend/test/data/node/test_image_decoder_decode_bmp_rgb/model.onnx | 20 | ❌ | Unsupported op ImageDecoder |
 | onnx-org/onnx/backend/test/data/node/test_image_decoder_decode_jpeg2k_rgb/model.onnx | 20 | ❌ | Unsupported op ImageDecoder |
@@ -890,7 +890,7 @@ Floating-point verification first ignores very small differences up to **1.0 × 
 | onnx-org/onnx/backend/test/data/node/test_logsoftmax_negative_axis_expanded_ver18/model.onnx | 18 | ✅ | OK (max ULP 1) |
 | onnx-org/onnx/backend/test/data/node/test_loop11/model.onnx | 11 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_loop13_seq/model.onnx | 13 | ✅ | OK (non-tensor outputs matched; max_abs_diff=0, max_ulp=58382658) |
-| onnx-org/onnx/backend/test/data/node/test_loop16_seq_none/model.onnx | 16 | ❌ | Unsupported optional element type 'sequence_type' for 'opt_seq'. Hint: export the model with optional tensor inputs/outputs. |
+| onnx-org/onnx/backend/test/data/node/test_loop16_seq_none/model.onnx | 16 | ❌ | Unsupported op Loop |
 | onnx-org/onnx/backend/test/data/node/test_lpnormalization_default/model.onnx | 22 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_lppool_1d_default/model.onnx | 22 | ❌ | LpPool expects 2D kernel_shape |
 | onnx-org/onnx/backend/test/data/node/test_lppool_2d_default/model.onnx | 22 | ✅ | OK (max ULP 0) |
@@ -1052,7 +1052,7 @@ Floating-point verification first ignores very small differences up to **1.0 × 
 | onnx-org/onnx/backend/test/data/node/test_onehot_with_axis/model.onnx | 11 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_onehot_with_negative_axis/model.onnx | 11 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_onehot_without_axis/model.onnx | 11 | ✅ | OK (max ULP 0) |
-| onnx-org/onnx/backend/test/data/node/test_optional_get_element_optional_sequence/model.onnx | 18 | ❌ | Unsupported optional element type 'sequence_type' for 'optional_input'. Hint: export the model with optional tensor inputs/outputs. |
+| onnx-org/onnx/backend/test/data/node/test_optional_get_element_optional_sequence/model.onnx | 18 | ❌ | Unsupported op OptionalGetElement |
 | onnx-org/onnx/backend/test/data/node/test_optional_get_element_optional_tensor/model.onnx | 18 | ❌ | Unsupported op OptionalGetElement |
 | onnx-org/onnx/backend/test/data/node/test_optional_get_element_sequence/model.onnx | 18 | ❌ | Unsupported op OptionalGetElement |
 | onnx-org/onnx/backend/test/data/node/test_optional_get_element_tensor/model.onnx | 18 | ❌ | Unsupported op OptionalGetElement |

--- a/src/emx_onnx_cgen/compiler.py
+++ b/src/emx_onnx_cgen/compiler.py
@@ -437,10 +437,14 @@ class Compiler:
             return elem
 
         input_names = tuple(value.name for value in graph.inputs)
+
+        def is_optional_value_type(value_type: ValueType) -> bool:
+            return bool(getattr(value_type, "is_optional", False))
+
         input_optional_names = tuple(
             (
                 _optional_flag_name(value.name)
-                if isinstance(value.type, TensorType) and value.type.is_optional
+                if is_optional_value_type(value.type)
                 else None
             )
             for value in graph.inputs
@@ -456,7 +460,7 @@ class Compiler:
         output_optional_names = tuple(
             (
                 _optional_flag_name(value.name)
-                if isinstance(value.type, TensorType) and value.type.is_optional
+                if is_optional_value_type(value.type)
                 else None
             )
             for value in graph.outputs

--- a/src/emx_onnx_cgen/ir/model.py
+++ b/src/emx_onnx_cgen/ir/model.py
@@ -19,6 +19,7 @@ class TensorType:
 @dataclass(frozen=True)
 class SequenceType:
     elem: TensorType
+    is_optional: bool = False
 
 
 ValueType = TensorType | SequenceType

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_identity_opt__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_identity_opt__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported optional element type 'sequence_type' for 'opt_in'. Hint: export the model with optional tensor inputs/outputs.",
+  "error": "Unsupported non-tensor value 'opt_in' in op Identity.",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_identity_opt model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Identity"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_if_opt__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_if_opt__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported optional element type 'sequence_type' for 'sequence'. Hint: export the model with optional tensor inputs/outputs.",
+  "error": "Unsupported op If",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_if_opt model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "If"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_loop16_seq_none__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_loop16_seq_none__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported optional element type 'sequence_type' for 'opt_seq'. Hint: export the model with optional tensor inputs/outputs.",
+  "error": "Unsupported op Loop",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_loop16_seq_none model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Loop"

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_optional_get_element_optional_sequence__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_optional_get_element_optional_sequence__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported optional element type 'sequence_type' for 'optional_input'. Hint: export the model with optional tensor inputs/outputs.",
+  "error": "Unsupported op OptionalGetElement",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_optional_get_element_optional_sequence model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "OptionalGetElement"


### PR DESCRIPTION
### Motivation

- Some official ONNX tests use `optional<sequence<tensor<...>>>` inputs/outputs and the importer previously raised `Unsupported optional element type` instead of representing the value, which blocked downstream validation and lowered diagnostics.

### Description

- Add `is_optional: bool` to `SequenceType` in the IR so `optional<sequence<...>>` can be represented (`src/emx_onnx_cgen/ir/model.py`).
- Extend ONNX import logic to accept `optional_type` whose element is a `sequence_type` of tensors and produce `SequenceType(..., is_optional=True)` while preserving explicit errors for unsupported element kinds (`src/emx_onnx_cgen/onnx_import.py`).
- Make IO optional-flag detection generic so optional flags are emitted for any optional value type (including optional sequences) by adding a small helper used when building IO specs (`src/emx_onnx_cgen/compiler.py`).
- Add a unit test that verifies importing an `optional<sequence<tensor<...>>>` value marks the input as optional (`tests/test_onnx_import.py`).
- Update affected expected-error snapshots and generated support docs to reflect the new importer behavior and the actual downstream errors that occur after import (`tests/expected_errors/**.json`, `ONNX_SUPPORT.md`, `ONNX_ERRORS_HISTOGRAM.md`).

### Testing

- Ran the targeted import test: `pytest -q tests/test_onnx_import.py -k optional_sequence` which passed (1 passed, others deselected).
- Ran the targeted official ONNX expectation tests for the previously failing models; the updated expectations match actual results and those tests passed.
- Refreshed references with `UPDATE_REFS=1 pytest -q tests/test_official_onnx_files_docs.py::test_official_onnx_file_support_doc` which passed.
- Ran the full test suite with parallel execution: `pytest -n auto -q --maxfail=10` and all tests passed (2223 passed, 1 skipped, 2 xfailed; run time ~97s).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699bc6be8e088325b0fab09b844014d8)