### PR TITLE
codegen: emit zero for LpNormalization with zero norm

### DIFF
--- a/ONNX_ERRORS.md
+++ b/ONNX_ERRORS.md
@@ -7,7 +7,7 @@ Aggregates non-success verification outcomes.
 
 | Error message | Count | Opset versions |
 | --- | --- | --- |
-| Out of tolerance | 43 | 7, 17, 21, 22 |
+| Out of tolerance | 42 | 7, 17, 21 |
 | Missing shape for '*' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. | 14 | 27 |
 | Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 8 |  |
 | Range does not support dtype bfloat16 (while lowering node_index=0, op_type=Range, name=<unnamed>, inputs=[start: tensor[dtype=bfloat16, shape=()], limit: tensor[dtype=bfloat16, shape=()], delta: tensor[dtype=bfloat16, shape=()]], outputs=[output: tensor[dtype=bfloat16, shape=(2,), dim_params=(None,)]]) | 1 | 27 |
@@ -22,7 +22,6 @@ Aggregates non-success verification outcomes.
 | Out of tolerance | 7 | 4 |
 | Out of tolerance | 17 | 13 |
 | Out of tolerance | 21 | 4 |
-| Out of tolerance | 22 | 1 |
 | Missing shape for '*' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. | 27 | 14 |
 | Range does not support dtype bfloat16 (while lowering node_index=0, op_type=Range, name=<unnamed>, inputs=[start: tensor[dtype=bfloat16, shape=()], limit: tensor[dtype=bfloat16, shape=()], delta: tensor[dtype=bfloat16, shape=()]], outputs=[output: tensor[dtype=bfloat16, shape=(2,), dim_params=(None,)]]) | 27 | 1 |
 | Range does not support dtype float16 (while lowering node_index=0, op_type=Range, name=<unnamed>, inputs=[start: tensor[dtype=float16, shape=()], limit: tensor[dtype=float16, shape=()], delta: tensor[dtype=float16, shape=()]], outputs=[output: tensor[dtype=float16, shape=(2,), dim_params=(None,)]]) | 27 | 1 |
@@ -35,7 +34,6 @@ Lists every ONNX file with a non-success verification outcome.
 
 | File | Opset | Verification | Supported | Error |
 | --- | --- | --- | --- | --- |
-| node/test_l2normalization_axis_0/model.onnx | 22 | Data/Data | ❌ | Out of tolerance (max ULP 4294967295) |
 | node/test_linear_attention_decode_step_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_decode_step_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
 | node/test_linear_attention_delta_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_delta_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
 | node/test_linear_attention_explicit_scale_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_explicit_scale_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |

--- a/ONNX_SUPPORT.md
+++ b/ONNX_SUPPORT.md
@@ -7,7 +7,7 @@ Overview:
 
 | Test suite | Coverage | Version |
 | --- | --- | --- |
-| [Official ONNX test coverage](#official-onnx-test-coverage) | 1891 / 1914, 98.8% | 1.22.0 |
+| [Official ONNX test coverage](#official-onnx-test-coverage) | 1892 / 1914, 98.9% | 1.22.0 |
 | [ONNX Runtime artifact coverage](#onnx-runtime-artifact-coverage) | 4278 / 4324, 98.9% | n/a |
 | [Local ONNX test coverage](#local-onnx-test-coverage) | 9 / 9, 100.0% | n/a |
 
@@ -21,7 +21,7 @@ The `Verification` column uses `Input/Reference` notation (for example `Random/O
 
 Test directory: `onnx-org/onnx/backend/test/data`
 
-Coverage 1891 / 1914 ONNX files (98.8%).
+Coverage 1892 / 1914 ONNX files (98.9%).
 
 | File | Opset | Verification | Supported | Error |
 | --- | --- | --- | --- | --- |
@@ -867,7 +867,7 @@ Coverage 1891 / 1914 ONNX files (98.8%).
 | node/test_l1normalization_axis_0/model.onnx | 22 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_l1normalization_axis_1/model.onnx | 22 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_l1normalization_axis_last/model.onnx | 22 | Data/Data | ✅ | OK (max ULP 0) |
-| node/test_l2normalization_axis_0/model.onnx | 22 | Data/Data | ❌ | Out of tolerance (max ULP 4294967295) |
+| node/test_l2normalization_axis_0/model.onnx | 22 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_l2normalization_axis_1/model.onnx | 22 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_layer_normalization_2d_axis0/model.onnx | 17 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_layer_normalization_2d_axis0_expanded/model.onnx | 17 | Data/Data | ✅ | OK (max ULP 2) |

--- a/src/emx_onnx_cgen/templates/lp_normalization_op.c.j2
+++ b/src/emx_onnx_cgen/templates/lp_normalization_op.c.j2
@@ -20,7 +20,9 @@ EMX_NODE_FN void {{ op_name }}({{ dim_args }}{{ params | join(', ') }}) {
             acc = {{ scalar_fn(SF.SQRT, dtype) }}(acc);
 {% endif %}
             for (idx_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
-                output_flat[base + axis_idx * inner] = input_flat[base + axis_idx * inner] / acc;
+                output_flat[base + axis_idx * inner] =
+                    acc == {{ zero_literal }} ? {{ zero_literal }}
+                                              : input_flat[base + axis_idx * inner] / acc;
             }
         }
     }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_l1normalization_axis_0__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_l1normalization_axis_0__model.onnx.json
@@ -6,5 +6,5 @@
     "LpNormalization"
   ],
   "opset_version": 22,
-  "generated_checksum": "ced20dcc228070a2a69c242c97e2caa66564c21e9653c0cc0e75e7f61b87394d"
+  "generated_checksum": "1163043eb3695d8da51062163e7bb4f621e8ab6bdaecd72b1db435d2d12d997d"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_l1normalization_axis_1__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_l1normalization_axis_1__model.onnx.json
@@ -6,5 +6,5 @@
     "LpNormalization"
   ],
   "opset_version": 22,
-  "generated_checksum": "b7404c33b56ab73e3a1d10db74ba71e89688cec144e23fd1edb980ad6f235d8a"
+  "generated_checksum": "a9a87bc4e39bf1e64d42b44cb37a654b5b022918beaf959be39dff5bea7483a3"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_l1normalization_axis_last__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_l1normalization_axis_last__model.onnx.json
@@ -6,5 +6,5 @@
     "LpNormalization"
   ],
   "opset_version": 22,
-  "generated_checksum": "73dd70c43ae0be16878cda93cec30468d45a2906a04f5c7ed0fc985be3237204"
+  "generated_checksum": "b784f49b2f979bc444ef03fe0e66ec01ef090c3f3b0b557babef35883e7b06a5"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_l2normalization_axis_0__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_l2normalization_axis_0__model.onnx.json
@@ -1,10 +1,10 @@
 {
-  "error": "Out of tolerance (max ULP 4294967295)",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_l2normalization_axis_0 model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
     "LpNormalization"
   ],
   "opset_version": 22,
-  "generated_checksum": "908a686c9d455d63a2b76de152f48c92420984fa7afd496f911f28965e6a5c9d"
+  "generated_checksum": "7b08da3088f6e0f9ffe03ca211135185afc1ccffd094ad37b9662330a7d2f6b7"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_l2normalization_axis_1__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_l2normalization_axis_1__model.onnx.json
@@ -6,5 +6,5 @@
     "LpNormalization"
   ],
   "opset_version": 22,
-  "generated_checksum": "bf557d3f8d3bd793b04109edaff8b27476e0f4bd56315a5838ba42aaf9de5711"
+  "generated_checksum": "18ab49e190849ec23f695fbe2976e1feaa63b85410522e0b2046a7afa089473b"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_lpnormalization_default__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_lpnormalization_default__model.onnx.json
@@ -6,5 +6,5 @@
     "LpNormalization"
   ],
   "opset_version": 22,
-  "generated_checksum": "9867ae518393713139f7f8f4b5794f002930c3f527c053e75de8ccd52f323579"
+  "generated_checksum": "380ae6a98a24e99643f28abd61cee9a190b0a1b2843982fbebeda9dc7d519c6f"
 }

--- a/tests/golden/op_lpnormalization_lp_normalization.c
+++ b/tests/golden/op_lpnormalization_lp_normalization.c
@@ -78,7 +78,9 @@ EMX_NODE_FN void node0_lpnormalization(const float input0[2][3], float output[2]
                 acc += ref_scalar_f32_abs(value);
             }
             for (idx_t axis_idx = 0; axis_idx < axis_size; ++axis_idx) {
-                output_flat[base + axis_idx * inner] = input_flat[base + axis_idx * inner] / acc;
+                output_flat[base + axis_idx * inner] =
+                acc == 0.0f ? 0.0f
+                : input_flat[base + axis_idx * inner] / acc;
             }
         }
     }


### PR DESCRIPTION
ONNX's LpNormalization reference returns 0 when the computed norm is 0
(matching numpy's `np.where(norm == 0, 0, x / norm)`), avoiding a 0/0 NaN.
The generated C divided unconditionally, so test_l2normalization_axis_0 —
whose axis-0 slice at [.,1,2] is all zeros — produced NaN and failed
verification out of tolerance.

Guard the division so a zero norm yields 0, and refresh the golden output,
expectation, and support docs.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WDNu9LotB4aQcJy4ZnMxnj