### PR TITLE
Support int32/uint32 inputs for DequantizeLinear and add tests

### DIFF
--- a/src/emx_onnx_cgen/lowering/dequantize_linear.py
+++ b/src/emx_onnx_cgen/lowering/dequantize_linear.py
@@ -94,9 +94,11 @@ def lower_dequantize_linear(graph: Graph, node: Node) -> DequantizeLinearOp:
         ScalarType.I8,
         ScalarType.U16,
         ScalarType.I16,
+        ScalarType.I32,
+        ScalarType.U32,
     }:
         raise UnsupportedOpError(
-            "DequantizeLinear supports int8/uint8/int16/uint16 inputs only"
+            "DequantizeLinear supports int8/uint8/int16/uint16/int32/uint32 inputs only"
         )
     if not scale_dtype.is_float or not output_dtype.is_float:
         raise UnsupportedOpError(


### PR DESCRIPTION
### Motivation

- Extend lowering support for `DequantizeLinear` to accept 32-bit integer inputs so the compiler can lower models that use `INT32`/`UINT32` quantized tensors.

### Description

- Allow `ScalarType.I32` and `ScalarType.U32` in the input dtype whitelist in `src/emx_onnx_cgen/lowering/dequantize_linear.py` and update the error message accordingly. 
- Preserve existing dtype checks for `scale`/`output` and `zero_point` while returning the same `DequantizeLinearOp` spec values. 
- Add model builders ` _make_dequantize_linear_int32_model` and `_make_dequantize_linear_uint32_model` to `tests/test_ops.py` and add tests `test_dequantize_linear_int32_matches_onnxruntime` and `test_dequantize_linear_uint32_codegen_smoke` to validate runtime parity and codegen respectively. 
- Skip the ONNX checker for the `UINT32` model because `uint32` is a compiler extension used only for lowering tests.

### Testing

- Added `test_dequantize_linear_int32_matches_onnxruntime` which runs the model through the ONNX Runtime comparison test and passed. 
- Added `test_dequantize_linear_uint32_codegen_smoke` which compiles the `UINT32` model with `Compiler(CompilerOptions())` and asserts the generated output contains `OpType: DequantizeLinear`, and it passed. 
- Ran the existing operator test suite locally with the new tests included and observed no regressions in related `DequantizeLinear` lowering checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699f6291bde883259eeec225870caa44)