### PR TITLE
codegen: apply Attention softcap before mask/bias addition

### DIFF
--- a/ONNX_ERRORS.md
+++ b/ONNX_ERRORS.md
@@ -7,7 +7,7 @@ Aggregates non-success verification outcomes.
 
 | Error message | Count | Opset versions |
 | --- | --- | --- |
-| Out of tolerance | 48 | 7, 17, 21, 22, 23 |
+| Out of tolerance | 43 | 7, 17, 21, 22 |
 | Missing shape for '*' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. | 14 | 27 |
 | Unsupported op ai.onnx.preview.FlexAttention | 11 | 26 |
 | Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 8 |  |
@@ -30,7 +30,6 @@ Aggregates non-success verification outcomes.
 | Out of tolerance | 17 | 13 |
 | Out of tolerance | 21 | 4 |
 | Out of tolerance | 22 | 1 |
-| Out of tolerance | 23 | 4 |
 | Unsupported op ai.onnx.preview.FlexAttention | 26 | 11 |
 | Missing shape for '*' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. | 27 | 14 |
 | CausalConvWithState must have 4 inputs and 2 outputs (while lowering node_index=0, op_type=CausalConvWithState, name=<unnamed>, inputs=[input: tensor[dtype=float, shape=(2, 4, 8), dim_params=(None, None, None)], weight: tensor[dtype=float, shape=(4, 1, 4), dim_params=(None, None, None)]], outputs=[output: tensor[dtype=float, shape=(2, 4, 8), dim_params=(None, None, None)], present_state: tensor[dtype=float, shape=(2, 4, 3), dim_params=(None, None, None)]]) | 27 | 3 |
@@ -50,11 +49,6 @@ Lists every ONNX file with a non-success verification outcome.
 
 | File | Opset | Verification | Supported | Error |
 | --- | --- | --- | --- | --- |
-| node/test_adam_multiple/model.onnx |  | Data/Data | ❌ | Out of tolerance (max ULP 62311) |
-| node/test_attention_3d_with_past_and_present_qk_matmul_softcap/model.onnx | 23 | Data/Data | ❌ | Out of tolerance (max ULP 16719215) |
-| node/test_attention_4d_softcap_neginf_mask/model.onnx | 23 | Data/Data | ❌ | Out of tolerance (max ULP 2662733) |
-| node/test_attention_4d_softcap_neginf_mask_poison/model.onnx | 23 | Data/Data | ❌ | Out of tolerance (max ULP 80746724) |
-| node/test_attention_4d_with_qk_matmul_softcap/model.onnx | 23 | Data/Data | ❌ | Out of tolerance (max ULP 16161280) |
 | node/test_causal_conv_with_state_b1_c1_degenerate/model.onnx | 27 | Data/Data | ❌ | CausalConvWithState must have 4 inputs and 2 outputs (while lowering node_index=0, op_type=CausalConvWithState, name=<unnamed>, inputs=[input: tensor[dtype=float, shape=(1, 1, 6), dim_params=(None, None, None)], weight: tensor[dtype=float, shape=(1, 1, 4), dim_params=(None, None, None)]], outputs=[output: tensor[dtype=float, shape=(1, 1, 6), dim_params=(None, None, None)], present_state: tensor[dtype=float, shape=(1, 1, 3), dim_params=(None, None, None)]]) |
 | node/test_causal_conv_with_state_basic/model.onnx | 27 | Data/Data | ❌ | CausalConvWithState must have 4 inputs and 2 outputs (while lowering node_index=0, op_type=CausalConvWithState, name=<unnamed>, inputs=[input: tensor[dtype=float, shape=(2, 4, 8), dim_params=(None, None, None)], weight: tensor[dtype=float, shape=(4, 1, 4), dim_params=(None, None, None)]], outputs=[output: tensor[dtype=float, shape=(2, 4, 8), dim_params=(None, None, None)], present_state: tensor[dtype=float, shape=(2, 4, 3), dim_params=(None, None, None)]]) |
 | node/test_causal_conv_with_state_fp16/model.onnx | 27 | Data/Data | ❌ | CausalConvWithState must have 4 inputs and 2 outputs (while lowering node_index=0, op_type=CausalConvWithState, name=<unnamed>, inputs=[input: tensor[dtype=float16, shape=(2, 4, 8), dim_params=(None, None, None)], weight: tensor[dtype=float16, shape=(4, 1, 4), dim_params=(None, None, None)]], outputs=[output: tensor[dtype=float16, shape=(2, 4, 8), dim_params=(None, None, None)], present_state: tensor[dtype=float16, shape=(2, 4, 3), dim_params=(None, None, None)]]) |

--- a/ONNX_SUPPORT.md
+++ b/ONNX_SUPPORT.md
@@ -7,7 +7,7 @@ Overview:
 
 | Test suite | Coverage | Version |
 | --- | --- | --- |
-| [Official ONNX test coverage](#official-onnx-test-coverage) | 1866 / 1914, 97.5% | 1.22.0 |
+| [Official ONNX test coverage](#official-onnx-test-coverage) | 1871 / 1914, 97.8% | 1.22.0 |
 | [ONNX Runtime artifact coverage](#onnx-runtime-artifact-coverage) | 4278 / 4324, 98.9% | n/a |
 | [Local ONNX test coverage](#local-onnx-test-coverage) | 9 / 9, 100.0% | n/a |
 
@@ -21,7 +21,7 @@ The `Verification` column uses `Input/Reference` notation (for example `Random/O
 
 Test directory: `onnx-org/onnx/backend/test/data`
 
-Coverage 1866 / 1914 ONNX files (97.5%).
+Coverage 1871 / 1914 ONNX files (97.8%).
 
 | File | Opset | Verification | Supported | Error |
 | --- | --- | --- | --- | --- |
@@ -37,12 +37,12 @@ Coverage 1866 / 1914 ONNX files (97.5%).
 | node/test_abs/model.onnx | 13 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_acos/model.onnx | 22 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_acos_example/model.onnx | 22 | Data/Data | ✅ | OK (max ULP 0) |
-| node/test_acosh/model.onnx | 22 | Data/Data | ✅ | OK (max ULP 0) |
+| node/test_acosh/model.onnx | 22 | Data/Data | ✅ | OK (max ULP 1) |
 | node/test_acosh_example/model.onnx | 22 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_adagrad/model.onnx |  | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_adagrad_multiple/model.onnx |  | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_adam/model.onnx |  | Data/Data | ✅ | OK (max ULP 0) |
-| node/test_adam_multiple/model.onnx |  | Data/Data | ❌ | Out of tolerance (max ULP 62311) |
+| node/test_adam_multiple/model.onnx |  | Data/Data | ✅ | OK (max ULP 1) |
 | node/test_add/model.onnx | 14 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_add_bcast/model.onnx | 14 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_add_int16/model.onnx | 14 | Data/Data | ✅ | OK (max abs diff 0) |
@@ -157,7 +157,7 @@ Coverage 1866 / 1914 ONNX files (97.5%).
 | node/test_attention_3d_with_past_and_present_qk_matmul_bias/model.onnx | 23 | Data/Data | ✅ | OK (max ULP 3) |
 | node/test_attention_3d_with_past_and_present_qk_matmul_bias_expanded/model.onnx | 23 | Data/Data | ✅ | OK (max ULP 2) |
 | node/test_attention_3d_with_past_and_present_qk_matmul_expanded/model.onnx | 23 | Data/Data | ✅ | OK (max ULP 3) |
-| node/test_attention_3d_with_past_and_present_qk_matmul_softcap/model.onnx | 23 | Data/Data | ❌ | Out of tolerance (max ULP 16719215) |
+| node/test_attention_3d_with_past_and_present_qk_matmul_softcap/model.onnx | 23 | Data/Data | ✅ | OK (max ULP 5) |
 | node/test_attention_3d_with_past_and_present_qk_matmul_softcap_expanded/model.onnx | 23 | Data/Data | ✅ | OK (max ULP 4) |
 | node/test_attention_3d_with_past_and_present_qk_matmul_softmax/model.onnx | 23 | Data/Data | ✅ | OK (max ULP 3) |
 | node/test_attention_3d_with_past_and_present_qk_matmul_softmax_expanded/model.onnx | 23 | Data/Data | ✅ | OK (max ULP 0) |
@@ -217,9 +217,9 @@ Coverage 1866 / 1914 ONNX files (97.5%).
 | node/test_attention_4d_scaled_expanded/model.onnx | 23 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_attention_4d_softcap/model.onnx | 23 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_attention_4d_softcap_expanded/model.onnx | 23 | Data/Data | ✅ | OK (max ULP 0) |
-| node/test_attention_4d_softcap_neginf_mask/model.onnx | 23 | Data/Data | ❌ | Out of tolerance (max ULP 2662733) |
+| node/test_attention_4d_softcap_neginf_mask/model.onnx | 23 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_attention_4d_softcap_neginf_mask_expanded/model.onnx | 23 | Data/Data | ✅ | OK (max ULP 0) |
-| node/test_attention_4d_softcap_neginf_mask_poison/model.onnx | 23 | Data/Data | ❌ | Out of tolerance (max ULP 80746724) |
+| node/test_attention_4d_softcap_neginf_mask_poison/model.onnx | 23 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_attention_4d_softcap_neginf_mask_poison_expanded/model.onnx | 23 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_attention_4d_with_past_and_present/model.onnx | 23 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_attention_4d_with_past_and_present_expanded/model.onnx | 23 | Data/Data | ✅ | OK (max ULP 3) |
@@ -239,7 +239,7 @@ Coverage 1866 / 1914 ONNX files (97.5%).
 | node/test_attention_4d_with_qk_matmul_bias/model.onnx | 23 | Data/Data | ✅ | OK (max ULP 2) |
 | node/test_attention_4d_with_qk_matmul_bias_expanded/model.onnx | 23 | Data/Data | ✅ | OK (max ULP 1) |
 | node/test_attention_4d_with_qk_matmul_expanded/model.onnx | 23 | Data/Data | ✅ | OK (max ULP 2) |
-| node/test_attention_4d_with_qk_matmul_softcap/model.onnx | 23 | Data/Data | ❌ | Out of tolerance (max ULP 16161280) |
+| node/test_attention_4d_with_qk_matmul_softcap/model.onnx | 23 | Data/Data | ✅ | OK (max ULP 3) |
 | node/test_attention_4d_with_qk_matmul_softcap_expanded/model.onnx | 23 | Data/Data | ✅ | OK (max ULP 4) |
 | node/test_attention_4d_with_qk_matmul_softmax/model.onnx | 23 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_attention_4d_with_qk_matmul_softmax_expanded/model.onnx | 23 | Data/Data | ✅ | OK (max ULP 0) |

--- a/src/emx_onnx_cgen/templates/attention_op.c.j2
+++ b/src/emx_onnx_cgen/templates/attention_op.c.j2
@@ -120,22 +120,22 @@ EMX_NODE_FN void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
                     if ({{ is_causal }} && ki > qi + {{ past_seq }}) {
                         bias = {{ min_literal }};
                     }
-                    {{ c_type }} score_bias = score + bias;
-                    {{ c_type }} score_softcap = score_bias;
+                    {{ c_type }} score_softcap = score;
                     if (softcap != {{ zero_literal }}) {
-                        score_softcap = softcap * {{ scalar_fn(SF.TANH, dtype) }}(score_bias / softcap);
+                        score_softcap = softcap * {{ scalar_fn(SF.TANH, dtype) }}(score / softcap);
                     }
+                    {{ c_type }} score_bias = score_softcap + bias;
                     {% if output_qk_matmul %}
                     if ({{ qk_matmul_output_mode }} == 0) {
                         {{ output_qk_matmul }}[b][h][qi][ki] = score;
                     } else if ({{ qk_matmul_output_mode }} == 1) {
-                        {{ output_qk_matmul }}[b][h][qi][ki] = score_bias;
-                    } else if ({{ qk_matmul_output_mode }} == 2) {
                         {{ output_qk_matmul }}[b][h][qi][ki] = score_softcap;
+                    } else if ({{ qk_matmul_output_mode }} == 2) {
+                        {{ output_qk_matmul }}[b][h][qi][ki] = score_bias;
                     }
                     {% endif %}
-                    scores[ki] = score_softcap;
-                    max_score = {{ scalar_fn(SF.MAXIMUM, dtype) }}(max_score, score_softcap);
+                    scores[ki] = score_bias;
+                    max_score = {{ scalar_fn(SF.MAXIMUM, dtype) }}(max_score, score_bias);
                 }
                 {{ c_type }} weights[{{ total_seq }}];
                 {{ c_type }} sum = {{ zero_literal }};

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "6e26a809d3687dc1132270ce0ec06297062dbcf40af86cf70bf95fffcbbafbc5"
+  "generated_checksum": "ebef9204551ede793194604a097621ba36ee3db10e15549ae96bb3d9bea901d8"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_attn_mask__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_attn_mask__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "9c85128d6e0e189e66985a695ff9e349c2e7dac79619b70b5cc2bea9952ca093"
+  "generated_checksum": "9f3d8cee43330647837a2e156197fc509e34db4739df9397d0e5c7a400280b8b"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_causal__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_causal__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "2bc126f1e42b804f760fa044d3fdd844158f7c46e0a918a6dc85e94d77bd1ab2"
+  "generated_checksum": "fcaafc1ab29e377b74902bcc5b169d632b07c4b97ae14e51f2da19da9e29def4"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_diff_heads_sizes__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_diff_heads_sizes__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "ac442b294daa4e9cf627054a970a37c206cf97e4d19fbece5b46099840101908"
+  "generated_checksum": "0f88ba7a7941d772bb8a14be37561daa366f9555dcaf7fad889b2f067de90b9c"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_diff_heads_sizes_attn_mask__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_diff_heads_sizes_attn_mask__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "9f011a988942c8a44770b8cb20bc94fc39a349d65efb68cc017b2845a30c8760"
+  "generated_checksum": "09f54a377b6620ccecdf1a59e9f7f47d4c910b7bd0fad8958def6b07432e3d26"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_diff_heads_sizes_causal__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_diff_heads_sizes_causal__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "24c94b65b8d0e6b1a9ce5320b20e03037b17aa7dfc8d5ea2620f84d4a4aae8ce"
+  "generated_checksum": "d44907b35709b283ceaf9a0910aeeacea72a9e96034a46fd8f258326a529bfcf"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_diff_heads_sizes_scaled__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_diff_heads_sizes_scaled__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "7d6dec01ec9c67484ee822dc2659f36cacaa8fe607b170c2223c2c3fe3333fad"
+  "generated_checksum": "798979c2f18b01c343e029db624d1a3a708ee847aebc842afba764a42412b235"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_diff_heads_sizes_softcap__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_diff_heads_sizes_softcap__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "f9fbea665785e8b4c519a4094e0acd395e1095ee5d9a52a955c5813288bf2a21"
+  "generated_checksum": "20c4785b040c0a2ef5d53230ac1b1eb70af85de37ae475f05f7941f8f1d0a574"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_diff_heads_with_past_and_present__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_diff_heads_with_past_and_present__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "d232e351f8bf80537ebac4298ebc7ef91f9927fb5a35236a9a2da24b7650385f"
+  "generated_checksum": "978dcff03c977a90d6f5711a6e08c48002b12ef2b4f1039c76441a8fa299d881"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_gqa__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_gqa__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "a62fb5752a30ffc131419b0eabdaaa38117869f4a345b3537727ac7b0ce3b22f"
+  "generated_checksum": "2a31e5aadac39e3c84fdc34f6800451677fa536a8e42451975f09b70615ab4d4"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_gqa_attn_mask__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_gqa_attn_mask__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "fe798cefcdf1d69c3c19dd1dd9a779326e28335631cbb46f8ac5de24d332b49d"
+  "generated_checksum": "a9dd9c186389b8df50a0e90e5b8017faf41ef6f403c49a984fb3c52f13f081c5"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_gqa_causal__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_gqa_causal__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "0bdb7899dce0a5a62ae50ef235582c3952eacc90e4f185f4c733ded267a56c56"
+  "generated_checksum": "ac38530cf675d410d52d6f5130e9cfc1775466099b1ed040692a22da54b56ddf"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_gqa_scaled__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_gqa_scaled__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "a4fc6107bf342697c3da2b62c8189ecc2c847f5bc54371ecdcbf28d42303c583"
+  "generated_checksum": "ec06c327d15c35be13af8fa16c84171bf800ac26b4bd5620be67a77536de681e"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_gqa_softcap__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_gqa_softcap__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "a3f0d1ed53517e826a8c9f5db01e18cb5603cd599fee7a5710699f46c831299e"
+  "generated_checksum": "26612b4430a1bd26ec60982e46d1f1df8168e4670396adce0c0f3ef576725ad9"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_gqa_with_past_and_present__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_gqa_with_past_and_present__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "c48e618a14c536bb79c9495fb62b64891c5b4476b46a2b0d458693aa3ee74792"
+  "generated_checksum": "39e4528f320ddd02bcdfea1cefe0abee59b2d8e6486482404506c5c018419d40"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_scaled__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_scaled__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "044456cd6df1b48756d76ee51a236e57ef49e36b4331de6ddc029ecbc6474b2f"
+  "generated_checksum": "97111888cfc1911724ad310e0393529cd2549261105c76b9d7f3ef31e3cf1940"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_softcap__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_softcap__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "953b31a05a3456001f6a4b029076c65a34aea87674e51983cb2c999317e82b14"
+  "generated_checksum": "97509e057c008c004ef7ce3f1d5b2a50c77fd51ba817ba08680dbfb62ecf6c6d"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_transpose_verification__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_transpose_verification__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "85b72c40a078558769268c2ca6ae9d1fefd9fb86656a21efa587ebd6d0dc99fe"
+  "generated_checksum": "7830d395db212df42b64ab3ba54207e7ea9cc356421aecc41f8583edaa22a08f"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_with_past_and_present__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_with_past_and_present__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "81494a788d6c5039cb7393ca5551baafc6d1b46aa14bc1ebec03832d2e723894"
+  "generated_checksum": "9644dbb37f24c61b52570908fcf786086b5a0561e416f15552ab8897d29cae16"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_with_past_and_present_qk_matmul__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_with_past_and_present_qk_matmul__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "bc94722dacc01f1e22311dffd3db8e3a8506811ed04bbd242f4d429a81bd4de0"
+  "generated_checksum": "25703133075fc5658fe7137a98b570dedf0fd8911c42b7b6f4ff78c42100b440"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_with_past_and_present_qk_matmul_bias__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_with_past_and_present_qk_matmul_bias__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "c91d97097881a0db2406519558643991c4c81beba72968a9898a90e153d8a47b"
+  "generated_checksum": "daccab66a4fa0250d7777dbba0778471699e025077a6d6c8b4c9e1fd23beaecd"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_with_past_and_present_qk_matmul_softcap__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_with_past_and_present_qk_matmul_softcap__model.onnx.json
@@ -1,10 +1,10 @@
 {
-  "error": "Out of tolerance (max ULP 16719215)",
+  "error": "OK (max ULP 5)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_attention_3d_with_past_and_present_qk_matmul_softcap model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "2eef12a4913354b381f79d3b1f39acc9940f6bb28ae802554c7adf8545b1fdbe"
+  "generated_checksum": "e89cd8825763ad886e8080a6fb30f9a8b7beb349208a5b4a40a1067a3e0cc185"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_with_past_and_present_qk_matmul_softmax__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_3d_with_past_and_present_qk_matmul_softmax__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "54942ef80cca57a05dbc1c1d287967184f9bde48732cfb9c0bcd1f0febf6ced2"
+  "generated_checksum": "b0512544fdac30614ab6eb23a771872e2f497899590c42ed142cc577e4600240"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "7a6214405192e33dcc364df0b188c02fce1665b5a4abc12df3cc661bcfa51d4e"
+  "generated_checksum": "d39c10b01ecc0802165394031ea3fe8db473789dcf189383e054c6ea6bbb828f"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_attn_mask_3d__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_attn_mask_3d__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "537ab30049b168991b775056c427e75650645c2d27565963bb04b46e030bf50f"
+  "generated_checksum": "db39810d5cb0582ecdcba48230f084b11d531db00fb462e6df3e6f259e028b05"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_attn_mask_3d_causal__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_attn_mask_3d_causal__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "b4f885520ac6cffa42445aa2dd1ccf44bd13508fe45fdb13ee46021975f83bf7"
+  "generated_checksum": "46e6962806ebae8f596b880ce6f1aaa8e7a1444ca89c282bdcf8f34ab7d78c11"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_attn_mask_4d__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_attn_mask_4d__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "9556b2479aeec4d0712cf069aa31b78f34474d0cbf6196438aeded01b1e2972c"
+  "generated_checksum": "2c03d13108f2b85b1536082493a25e71db8d7854777d9512d21f8b8f3aaf5543"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_attn_mask_4d_causal__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_attn_mask_4d_causal__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "dd486b38599d627a6f3452c983c6af02d5c64e251dc1fa9bbe2dc5fe0390be07"
+  "generated_checksum": "20369150941c3ae8027a51b6ce361ca4d2531d25c091f12944451f5901db8adc"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_attn_mask__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_attn_mask__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "e86687d8f22d876b5d244907405575989276e0f6b9a5f62a7719892adaddd0c3"
+  "generated_checksum": "76f00b0f7f89a8e4c999c2659a2748422a3b3446fbc4df2e0987a99d54f28455"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_attn_mask_bool_4d__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_attn_mask_bool_4d__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "cff984671321e284dc316cb990c8e31702d4cb4f2bb09eec605e241aadf57880"
+  "generated_checksum": "e15d3182ee20952683760bac5641f54d39486a6ae5fa31b1353a41269bb2ac7d"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_attn_mask_bool__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_attn_mask_bool__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "44a206494aa86348b747b78372eb20aff79a5b70956a762074416e2b74c58c48"
+  "generated_checksum": "3875f36092278fa17dd80ef00f3f7ff5689437d83ac531ce0550b7ca12eb9079"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_causal__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_causal__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "b96fdde036db4bfde37c2be800977ca54126e9bbed727d6017eb6b9d8786d5fb"
+  "generated_checksum": "ed0a70b1e9c66f26b193853ff0f5dcbe4ccbbcea178fd8856a81d3879091e41a"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_diff_heads_mask4d_padded_kv__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_diff_heads_mask4d_padded_kv__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 24,
-  "generated_checksum": "59204a8584d04282dc9da9b94779340b952416efa38ef7738f73a4a21e9c75d6"
+  "generated_checksum": "2e8d22a51a71b984de984a56c313ebeb487fe9ba220556c6e03d5a291b23c4c1"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_diff_heads_sizes__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_diff_heads_sizes__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "e6844f1f3ddf8e93e539f81137eee6b405911e01aee015b8f18809f2d33347eb"
+  "generated_checksum": "f49ac1afcd11bda31cc4d114826792fad9a823c0caa756ff7c06fa6f1bc42391"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_diff_heads_sizes_attn_mask__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_diff_heads_sizes_attn_mask__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "2f5a6524b9508448fe3c8391293491cbdaa39210566bf19e0e48971ae085b547"
+  "generated_checksum": "b0c35d7e68eac35965560c40215c4d82a2edb60c8ceae18707c0e1d3b86d5b81"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_diff_heads_sizes_causal__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_diff_heads_sizes_causal__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "0c6a7631cb5b023e5b512951f0badf5cf7846966d53b4ebb3dd6824c3c32a08b"
+  "generated_checksum": "a74a1d1a17a410468516f9f5c78413eff7d36312dfd1f26240bc29362b454ceb"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_diff_heads_sizes_scaled__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_diff_heads_sizes_scaled__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "45d0c01738fd6a77fafe58d19c155d29dc74b21a06e5b7d71194ce486ca9d547"
+  "generated_checksum": "6cd59d10d1be03ede789754756db343e853c77104e34e3f43f80785578a0751a"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_diff_heads_sizes_softcap__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_diff_heads_sizes_softcap__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "d5cf8f06fa07f70343b177bebd2748d13229f108b168445f08be81e6cd90b32b"
+  "generated_checksum": "48a7699f2c38f501f997ea9c8b379a8e54e6e05b42df35d3bec861e9f5f64ad0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_diff_heads_with_past_and_present__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_diff_heads_with_past_and_present__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "9c684b47beea3dd2c6606fa71a572be4e79137e92ebcfda33b9e2e44606bdc2c"
+  "generated_checksum": "7fe0cff44b0ddb24a5e271aadcb5173d2cde770c3d470ab729b867c5ee2e9b8e"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_diff_heads_with_past_and_present_mask3d__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_diff_heads_with_past_and_present_mask3d__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "e6ba33440597613e85233129365e1a05eefd2da2dd8a5646c2056cd60afb886b"
+  "generated_checksum": "7210a68ee4e6ad2421805849ff5678433a12012eda5c045dd8cb380d45077a0f"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_diff_heads_with_past_and_present_mask4d__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_diff_heads_with_past_and_present_mask4d__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "b3970f5dcd147ee3d028e8d976d69744f3241cb49949a07d9c9a8a8015213e87"
+  "generated_checksum": "2b9866884de82a1339224e3ce311834d547e69d8ac29cd716cc5f27252927def"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_fp16__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_fp16__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "1acbb723ba20ee48c5eee7bd15ffb9083465676fbf922908419fe3705633dd9c"
+  "generated_checksum": "d60fa0ce862aab3d6695f8a676637daa3a9184eeeb14eac6d4fd1c4fb51b2658"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_gqa__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_gqa__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "13f577f599031e5e813effd3ff2e5a49bd2ea34922574946f271c1ea95fd0fb4"
+  "generated_checksum": "742173da8ffde6b30ce7e1b940534cd6420340e4401921c5ec3a79e69768b668"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_gqa_attn_mask__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_gqa_attn_mask__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "ce9567540f7b80269af4860dc9ac5cbc3edd482173cc9a23c86b2be3d4731faf"
+  "generated_checksum": "593c3c2b7d3c3aac1e184a91fd36017f6932777fe63cdeb3218640efd6e41679"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_gqa_causal__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_gqa_causal__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "00fb4a474b50204cc37ca498fc92fd1433225e3c22d26a5b7ad84f52a129c923"
+  "generated_checksum": "6e7a8820ec1c900e80bd51e8e8dff96b0f733f3969620bbb65c387bdb50899d7"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_gqa_scaled__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_gqa_scaled__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "bff0c968c4a5a9d28402f082abd2c90dae5554e0321326fedc197139172da19a"
+  "generated_checksum": "e7a13ab54c8ecb0ca509d71fd4a15afdc5a89b73c393d5e36a0dc0467d219712"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_gqa_softcap__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_gqa_softcap__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "a6dab2e8b498223fa57fb9ec30ce1f8a8f926f67d5d4e7b3c547fb2031584ab9"
+  "generated_checksum": "dbdbad696f08f3a1285664edb3e72a2eb755925a75d91fbbc569ba8255d26ace"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_gqa_with_past_and_present__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_gqa_with_past_and_present__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "c63fc4083036cba9bbc6ed4f51be734be11c55ba8841b39720682e9ec2bad692"
+  "generated_checksum": "de7ce3a41d19c126a95521548851669670880e66adaf7d6906a37e5ebe7baa84"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_gqa_with_past_and_present_fp16__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_gqa_with_past_and_present_fp16__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "0b0bdd7bb5d303587b6e58f94923d4fb2a6650c8563f3b94a1a80e376f92f7f6"
+  "generated_checksum": "f7d689bb63453f58eea2dafca009f677f7ae4185ad2c70b1c1f09a5c09ebcbaa"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_scaled__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_scaled__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "7edf94d94b684bb5ce429e43254ca3d626f32998733d466645f789e18ab80f52"
+  "generated_checksum": "4570e3f0c07da26722a810ee63a59dde572060ac847319eb420f93449d004c67"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_softcap__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_softcap__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "e90e229295ccfa76d178c16e5eefa03f8f5828ed6369ec52b060e470ded89135"
+  "generated_checksum": "0a0acb8dcef2f12008251d8a400fa37bf1678b05fbe8b3e3cf16cbc9c7c00178"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_softcap_neginf_mask__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_softcap_neginf_mask__model.onnx.json
@@ -1,10 +1,10 @@
 {
-  "error": "Out of tolerance (max ULP 2662733)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_attention_4d_softcap_neginf_mask model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "348cd277fc22eb3af9c588f5add1cc6a28d04fae546f02245375c05eaff295c4"
+  "generated_checksum": "01f785abbbb4ba9054f019275633b79df2e4393a11bbb653eaa8a4c0f149bbde"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_softcap_neginf_mask_poison__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_softcap_neginf_mask_poison__model.onnx.json
@@ -1,10 +1,10 @@
 {
-  "error": "Out of tolerance (max ULP 80746724)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_attention_4d_softcap_neginf_mask_poison model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "83506826202ca26926aa5556bab90f4ee3417024db6535f4620f49c3caa8a325"
+  "generated_checksum": "0cfb734f66c68e44fea59a6ba6c8391f07dfda3f08d7dbc368614343e4326d48"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "95d46b4f107388a36751c5ea7f5aa3c9843c13ce9f10c02fc716768111c81c47"
+  "generated_checksum": "081e2b6941981e7cc6459eb6ff0bdd15914ae688310360aa760c31158face348"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present_qk_matmul__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present_qk_matmul__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "761eb80948c3eda31db3d35867ae44d15086d4c97892ab2e2a066b838592e4c6"
+  "generated_checksum": "42154c0cc8d6583ffed3b490ce83129688bc7f7ed2fb21a8dad4722ebaa7331d"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "31f91842666ddb06dfd7f548c53a53815aa93a73e3d51b1645ea3608db31e614"
+  "generated_checksum": "85a1b7c0ccb1ef8b56e8edae418ae7ca5f25a0d2c1264b2cb7e2f29b1c8fbcd1"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "c065fb9c8fd5ac3028a17a09e00052836896e025526f6ebdc9619868c045355c"
+  "generated_checksum": "4d45cc336aab08d153b9a24c109c12b473e1a88eea0e9f7fa3a1ef44a32be386"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "ee214b51baf5b5a66441e00d591df892cb170197aeaaf2fa84429f42940c5449"
+  "generated_checksum": "cf0837d995023e36543e87aa692c05184159f912ebdd81d7d6216253a5482bb4"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "1270ae1879d5f4ac0001c8695b8181433970edebac4beaa8c312ad04a855af1b"
+  "generated_checksum": "af7246844a83c90b0a8043ddb600a3e8b76260129db1f88a877de896c72bdec6"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present_qk_matmul_bias__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_past_and_present_qk_matmul_bias__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "ee354b6ed9736af03c199f122d51b5962b0774d583d851cb04c8a19ce2025c34"
+  "generated_checksum": "53eff84e8ab261b437142db7513908d86565be705839602bc90738f30c2fe61e"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_qk_matmul__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_qk_matmul__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "d8bc440a2c5bf102a66517a5328dbe704a6bde5167f51c82962fb5c94ea83d48"
+  "generated_checksum": "60e6edc32c0dfd1762954e5dc45a3464a13add733c280617c271283488c4db0b"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_qk_matmul_bias__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_qk_matmul_bias__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "d340bacdd54496f63e6e083bfea91918f5937bb18b7708e42015052953bec64c"
+  "generated_checksum": "7d1b10fe700e6a6c2beacc3ac3761d64b9fcf99a6e1a022433974972a43a0a6c"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_qk_matmul_softcap__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_qk_matmul_softcap__model.onnx.json
@@ -1,10 +1,10 @@
 {
-  "error": "Out of tolerance (max ULP 16161280)",
+  "error": "OK (max ULP 3)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_attention_4d_with_qk_matmul_softcap model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "4377ead4c28a63f5b5146c995ae29ce7ca2060de18d5575aa2d75c49624d935f"
+  "generated_checksum": "015aad0c8b40df312f7de12e4a5714c338d179c6cbeacc2b1e06bf008c172a31"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_qk_matmul_softmax__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_attention_4d_with_qk_matmul_softmax__model.onnx.json
@@ -6,5 +6,5 @@
     "Attention"
   ],
   "opset_version": 23,
-  "generated_checksum": "e19e464c59e6f7f38777403115a32b502dd5c26e630387244a4df06212b2b883"
+  "generated_checksum": "d4182f6b1cb14eaf24316e3c67ae25461b141a1a55fc53ca98443501ff3ce5bd"
 }

--- a/tests/golden/op_attention_attention.c
+++ b/tests/golden/op_attention_attention.c
@@ -93,13 +93,13 @@ EMX_NODE_FN void node0_attention(const float input_q[1][2][3][4], const float in
                     if (0 && ki > qi + 0) {
                         bias = -INFINITY;
                     }
-                    float score_bias = score + bias;
-                    float score_softcap = score_bias;
+                    float score_softcap = score;
                     if (softcap != 0.0f) {
-                        score_softcap = softcap * ref_scalar_f32_tanh(score_bias / softcap);
+                        score_softcap = softcap * ref_scalar_f32_tanh(score / softcap);
                     }
-                    scores[ki] = score_softcap;
-                    max_score = ref_scalar_f32_maximum(max_score, score_softcap);
+                    float score_bias = score_softcap + bias;
+                    scores[ki] = score_bias;
+                    max_score = ref_scalar_f32_maximum(max_score, score_bias);
                 }
                 float weights[5];
                 float sum = 0.0f;


### PR DESCRIPTION
The Attention C template computed softcap over (score + bias) and emitted
score + bias for qk_matmul_output_mode 1. Per the ONNX Attention spec,
softcap must be applied to the scaled QK score *before* the attention
mask/bias is added:

  QKAttnSoftcapped       = softcap * tanh(score / softcap)   (mode 1)
  QKAttnWeightSoftcap    = QKAttnSoftcapped + bias            (mode 2)
  Softmax(QKAttnWeightSoftcap)                                (mode 3)

The previous ordering also leaked probability into masked positions: a
-inf mask bias added before softcap mapped to -softcap (finite) instead
of staying -inf, so masked entries got nonzero softmax weight.

Reorder so softcap is applied to the bare scaled score, then add bias.
This fixes test_attention_3d_with_past_and_present_qk_matmul_softcap and
three further softcap+mask tests (4d_with_qk_matmul_softcap,
4d_softcap_neginf_mask, 4d_softcap_neginf_mask_poison), all of which now
verify OK. Refresh the affected expected_errors entries and coverage docs.