### PR TITLE
import: expand ai.onnx.preview.FlexAttention to primitive ops

### DIFF
--- a/ONNX_ERRORS.md
+++ b/ONNX_ERRORS.md
@@ -9,7 +9,6 @@ Aggregates non-success verification outcomes.
 | --- | --- | --- |
 | Out of tolerance | 43 | 7, 17, 21, 22 |
 | Missing shape for '*' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. | 14 | 27 |
-| Unsupported op ai.onnx.preview.FlexAttention | 11 | 26 |
 | Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 8 |  |
 | Range does not support dtype bfloat16 (while lowering node_index=0, op_type=Range, name=<unnamed>, inputs=[start: tensor[dtype=bfloat16, shape=()], limit: tensor[dtype=bfloat16, shape=()], delta: tensor[dtype=bfloat16, shape=()]], outputs=[output: tensor[dtype=bfloat16, shape=(2,), dim_params=(None,)]]) | 1 | 27 |
 | Range does not support dtype float16 (while lowering node_index=0, op_type=Range, name=<unnamed>, inputs=[start: tensor[dtype=float16, shape=()], limit: tensor[dtype=float16, shape=()], delta: tensor[dtype=float16, shape=()]], outputs=[output: tensor[dtype=float16, shape=(2,), dim_params=(None,)]]) | 1 | 27 |
@@ -24,7 +23,6 @@ Aggregates non-success verification outcomes.
 | Out of tolerance | 17 | 13 |
 | Out of tolerance | 21 | 4 |
 | Out of tolerance | 22 | 1 |
-| Unsupported op ai.onnx.preview.FlexAttention | 26 | 11 |
 | Missing shape for '*' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. | 27 | 14 |
 | Range does not support dtype bfloat16 (while lowering node_index=0, op_type=Range, name=<unnamed>, inputs=[start: tensor[dtype=bfloat16, shape=()], limit: tensor[dtype=bfloat16, shape=()], delta: tensor[dtype=bfloat16, shape=()]], outputs=[output: tensor[dtype=bfloat16, shape=(2,), dim_params=(None,)]]) | 27 | 1 |
 | Range does not support dtype float16 (while lowering node_index=0, op_type=Range, name=<unnamed>, inputs=[start: tensor[dtype=float16, shape=()], limit: tensor[dtype=float16, shape=()], delta: tensor[dtype=float16, shape=()]], outputs=[output: tensor[dtype=float16, shape=(2,), dim_params=(None,)]]) | 27 | 1 |
@@ -37,17 +35,6 @@ Lists every ONNX file with a non-success verification outcome.
 
 | File | Opset | Verification | Supported | Error |
 | --- | --- | --- | --- | --- |
-| node/test_flexattention/model.onnx | 26 | Data/Data | ❌ | Unsupported op ai.onnx.preview.FlexAttention |
-| node/test_flexattention_causal_mask/model.onnx | 26 | Data/Data | ❌ | Unsupported op ai.onnx.preview.FlexAttention |
-| node/test_flexattention_diff_head_sizes/model.onnx | 26 | Data/Data | ❌ | Unsupported op ai.onnx.preview.FlexAttention |
-| node/test_flexattention_double/model.onnx | 26 | Data/Data | ❌ | Unsupported op ai.onnx.preview.FlexAttention |
-| node/test_flexattention_fp16/model.onnx | 26 | Data/Data | ❌ | Unsupported op ai.onnx.preview.FlexAttention |
-| node/test_flexattention_gqa/model.onnx | 26 | Data/Data | ❌ | Unsupported op ai.onnx.preview.FlexAttention |
-| node/test_flexattention_prob_mod/model.onnx | 26 | Data/Data | ❌ | Unsupported op ai.onnx.preview.FlexAttention |
-| node/test_flexattention_relative_positional/model.onnx | 26 | Data/Data | ❌ | Unsupported op ai.onnx.preview.FlexAttention |
-| node/test_flexattention_scaled/model.onnx | 26 | Data/Data | ❌ | Unsupported op ai.onnx.preview.FlexAttention |
-| node/test_flexattention_score_mod/model.onnx | 26 | Data/Data | ❌ | Unsupported op ai.onnx.preview.FlexAttention |
-| node/test_flexattention_soft_cap/model.onnx | 26 | Data/Data | ❌ | Unsupported op ai.onnx.preview.FlexAttention |
 | node/test_l2normalization_axis_0/model.onnx | 22 | Data/Data | ❌ | Out of tolerance (max ULP 4294967295) |
 | node/test_linear_attention_decode_step_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_decode_step_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
 | node/test_linear_attention_delta_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_delta_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |

--- a/ONNX_SUPPORT.md
+++ b/ONNX_SUPPORT.md
@@ -7,7 +7,7 @@ Overview:
 
 | Test suite | Coverage | Version |
 | --- | --- | --- |
-| [Official ONNX test coverage](#official-onnx-test-coverage) | 1880 / 1914, 98.2% | 1.22.0 |
+| [Official ONNX test coverage](#official-onnx-test-coverage) | 1891 / 1914, 98.8% | 1.22.0 |
 | [ONNX Runtime artifact coverage](#onnx-runtime-artifact-coverage) | 4278 / 4324, 98.9% | n/a |
 | [Local ONNX test coverage](#local-onnx-test-coverage) | 9 / 9, 100.0% | n/a |
 
@@ -21,7 +21,7 @@ The `Verification` column uses `Input/Reference` notation (for example `Random/O
 
 Test directory: `onnx-org/onnx/backend/test/data`
 
-Coverage 1880 / 1914 ONNX files (98.2%).
+Coverage 1891 / 1914 ONNX files (98.8%).
 
 | File | Opset | Verification | Supported | Error |
 | --- | --- | --- | --- | --- |
@@ -711,27 +711,27 @@ Coverage 1880 / 1914 ONNX files (98.2%).
 | node/test_flatten_negative_axis2/model.onnx | 25 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_flatten_negative_axis3/model.onnx | 25 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_flatten_negative_axis4/model.onnx | 25 | Data/Data | ✅ | OK (max ULP 0) |
-| node/test_flexattention/model.onnx | 26 | Data/Data | ❌ | Unsupported op ai.onnx.preview.FlexAttention |
-| node/test_flexattention_causal_mask/model.onnx | 26 | Data/Data | ❌ | Unsupported op ai.onnx.preview.FlexAttention |
+| node/test_flexattention/model.onnx | 26 | Data/Data | ✅ | OK (max ULP 3) |
+| node/test_flexattention_causal_mask/model.onnx | 26 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_flexattention_causal_mask_expanded_ver26/model.onnx | 26 | Data/Data | ✅ | OK (max ULP 0) |
-| node/test_flexattention_diff_head_sizes/model.onnx | 26 | Data/Data | ❌ | Unsupported op ai.onnx.preview.FlexAttention |
+| node/test_flexattention_diff_head_sizes/model.onnx | 26 | Data/Data | ✅ | OK (max ULP 3) |
 | node/test_flexattention_diff_head_sizes_expanded_ver26/model.onnx | 26 | Data/Data | ✅ | OK (max ULP 3) |
-| node/test_flexattention_double/model.onnx | 26 | Data/Data | ❌ | Unsupported op ai.onnx.preview.FlexAttention |
+| node/test_flexattention_double/model.onnx | 26 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_flexattention_double_expanded_ver26/model.onnx | 26 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_flexattention_expanded_ver26/model.onnx | 26 | Data/Data | ✅ | OK (max ULP 3) |
-| node/test_flexattention_fp16/model.onnx | 26 | Data/Data | ❌ | Unsupported op ai.onnx.preview.FlexAttention |
+| node/test_flexattention_fp16/model.onnx | 26 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_flexattention_fp16_expanded_ver26/model.onnx | 26 | Data/Data | ✅ | OK (max ULP 0) |
-| node/test_flexattention_gqa/model.onnx | 26 | Data/Data | ❌ | Unsupported op ai.onnx.preview.FlexAttention |
+| node/test_flexattention_gqa/model.onnx | 26 | Data/Data | ✅ | OK (max ULP 3) |
 | node/test_flexattention_gqa_expanded_ver26/model.onnx | 26 | Data/Data | ✅ | OK (max ULP 3) |
-| node/test_flexattention_prob_mod/model.onnx | 26 | Data/Data | ❌ | Unsupported op ai.onnx.preview.FlexAttention |
+| node/test_flexattention_prob_mod/model.onnx | 26 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_flexattention_prob_mod_expanded_ver26/model.onnx | 26 | Data/Data | ✅ | OK (max ULP 0) |
-| node/test_flexattention_relative_positional/model.onnx | 26 | Data/Data | ❌ | Unsupported op ai.onnx.preview.FlexAttention |
+| node/test_flexattention_relative_positional/model.onnx | 26 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_flexattention_relative_positional_expanded_ver26/model.onnx | 26 | Data/Data | ✅ | OK (max ULP 0) |
-| node/test_flexattention_scaled/model.onnx | 26 | Data/Data | ❌ | Unsupported op ai.onnx.preview.FlexAttention |
+| node/test_flexattention_scaled/model.onnx | 26 | Data/Data | ✅ | OK (max ULP 4) |
 | node/test_flexattention_scaled_expanded_ver26/model.onnx | 26 | Data/Data | ✅ | OK (max ULP 4) |
-| node/test_flexattention_score_mod/model.onnx | 26 | Data/Data | ❌ | Unsupported op ai.onnx.preview.FlexAttention |
+| node/test_flexattention_score_mod/model.onnx | 26 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_flexattention_score_mod_expanded_ver26/model.onnx | 26 | Data/Data | ✅ | OK (max ULP 0) |
-| node/test_flexattention_soft_cap/model.onnx | 26 | Data/Data | ❌ | Unsupported op ai.onnx.preview.FlexAttention |
+| node/test_flexattention_soft_cap/model.onnx | 26 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_flexattention_soft_cap_expanded_ver26/model.onnx | 26 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_floor/model.onnx | 13 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_floor_example/model.onnx | 13 | Data/Data | ✅ | OK (max ULP 0) |

--- a/SUPPORT_OPS.md
+++ b/SUPPORT_OPS.md
@@ -5,7 +5,7 @@
 
 Operators are marked supported when they appear in an ONNX file with a successful verify result.
 
-Supported operators: 263 / 265
+Supported operators: 264 / 265
 
 | Operator | Supported |
 | --- | --- |
@@ -213,7 +213,7 @@ Supported operators: 263 / 265
 | ai.onnx.ml.Binarizer | ✅ |
 | ai.onnx.ml.LabelEncoder | ✅ |
 | ai.onnx.ml.TreeEnsemble | ✅ |
-| ai.onnx.preview.FlexAttention | ❌ |
+| ai.onnx.preview.FlexAttention | ✅ |
 | ai.onnx.preview.training.Adagrad | ✅ |
 | ai.onnx.preview.training.Adam | ✅ |
 | ai.onnx.preview.training.Gradient | ✅ |

--- a/src/emx_onnx_cgen/onnx_import.py
+++ b/src/emx_onnx_cgen/onnx_import.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable, Mapping
+from typing import Callable, Iterable, Mapping
 
 import onnx
 import numpy as np
@@ -1617,10 +1617,164 @@ def _expand_image_decoder_nodes(
     return model, expanded
 
 
+_FLEXATTENTION_DOMAIN = "ai.onnx.preview"
+
+
+def _rename_function_node(
+    internal_node: onnx.NodeProto,
+    rename: "Callable[[str], str]",
+    prefix: str,
+) -> onnx.NodeProto:
+    """Clone a function-body node, rewiring its edges and nested subgraphs."""
+    new_node = onnx.NodeProto()
+    new_node.CopyFrom(internal_node)
+    new_node.ClearField("input")
+    new_node.ClearField("output")
+    new_node.input.extend(rename(name) for name in internal_node.input)
+    new_node.output.extend(rename(name) for name in internal_node.output)
+    for attr_index, attr in enumerate(internal_node.attribute):
+        if attr.type != onnx.AttributeProto.GRAPH:
+            continue
+        subgraph = new_node.attribute[attr_index].g
+        local: dict[str, str] = {}
+        for descriptor in list(subgraph.input) + list(subgraph.output):
+            local[descriptor.name] = descriptor.name = prefix + descriptor.name
+        for initializer in subgraph.initializer:
+            local[initializer.name] = initializer.name = prefix + initializer.name
+
+        def subgraph_rename(name: str, _local: dict[str, str] = local) -> str:
+            return _local[name] if name in _local else rename(name)
+
+        renamed = [
+            _rename_function_node(child, subgraph_rename, prefix)
+            for child in subgraph.node
+        ]
+        subgraph.ClearField("node")
+        subgraph.node.extend(renamed)
+    return new_node
+
+
+def _expand_function_body(
+    node: onnx.NodeProto, function_proto: onnx.FunctionProto, prefix: str
+) -> list[onnx.NodeProto]:
+    """Inline a function body for ``node``, mapping formal I/O onto its edges."""
+    io_names: dict[str, str] = {}
+    for index, formal in enumerate(function_proto.input):
+        io_names[formal] = node.input[index] if index < len(node.input) else ""
+    for index, formal in enumerate(function_proto.output):
+        if index < len(node.output) and node.output[index] != "":
+            io_names[formal] = node.output[index]
+
+    def rename(name: str) -> str:
+        if name in io_names:
+            return io_names[name]
+        if name == "":
+            return ""
+        return prefix + name
+
+    return [
+        _rename_function_node(child, rename, prefix) for child in function_proto.node
+    ]
+
+
+def _flexattention_function_proto(
+    node: onnx.NodeProto,
+    input_types: list[onnx.TypeProto],
+    preview_version: int,
+) -> onnx.FunctionProto:
+    """Build the FlexAttention function body for a concrete node.
+
+    FlexAttention is a context-dependent ONNX function: the body depends on the
+    node's element types and on its ``score_mod``/``prob_mod`` subgraphs, which
+    are inlined by the schema's builder. This mirrors how the official
+    ``*_expanded_ver26`` reference models are produced.
+    """
+    schema = onnx.defs.get_schema(
+        node.op_type, preview_version, domain=_FLEXATTENTION_DOMAIN
+    )
+    available = sorted(schema.context_dependent_function_opset_versions)
+    if not available:
+        raise UnsupportedOpError(
+            "Unsupported op FlexAttention (no function body available)"
+        )
+    # Pick the newest function definition not exceeding the imported version.
+    eligible = [version for version in available if version <= preview_version]
+    selected = eligible[-1] if eligible else available[0]
+    body = schema.get_context_dependent_function_with_opset_version(
+        selected,
+        node.SerializeToString(),
+        [type_proto.SerializeToString() for type_proto in input_types],
+    )
+    if not body:
+        raise UnsupportedOpError(
+            "Unsupported op FlexAttention (function body unavailable for inputs)"
+        )
+    function_proto = onnx.FunctionProto()
+    function_proto.ParseFromString(body)
+    return function_proto
+
+
+def _expand_flexattention_nodes(
+    model: onnx.ModelProto,
+) -> tuple[onnx.ModelProto, bool]:
+    """Decompose ``ai.onnx.preview.FlexAttention`` into primitive ONNX ops.
+
+    The replacement reuses the operator's context-dependent function body, which
+    expands scaled dot-product attention (including GQA head expansion and any
+    inlined ``score_mod``/``prob_mod`` subgraphs) into standard ops the rest of
+    the pipeline already supports.
+    """
+    graph = model.graph
+    preview_version = next(
+        (
+            int(opset.version)
+            for opset in model.opset_import
+            if opset.domain == _FLEXATTENTION_DOMAIN
+        ),
+        1,
+    )
+    new_nodes: list[onnx.NodeProto] = []
+    expanded = False
+
+    for node_index, node in enumerate(graph.node):
+        if not (
+            node.op_type == "FlexAttention" and node.domain == _FLEXATTENTION_DOMAIN
+        ):
+            new_nodes.append(node)
+            continue
+        if len(node.input) < 3:
+            raise UnsupportedOpError(
+                "FlexAttention requires query, key, and value inputs"
+            )
+
+        input_types: list[onnx.TypeProto] = []
+        for input_name in node.input:
+            type_proto = onnx.TypeProto()
+            type_proto.tensor_type.elem_type = _tensor_elem_type_from_value_info(
+                graph, input_name
+            )
+            input_types.append(type_proto)
+
+        function_proto = _flexattention_function_proto(
+            node, input_types, preview_version
+        )
+        prefix = f"_flexattn_{node_index}_"
+        new_nodes.extend(_expand_function_body(node, function_proto, prefix))
+        expanded = True
+
+    if not expanded:
+        return model, False
+
+    del graph.node[:]
+    graph.node.extend(new_nodes)
+    return model, True
+
+
 def prepare_onnx_model(model: onnx.ModelProto) -> onnx.ModelProto:
     prepared = onnx.ModelProto()
     prepared.CopyFrom(model)
     prepared, _ = _expand_image_decoder_nodes(prepared)
+    prepared, _ = _expand_flexattention_nodes(prepared)
     prepared, _ = _expand_scan_nodes(prepared)
     prepared, _ = _expand_if_nodes(prepared)
     prepared, _ = _expand_sequence_map_nodes(prepared)

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_flexattention__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_flexattention__model.onnx.json
@@ -1,9 +1,10 @@
 {
-  "error": "Unsupported op ai.onnx.preview.FlexAttention",
+  "error": "OK (max ULP 3)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_flexattention model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
     "ai.onnx.preview.FlexAttention"
   ],
-  "opset_version": 26
+  "opset_version": 26,
+  "generated_checksum": "97b903bd79a8f9e26c3dfa918f530a70d39d1013c203b1723be44834c63a1559"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_flexattention_causal_mask__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_flexattention_causal_mask__model.onnx.json
@@ -1,9 +1,10 @@
 {
-  "error": "Unsupported op ai.onnx.preview.FlexAttention",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_flexattention_causal_mask model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
     "ai.onnx.preview.FlexAttention"
   ],
-  "opset_version": 26
+  "opset_version": 26,
+  "generated_checksum": "dcdcde29a0700d40fed6c44569a14c23feccede655d42deec87c05d04a7b101f"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_flexattention_diff_head_sizes__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_flexattention_diff_head_sizes__model.onnx.json
@@ -1,9 +1,10 @@
 {
-  "error": "Unsupported op ai.onnx.preview.FlexAttention",
+  "error": "OK (max ULP 3)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_flexattention_diff_head_sizes model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
     "ai.onnx.preview.FlexAttention"
   ],
-  "opset_version": 26
+  "opset_version": 26,
+  "generated_checksum": "cde455aaee0fb615a81931adb9b9aebd53a00edc463979f6512e6d3fcc22dcc5"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_flexattention_double__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_flexattention_double__model.onnx.json
@@ -1,9 +1,10 @@
 {
-  "error": "Unsupported op ai.onnx.preview.FlexAttention",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_flexattention_double model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
     "ai.onnx.preview.FlexAttention"
   ],
-  "opset_version": 26
+  "opset_version": 26,
+  "generated_checksum": "861e516d5b26d7d36bacc66e579bc6f11ff15171a8a2339dadc14dce9e369e5b"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_flexattention_fp16__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_flexattention_fp16__model.onnx.json
@@ -1,9 +1,10 @@
 {
-  "error": "Unsupported op ai.onnx.preview.FlexAttention",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_flexattention_fp16 model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
     "ai.onnx.preview.FlexAttention"
   ],
-  "opset_version": 26
+  "opset_version": 26,
+  "generated_checksum": "887106094282f85ba739e6a772269c82fbc5f10077a9a7374959d4d17611e356"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_flexattention_gqa__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_flexattention_gqa__model.onnx.json
@@ -1,9 +1,10 @@
 {
-  "error": "Unsupported op ai.onnx.preview.FlexAttention",
+  "error": "OK (max ULP 3)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_flexattention_gqa model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
     "ai.onnx.preview.FlexAttention"
   ],
-  "opset_version": 26
+  "opset_version": 26,
+  "generated_checksum": "f778bb07a954c27c462cd71d6aff341cf8562b8033d97d784ec35ee45e275002"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_flexattention_prob_mod__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_flexattention_prob_mod__model.onnx.json
@@ -1,9 +1,10 @@
 {
-  "error": "Unsupported op ai.onnx.preview.FlexAttention",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_flexattention_prob_mod model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
     "ai.onnx.preview.FlexAttention"
   ],
-  "opset_version": 26
+  "opset_version": 26,
+  "generated_checksum": "d4b7a515dce8cd524d83ba55444cd096c5c1b24645d7d98d167c1ad9f669947b"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_flexattention_relative_positional__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_flexattention_relative_positional__model.onnx.json
@@ -1,9 +1,10 @@
 {
-  "error": "Unsupported op ai.onnx.preview.FlexAttention",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_flexattention_relative_positional model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
     "ai.onnx.preview.FlexAttention"
   ],
-  "opset_version": 26
+  "opset_version": 26,
+  "generated_checksum": "015c79446c7486c59bfe0bf77fce1bf95f80b8b95124c0dbe615d2aa45943f97"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_flexattention_scaled__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_flexattention_scaled__model.onnx.json
@@ -1,9 +1,10 @@
 {
-  "error": "Unsupported op ai.onnx.preview.FlexAttention",
+  "error": "OK (max ULP 4)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_flexattention_scaled model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
     "ai.onnx.preview.FlexAttention"
   ],
-  "opset_version": 26
+  "opset_version": 26,
+  "generated_checksum": "3463f1d43d234454140bf3cd5711b55f2b0f9351aa4103fb12f295dd6baacb72"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_flexattention_score_mod__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_flexattention_score_mod__model.onnx.json
@@ -1,9 +1,10 @@
 {
-  "error": "Unsupported op ai.onnx.preview.FlexAttention",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_flexattention_score_mod model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
     "ai.onnx.preview.FlexAttention"
   ],
-  "opset_version": 26
+  "opset_version": 26,
+  "generated_checksum": "f6bf71bc6734ed343b262a58e8effa237fd32d80794dee7437295cb4ef9299b0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_flexattention_soft_cap__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_flexattention_soft_cap__model.onnx.json
@@ -1,9 +1,10 @@
 {
-  "error": "Unsupported op ai.onnx.preview.FlexAttention",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_flexattention_soft_cap model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
     "ai.onnx.preview.FlexAttention"
   ],
-  "opset_version": 26
+  "opset_version": 26,
+  "generated_checksum": "62c815da5614e445eb9b1a7f435fb710298cfda695b54255653c1df2b77c7781"
 }

--- a/tests/test_onnx_import.py
+++ b/tests/test_onnx_import.py
@@ -407,3 +407,64 @@ def test_import_optional_sequence_value_info_marks_sequence_optional() -> None:
 
     assert imported.inputs[0].name == "opt_seq"
     assert imported.inputs[0].type.is_optional
+
+
+def _make_flexattention_model(
+    *,
+    score_mod: onnx.GraphProto | None = None,
+) -> onnx.ModelProto:
+    shape = [1, 2, 3, 4]
+    q = helper.make_tensor_value_info("Q", TensorProto.FLOAT, shape)
+    k = helper.make_tensor_value_info("K", TensorProto.FLOAT, shape)
+    v = helper.make_tensor_value_info("V", TensorProto.FLOAT, shape)
+    y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, shape)
+    attrs: dict[str, object] = {}
+    if score_mod is not None:
+        attrs["score_mod"] = score_mod
+    node = helper.make_node(
+        "FlexAttention",
+        inputs=["Q", "K", "V"],
+        outputs=["Y"],
+        domain="ai.onnx.preview",
+        **attrs,
+    )
+    graph = helper.make_graph([node], "flexattention_graph", [q, k, v], [y])
+    model = helper.make_model(
+        graph,
+        producer_name="onnx2c",
+        opset_imports=[
+            helper.make_operatorsetid("", 26),
+            helper.make_operatorsetid("ai.onnx.preview", 1),
+        ],
+    )
+    model.ir_version = 10
+    return model
+
+
+def test_import_flexattention_expands_to_primitive_ops() -> None:
+    model = _make_flexattention_model()
+
+    imported = import_onnx(model)
+
+    op_types = [node.op_type for node in imported.nodes]
+    assert "FlexAttention" not in op_types
+    # Scaled dot-product attention decomposes into two MatMuls around a Softmax.
+    assert op_types.count("MatMul") == 2
+    assert "Softmax" in op_types
+
+
+def test_import_flexattention_inlines_score_mod_subgraph() -> None:
+    score_mod = helper.make_graph(
+        [helper.make_node("Add", inputs=["scores", "scores"], outputs=["scores_out"])],
+        "score_mod",
+        [helper.make_tensor_value_info("scores", TensorProto.FLOAT, [1, 2, 3, 3])],
+        [helper.make_tensor_value_info("scores_out", TensorProto.FLOAT, [1, 2, 3, 3])],
+    )
+    model = _make_flexattention_model(score_mod=score_mod)
+
+    imported = import_onnx(model)
+
+    op_types = [node.op_type for node in imported.nodes]
+    assert "FlexAttention" not in op_types
+    # The score_mod body (an Add) is inlined into the expanded graph.
+    assert "Add" in op_types


### PR DESCRIPTION
FlexAttention is a context-dependent ONNX function whose body decomposes
scaled dot-product attention (including GQA head expansion and inlined
score_mod/prob_mod subgraphs) into standard ops the pipeline already
supports. Add a prepare-time expansion pass that reuses the operator's
schema function body, mirroring how the official *_expanded_ver26
reference models are produced.

This makes all 11 node/test_flexattention* models verify against ORT.
Refreshes expected-error fixtures and regenerates the support docs.