### PR TITLE
[codex] clarify dynamic dimension diagnostics

### DIFF
--- a/src/emx_onnx_cgen/codegen/c_emitter.py
+++ b/src/emx_onnx_cgen/codegen/c_emitter.py
@@ -3680,7 +3680,9 @@ class CEmitter:
         count = 1
         for dim in shape:
             if dim < 0:
-                raise CodegenError("Dynamic dims are not supported")
+                raise CodegenError(
+                    f"Cannot compute static element count for dynamic shape {shape}"
+                )
             if dim == 0:
                 return 0
             count *= dim

--- a/src/emx_onnx_cgen/ir/op_base.py
+++ b/src/emx_onnx_cgen/ir/op_base.py
@@ -878,7 +878,9 @@ class CEmitterCompat:
         count = 1
         for dim in shape:
             if dim < 0:
-                raise ValueError("Dynamic dims are not supported for element_count")
+                raise ValueError(
+                    f"Cannot compute element_count for dynamic shape {shape}"
+                )
             if dim == 0:
                 return 0
             count *= dim

--- a/src/emx_onnx_cgen/ir/ops/nn.py
+++ b/src/emx_onnx_cgen/ir/ops/nn.py
@@ -32,7 +32,9 @@ def _shape_product(shape: tuple[int, ...]) -> int:
     product = 1
     for dim in shape:
         if dim < 0:
-            raise ShapeInferenceError("Dynamic dims are not supported")
+            raise ShapeInferenceError(
+                f"Cannot compute static shape product for dynamic shape {shape}"
+            )
         product *= dim
     return product
 

--- a/src/emx_onnx_cgen/lowering/common.py
+++ b/src/emx_onnx_cgen/lowering/common.py
@@ -1348,7 +1348,9 @@ def shape_product(shape: tuple[int, ...]) -> int:
     product = 1
     for dim in shape:
         if dim < 0:
-            raise ShapeInferenceError("Dynamic dims are not supported")
+            raise ShapeInferenceError(
+                f"Cannot compute static shape product for dynamic shape {shape}"
+            )
         if dim == 0:
             return 0
         product *= dim

--- a/src/emx_onnx_cgen/lowering/constant_of_shape.py
+++ b/src/emx_onnx_cgen/lowering/constant_of_shape.py
@@ -53,7 +53,9 @@ def lower_constant_of_shape(graph: Graph, node: Node) -> ConstantOfShapeOp:
         raise ShapeInferenceError("ConstantOfShape input length must match output rank")
     for dim in output_shape:
         if dim < 0:
-            raise ShapeInferenceError("Dynamic dims are not supported")
+            raise ShapeInferenceError(
+                f"ConstantOfShape output shape must be static, got {output_shape}"
+            )
     input_dtype = _value_dtype(graph, node.inputs[0], node)
     if input_dtype != ScalarType.I64:
         raise UnsupportedOpError(

--- a/src/emx_onnx_cgen/lowering/flatten.py
+++ b/src/emx_onnx_cgen/lowering/flatten.py
@@ -28,7 +28,10 @@ def _flatten_output_shape(
         if dim < 0:
             if expected_shape is not None:
                 return expected_shape
-            raise ShapeInferenceError("Dynamic dims are not supported")
+            raise ShapeInferenceError(
+                "Flatten requires static input dimensions unless the output "
+                f"shape is known, got input shape {input_shape}"
+            )
     first = shape_product(input_shape[:axis]) if axis else 1
     second = shape_product(input_shape[axis:]) if axis < rank else 1
     return (first, second)

--- a/src/emx_onnx_cgen/lowering/reshape.py
+++ b/src/emx_onnx_cgen/lowering/reshape.py
@@ -26,7 +26,9 @@ def _shape_product(shape: tuple[int, ...]) -> int:
     product = 1
     for dim in shape:
         if dim < 0:
-            raise ShapeInferenceError("Dynamic dims are not supported")
+            raise ShapeInferenceError(
+                f"Reshape cannot compute element count for dynamic shape {shape}"
+            )
         product *= dim
     return product
 

--- a/src/emx_onnx_cgen/lowering/slice.py
+++ b/src/emx_onnx_cgen/lowering/slice.py
@@ -236,7 +236,10 @@ def _normalize_slices(
         seen_axes.add(normalized_axis)
         dim = input_shape[normalized_axis]
         if dim < 0:
-            raise ShapeInferenceError("Dynamic dims are not supported")
+            raise ShapeInferenceError(
+                f"{node.op_type} sliced axis {normalized_axis} must be static, "
+                f"got input shape {input_shape}"
+            )
         step = int(steps[index])
         if step == 0:
             raise UnsupportedOpError(f"{node.op_type} steps must be non-zero")
@@ -273,10 +276,6 @@ def resolve_slice_spec(graph: Graph, node: Node) -> SliceSpec:
             f"{node.op_type} expects matching input/output dtypes, "
             f"got {input_dtype} and {output_dtype}"
         )
-    if any(dim < 0 for dim in input_shape):
-        raise ShapeInferenceError("Dynamic dims are not supported")
-    if any(dim < 0 for dim in output_shape):
-        raise ShapeInferenceError("Dynamic dims are not supported")
     inputs = _resolve_inputs(graph, node)
     if inputs.starts is None or inputs.ends is None:
         raise UnsupportedOpError(


### PR DESCRIPTION
## Summary

Follows up on the generic node-context diagnostics by cleaning up stale or overly generic dynamic-dimension messages.

Changes:
- Removes the obsolete blanket dynamic-shape rejection in `resolve_slice_spec`, matching the Slice support on `origin/main` for dynamic non-sliced dimensions.
- Reports dynamic sliced axes specifically for Slice instead of the generic `Dynamic dims are not supported`.
- Rewords generic helper errors for shape products and element counts to name the failed operation and include the dynamic shape.
- Leaves operator-specific messages such as `CDist does not support dynamic K dimension` unchanged because those are still semantically precise.

## Validation

- `.venv\Scripts\python.exe -m pytest tests\test_compiler.py tests\test_ops.py::test_slice_with_dynamic_batch_compiles -q` (`12 passed, 11 skipped in 4.54s`)
- `.venv\Scripts\python.exe -m ruff check src\emx_onnx_cgen\codegen\c_emitter.py src\emx_onnx_cgen\ir\op_base.py src\emx_onnx_cgen\ir\ops\nn.py src\emx_onnx_cgen\lowering\common.py src\emx_onnx_cgen\lowering\constant_of_shape.py src\emx_onnx_cgen\lowering\flatten.py src\emx_onnx_cgen\lowering\reshape.py src\emx_onnx_cgen\lowering\slice.py tests\test_compiler.py`

## Notes

PR #725 was already merged into `main`, so this is a separate follow-up PR based on current `origin/main`.
