### PR TITLE
gemm: accept row-vector bias for transA local ONNX case

### DIFF
--- a/ONNX_ERRORS_HISTOGRAM.md
+++ b/ONNX_ERRORS_HISTOGRAM.md
@@ -56,7 +56,6 @@ This histogram is test-suite-overarching.
 | Where inputs must be broadcastable, got ((), (1,), (0,)) | 2 | 20 |
 | ConvTranspose output shape must be fully defined and non-negative | 1 | 22 |
 | Dropout mask output is not supported | 1 | 22 |
-| Gemm bias input must be broadcastable to output shape, got (2,) vs (2, 4) | 1 | 12 |
 | Graph must contain at least one node | 1 | 25 |
 | Pad value input must be a scalar | 1 | 24 |
 | ReduceMax does not support dtype bool | 1 | 20 |
@@ -74,7 +73,6 @@ This histogram is test-suite-overarching.
 | --- | --- | --- |
 | Out of tolerance | 8 | 1 |
 | Out of tolerance | 9 | 5 |
-| Gemm bias input must be broadcastable to output shape, got (2,) vs (2, 4) | 12 | 1 |
 | Unsupported op TreeEnsembleClassifier | 12 | 1 |
 | Resize coordinate_transformation_mode '*' is not supported | 13 | 1 |
 | Unsupported non-tensor value '*' in op Identity. | 16 | 1 |

--- a/ONNX_SUPPORT.md
+++ b/ONNX_SUPPORT.md
@@ -5,7 +5,7 @@ Overview:
 | Test suite | Coverage | Version |
 | --- | --- | --- |
 | [Official ONNX test coverage](#official-onnx-test-coverage) | 1485 / 1802, 82.4% | 1.20.1 |
-| [ONNX2C test coverage](#onnx2c-test-coverage) | 114 / 125, 91.2% | n/a |
+| [ONNX2C test coverage](#onnx2c-test-coverage) | 115 / 125, 92.0% | n/a |
 
 See [`ONNX_ERRORS_HISTOGRAM.md`](ONNX_ERRORS_HISTOGRAM.md) for the error histogram.
 
@@ -1826,7 +1826,7 @@ Coverage 1485 / 1802 ONNX files (82.4%).
 
 Test directory: `onnx2c-org/test`
 
-Coverage 114 / 125 ONNX files (91.2%).
+Coverage 115 / 125 ONNX files (92.0%).
 
 | File | Opset | Supported | Error |
 | --- | --- | --- | --- |
@@ -1846,7 +1846,7 @@ Coverage 114 / 125 ONNX files (91.2%).
 | local_ops/test_gemm_C1xN/model.onnx | 12 | ✅ | OK (max ULP 0) |
 | local_ops/test_gemm_C1xN_transA/model.onnx | 12 | ✅ | OK (max ULP 1) |
 | local_ops/test_gemm_C1xN_transA_transB/model.onnx | 12 | ✅ | OK (max ULP 1) |
-| local_ops/test_gemm_CM_transA/model.onnx | 12 | ❌ | Gemm bias input must be broadcastable to output shape, got (2,) vs (2, 4) |
+| local_ops/test_gemm_CM_transA/model.onnx | 12 | ✅ | OK |
 | local_ops/test_gemm_CMx1/model.onnx | 12 | ✅ | OK (max ULP 1) |
 | local_ops/test_gemm_CMx1_transA/model.onnx | 12 | ✅ | OK (max ULP 0) |
 | local_ops/test_gemm_CMx1_transA_transB/model.onnx | 12 | ✅ | OK (max ULP 0) |

--- a/src/emx_onnx_cgen/codegen/c_emitter.py
+++ b/src/emx_onnx_cgen/codegen/c_emitter.py
@@ -6580,6 +6580,7 @@ class CEmitter:
             trans_a = bool(self._derived(op, "trans_a"))
             trans_b = bool(self._derived(op, "trans_b"))
             c_shape = self._derived(op, "c_shape")
+            c_axis = str(self._derived(op, "c_axis"))
             input_a_shape = (k, m) if trans_a else (m, k)
             input_b_shape = (n, k) if trans_b else (k, n)
             input_a_suffix = self._param_array_suffix(input_a_shape)
@@ -6649,6 +6650,7 @@ class CEmitter:
                 c_rank=c_rank,
                 c_dim0=c_dim0,
                 c_dim1=c_dim1,
+                c_axis=c_axis,
             ).rstrip()
             return with_node_comment(rendered)
         if isinstance(op, AttentionOp):

--- a/src/emx_onnx_cgen/templates/gemm_op.c.j2
+++ b/src/emx_onnx_cgen/templates/gemm_op.c.j2
@@ -21,8 +21,13 @@ EMX_NODE_FN void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
             idx_t c_j = {% if c_dim1 == 1 %}0{% else %}j{% endif %};
             const {{ c_type }} bias = {{ input_c }}[c_i][c_j];
             {% elif c_rank == 1 %}
+            {% if c_axis == "row" %}
+            idx_t c_i = {% if c_dim1 == 1 %}0{% else %}i{% endif %};
+            const {{ c_type }} bias = {{ input_c }}[c_i];
+            {% else %}
             idx_t c_j = {% if c_dim1 == 1 %}0{% else %}j{% endif %};
             const {{ c_type }} bias = {{ input_c }}[c_j];
+            {% endif %}
             {% else %}
             const {{ c_type }} bias = {{ input_c }}[0];
             {% endif %}

--- a/tests/expected_errors/onnx2c-org__test__local_ops__test_gemm_CM_transA__model.onnx.json
+++ b/tests/expected_errors/onnx2c-org__test__local_ops__test_gemm_CM_transA__model.onnx.json
@@ -1,8 +1,9 @@
 {
-  "error": "Gemm bias input must be broadcastable to output shape, got (2,) vs (2, 4)",
+  "error": "OK",
   "command_line": "verify --model-base-dir onnx2c-org/test/local_ops/test_gemm_CM_transA model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Gemm"
   ],
-  "opset_version": 12
+  "opset_version": 12,
+  "generated_checksum": "8ddd3797edf9b6ce81cd786f56dad79eebddcb5af60de8ec335e4ec07a44ae29"
 }


### PR DESCRIPTION
### Motivation
- The local ONNX test `local_ops/test_gemm_CM_transA/model.onnx` uses `transA=1` with a rank‑1 bias shaped to the output rows (`M`), which was rejected as not broadcastable by the previous logic.
- The change aims to allow this valid ONNX pattern, ensure correct C emission for row-biased Gemm, and mark the test as supported in expectations/docs.

### Description
- Extend `GemmOp._validate_bias_shape` to recognize rank‑1 biases that match `M` and return a bias-axis hint (`"row" | "col" | "scalar" | "matrix"`).
- Persist the derived `c_axis` via `ctx.set_derived(...)` during shape inference so codegen can select the correct indexing for 1D biases.
- Thread `c_axis` through the C emitter and pass it into the `gemm_op.c.j2` template so the emitted C indexes 1D bias by `i` when `c_axis == "row"` (previously it always indexed by `j`).
- Update the ONNX expectation for `test_gemm_CM_transA` to `OK` with a generated checksum, and refresh the support documentation/histogram entries to reflect the new supported status.

### Testing
- Ran `PYTHONPATH=src python -m emx_onnx_cgen.cli verify --model-base-dir onnx2c-org/test/local_ops/test_gemm_CM_transA model.onnx --test-data-dir test_data_set_0` which completed successfully (exit 0).
- Ran targeted tests `pytest -q tests/test_official_onnx_files.py -k test_gemm_CM_transA -q` and `pytest -q tests/test_ops.py -k Gemm -q`, both of which passed.
- Updated references via `UPDATE_REFS=1 pytest -q tests/test_official_onnx_files_docs.py::test_official_onnx_file_support_doc -q` which completed successfully.
- Executed the full test suite `pytest -n auto -q --maxfail=10`, resulting in `2280 passed, 1 skipped, 2 xfailed, 1 warning` in ~134.66s (0:02:14).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a03b87f90c8325b2602164328f6978)