### PR TITLE
Respect legacy Softmax/LogSoftmax axis semantics for opset < 13 and add tests

### DIFF
--- a/ONNX_ERRORS_HISTOGRAM.md
+++ b/ONNX_ERRORS_HISTOGRAM.md
@@ -13,9 +13,9 @@ This histogram is test-suite-overarching.
 | Unsupported elem_type 25 (UINT2) for tensor '*'. | 17 | 25 |
 | Unsupported elem_type 26 (INT2) for tensor '*'. | 17 | 25 |
 | Unsupported elem_type 23 (FLOAT4E2M1) for tensor '*'. | 14 | 25 |
-| Out of tolerance | 12 | 8, 9, 19, 22 |
 | Unsupported op ImageDecoder | 9 | 20 |
 | Dropout supports only the data input and 1 or 2 outputs | 8 | 22 |
+| Out of tolerance | 8 | 8, 9, 19, 22 |
 | Unsupported op Loop | 7 | 16, 17 |
 | Unsupported op CenterCropPad | 6 | 18 |
 | Unsupported op DFT | 6 | 19, 20 |
@@ -72,7 +72,7 @@ This histogram is test-suite-overarching.
 | Error message | Opset | Count |
 | --- | --- | --- |
 | Out of tolerance | 8 | 1 |
-| Out of tolerance | 9 | 5 |
+| Out of tolerance | 9 | 1 |
 | Unsupported op TreeEnsembleClassifier | 12 | 1 |
 | Resize coordinate_transformation_mode '*' is not supported | 13 | 1 |
 | Unsupported non-tensor value '*' in op Identity. | 16 | 1 |

--- a/ONNX_SUPPORT.md
+++ b/ONNX_SUPPORT.md
@@ -4,8 +4,8 @@ Overview:
 
 | Test suite | Coverage | Version |
 | --- | --- | --- |
-| [Official ONNX test coverage](#official-onnx-test-coverage) | 1485 / 1802, 82.4% | 1.20.1 |
-| [ONNX2C test coverage](#onnx2c-test-coverage) | 115 / 125, 92.0% | n/a |
+| [Official ONNX test coverage](#official-onnx-test-coverage) | 1486 / 1802, 82.5% | 1.20.1 |
+| [ONNX2C test coverage](#onnx2c-test-coverage) | 118 / 125, 94.4% | n/a |
 
 See [`ONNX_ERRORS_HISTOGRAM.md`](ONNX_ERRORS_HISTOGRAM.md) for the error histogram.
 
@@ -15,7 +15,7 @@ Floating-point verification first ignores very small differences up to **1.0 × 
 
 Test directory: `onnx-org/onnx/backend/test/data`
 
-Coverage 1485 / 1802 ONNX files (82.4%).
+Coverage 1486 / 1802 ONNX files (82.5%).
 
 | File | Opset | Supported | Error |
 | --- | --- | --- | --- |
@@ -25,7 +25,7 @@ Coverage 1485 / 1802 ONNX files (82.4%).
 | light/light_inception_v2.onnx | 9 | ✅ | OK (max ULP 0) |
 | light/light_resnet50.onnx | 9 | ✅ | OK (max ULP 0) |
 | light/light_shufflenet.onnx | 9 | ✅ | OK (max ULP 0) |
-| light/light_squeezenet.onnx | 9 | ❌ | Out of tolerance (max ULP 83684753) |
+| light/light_squeezenet.onnx | 9 | ✅ | OK (max ULP 0) |
 | light/light_vgg19.onnx | 9 | ✅ | OK (max ULP 0) |
 | light/light_zfnet512.onnx | 9 | ✅ | OK (max ULP 0) |
 | node/test_abs/model.onnx | 13 | ✅ | OK (max ULP 0) |
@@ -1826,7 +1826,7 @@ Coverage 1485 / 1802 ONNX files (82.4%).
 
 Test directory: `onnx2c-org/test`
 
-Coverage 115 / 125 ONNX files (92.0%).
+Coverage 118 / 125 ONNX files (94.4%).
 
 | File | Opset | Supported | Error |
 | --- | --- | --- | --- |
@@ -1910,9 +1910,9 @@ Coverage 115 / 125 ONNX files (92.0%).
 | local_ops/test_slice_end_INT64_MAX/model.onnx | 12 | ✅ | OK (max ULP 0) |
 | mnist/model.onnx | 8 | ❌ | Out of tolerance (max ULP 160) |
 | mnist/pytorch.onnx | 9 | ❌ | Out of tolerance (max ULP 2295973698) |
-| old_onnx_backend/11/test_softmax_axis_0/model.onnx | 9 | ❌ | Out of tolerance (max ULP 46450665) |
-| old_onnx_backend/11/test_softmax_axis_1/model.onnx | 9 | ❌ | Out of tolerance (max ULP 27819707) |
-| old_onnx_backend/11/test_softmax_default_axis/model.onnx | 9 | ❌ | Out of tolerance (max ULP 24092299) |
+| old_onnx_backend/11/test_softmax_axis_0/model.onnx | 9 | ✅ | OK (max ULP 0) |
+| old_onnx_backend/11/test_softmax_axis_1/model.onnx | 9 | ✅ | OK (max ULP 0) |
+| old_onnx_backend/11/test_softmax_default_axis/model.onnx | 9 | ✅ | OK (max ULP 0) |
 | old_onnx_backend/11/test_squeeze/model.onnx | 9 | ✅ | OK (max ULP 0) |
 | old_onnx_backend/11/test_squeeze_negative_axes/model.onnx | 11 | ✅ | OK (max ULP 0) |
 | old_onnx_backend/11/test_unsqueeze_axis_0/model.onnx | 11 | ✅ | OK (max ULP 0) |

--- a/src/emx_onnx_cgen/codegen/c_emitter.py
+++ b/src/emx_onnx_cgen/codegen/c_emitter.py
@@ -1485,12 +1485,14 @@ class CEmitter:
                 input0=name_map.get(op.input0, op.input0),
                 output=name_map.get(op.output, op.output),
                 axis=op.axis,
+                use_legacy_axis_semantics=op.use_legacy_axis_semantics,
             )
         if isinstance(op, LogSoftmaxOp):
             return LogSoftmaxOp(
                 input0=name_map.get(op.input0, op.input0),
                 output=name_map.get(op.output, op.output),
                 axis=op.axis,
+                use_legacy_axis_semantics=op.use_legacy_axis_semantics,
             )
         if isinstance(op, HardmaxOp):
             return HardmaxOp(
@@ -4695,12 +4697,14 @@ class CEmitter:
                 input0=temp_map.get(op.input0, op.input0),
                 output=temp_map.get(op.output, op.output),
                 axis=op.axis,
+                use_legacy_axis_semantics=op.use_legacy_axis_semantics,
             )
         if isinstance(op, LogSoftmaxOp):
             return LogSoftmaxOp(
                 input0=temp_map.get(op.input0, op.input0),
                 output=temp_map.get(op.output, op.output),
                 axis=op.axis,
+                use_legacy_axis_semantics=op.use_legacy_axis_semantics,
             )
         if isinstance(op, HardmaxOp):
             return HardmaxOp(
@@ -14031,7 +14035,9 @@ class CEmitter:
         lines.append(f"_Bool {model.name}_load(const char *path) {{")
         lines.append('    FILE *file = fopen(path, "rb");')
         lines.append("    if (!file) {")
-        lines.append('        fprintf(stderr, "Failed to open weight file: %s\\n", path);')
+        lines.append(
+            '        fprintf(stderr, "Failed to open weight file: %s\\n", path);'
+        )
         lines.append("        return 0;")
         lines.append("    }")
         lines.append(f"    _Bool ok = {model.name}_load_file(file);")

--- a/src/emx_onnx_cgen/lowering/logsoftmax.py
+++ b/src/emx_onnx_cgen/lowering/logsoftmax.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from ..ir.ops import LogSoftmaxOp
 from ..errors import UnsupportedOpError
 from ..ir.model import Graph, Node
+from .common import onnx_opset_version
 from .registry import register_lowering
 
 
@@ -10,8 +11,10 @@ from .registry import register_lowering
 def lower_logsoftmax(graph: Graph, node: Node) -> LogSoftmaxOp:
     if len(node.inputs) != 1 or len(node.outputs) != 1:
         raise UnsupportedOpError("LogSoftmax must have 1 input and 1 output")
+    opset_version = onnx_opset_version(graph)
     return LogSoftmaxOp(
         input0=node.inputs[0],
         output=node.outputs[0],
         axis=int(node.attrs["axis"]) if "axis" in node.attrs else None,
+        use_legacy_axis_semantics=opset_version is not None and opset_version < 13,
     )

--- a/src/emx_onnx_cgen/lowering/softmax.py
+++ b/src/emx_onnx_cgen/lowering/softmax.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from ..ir.ops import SoftmaxOp
 from ..errors import UnsupportedOpError
 from ..ir.model import Graph, Node
+from .common import onnx_opset_version
 from .registry import register_lowering
 
 
@@ -10,8 +11,10 @@ from .registry import register_lowering
 def lower_softmax(graph: Graph, node: Node) -> SoftmaxOp:
     if len(node.inputs) != 1 or len(node.outputs) != 1:
         raise UnsupportedOpError("Softmax must have 1 input and 1 output")
+    opset_version = onnx_opset_version(graph)
     return SoftmaxOp(
         input0=node.inputs[0],
         output=node.outputs[0],
         axis=int(node.attrs["axis"]) if "axis" in node.attrs else None,
+        use_legacy_axis_semantics=opset_version is not None and opset_version < 13,
     )

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__light__light_squeezenet.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__light__light_squeezenet.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Out of tolerance (max ULP 83684753)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/light light_squeezenet.onnx",
   "operators": [
     "ConstantOfShape",
@@ -12,5 +12,5 @@
     "Softmax"
   ],
   "opset_version": 9,
-  "generated_checksum": "54692140128c5959821c18a69e97b40622a86bf3fb46b2ab3db2885546ecd026"
+  "generated_checksum": "1949b7b288a5435ec5c454aa7b5ff5cb40a724b0ac927007db08489e005c7964"
 }

--- a/tests/expected_errors/onnx2c-org__test__old_onnx_backend__11__test_softmax_axis_0__model.onnx.json
+++ b/tests/expected_errors/onnx2c-org__test__old_onnx_backend__11__test_softmax_axis_0__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Out of tolerance (max ULP 46450665)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx2c-org/test/old_onnx_backend/11/test_softmax_axis_0 model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Softmax"
   ],
   "opset_version": 9,
-  "generated_checksum": "a407fae18a36a527b35e9f0a66eb030e41eeba6147ff0f3ddfa3f6a7d42fecf5"
+  "generated_checksum": "41f6fdfc8de45000c745fa94751e952df905fab91524c8c08709098e8188720d"
 }

--- a/tests/expected_errors/onnx2c-org__test__old_onnx_backend__11__test_softmax_axis_1__model.onnx.json
+++ b/tests/expected_errors/onnx2c-org__test__old_onnx_backend__11__test_softmax_axis_1__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Out of tolerance (max ULP 27819707)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx2c-org/test/old_onnx_backend/11/test_softmax_axis_1 model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Softmax"
   ],
   "opset_version": 9,
-  "generated_checksum": "669060e711c8f3cb4dbe10f4529598d289866f6ccbfea86488c38deb21a2d35f"
+  "generated_checksum": "9f9db981fbe5db583fb47992f58e8499518714059e911931f9a6c50bbdf811ee"
 }

--- a/tests/expected_errors/onnx2c-org__test__old_onnx_backend__11__test_softmax_default_axis__model.onnx.json
+++ b/tests/expected_errors/onnx2c-org__test__old_onnx_backend__11__test_softmax_default_axis__model.onnx.json
@@ -1,9 +1,9 @@
 {
-  "error": "Out of tolerance (max ULP 24092299)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx2c-org/test/old_onnx_backend/11/test_softmax_default_axis model.onnx --test-data-dir test_data_set_0",
   "operators": [
     "Softmax"
   ],
   "opset_version": 9,
-  "generated_checksum": "20f71b9917b735c2fcbf0c5726edfada153a1dbbdd3efc292d749a23459161fd"
+  "generated_checksum": "dcddc8130e8e9f281f93fe3641a5fba58f9978b54170dd98d6d322927bb3bbe2"
 }

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -5867,3 +5867,45 @@ def test_rms_normalization_run_matches_numpy() -> None:
     expected = data / np.sqrt(mean_square + 1e-5)
     expected = expected * scale.reshape(1, 1, 4)
     np.testing.assert_allclose(outputs["out"], expected, rtol=1e-5, atol=1e-6)
+
+
+def test_softmax_uses_legacy_axis_semantics_before_opset13() -> None:
+    model = _make_operator_model(
+        op_type="Softmax",
+        input_shapes=[[2, 3, 4]],
+        output_shape=[2, 3, 4],
+        dtype=TensorProto.FLOAT,
+        attrs={"axis": 1},
+        opset=11,
+    )
+    graph = import_onnx(model)
+    load_lowering_registry()
+    op = get_lowering("Softmax")(graph, graph.nodes[0])
+    op_ctx = OpContext(GraphContext(graph))
+    op.infer_shapes(op_ctx)
+
+    assert op.use_legacy_axis_semantics is True
+    assert op_ctx.require_derived(op, "outer") == 2
+    assert op_ctx.require_derived(op, "axis_size") == 12
+    assert op_ctx.require_derived(op, "inner") == 1
+
+
+def test_softmax_uses_axis_dimension_from_opset13() -> None:
+    model = _make_operator_model(
+        op_type="Softmax",
+        input_shapes=[[2, 3, 4]],
+        output_shape=[2, 3, 4],
+        dtype=TensorProto.FLOAT,
+        attrs={"axis": 1},
+        opset=13,
+    )
+    graph = import_onnx(model)
+    load_lowering_registry()
+    op = get_lowering("Softmax")(graph, graph.nodes[0])
+    op_ctx = OpContext(GraphContext(graph))
+    op.infer_shapes(op_ctx)
+
+    assert op.use_legacy_axis_semantics is False
+    assert op_ctx.require_derived(op, "outer") == 2
+    assert op_ctx.require_derived(op, "axis_size") == 3
+    assert op_ctx.require_derived(op, "inner") == 4


### PR DESCRIPTION
### Motivation
- ONNX changed the default `axis` interpretation for `Softmax`/`LogSoftmax` in opset 13, so older models must retain legacy semantics to compute correct shapes and reductions.
- Lowering and code emission must propagate that semantics so downstream shape inference and generated code use the correct `axis_size`/`inner` values.

### Description
- Added `use_legacy_axis_semantics: bool` to `SoftmaxOp` and `LogSoftmaxOp` and threaded the flag through lowering and emitter (`softmax.py`, `logsoftmax.py`, and `c_emitter.py`).
- Updated `infer_shapes` for `SoftmaxOp` and `LogSoftmaxOp` to compute `axis_size` and `inner` differently when legacy semantics are enabled, and adjusted `HardmaxOp` to detect legacy semantics based on the opset version.
- Lowerings now consult `onnx_opset_version(graph)` and set `use_legacy_axis_semantics = opset_version is not None and opset_version < 13` when creating `SoftmaxOp`/`LogSoftmaxOp` instances.
- Added unit tests `test_softmax_uses_legacy_axis_semantics_before_opset13` and `test_softmax_uses_axis_dimension_from_opset13` in `tests/test_ops.py`, and updated expected error/coverage snapshots and documentation entries to reflect corrected results; also a small formatting cleanup in `c_emitter.py`.

### Testing
- Ran the new unit tests in `tests/test_ops.py` and both tests `test_softmax_uses_legacy_axis_semantics_before_opset13` and `test_softmax_uses_axis_dimension_from_opset13` passed. 
- Updated expected error files for `light_squeezenet.onnx` and several `old_onnx_backend` softmax tests to reflect that they now report `OK (max ULP 0)` in automated verification. 
- Updated coverage totals in `ONNX_SUPPORT.md` and the histogram in `ONNX_ERRORS_HISTOGRAM.md` to match the automated test results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a04df29248832582f93fc18505ef73)