### PR TITLE
[codex] add node context to compiler diagnostics

### DIFF
--- a/src/emx_onnx_cgen/codegen/c_emitter.py
+++ b/src/emx_onnx_cgen/codegen/c_emitter.py
@@ -18,7 +18,7 @@ from jinja2 import (
 import numpy as np
 from onnx import GraphProto
 
-from ..errors import CodegenError
+from ..errors import CodegenError, CompilerError
 from ..testbench_output_format import parse_testbench_output_format
 from ..sequence_shape_hints import SequenceElementShapeHint
 from ..ir.op_base import (
@@ -1389,10 +1389,7 @@ class CEmitter:
         value_name_map = self._build_value_name_map(name_map, temp_name_map)
         self._emit_state.value_name_map = value_name_map
         self._propagate_tensor_dim_names(resolved_ops, tensor_dim_names)
-        operator_fns = "\n\n".join(
-            op.emit(self, EmitContext(op_index=index))
-            for index, op in enumerate(resolved_ops)
-        )
+        operator_fns = self._emit_operator_functions(model, resolved_ops)
         wrapper_fn = self._emit_model_wrapper(
             model,
             resolved_ops,
@@ -1615,10 +1612,7 @@ class CEmitter:
         value_name_map = self._build_value_name_map(name_map, temp_name_map)
         self._emit_state.value_name_map = value_name_map
         self._propagate_tensor_dim_names(resolved_ops, tensor_dim_names)
-        operator_fns = "\n\n".join(
-            op.emit(self, EmitContext(op_index=index))
-            for index, op in enumerate(resolved_ops)
-        )
+        operator_fns = self._emit_operator_functions(model, resolved_ops)
         wrapper_fn = self._emit_model_wrapper(
             model,
             resolved_ops,
@@ -2805,6 +2799,40 @@ class CEmitter:
 
     def render_op(self, op: OpBase, ctx: EmitContext) -> str:
         return op.emit(self, ctx)
+
+    @staticmethod
+    def _format_codegen_failure_summary(
+        model: LoweredModel,
+        op: OpBase,
+        *,
+        op_index: int,
+    ) -> str:
+        if op_index >= len(model.node_infos):
+            return f"while emitting op_index={op_index}, op_class={type(op).__name__}"
+        node_info = model.node_infos[op_index]
+        return (
+            f"while emitting node_index={op_index}, op_type={node_info.op_type}, "
+            f"name={node_info.name or '<unnamed>'}, op_class={type(op).__name__}, "
+            f"inputs={list(node_info.inputs)}, outputs={list(node_info.outputs)}"
+        )
+
+    def _emit_operator_functions(
+        self,
+        model: LoweredModel,
+        resolved_ops: Sequence[OpBase],
+    ) -> str:
+        rendered_ops: list[str] = []
+        for index, op in enumerate(resolved_ops):
+            try:
+                rendered_ops.append(op.emit(self, EmitContext(op_index=index)))
+            except CompilerError as exc:
+                summary = self._format_codegen_failure_summary(
+                    model,
+                    op,
+                    op_index=index,
+                )
+                raise type(exc)(f"{exc} ({summary})") from exc
+        return "\n\n".join(rendered_ops)
 
     def require_emit_state(self) -> _EmitState:
         if self._emit_state is None:

--- a/src/emx_onnx_cgen/compiler.py
+++ b/src/emx_onnx_cgen/compiler.py
@@ -919,9 +919,7 @@ class Compiler:
         ctx: GraphContext,
         action: Callable[[OpBase], None],
     ) -> None:
-        for node_index, (op, node_info) in enumerate(
-            zip(ops, node_infos, strict=True)
-        ):
+        for node_index, (op, node_info) in enumerate(zip(ops, node_infos, strict=True)):
             try:
                 action(op)
             except CompilerError as exc:

--- a/src/emx_onnx_cgen/compiler.py
+++ b/src/emx_onnx_cgen/compiler.py
@@ -20,7 +20,12 @@ from .codegen.c_emitter import (
     ModelHeader,
     NodeInfo,
 )
-from .errors import ShapeInferenceError, UnsupportedOpError, unsupported_op_message
+from .errors import (
+    CompilerError,
+    ShapeInferenceError,
+    UnsupportedOpError,
+    unsupported_op_message,
+)
 from .invariants import (
     check_graph_integrity,
     check_inferred_shapes,
@@ -510,16 +515,31 @@ class Compiler:
             output_types,
         ) = self._collect_io_specs(graph)
         ops, node_infos = self._lower_nodes(ctx)
-        check_lowered_ops(ops)
+        self._check_lowered_ops(ops, node_infos, ctx)
         op_ctx = OpContext(ctx)
-        for op in ops:
-            op.validate(op_ctx)
-        for op in ops:
-            op.infer_types(op_ctx)
-        check_inferred_types(ops, op_ctx)
-        for op in ops:
-            op.infer_shapes(op_ctx)
-        check_inferred_shapes(ops, op_ctx)
+        self._run_op_phase(
+            "validate",
+            ops,
+            node_infos,
+            ctx,
+            lambda op: op.validate(op_ctx),
+        )
+        self._run_op_phase(
+            "infer_types",
+            ops,
+            node_infos,
+            ctx,
+            lambda op: op.infer_types(op_ctx),
+        )
+        self._check_inferred_types(ops, node_infos, op_ctx)
+        self._run_op_phase(
+            "infer_shapes",
+            ops,
+            node_infos,
+            ctx,
+            lambda op: op.infer_shapes(op_ctx),
+        )
+        self._check_inferred_shapes(ops, node_infos, op_ctx)
         ops, node_infos = self._prune_dead_ops(ops, node_infos, output_names)
         refreshed_output_types: list[ValueType] = []
         refreshed_output_shapes: list[tuple[int, ...]] = []
@@ -833,6 +853,162 @@ class Compiler:
             lines.append(f"  - {self._format_debug_value(ctx, name)}")
         return "\n".join(lines)
 
+    def _format_lowering_failure_summary(
+        self,
+        ctx: GraphContext,
+        node: Node,
+        *,
+        node_index: int,
+    ) -> str:
+        inputs = ", ".join(self._format_debug_value(ctx, name) for name in node.inputs)
+        outputs = ", ".join(
+            self._format_debug_value(ctx, name) for name in node.outputs
+        )
+        return (
+            f"while lowering node_index={node_index}, op_type={node.op_type}, "
+            f"name={node.name or '<unnamed>'}, inputs=[{inputs}], "
+            f"outputs=[{outputs}]"
+        )
+
+    def _format_node_info_failure_summary(
+        self,
+        ctx: GraphContext,
+        node_info: NodeInfo,
+        *,
+        node_index: int,
+        phase: str,
+        op: OpBase | None = None,
+    ) -> str:
+        inputs = ", ".join(
+            self._format_debug_value(ctx, name) for name in node_info.inputs
+        )
+        outputs = ", ".join(
+            self._format_debug_value(ctx, name) for name in node_info.outputs
+        )
+        op_class = f", op_class={type(op).__name__}" if op is not None else ""
+        return (
+            f"during {phase} for node_index={node_index}, "
+            f"op_type={node_info.op_type}, name={node_info.name or '<unnamed>'}"
+            f"{op_class}, inputs=[{inputs}], outputs=[{outputs}]"
+        )
+
+    def _raise_with_node_info_context(
+        self,
+        exc: CompilerError,
+        ctx: GraphContext,
+        node_info: NodeInfo,
+        *,
+        node_index: int,
+        phase: str,
+        op: OpBase | None = None,
+    ) -> None:
+        summary = self._format_node_info_failure_summary(
+            ctx,
+            node_info,
+            node_index=node_index,
+            phase=phase,
+            op=op,
+        )
+        raise type(exc)(f"{exc} ({summary})") from exc
+
+    def _run_op_phase(
+        self,
+        phase: str,
+        ops: Sequence[OpBase],
+        node_infos: Sequence[NodeInfo],
+        ctx: GraphContext,
+        action: Callable[[OpBase], None],
+    ) -> None:
+        for node_index, (op, node_info) in enumerate(
+            zip(ops, node_infos, strict=True)
+        ):
+            try:
+                action(op)
+            except CompilerError as exc:
+                self._raise_with_node_info_context(
+                    exc,
+                    ctx,
+                    node_info,
+                    node_index=node_index,
+                    phase=phase,
+                    op=op,
+                )
+
+    def _check_lowered_ops(
+        self,
+        ops: Sequence[OpBase],
+        node_infos: Sequence[NodeInfo],
+        ctx: GraphContext,
+    ) -> None:
+        try:
+            check_lowered_ops(ops)
+        except CompilerError as exc:
+            for node_index, (op, node_info) in enumerate(
+                zip(ops, node_infos, strict=True)
+            ):
+                try:
+                    check_lowered_ops((op,))
+                except CompilerError:
+                    self._raise_with_node_info_context(
+                        exc,
+                        ctx,
+                        node_info,
+                        node_index=node_index,
+                        phase="check_lowered_ops",
+                        op=op,
+                    )
+            raise
+
+    def _check_inferred_types(
+        self,
+        ops: Sequence[OpBase],
+        node_infos: Sequence[NodeInfo],
+        op_ctx: OpContext,
+    ) -> None:
+        try:
+            check_inferred_types(ops, op_ctx)
+        except CompilerError as exc:
+            for node_index, (op, node_info) in enumerate(
+                zip(ops, node_infos, strict=True)
+            ):
+                try:
+                    check_inferred_types((op,), op_ctx)
+                except CompilerError:
+                    self._raise_with_node_info_context(
+                        exc,
+                        op_ctx.graph,
+                        node_info,
+                        node_index=node_index,
+                        phase="check_inferred_types",
+                        op=op,
+                    )
+            raise
+
+    def _check_inferred_shapes(
+        self,
+        ops: Sequence[OpBase],
+        node_infos: Sequence[NodeInfo],
+        op_ctx: OpContext,
+    ) -> None:
+        try:
+            check_inferred_shapes(ops, op_ctx)
+        except CompilerError as exc:
+            for node_index, (op, node_info) in enumerate(
+                zip(ops, node_infos, strict=True)
+            ):
+                try:
+                    check_inferred_shapes((op,), op_ctx)
+                except CompilerError:
+                    self._raise_with_node_info_context(
+                        exc,
+                        op_ctx.graph,
+                        node_info,
+                        node_index=node_index,
+                        phase="check_inferred_shapes",
+                        op=op,
+                    )
+            raise
+
     def _lower_nodes(self, ctx: GraphContext) -> tuple[list[OpBase], list[NodeInfo]]:
         ops: list[OpBase] = []
         node_infos: list[NodeInfo] = []
@@ -845,17 +1021,21 @@ class Compiler:
                 )
             try:
                 ops.append(lowering(ctx, node))
-            except (ShapeInferenceError, UnsupportedOpError) as exc:
-                if not self._debug_lowering_failures:
-                    raise
-                debug_context = self._format_lowering_debug_context(
+            except CompilerError as exc:
+                summary = self._format_lowering_failure_summary(
                     ctx,
                     node,
                     node_index=node_index,
                 )
-                raise type(exc)(
-                    f"{exc}\n\nLowering debug context:\n{debug_context}"
-                ) from exc
+                message = f"{exc} ({summary})"
+                if self._debug_lowering_failures:
+                    debug_context = self._format_lowering_debug_context(
+                        ctx,
+                        node,
+                        node_index=node_index,
+                    )
+                    message = f"{message}\n\nLowering debug context:\n{debug_context}"
+                raise type(exc)(message) from exc
             node_infos.append(
                 NodeInfo(
                     op_type=node.op_type,

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -6,8 +6,30 @@ import onnx
 from onnx import TensorProto, helper
 import pytest
 
+from shared.scalar_types import ScalarType
+
+from emx_onnx_cgen.codegen.c_emitter import NodeInfo
 from emx_onnx_cgen.compiler import Compiler, CompilerOptions
 from emx_onnx_cgen.errors import ShapeInferenceError, UnsupportedOpError
+from emx_onnx_cgen.ir.context import GraphContext
+from emx_onnx_cgen.ir.model import Graph, TensorType, Value
+from emx_onnx_cgen.ir.op_base import EmitContext, Emitter, OpBase
+from emx_onnx_cgen.ir.op_context import OpContext
+
+
+class _FailingValidateOp(OpBase):
+    __io_inputs__ = ("input0",)
+    __io_outputs__ = ("output",)
+
+    def __init__(self, input0: str, output: str) -> None:
+        self.input0 = input0
+        self.output = output
+
+    def validate(self, ctx: OpContext) -> None:
+        raise ShapeInferenceError("validation failed")
+
+    def emit(self, emitter: Emitter, ctx: EmitContext) -> str:
+        raise NotImplementedError
 
 
 def _make_split_dynamic_dim_model() -> onnx.ModelProto:
@@ -206,7 +228,7 @@ _OFFICIAL_SEQUENCE_MODELS = (
 )
 
 
-def test_compile_debug_lowering_failure_context_disabled_by_default() -> None:
+def test_compile_reports_lowering_failure_node_context_by_default() -> None:
     compiler = Compiler(CompilerOptions())
 
     with pytest.raises(
@@ -214,7 +236,18 @@ def test_compile_debug_lowering_failure_context_disabled_by_default() -> None:
     ) as exc_info:
         compiler.compile(_make_split_dynamic_dim_model())
 
-    assert "Lowering debug context:" not in str(exc_info.value)
+    message = str(exc_info.value)
+    assert "while lowering node_index=0, op_type=Split, name=split_dynamic" in message
+    assert (
+        "inputs=[x: tensor[dtype=float, shape=(-1, 2, 3), "
+        "dim_params=('N', None, None)]]"
+    ) in message
+    assert (
+        "outputs=[y0: tensor[dtype=float, shape=(-1, 1, 3), "
+        "dim_params=('N', None, None)], y1: tensor[dtype=float, "
+        "shape=(-1, 1, 3), dim_params=('N', None, None)]]"
+    ) in message
+    assert "Lowering debug context:" not in message
 
 
 def test_compile_debug_lowering_failure_context_enabled() -> None:
@@ -226,6 +259,7 @@ def test_compile_debug_lowering_failure_context_enabled() -> None:
         compiler.compile(_make_split_dynamic_dim_model())
 
     message = str(exc_info.value)
+    assert "while lowering node_index=0, op_type=Split, name=split_dynamic" in message
     assert "Lowering debug context:" in message
     assert "node_index: 0" in message
     assert "op_type: Split" in message
@@ -238,6 +272,61 @@ def test_compile_debug_lowering_failure_context_enabled() -> None:
         "y0: tensor[dtype=float, shape=(-1, 1, 3), dim_params=('N', None, None)]"
         in message
     )
+
+
+def test_op_phase_failures_report_node_context() -> None:
+    compiler = Compiler(CompilerOptions())
+    graph = Graph(
+        inputs=(
+            Value(
+                name="x",
+                type=TensorType(
+                    dtype=ScalarType.F32,
+                    shape=(2, 3),
+                    dim_params=(None, None),
+                ),
+            ),
+        ),
+        outputs=(
+            Value(
+                name="y",
+                type=TensorType(
+                    dtype=ScalarType.F32,
+                    shape=(2, 3),
+                    dim_params=(None, None),
+                ),
+            ),
+        ),
+        nodes=(),
+        initializers=(),
+    )
+    ctx = GraphContext(graph)
+    op_ctx = OpContext(ctx)
+    op = _FailingValidateOp("x", "y")
+    node_info = NodeInfo(
+        op_type="Identity",
+        name="identity_validate",
+        inputs=("x",),
+        outputs=("y",),
+        attrs={},
+    )
+
+    with pytest.raises(ShapeInferenceError, match="validation failed") as exc_info:
+        compiler._run_op_phase(  # noqa: SLF001
+            "validate",
+            (op,),
+            (node_info,),
+            ctx,
+            lambda current_op: current_op.validate(op_ctx),
+        )
+
+    message = str(exc_info.value)
+    assert (
+        "during validate for node_index=0, op_type=Identity, "
+        "name=identity_validate, op_class=_FailingValidateOp"
+    ) in message
+    assert "x: tensor[dtype=float, shape=(2, 3), dim_params=(None, None)]" in message
+    assert "y: tensor[dtype=float, shape=(2, 3), dim_params=(None, None)]" in message
 
 
 def test_compile_reports_unsupported_op_with_domain() -> None:


### PR DESCRIPTION
## Summary

Adds a generic diagnostics layer around compiler phases that operate on ONNX nodes or lowered ops. Compiler errors from lowering, lowered-op checks, validation, type inference, shape inference, and per-op C emission now include node/op context with index, op type, name, op class where available, and typed input/output shape details.

## Motivation

Customer-facing failures such as `Dynamic dims are not supported` did not identify the affected ONNX node. The root cause was that many operator implementations raised concise semantic errors, but the central pipeline did not consistently attach the current node context before the error reached the CLI.

## Validation

- `.venv\Scripts\python.exe -m pytest tests\test_compiler.py -q` (`22 passed in 4.18s`)
- `.venv\Scripts\python.exe -m ruff check src\emx_onnx_cgen\compiler.py src\emx_onnx_cgen\codegen\c_emitter.py tests\test_compiler.py`
- Manual check with `tests/onnx/slice_dynamic_batch.onnx` from `origin/copilot/find-dynamic-dims-issue`: failure now reports `node_index=0`, `op_type=Slice`, inputs, outputs, and dim params.