### PR TITLE
lowering: normalize byte-encoded LSTM direction attribute

### DIFF
--- a/ONNX_ERRORS_HISTOGRAM.md
+++ b/ONNX_ERRORS_HISTOGRAM.md
@@ -25,7 +25,6 @@ This histogram is test-suite-overarching.
 | Unsupported op Col2Im | 5 | 18 |
 | Unsupported op StringConcat | 5 | 20 |
 | OptionalHasElement expects exactly one non-empty input. | 4 | 18 |
-| Unsupported LSTM direction b'*' | 4 | 11 |
 | Unsupported elem_type 24 (FLOAT8E8M0) for tensor '*'. | 4 | 25 |
 | Unsupported op AffineGrid | 4 | 20 |
 | Unsupported op DeformConv | 4 | 22 |
@@ -75,7 +74,6 @@ This histogram is test-suite-overarching.
 | --- | --- | --- |
 | Out of tolerance | 8 | 1 |
 | Out of tolerance | 9 | 5 |
-| Unsupported LSTM direction b'*' | 11 | 4 |
 | Gemm bias input must be broadcastable to output shape, got (2,) vs (2, 4) | 12 | 1 |
 | Unsupported op TreeEnsembleClassifier | 12 | 1 |
 | Resize coordinate_transformation_mode '*' is not supported | 13 | 1 |

--- a/ONNX_SUPPORT.md
+++ b/ONNX_SUPPORT.md
@@ -5,7 +5,7 @@ Overview:
 | Test suite | Coverage | Version |
 | --- | --- | --- |
 | [Official ONNX test coverage](#official-onnx-test-coverage) | 1485 / 1802, 82.4% | 1.20.1 |
-| [ONNX2C test coverage](#onnx2c-test-coverage) | 110 / 125, 88.0% | n/a |
+| [ONNX2C test coverage](#onnx2c-test-coverage) | 114 / 125, 91.2% | n/a |
 
 See [`ONNX_ERRORS_HISTOGRAM.md`](ONNX_ERRORS_HISTOGRAM.md) for the error histogram.
 
@@ -1826,7 +1826,7 @@ Coverage 1485 / 1802 ONNX files (82.4%).
 
 Test directory: `onnx2c-org/test`
 
-Coverage 110 / 125 ONNX files (88.0%).
+Coverage 114 / 125 ONNX files (91.2%).
 
 | File | Opset | Supported | Error |
 | --- | --- | --- | --- |
@@ -1860,11 +1860,11 @@ Coverage 110 / 125 ONNX files (88.0%).
 | local_ops/test_gemm_CN_transB/model.onnx | 12 | ✅ | OK (max ULP 0) |
 | local_ops/test_lstm_activations/model.onnx | 11 | ✅ | OK (max ULP 0) |
 | local_ops/test_lstm_all_outputs/model.onnx | 11 | ✅ | OK (max ULP 0) |
-| local_ops/test_lstm_bidirectional/model.onnx | 11 | ❌ | Unsupported LSTM direction b'bidirectional' |
+| local_ops/test_lstm_bidirectional/model.onnx | 11 | ✅ | OK (max ULP 0) |
 | local_ops/test_lstm_clip/model.onnx | 11 | ✅ | OK (max ULP 0) |
 | local_ops/test_lstm_intermediate_h/model.onnx | 11 | ✅ | OK (max ULP 0) |
 | local_ops/test_lstm_missing_inputs/model.onnx | 12 | ✅ | OK (max ULP 0) |
-| local_ops/test_lstm_reverse/model.onnx | 11 | ❌ | Unsupported LSTM direction b'reverse' |
+| local_ops/test_lstm_reverse/model.onnx | 11 | ✅ | OK (max ULP 0) |
 | local_ops/test_lstm_seq_length/model.onnx | 11 | ✅ | OK (max ULP 0) |
 | local_ops/test_lstm_simple/model.onnx | 12 | ✅ | OK (max ULP 0) |
 | local_ops/test_lstm_with_initial_state/model.onnx | 12 | ✅ | OK (max ULP 5) |
@@ -1943,8 +1943,8 @@ Coverage 110 / 125 ONNX files (88.0%).
 | simple_networks/conv_k2_s2.onnx | 11 | ✅ | OK (max ULP 0) |
 | simple_networks/fp_bfloat16.onnx | 22 | ❌ | Cast input and output shapes must match |
 | simple_networks/fp_float16.onnx | 22 | ❌ | Cast input and output shapes must match |
-| simple_networks/lstm_k1_b1_r1.onnx | 11 | ❌ | Unsupported LSTM direction b'forward' |
-| simple_networks/lstm_k1_b1_r1_relu.onnx | 11 | ❌ | Unsupported LSTM direction b'forward' |
+| simple_networks/lstm_k1_b1_r1.onnx | 11 | ✅ | OK (max ULP 0) |
+| simple_networks/lstm_k1_b1_r1_relu.onnx | 11 | ✅ | OK (max ULP 0) |
 | simple_networks/maxpool_k2.onnx | 12 | ✅ | OK (max ULP 0) |
 | simple_networks/maxpool_k2_s2.onnx | 12 | ✅ | OK (max ULP 0) |
 | simple_networks/random_uniform.onnx | 22 | ❌ | Unsupported op RandomUniform |

--- a/src/emx_onnx_cgen/lowering/lstm.py
+++ b/src/emx_onnx_cgen/lowering/lstm.py
@@ -85,6 +85,14 @@ def _normalize_activation_names(values: Iterable[object]) -> list[str]:
     return names
 
 
+def _normalize_direction(value: object) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    if isinstance(value, str):
+        return value
+    raise UnsupportedOpError("LSTM direction must be a string")
+
+
 def _resolve_activation_params(
     activations: Sequence[str],
     activation_alpha: Sequence[float] | None,
@@ -218,8 +226,8 @@ def resolve_lstm_spec(graph: Graph, node: Node) -> LstmSpec:
         hidden_size = w_shape[1] // 4
     else:
         hidden_size = int(hidden_size_attr)
-    _validate_direction(str(node.attrs.get("direction", "forward")), num_directions)
-    direction = str(node.attrs.get("direction", "forward"))
+    direction = _normalize_direction(node.attrs.get("direction", "forward"))
+    _validate_direction(direction, num_directions)
     expected_w_shape = (num_directions, 4 * hidden_size, input_size)
     _expect_shape(input_w, w_shape, expected_w_shape)
     r_shape = value_shape(graph, input_r, node)

--- a/tests/expected_errors/onnx2c-org__test__local_ops__test_lstm_bidirectional__model.onnx.json
+++ b/tests/expected_errors/onnx2c-org__test__local_ops__test_lstm_bidirectional__model.onnx.json
@@ -1,8 +1,9 @@
 {
-  "error": "Unsupported LSTM direction b'bidirectional'",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx2c-org/test/local_ops/test_lstm_bidirectional model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "LSTM"
   ],
-  "opset_version": 11
+  "opset_version": 11,
+  "generated_checksum": "78f72f9f9ee38b510f4c2c9ba496faf101d9bc1ce53e7a80fbb78e1e7fcf6007"
 }

--- a/tests/expected_errors/onnx2c-org__test__local_ops__test_lstm_reverse__model.onnx.json
+++ b/tests/expected_errors/onnx2c-org__test__local_ops__test_lstm_reverse__model.onnx.json
@@ -1,8 +1,9 @@
 {
-  "error": "Unsupported LSTM direction b'reverse'",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx2c-org/test/local_ops/test_lstm_reverse model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "LSTM"
   ],
-  "opset_version": 11
+  "opset_version": 11,
+  "generated_checksum": "db6b78c80c4b3abdd2f77613cd6391fa2be4b73d4b5fbea1dbfb2b2262ded1aa"
 }

--- a/tests/expected_errors/onnx2c-org__test__simple_networks__lstm_k1_b1_r1.onnx.json
+++ b/tests/expected_errors/onnx2c-org__test__simple_networks__lstm_k1_b1_r1.onnx.json
@@ -1,10 +1,11 @@
 {
-  "error": "Unsupported LSTM direction b'forward'",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx2c-org/test/simple_networks lstm_k1_b1_r1.onnx",
   "operators": [
     "Transpose",
     "LSTM",
     "Squeeze"
   ],
-  "opset_version": 11
+  "opset_version": 11,
+  "generated_checksum": "0602019fbeb9d94d68155c190f14fa028cc057d1bad26a7cd743488ffcf7defc"
 }

--- a/tests/expected_errors/onnx2c-org__test__simple_networks__lstm_k1_b1_r1_relu.onnx.json
+++ b/tests/expected_errors/onnx2c-org__test__simple_networks__lstm_k1_b1_r1_relu.onnx.json
@@ -1,10 +1,11 @@
 {
-  "error": "Unsupported LSTM direction b'forward'",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx2c-org/test/simple_networks lstm_k1_b1_r1_relu.onnx",
   "operators": [
     "Transpose",
     "LSTM",
     "Squeeze"
   ],
-  "opset_version": 11
+  "opset_version": 11,
+  "generated_checksum": "4329ba181b53a6fa832e56d099618485b5b71fca72ba607ae78696f73fd7ec30"
 }


### PR DESCRIPTION
### Motivation

- Prevent false "Unsupported LSTM direction" failures when ONNX provides the `direction` attribute as `bytes` (e.g. `b'forward'`) which was being stringified and mismatched against expected direction names.

### Description

- Add `_normalize_direction` to decode `bytes` to `str` and validate the attribute type via `UnsupportedOpError` if not `str`/`bytes`.
- Use `_normalize_direction` when resolving the LSTM spec before calling `_validate_direction` so `forward`, `reverse`, and `bidirectional` are recognized whether provided as `bytes` or `str`.
- Update four expected-error JSON fixtures for affected LSTM models and regenerate `ONNX_SUPPORT.md` and `ONNX_ERRORS_HISTOGRAM.md` to reflect that those models now verify successfully.
- No new dependencies and existing validation behavior for proper string attributes is preserved.

### Testing

- Ran `pytest -q tests/test_official_onnx_files.py -k "lstm_k1_b1_r1 or test_lstm_reverse or test_lstm_bidirectional"` and the targeted tests passed (`4 passed, 1923 deselected`).
- Ran `pytest -q tests/test_official_onnx_files_docs.py` and it passed (`1 passed`).
- Refreshed references with `UPDATE_REFS=1 pytest -q tests/test_official_onnx_files.py -k "lstm_k1_b1_r1 or test_lstm_reverse or test_lstm_bidirectional"` which succeeded and updated the expected JSONs.
- Verified the small targeted run `pytest -q tests -k "lstm and direction"` passed (`1 passed, 2282 deselected`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a01634f91483258a301ee85d4de885)