### PR TITLE
codegen: saturate QLinearMatMul output instead of wrapping

### DIFF
--- a/ONNX_ERRORS.md
+++ b/ONNX_ERRORS.md
@@ -7,7 +7,7 @@ Aggregates non-success verification outcomes.
 
 | Error message | Count | Opset versions |
 | --- | --- | --- |
-| Out of tolerance | 42 | 7, 17, 21 |
+| Out of tolerance | 38 | 7, 17 |
 | Missing shape for '*' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. | 14 | 27 |
 | Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 8 |  |
 | Range does not support dtype bfloat16 (while lowering node_index=0, op_type=Range, name=<unnamed>, inputs=[start: tensor[dtype=bfloat16, shape=()], limit: tensor[dtype=bfloat16, shape=()], delta: tensor[dtype=bfloat16, shape=()]], outputs=[output: tensor[dtype=bfloat16, shape=(2,), dim_params=(None,)]]) | 1 | 27 |
@@ -21,7 +21,6 @@ Aggregates non-success verification outcomes.
 | --- | --- | --- |
 | Out of tolerance | 7 | 4 |
 | Out of tolerance | 17 | 13 |
-| Out of tolerance | 21 | 4 |
 | Missing shape for '*' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. | 27 | 14 |
 | Range does not support dtype bfloat16 (while lowering node_index=0, op_type=Range, name=<unnamed>, inputs=[start: tensor[dtype=bfloat16, shape=()], limit: tensor[dtype=bfloat16, shape=()], delta: tensor[dtype=bfloat16, shape=()]], outputs=[output: tensor[dtype=bfloat16, shape=(2,), dim_params=(None,)]]) | 27 | 1 |
 | Range does not support dtype float16 (while lowering node_index=0, op_type=Range, name=<unnamed>, inputs=[start: tensor[dtype=float16, shape=()], limit: tensor[dtype=float16, shape=()], delta: tensor[dtype=float16, shape=()]], outputs=[output: tensor[dtype=float16, shape=(2,), dim_params=(None,)]]) | 27 | 1 |
@@ -48,10 +47,6 @@ Lists every ONNX file with a non-success verification outcome.
 | node/test_linear_attention_linear_t1_no_past_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_linear_t1_no_past_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
 | node/test_linear_attention_no_past_explicit_zeros_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_no_past_explicit_zeros_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
 | node/test_linear_attention_prefill_with_past_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_prefill_with_past_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
-| node/test_qlinearmatmul_2D_int8_float16/model.onnx | 21 | Data/Data | ❌ | Out of tolerance (max abs diff 148) |
-| node/test_qlinearmatmul_2D_int8_float32/model.onnx | 21 | Data/Data | ❌ | Out of tolerance (max abs diff 148) |
-| node/test_qlinearmatmul_3D_int8_float16/model.onnx | 21 | Data/Data | ❌ | Out of tolerance (max abs diff 247) |
-| node/test_qlinearmatmul_3D_int8_float32/model.onnx | 21 | Data/Data | ❌ | Out of tolerance (max abs diff 248) |
 | node/test_range_bfloat16_type_positive_delta/model.onnx | 27 | Data/Data | ❌ | Range does not support dtype bfloat16 (while lowering node_index=0, op_type=Range, name=<unnamed>, inputs=[start: tensor[dtype=bfloat16, shape=()], limit: tensor[dtype=bfloat16, shape=()], delta: tensor[dtype=bfloat16, shape=()]], outputs=[output: tensor[dtype=bfloat16, shape=(2,), dim_params=(None,)]]) |
 | node/test_range_bfloat16_type_positive_delta_expanded/model.onnx | 27 | Data/Data | ❌ | Unsupported op Loop (while lowering node_index=9, op_type=Loop, name=<unnamed>, inputs=[Range_test_range_bfloat16_type_positive_delta_expanded_function_n: tensor[dtype=int64, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_loop_cond: tensor[dtype=bool, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_start_s: tensor[dtype=float, shape=()]], outputs=[Range_test_range_bfloat16_type_positive_delta_expanded_function_variadic_output: tensor[dtype=float, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_output_s: tensor[dtype=float, shape=()]]) |
 | node/test_range_float16_type_positive_delta/model.onnx | 27 | Data/Data | ❌ | Range does not support dtype float16 (while lowering node_index=0, op_type=Range, name=<unnamed>, inputs=[start: tensor[dtype=float16, shape=()], limit: tensor[dtype=float16, shape=()], delta: tensor[dtype=float16, shape=()]], outputs=[output: tensor[dtype=float16, shape=(2,), dim_params=(None,)]]) |

--- a/ONNX_SUPPORT.md
+++ b/ONNX_SUPPORT.md
@@ -7,7 +7,7 @@ Overview:
 
 | Test suite | Coverage | Version |
 | --- | --- | --- |
-| [Official ONNX test coverage](#official-onnx-test-coverage) | 1892 / 1914, 98.9% | 1.22.0 |
+| [Official ONNX test coverage](#official-onnx-test-coverage) | 1896 / 1914, 99.1% | 1.22.0 |
 | [ONNX Runtime artifact coverage](#onnx-runtime-artifact-coverage) | 4278 / 4324, 98.9% | n/a |
 | [Local ONNX test coverage](#local-onnx-test-coverage) | 9 / 9, 100.0% | n/a |
 
@@ -21,7 +21,7 @@ The `Verification` column uses `Input/Reference` notation (for example `Random/O
 
 Test directory: `onnx-org/onnx/backend/test/data`
 
-Coverage 1892 / 1914 ONNX files (98.9%).
+Coverage 1896 / 1914 ONNX files (99.1%).
 
 | File | Opset | Verification | Supported | Error |
 | --- | --- | --- | --- | --- |
@@ -1208,12 +1208,12 @@ Coverage 1892 / 1914 ONNX files (98.9%).
 | node/test_prelu_example/model.onnx | 16 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_prelu_example_expanded/model.onnx | 16 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_qlinearconv/model.onnx | 10 | Data/Data | ✅ | OK (max abs diff 0) |
-| node/test_qlinearmatmul_2D_int8_float16/model.onnx | 21 | Data/Data | ❌ | Out of tolerance (max abs diff 148) |
-| node/test_qlinearmatmul_2D_int8_float32/model.onnx | 21 | Data/Data | ❌ | Out of tolerance (max abs diff 148) |
+| node/test_qlinearmatmul_2D_int8_float16/model.onnx | 21 | Data/Data | ✅ | OK (max abs diff 0) |
+| node/test_qlinearmatmul_2D_int8_float32/model.onnx | 21 | Data/Data | ✅ | OK (max abs diff 0) |
 | node/test_qlinearmatmul_2D_uint8_float16/model.onnx | 21 | Data/Data | ✅ | OK (max abs diff 0) |
 | node/test_qlinearmatmul_2D_uint8_float32/model.onnx | 21 | Data/Data | ✅ | OK (max abs diff 0) |
-| node/test_qlinearmatmul_3D_int8_float16/model.onnx | 21 | Data/Data | ❌ | Out of tolerance (max abs diff 247) |
-| node/test_qlinearmatmul_3D_int8_float32/model.onnx | 21 | Data/Data | ❌ | Out of tolerance (max abs diff 248) |
+| node/test_qlinearmatmul_3D_int8_float16/model.onnx | 21 | Data/Data | ✅ | OK (max abs diff 0) |
+| node/test_qlinearmatmul_3D_int8_float32/model.onnx | 21 | Data/Data | ✅ | OK (max abs diff 0) |
 | node/test_qlinearmatmul_3D_uint8_float16/model.onnx | 21 | Data/Data | ✅ | OK (max abs diff 0) |
 | node/test_qlinearmatmul_3D_uint8_float32/model.onnx | 21 | Data/Data | ✅ | OK (max abs diff 0) |
 | node/test_quantizelinear/model.onnx | 25 | Data/Data | ✅ | OK (max abs diff 0) |

--- a/src/emx_onnx_cgen/ir/ops/nn.py
+++ b/src/emx_onnx_cgen/ir/ops/nn.py
@@ -766,7 +766,7 @@ class QLinearMatMulOp(MatMulLikeOpBase):
                 min_literal=min_literal,
                 max_literal=max_literal,
                 enable_integer_requant=scale_dtype != ScalarType.F16,
-                output_wrap=not emitter.replicate_ort_bugs,
+                output_wrap=False,
                 output_is_signed=self.dtype.is_signed,
                 dim_args=emitter.dim_args_str(),
             )

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_qlinearmatmul_2D_int8_float16__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_qlinearmatmul_2D_int8_float16__model.onnx.json
@@ -1,10 +1,10 @@
 {
-  "error": "Out of tolerance (max abs diff 148)",
+  "error": "OK (max abs diff 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_qlinearmatmul_2D_int8_float16 model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
     "QLinearMatMul"
   ],
   "opset_version": 21,
-  "generated_checksum": "0719846e2137029f2131a8f32257cca7cbef6300ec617684b3a47763765ec8f5"
+  "generated_checksum": "40089ba814261e0d156bf8f3a9cca92bdf23dacd985a5080af29371603d2f69b"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_qlinearmatmul_2D_int8_float32__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_qlinearmatmul_2D_int8_float32__model.onnx.json
@@ -1,10 +1,10 @@
 {
-  "error": "Out of tolerance (max abs diff 148)",
+  "error": "OK (max abs diff 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_qlinearmatmul_2D_int8_float32 model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
     "QLinearMatMul"
   ],
   "opset_version": 21,
-  "generated_checksum": "cbcb18a4c2f45a8521710ed300a7f9f09189c531f870ce531f2fe9f6dfab4181"
+  "generated_checksum": "cff9d7858487ede300f9cd89ebec2e12a6690d5163148d76f424e5422b5123a5"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_qlinearmatmul_2D_uint8_float16__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_qlinearmatmul_2D_uint8_float16__model.onnx.json
@@ -6,5 +6,5 @@
     "QLinearMatMul"
   ],
   "opset_version": 21,
-  "generated_checksum": "732dbe8fb7cdc42fa1b997017c4f0646c1df6ff030d088202aa93d5ed24193f9"
+  "generated_checksum": "31be405e66ef859b7359869671224d7e891eb754dce8270877ab1c8bcef81af9"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_qlinearmatmul_2D_uint8_float32__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_qlinearmatmul_2D_uint8_float32__model.onnx.json
@@ -6,5 +6,5 @@
     "QLinearMatMul"
   ],
   "opset_version": 21,
-  "generated_checksum": "9a32c4f684859d8f9091ed2eca41fb17e74efa758e5dd6760a7017550dc6f152"
+  "generated_checksum": "175d246366aa937869e4d6b377df8c2d22a39b87f4177037346a46cf68a86256"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_qlinearmatmul_3D_int8_float16__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_qlinearmatmul_3D_int8_float16__model.onnx.json
@@ -1,10 +1,10 @@
 {
-  "error": "Out of tolerance (max abs diff 247)",
+  "error": "OK (max abs diff 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_qlinearmatmul_3D_int8_float16 model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
     "QLinearMatMul"
   ],
   "opset_version": 21,
-  "generated_checksum": "1a1d8f5fa7cd3eac7139914799fb802bddaf456a23fcb4343d0ac231e30eda35"
+  "generated_checksum": "fcbe1b7e2458c528593c1c886dfee8cb71d6ce415eada8d5263635e5447404e6"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_qlinearmatmul_3D_int8_float32__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_qlinearmatmul_3D_int8_float32__model.onnx.json
@@ -1,10 +1,10 @@
 {
-  "error": "Out of tolerance (max abs diff 248)",
+  "error": "OK (max abs diff 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_qlinearmatmul_3D_int8_float32 model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
     "QLinearMatMul"
   ],
   "opset_version": 21,
-  "generated_checksum": "1bc6e50c22dc335ff558271e77279dd1d202c844e8acb44df07c75023c3f019f"
+  "generated_checksum": "ab46b03e808276f0bd8d553ceef23b81095c9671c15aed4daa42a91f295ce6c9"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_qlinearmatmul_3D_uint8_float16__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_qlinearmatmul_3D_uint8_float16__model.onnx.json
@@ -6,5 +6,5 @@
     "QLinearMatMul"
   ],
   "opset_version": 21,
-  "generated_checksum": "af507a6d5ceb61592df49b6ac6500b7a4b85b3592df82aee3e24ae0c9705d600"
+  "generated_checksum": "785f9b792755d6c3bf8724e3b38c057f248d4c967fb986058e59fe00bd2c2bf7"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_qlinearmatmul_3D_uint8_float32__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_qlinearmatmul_3D_uint8_float32__model.onnx.json
@@ -6,5 +6,5 @@
     "QLinearMatMul"
   ],
   "opset_version": 21,
-  "generated_checksum": "3df425d36ee7c1e1575a12ebc2748ec7383a79ca98f1da4a38a869b1c7477ee9"
+  "generated_checksum": "cf0da679b874c25fe12fbf27ab81cc97fa82e5347f55566ae2a79635d7cdbccd"
 }


### PR DESCRIPTION
QLinearMatMul rendered its output with output_wrap=not replicate_ort_bugs,
so by default it wrapped values that exceeded the output dtype range
instead of saturating. The ONNX spec (and ONNX Runtime) saturate the
quantized result, so signed int8 outputs that overflowed produced wrong
values (e.g. -236 emitted as 20 instead of clamping to -128), failing the
test_qlinearmatmul_2D/3D int8 backend tests.

Always saturate the output (output_wrap=False); this matches ORT, so the
--replicate-ort-bugs path is unchanged (it already saturated). Refreshed
the QLinearMatMul expected_errors checksums and the generated ONNX support
docs.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01T5ph9dC4tmKiswAe4G38rp