### PR TITLE
onnx_import: improve If expansion type inference and update refs

### DIFF
--- a/ONNX_ERRORS_HISTOGRAM.md
+++ b/ONNX_ERRORS_HISTOGRAM.md
@@ -21,7 +21,6 @@
 | Unsupported op SequenceMap | 6 | 17 |
 | Unsupported op StringSplit | 6 | 20 |
 | Unsupported op Col2Im | 5 | 18 |
-| Unsupported op If | 5 | 16, 20 |
 | Unsupported op StringConcat | 5 | 20 |
 | OptionalHasElement expects exactly one non-empty input. | 4 | 18 |
 | Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 4 | 25 |
@@ -40,6 +39,7 @@
 | LpPool supports auto_pad=NOTSET only | 2 | 22 |
 | QuantizeLinear block_size is not supported | 2 | 25 |
 | Selu only supports alpha=1.6732632423543772 | 2 | 22 |
+| Split output shape must be (1,), got (2,) | 2 | 20 |
 | ThresholdedRelu only supports alpha=1.0 | 2 | 22 |
 | Unsupported non-tensor value '*' in op Identity. | 2 | 16, 25 |
 | Unsupported op Adam | 2 |  |
@@ -50,6 +50,7 @@
 | Unsupported op MaxUnpool | 2 | 22 |
 | Unsupported op STFT | 2 | 17 |
 | Unsupported op TreeEnsemble | 2 |  |
+| Where inputs must be broadcastable, got ((), (1,), (0,)) | 2 | 20 |
 | ConvTranspose output shape must be fully defined and non-negative | 1 | 22 |
 | Dropout mask output is not supported | 1 | 22 |
 | Graph must contain at least one node | 1 | 25 |
@@ -58,6 +59,7 @@
 | ReduceMin does not support dtype bool | 1 | 20 |
 | Unsupported op ArrayFeatureExtractor | 1 |  |
 | Unsupported op Binarizer | 1 |  |
+| Unsupported op If | 1 | 16 |
 | Unsupported op MelWeightMatrix | 1 | 17 |
 
 ## Error frequency by opset
@@ -86,10 +88,11 @@
 | Unsupported op StringSplit | 20 | 6 |
 | Unsupported op StringConcat | 20 | 5 |
 | Unsupported op AffineGrid | 20 | 4 |
-| Unsupported op If | 20 | 4 |
 | Unsupported op DFT | 20 | 3 |
 | Unsupported op RegexFullMatch | 20 | 3 |
 | Gelu only supports approximate=none | 20 | 2 |
+| Split output shape must be (1,), got (2,) | 20 | 2 |
+| Where inputs must be broadcastable, got ((), (1,), (0,)) | 20 | 2 |
 | ReduceMax does not support dtype bool | 20 | 1 |
 | ReduceMin does not support dtype bool | 20 | 1 |
 | Dropout supports only the data input and 1 or 2 outputs | 22 | 8 |

--- a/ONNX_SUPPORT.md
+++ b/ONNX_SUPPORT.md
@@ -38,12 +38,12 @@ Floating-point verification first ignores very small differences up to **1.0 × 
 | onnx-org/onnx/backend/test/data/node/test_add_uint8/model.onnx | 14 | ✅ | OK (max ULP 0) |
 | onnx-org/onnx/backend/test/data/node/test_affine_grid_2d/model.onnx | 20 | ❌ | Unsupported op AffineGrid |
 | onnx-org/onnx/backend/test/data/node/test_affine_grid_2d_align_corners/model.onnx | 20 | ❌ | Unsupported op AffineGrid |
-| onnx-org/onnx/backend/test/data/node/test_affine_grid_2d_align_corners_expanded/model.onnx | 20 | ❌ | Unsupported op If |
-| onnx-org/onnx/backend/test/data/node/test_affine_grid_2d_expanded/model.onnx | 20 | ❌ | Unsupported op If |
+| onnx-org/onnx/backend/test/data/node/test_affine_grid_2d_align_corners_expanded/model.onnx | 20 | ❌ | Where inputs must be broadcastable, got ((), (1,), (0,)) |
+| onnx-org/onnx/backend/test/data/node/test_affine_grid_2d_expanded/model.onnx | 20 | ❌ | Where inputs must be broadcastable, got ((), (1,), (0,)) |
 | onnx-org/onnx/backend/test/data/node/test_affine_grid_3d/model.onnx | 20 | ❌ | Unsupported op AffineGrid |
 | onnx-org/onnx/backend/test/data/node/test_affine_grid_3d_align_corners/model.onnx | 20 | ❌ | Unsupported op AffineGrid |
-| onnx-org/onnx/backend/test/data/node/test_affine_grid_3d_align_corners_expanded/model.onnx | 20 | ❌ | Unsupported op If |
-| onnx-org/onnx/backend/test/data/node/test_affine_grid_3d_expanded/model.onnx | 20 | ❌ | Unsupported op If |
+| onnx-org/onnx/backend/test/data/node/test_affine_grid_3d_align_corners_expanded/model.onnx | 20 | ❌ | Split output shape must be (1,), got (2,) |
+| onnx-org/onnx/backend/test/data/node/test_affine_grid_3d_expanded/model.onnx | 20 | ❌ | Split output shape must be (1,), got (2,) |
 | onnx-org/onnx/backend/test/data/node/test_ai_onnx_ml_array_feature_extractor/model.onnx |  | ❌ | Unsupported op ArrayFeatureExtractor |
 | onnx-org/onnx/backend/test/data/node/test_ai_onnx_ml_binarizer/model.onnx |  | ❌ | Unsupported op Binarizer |
 | onnx-org/onnx/backend/test/data/node/test_ai_onnx_ml_label_encoder_string_int/model.onnx |  | ❌ | Unsupported op LabelEncoder |

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_affine_grid_2d_align_corners_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_affine_grid_2d_align_corners_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op If",
+  "error": "Where inputs must be broadcastable, got ((), (1,), (0,))",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_affine_grid_2d_align_corners_expanded model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Constant",

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_affine_grid_2d_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_affine_grid_2d_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op If",
+  "error": "Where inputs must be broadcastable, got ((), (1,), (0,))",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_affine_grid_2d_expanded model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Constant",

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_affine_grid_3d_align_corners_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_affine_grid_3d_align_corners_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op If",
+  "error": "Split output shape must be (1,), got (2,)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_affine_grid_3d_align_corners_expanded model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Constant",

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_affine_grid_3d_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_affine_grid_3d_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op If",
+  "error": "Split output shape must be (1,), got (2,)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_affine_grid_3d_expanded model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Constant",


### PR DESCRIPTION
### Motivation

- Expand `If` nodes more robustly when parent-graph `value_info` is missing by inferring output kinds from branch outputs and producing nodes so real-world ONNX graphs can be lowered at import time.

### Description

- Add `_value_info_kind`, `_branch_output_kind`, and `_if_output_kind` helpers and replace the previous parent-only tensor/sequence checks with branch-aware kind inference in `_expand_if_node`.
- Use producing branch-node heuristics (e.g., `SequenceConstruct`, `Optional`) to determine branch output kinds when branch `value_info` is absent.
- Add a regression test `test_import_if_without_parent_value_info_uses_branch_output_types` to verify `If` expansion into `Where` and follow-up nodes for intermediate `If` outputs without parent metadata.
- Refresh expected-error snapshots and generated support docs (`tests/expected_errors/*`, `ONNX_SUPPORT.md`, `ONNX_ERRORS_HISTOGRAM.md`) to reflect the importer now expanding additional `If` cases (downstream errors replace previous `Unsupported op If`).

### Testing

- Ran `pytest -q tests/test_onnx_import.py -k if` with the `if` tests passing (3 passed, 9 deselected) in ~0.86s.
- Ran targeted official-file checks `pytest -q tests/test_official_onnx_files.py -k "affine_grid_2d_expanded or affine_grid_2d_align_corners_expanded or affine_grid_3d_expanded or affine_grid_3d_align_corners_expanded"` which passed (4 passed) in ~2.09s.
- Updated references with `UPDATE_REFS=1 pytest -q tests/test_official_onnx_files_docs.py::test_official_onnx_file_support_doc` which passed (1 passed) in ~1.77s.
- Ran full test suite `pytest -n auto -q --maxfail=10` which completed successfully (2224 passed, 1 skipped, 2 xfailed) in ~134s.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699c19d0251c832583c3d737cdab69de)