### PR TITLE
Fold constant shape arithmetic and fix Scan opset compatibility

### DIFF
--- a/ONNX_ERRORS.md
+++ b/ONNX_ERRORS.md
@@ -8,7 +8,6 @@ Aggregates non-success verification outcomes.
 | Error message | Count | Opset versions |
 | --- | --- | --- |
 | Out of tolerance | 43 | 7, 17, 21, 22 |
-| Missing shape for '*' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. | 14 | 27 |
 | Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 8 |  |
 | Range does not support dtype bfloat16 (while lowering node_index=0, op_type=Range, name=<unnamed>, inputs=[start: tensor[dtype=bfloat16, shape=()], limit: tensor[dtype=bfloat16, shape=()], delta: tensor[dtype=bfloat16, shape=()]], outputs=[output: tensor[dtype=bfloat16, shape=(2,), dim_params=(None,)]]) | 1 | 27 |
 | Range does not support dtype float16 (while lowering node_index=0, op_type=Range, name=<unnamed>, inputs=[start: tensor[dtype=float16, shape=()], limit: tensor[dtype=float16, shape=()], delta: tensor[dtype=float16, shape=()]], outputs=[output: tensor[dtype=float16, shape=(2,), dim_params=(None,)]]) | 1 | 27 |
@@ -23,7 +22,6 @@ Aggregates non-success verification outcomes.
 | Out of tolerance | 17 | 13 |
 | Out of tolerance | 21 | 4 |
 | Out of tolerance | 22 | 1 |
-| Missing shape for '*' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. | 27 | 14 |
 | Range does not support dtype bfloat16 (while lowering node_index=0, op_type=Range, name=<unnamed>, inputs=[start: tensor[dtype=bfloat16, shape=()], limit: tensor[dtype=bfloat16, shape=()], delta: tensor[dtype=bfloat16, shape=()]], outputs=[output: tensor[dtype=bfloat16, shape=(2,), dim_params=(None,)]]) | 27 | 1 |
 | Range does not support dtype float16 (while lowering node_index=0, op_type=Range, name=<unnamed>, inputs=[start: tensor[dtype=float16, shape=()], limit: tensor[dtype=float16, shape=()], delta: tensor[dtype=float16, shape=()]], outputs=[output: tensor[dtype=float16, shape=(2,), dim_params=(None,)]]) | 27 | 1 |
 | Unsupported op Loop (while lowering node_index=9, op_type=Loop, name=<unnamed>, inputs=[Range_test_range_bfloat16_type_positive_delta_expanded_function_n: tensor[dtype=int64, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_loop_cond: tensor[dtype=bool, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_start_s: tensor[dtype=float, shape=()]], outputs=[Range_test_range_bfloat16_type_positive_delta_expanded_function_variadic_output: tensor[dtype=float, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_output_s: tensor[dtype=float, shape=()]]) | 27 | 1 |
@@ -36,20 +34,6 @@ Lists every ONNX file with a non-success verification outcome.
 | File | Opset | Verification | Supported | Error |
 | --- | --- | --- | --- | --- |
 | node/test_l2normalization_axis_0/model.onnx | 22 | Data/Data | ❌ | Out of tolerance (max ULP 4294967295) |
-| node/test_linear_attention_decode_step_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_decode_step_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
-| node/test_linear_attention_delta_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_delta_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
-| node/test_linear_attention_explicit_scale_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_explicit_scale_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
-| node/test_linear_attention_fp16_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_fp16_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
-| node/test_linear_attention_gated_delta_beta_scalar_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_gated_delta_beta_scalar_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
-| node/test_linear_attention_gated_delta_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_gated_delta_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
-| node/test_linear_attention_gated_delta_gqa_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_gated_delta_gqa_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
-| node/test_linear_attention_gated_delta_mqa_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_gated_delta_mqa_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
-| node/test_linear_attention_gated_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_gated_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
-| node/test_linear_attention_gated_per_head_decay_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_gated_per_head_decay_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
-| node/test_linear_attention_linear_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_linear_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
-| node/test_linear_attention_linear_t1_no_past_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_linear_t1_no_past_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
-| node/test_linear_attention_no_past_explicit_zeros_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_no_past_explicit_zeros_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
-| node/test_linear_attention_prefill_with_past_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_prefill_with_past_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
 | node/test_qlinearmatmul_2D_int8_float16/model.onnx | 21 | Data/Data | ❌ | Out of tolerance (max abs diff 148) |
 | node/test_qlinearmatmul_2D_int8_float32/model.onnx | 21 | Data/Data | ❌ | Out of tolerance (max abs diff 148) |
 | node/test_qlinearmatmul_3D_int8_float16/model.onnx | 21 | Data/Data | ❌ | Out of tolerance (max abs diff 247) |

--- a/ONNX_ERRORS.md
+++ b/ONNX_ERRORS.md
@@ -7,7 +7,7 @@ Aggregates non-success verification outcomes.
 
 | Error message | Count | Opset versions |
 | --- | --- | --- |
-| Out of tolerance | 43 | 7, 17, 21, 22 |
+| Out of tolerance | 38 | 7, 17 |
 | Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 8 |  |
 | Range does not support dtype bfloat16 (while lowering node_index=0, op_type=Range, name=<unnamed>, inputs=[start: tensor[dtype=bfloat16, shape=()], limit: tensor[dtype=bfloat16, shape=()], delta: tensor[dtype=bfloat16, shape=()]], outputs=[output: tensor[dtype=bfloat16, shape=(2,), dim_params=(None,)]]) | 1 | 27 |
 | Range does not support dtype float16 (while lowering node_index=0, op_type=Range, name=<unnamed>, inputs=[start: tensor[dtype=float16, shape=()], limit: tensor[dtype=float16, shape=()], delta: tensor[dtype=float16, shape=()]], outputs=[output: tensor[dtype=float16, shape=(2,), dim_params=(None,)]]) | 1 | 27 |
@@ -20,8 +20,6 @@ Aggregates non-success verification outcomes.
 | --- | --- | --- |
 | Out of tolerance | 7 | 4 |
 | Out of tolerance | 17 | 13 |
-| Out of tolerance | 21 | 4 |
-| Out of tolerance | 22 | 1 |
 | Range does not support dtype bfloat16 (while lowering node_index=0, op_type=Range, name=<unnamed>, inputs=[start: tensor[dtype=bfloat16, shape=()], limit: tensor[dtype=bfloat16, shape=()], delta: tensor[dtype=bfloat16, shape=()]], outputs=[output: tensor[dtype=bfloat16, shape=(2,), dim_params=(None,)]]) | 27 | 1 |
 | Range does not support dtype float16 (while lowering node_index=0, op_type=Range, name=<unnamed>, inputs=[start: tensor[dtype=float16, shape=()], limit: tensor[dtype=float16, shape=()], delta: tensor[dtype=float16, shape=()]], outputs=[output: tensor[dtype=float16, shape=(2,), dim_params=(None,)]]) | 27 | 1 |
 | Unsupported op Loop (while lowering node_index=9, op_type=Loop, name=<unnamed>, inputs=[Range_test_range_bfloat16_type_positive_delta_expanded_function_n: tensor[dtype=int64, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_loop_cond: tensor[dtype=bool, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_start_s: tensor[dtype=float, shape=()]], outputs=[Range_test_range_bfloat16_type_positive_delta_expanded_function_variadic_output: tensor[dtype=float, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_output_s: tensor[dtype=float, shape=()]]) | 27 | 1 |
@@ -33,11 +31,6 @@ Lists every ONNX file with a non-success verification outcome.
 
 | File | Opset | Verification | Supported | Error |
 | --- | --- | --- | --- | --- |
-| node/test_l2normalization_axis_0/model.onnx | 22 | Data/Data | ❌ | Out of tolerance (max ULP 4294967295) |
-| node/test_qlinearmatmul_2D_int8_float16/model.onnx | 21 | Data/Data | ❌ | Out of tolerance (max abs diff 148) |
-| node/test_qlinearmatmul_2D_int8_float32/model.onnx | 21 | Data/Data | ❌ | Out of tolerance (max abs diff 148) |
-| node/test_qlinearmatmul_3D_int8_float16/model.onnx | 21 | Data/Data | ❌ | Out of tolerance (max abs diff 247) |
-| node/test_qlinearmatmul_3D_int8_float32/model.onnx | 21 | Data/Data | ❌ | Out of tolerance (max abs diff 248) |
 | node/test_range_bfloat16_type_positive_delta/model.onnx | 27 | Data/Data | ❌ | Range does not support dtype bfloat16 (while lowering node_index=0, op_type=Range, name=<unnamed>, inputs=[start: tensor[dtype=bfloat16, shape=()], limit: tensor[dtype=bfloat16, shape=()], delta: tensor[dtype=bfloat16, shape=()]], outputs=[output: tensor[dtype=bfloat16, shape=(2,), dim_params=(None,)]]) |
 | node/test_range_bfloat16_type_positive_delta_expanded/model.onnx | 27 | Data/Data | ❌ | Unsupported op Loop (while lowering node_index=9, op_type=Loop, name=<unnamed>, inputs=[Range_test_range_bfloat16_type_positive_delta_expanded_function_n: tensor[dtype=int64, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_loop_cond: tensor[dtype=bool, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_start_s: tensor[dtype=float, shape=()]], outputs=[Range_test_range_bfloat16_type_positive_delta_expanded_function_variadic_output: tensor[dtype=float, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_output_s: tensor[dtype=float, shape=()]]) |
 | node/test_range_float16_type_positive_delta/model.onnx | 27 | Data/Data | ❌ | Range does not support dtype float16 (while lowering node_index=0, op_type=Range, name=<unnamed>, inputs=[start: tensor[dtype=float16, shape=()], limit: tensor[dtype=float16, shape=()], delta: tensor[dtype=float16, shape=()]], outputs=[output: tensor[dtype=float16, shape=(2,), dim_params=(None,)]]) |

--- a/ONNX_SUPPORT.md
+++ b/ONNX_SUPPORT.md
@@ -7,7 +7,7 @@ Overview:
 
 | Test suite | Coverage | Version |
 | --- | --- | --- |
-| [Official ONNX test coverage](#official-onnx-test-coverage) | 1905 / 1914, 99.5% | 1.22.0 |
+| [Official ONNX test coverage](#official-onnx-test-coverage) | 1910 / 1914, 99.8% | 1.22.0 |
 | [ONNX Runtime artifact coverage](#onnx-runtime-artifact-coverage) | 4278 / 4324, 98.9% | n/a |
 | [Local ONNX test coverage](#local-onnx-test-coverage) | 9 / 9, 100.0% | n/a |
 
@@ -21,7 +21,7 @@ The `Verification` column uses `Input/Reference` notation (for example `Random/O
 
 Test directory: `onnx-org/onnx/backend/test/data`
 
-Coverage 1905 / 1914 ONNX files (99.5%).
+Coverage 1910 / 1914 ONNX files (99.8%).
 
 | File | Opset | Verification | Supported | Error |
 | --- | --- | --- | --- | --- |

--- a/ONNX_SUPPORT.md
+++ b/ONNX_SUPPORT.md
@@ -7,7 +7,7 @@ Overview:
 
 | Test suite | Coverage | Version |
 | --- | --- | --- |
-| [Official ONNX test coverage](#official-onnx-test-coverage) | 1891 / 1914, 98.8% | 1.22.0 |
+| [Official ONNX test coverage](#official-onnx-test-coverage) | 1905 / 1914, 99.5% | 1.22.0 |
 | [ONNX Runtime artifact coverage](#onnx-runtime-artifact-coverage) | 4278 / 4324, 98.9% | n/a |
 | [Local ONNX test coverage](#local-onnx-test-coverage) | 9 / 9, 100.0% | n/a |
 
@@ -21,7 +21,7 @@ The `Verification` column uses `Input/Reference` notation (for example `Random/O
 
 Test directory: `onnx-org/onnx/backend/test/data`
 
-Coverage 1891 / 1914 ONNX files (98.8%).
+Coverage 1905 / 1914 ONNX files (99.5%).
 
 | File | Opset | Verification | Supported | Error |
 | --- | --- | --- | --- | --- |
@@ -957,33 +957,33 @@ Coverage 1891 / 1914 ONNX files (98.8%).
 | node/test_less_uint64/model.onnx | 13 | Data/Data | ✅ | OK (max abs diff 0) |
 | node/test_less_uint8/model.onnx | 13 | Data/Data | ✅ | OK (max abs diff 0) |
 | node/test_linear_attention_decode_step/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 0) |
-| node/test_linear_attention_decode_step_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_decode_step_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
+| node/test_linear_attention_decode_step_expanded/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_linear_attention_delta/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 3) |
-| node/test_linear_attention_delta_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_delta_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
+| node/test_linear_attention_delta_expanded/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_linear_attention_explicit_scale/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 2) |
-| node/test_linear_attention_explicit_scale_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_explicit_scale_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
+| node/test_linear_attention_explicit_scale_expanded/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 6) |
 | node/test_linear_attention_fp16/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 3) |
-| node/test_linear_attention_fp16_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_fp16_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
+| node/test_linear_attention_fp16_expanded/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_linear_attention_gated/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 67) |
 | node/test_linear_attention_gated_delta/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 18) |
 | node/test_linear_attention_gated_delta_beta_scalar/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 3) |
-| node/test_linear_attention_gated_delta_beta_scalar_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_gated_delta_beta_scalar_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
-| node/test_linear_attention_gated_delta_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_gated_delta_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
+| node/test_linear_attention_gated_delta_beta_scalar_expanded/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 0) |
+| node/test_linear_attention_gated_delta_expanded/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 6) |
 | node/test_linear_attention_gated_delta_gqa/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 26) |
-| node/test_linear_attention_gated_delta_gqa_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_gated_delta_gqa_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
+| node/test_linear_attention_gated_delta_gqa_expanded/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 19) |
 | node/test_linear_attention_gated_delta_mqa/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 3) |
-| node/test_linear_attention_gated_delta_mqa_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_gated_delta_mqa_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
-| node/test_linear_attention_gated_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_gated_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
+| node/test_linear_attention_gated_delta_mqa_expanded/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 3) |
+| node/test_linear_attention_gated_expanded/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 67) |
 | node/test_linear_attention_gated_per_head_decay/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 33) |
-| node/test_linear_attention_gated_per_head_decay_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_gated_per_head_decay_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
+| node/test_linear_attention_gated_per_head_decay_expanded/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 33) |
 | node/test_linear_attention_linear/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 1) |
-| node/test_linear_attention_linear_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_linear_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
+| node/test_linear_attention_linear_expanded/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 1) |
 | node/test_linear_attention_linear_t1_no_past/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 0) |
-| node/test_linear_attention_linear_t1_no_past_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_linear_t1_no_past_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
+| node/test_linear_attention_linear_t1_no_past_expanded/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_linear_attention_no_past_explicit_zeros/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 18) |
-| node/test_linear_attention_no_past_explicit_zeros_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_no_past_explicit_zeros_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
+| node/test_linear_attention_no_past_explicit_zeros_expanded/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 6) |
 | node/test_linear_attention_prefill_with_past/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 2) |
-| node/test_linear_attention_prefill_with_past_expanded/model.onnx | 27 | Data/Data | ❌ | Missing shape for 'LinearAttention_test_linear_attention_prefill_with_past_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes. |
+| node/test_linear_attention_prefill_with_past_expanded/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_log/model.onnx | 13 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_log_example/model.onnx | 13 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_logsoftmax_axis_0/model.onnx | 13 | Data/Data | ✅ | OK (max ULP 0) |

--- a/src/emx_onnx_cgen/onnx_import.py
+++ b/src/emx_onnx_cgen/onnx_import.py
@@ -5,6 +5,7 @@ from typing import Callable, Iterable, Mapping
 import onnx
 import numpy as np
 from onnx import helper, numpy_helper, shape_inference
+from onnx.reference import ReferenceEvaluator
 
 from shared.scalar_types import ScalarType
 
@@ -478,6 +479,92 @@ def _scan_state_inputs(
     return state_names
 
 
+def _emit_int_const(
+    new_nodes: list[onnx.NodeProto], name: str, values: list[int]
+) -> str:
+    new_nodes.append(
+        helper.make_node(
+            "Constant",
+            inputs=[],
+            outputs=[name],
+            name=f"{name}_const",
+            value=numpy_helper.from_array(
+                np.array(list(values), dtype=np.int64), name=name
+            ),
+        )
+    )
+    return name
+
+
+def _emit_slice(
+    new_nodes: list[onnx.NodeProto],
+    *,
+    name: str,
+    data: str,
+    starts: list[int],
+    ends: list[int],
+    axes: list[int],
+    opset_version: int,
+) -> None:
+    # Slice moved its starts/ends/axes/steps from attributes to inputs in opset 10.
+    if opset_version < 10:
+        new_nodes.append(
+            helper.make_node(
+                "Slice",
+                inputs=[data],
+                outputs=[name],
+                name=f"{name}_node",
+                starts=starts,
+                ends=ends,
+                axes=axes,
+            )
+        )
+        return
+    starts_c = _emit_int_const(new_nodes, f"{name}_starts", starts)
+    ends_c = _emit_int_const(new_nodes, f"{name}_ends", ends)
+    axes_c = _emit_int_const(new_nodes, f"{name}_axes", axes)
+    new_nodes.append(
+        helper.make_node(
+            "Slice",
+            inputs=[data, starts_c, ends_c, axes_c],
+            outputs=[name],
+            name=f"{name}_node",
+        )
+    )
+
+
+def _emit_squeeze_like(
+    new_nodes: list[onnx.NodeProto],
+    *,
+    op_type: str,
+    name: str,
+    data: str,
+    axes: list[int],
+    opset_version: int,
+) -> None:
+    # Squeeze/Unsqueeze moved their axes from an attribute to an input in opset 13.
+    if opset_version < 13:
+        new_nodes.append(
+            helper.make_node(
+                op_type,
+                inputs=[data],
+                outputs=[name],
+                name=f"{name}_node",
+                axes=axes,
+            )
+        )
+        return
+    axes_c = _emit_int_const(new_nodes, f"{name}_axes", axes)
+    new_nodes.append(
+        helper.make_node(
+            op_type,
+            inputs=[data, axes_c],
+            outputs=[name],
+            name=f"{name}_node",
+        )
+    )
+
+
 def _scan_iteration_inputs(
     *,
     prefix: str,
@@ -485,6 +572,7 @@ def _scan_iteration_inputs(
     scan_input_names: list[str],
     new_nodes: list[onnx.NodeProto],
     is_opset8: bool,
+    opset_version: int,
 ) -> list[str]:
     scan_iter_inputs: list[str] = []
     slice_axis = _scan_expected_axis(is_opset8)
@@ -492,25 +580,22 @@ def _scan_iteration_inputs(
     for scan_index, scan_name in enumerate(scan_input_names):
         slice_out = f"{prefix}_iter{iter_index}_scan{scan_index}_slice"
         squeeze_out = f"{prefix}_iter{iter_index}_scan{scan_index}_value"
-        new_nodes.append(
-            helper.make_node(
-                "Slice",
-                inputs=[scan_name],
-                outputs=[slice_out],
-                name=f"{slice_out}_node",
-                starts=[iter_index],
-                ends=[iter_index + 1],
-                axes=[slice_axis],
-            )
+        _emit_slice(
+            new_nodes,
+            name=slice_out,
+            data=scan_name,
+            starts=[iter_index],
+            ends=[iter_index + 1],
+            axes=[slice_axis],
+            opset_version=opset_version,
         )
-        new_nodes.append(
-            helper.make_node(
-                "Squeeze",
-                inputs=[slice_out],
-                outputs=[squeeze_out],
-                name=f"{squeeze_out}_node",
-                axes=squeeze_axes,
-            )
+        _emit_squeeze_like(
+            new_nodes,
+            op_type="Squeeze",
+            name=squeeze_out,
+            data=slice_out,
+            axes=squeeze_axes,
+            opset_version=opset_version,
         )
         scan_iter_inputs.append(squeeze_out)
     return scan_iter_inputs
@@ -598,6 +683,7 @@ def _expand_scan_nodes(model: onnx.ModelProto) -> tuple[onnx.ModelProto, bool]:
                 scan_input_names=scan_input_names,
                 new_nodes=new_nodes,
                 is_opset8=is_opset8,
+                opset_version=opset_version,
             )
             name_map: dict[str, str] = {}
             for index, value in enumerate(body.input[:num_state_inputs]):
@@ -656,14 +742,13 @@ def _expand_scan_nodes(model: onnx.ModelProto) -> tuple[onnx.ModelProto, bool]:
                     )
                 unsqueeze_out = f"{prefix}_iter{iter_index}_scanout{output_index}"
                 unsqueeze_axes = [0, 1] if is_opset8 else [0]
-                new_nodes.append(
-                    helper.make_node(
-                        "Unsqueeze",
-                        inputs=[mapped_output],
-                        outputs=[unsqueeze_out],
-                        name=f"{unsqueeze_out}_node",
-                        axes=unsqueeze_axes,
-                    )
+                _emit_squeeze_like(
+                    new_nodes,
+                    op_type="Unsqueeze",
+                    name=unsqueeze_out,
+                    data=mapped_output,
+                    axes=unsqueeze_axes,
+                    opset_version=opset_version,
                 )
                 scan_output_buffers[output_index].append(unsqueeze_out)
 
@@ -1770,20 +1855,295 @@ def _expand_flexattention_nodes(
     return model, True
 
 
+# Integer ops whose result can be evaluated at compile time when all of their
+# inputs are themselves compile-time constants. This is intentionally limited to
+# the operators that show up in shape arithmetic (e.g. the decomposition of
+# LinearAttention into Shape/Div/Concat feeding a ConstantOfShape).
+_FOLDABLE_INT_OPS = frozenset(
+    {
+        "Add",
+        "Cast",
+        "Concat",
+        "Constant",
+        "Div",
+        "Equal",
+        "Gather",
+        "Max",
+        "Min",
+        "Mod",
+        "Mul",
+        "Neg",
+        "Range",
+        "Reshape",
+        "Slice",
+        "Squeeze",
+        "Sub",
+        "Unsqueeze",
+        "Where",
+    }
+)
+_FOLD_MAX_ELEMS = 4096
+
+
+def _static_shape_from_value_info(
+    value_info: onnx.ValueInfoProto,
+) -> tuple[int, ...] | None:
+    tensor_type = value_info.type.tensor_type
+    if not tensor_type.HasField("shape"):
+        return None
+    dims: list[int] = []
+    for dim in tensor_type.shape.dim:
+        if not dim.HasField("dim_value"):
+            return None
+        dims.append(int(dim.dim_value))
+    return tuple(dims)
+
+
+class _ConstantFolder:
+    """Evaluates integer shape arithmetic subgraphs at import time."""
+
+    def __init__(self, graph: onnx.GraphProto) -> None:
+        self._init_map = {init.name: init for init in graph.initializer}
+        self._node_by_output: dict[str, onnx.NodeProto] = {}
+        for node in graph.node:
+            for output in node.output:
+                if output:
+                    self._node_by_output[output] = node
+        self._static_shapes: dict[str, tuple[int, ...]] = {}
+        for value_info in (*graph.input, *graph.value_info, *graph.output):
+            shape = _static_shape_from_value_info(value_info)
+            if shape is not None:
+                self._static_shapes[value_info.name] = shape
+        self._cache: dict[str, np.ndarray | None] = {}
+
+    def evaluate(self, name: str) -> np.ndarray | None:
+        return self._eval(name, depth=0)
+
+    def _accept(self, array: np.ndarray | None) -> np.ndarray | None:
+        if array is None:
+            return None
+        if array.dtype.kind not in {"i", "u", "b"}:
+            return None
+        if array.size > _FOLD_MAX_ELEMS:
+            return None
+        return array
+
+    def _eval(self, name: str, *, depth: int) -> np.ndarray | None:
+        if not name:
+            return None
+        if name in self._cache:
+            return self._cache[name]
+        if depth > 128:
+            return None
+        self._cache[name] = None
+        result: np.ndarray | None = None
+        initializer = self._init_map.get(name)
+        if initializer is not None:
+            result = self._accept(numpy_helper.to_array(initializer))
+        else:
+            node = self._node_by_output.get(name)
+            if node is not None and node.op_type in {"Shape", "Size"}:
+                result = self._accept(self._eval_shape(node))
+            elif node is not None and node.op_type in _FOLDABLE_INT_OPS:
+                outputs = self._eval_node(node, depth=depth)
+                if outputs is not None:
+                    for out_name, array in outputs.items():
+                        self._cache[out_name] = self._accept(array)
+                    return self._cache[name]
+        self._cache[name] = result
+        return result
+
+    def _eval_shape(self, node: onnx.NodeProto) -> np.ndarray | None:
+        if len(node.input) != 1 or not node.input[0]:
+            return None
+        shape = self._static_shapes.get(node.input[0])
+        if shape is None:
+            return None
+        if node.op_type == "Size":
+            return np.array(int(np.prod(shape, dtype=np.int64)), dtype=np.int64)
+        rank = len(shape)
+        attrs = {attr.name: helper.get_attribute_value(attr) for attr in node.attribute}
+        start = int(attrs.get("start", 0))
+        if start < 0:
+            start += rank
+        start = max(0, min(start, rank))
+        end_attr = attrs.get("end")
+        end = rank if end_attr is None else int(end_attr)
+        if end < 0:
+            end += rank
+        end = max(0, min(end, rank))
+        return np.array(shape[start:end], dtype=np.int64)
+
+    def _eval_node(
+        self, node: onnx.NodeProto, *, depth: int
+    ) -> dict[str, np.ndarray] | None:
+        feeds: dict[str, np.ndarray] = {}
+        for input_name in node.input:
+            if not input_name:
+                continue
+            array = self._eval(input_name, depth=depth + 1)
+            if array is None:
+                return None
+            feeds[input_name] = array
+        if node.input and not feeds:
+            return None
+        try:
+            evaluator = ReferenceEvaluator(node)
+            results = evaluator.run(None, feeds)
+        except Exception:  # pragma: no cover - defensive, skips folding
+            return None
+        outputs: dict[str, np.ndarray] = {}
+        for out_name, value in zip(node.output, results):
+            if not out_name:
+                continue
+            if not isinstance(value, np.ndarray):
+                return None
+            outputs[out_name] = value
+        return outputs
+
+
+def _fold_constant_of_shape_inputs(
+    model: onnx.ModelProto,
+) -> tuple[onnx.ModelProto, bool]:
+    """Resolve ConstantOfShape outputs whose shape is computed from constants.
+
+    ONNX shape inference (even with data propagation) does not fold integer
+    arithmetic such as ``Div`` when computing a shape tensor, leaving the
+    ConstantOfShape output with unknown dimensions. That blocks downstream
+    static-shape code generation (e.g. the expanded LinearAttention reference
+    function builds its recurrent state via Shape/Div/Concat/ConstantOfShape).
+    Here we evaluate such shape inputs at import time and rewire the
+    ConstantOfShape node to a constant initializer so the regular shape
+    inference pass can resolve the output statically.
+    """
+
+    graph = model.graph
+    targets: list[onnx.NodeProto] = []
+    value_info_map = {value_info.name: value_info for value_info in graph.value_info}
+    for node in graph.node:
+        if node.op_type != "ConstantOfShape" or len(node.input) != 1:
+            continue
+        if not node.input[0]:
+            continue
+        output_info = value_info_map.get(node.output[0])
+        if output_info is not None and _static_shape_from_value_info(output_info):
+            continue
+        targets.append(node)
+    if not targets:
+        return model, False
+
+    folder = _ConstantFolder(graph)
+    existing_names = {init.name for init in graph.initializer}
+    existing_names.update(
+        output for node in graph.node for output in node.output if output
+    )
+    existing_names.update(value_info.name for value_info in graph.input)
+    changed = False
+    resolved_outputs: set[str] = set()
+    for index, node in enumerate(targets):
+        values = folder.evaluate(node.input[0])
+        if values is None or values.ndim != 1:
+            continue
+        shape_values = [int(value) for value in values.reshape(-1)]
+        if any(value < 0 for value in shape_values):
+            continue
+        const_name = f"{node.output[0]}_folded_shape_{index}"
+        while const_name in existing_names:
+            const_name = f"_{const_name}"
+        existing_names.add(const_name)
+        graph.initializer.append(
+            numpy_helper.from_array(
+                np.array(shape_values, dtype=np.int64), name=const_name
+            )
+        )
+        node.input[0] = const_name
+        resolved_outputs.add(node.output[0])
+        changed = True
+
+    if not changed:
+        return model, False
+    # Drop the stale (dynamic) value_info for the rewired outputs so the next
+    # shape inference pass recomputes them from the folded constant shape rather
+    # than treating the leftover ``unk__N`` dim_params as already resolved.
+    stale = [
+        value_info
+        for value_info in graph.value_info
+        if value_info.name in resolved_outputs
+    ]
+    for value_info in stale:
+        graph.value_info.remove(value_info)
+    _prune_unused_nodes(graph)
+    return model, True
+
+
+def _collect_node_input_refs(node: onnx.NodeProto, used: set[str]) -> None:
+    for input_name in node.input:
+        if input_name:
+            used.add(input_name)
+    # Subgraphs (If/Loop/Scan bodies) may reference outer-scope values that do
+    # not appear in the node's input list. Treat every name referenced at any
+    # nesting level as used so pruning never deletes a producer they depend on.
+    for attr in node.attribute:
+        if attr.HasField("g"):
+            for sub_node in attr.g.node:
+                _collect_node_input_refs(sub_node, used)
+        for sub_graph in attr.graphs:
+            for sub_node in sub_graph.node:
+                _collect_node_input_refs(sub_node, used)
+
+
+def _prune_unused_nodes(graph: onnx.GraphProto) -> None:
+    keep: list[bool] = [True] * len(graph.node)
+    nodes = list(graph.node)
+    # Iterate to a fixpoint so chains of now-dead shape arithmetic are removed.
+    while True:
+        used: set[str] = {output.name for output in graph.output}
+        for kept, node in zip(keep, nodes):
+            if kept:
+                _collect_node_input_refs(node, used)
+        removed_any = False
+        for position, (kept, node) in enumerate(zip(keep, nodes)):
+            if not kept:
+                continue
+            if any(output and output in used for output in node.output):
+                continue
+            keep[position] = False
+            removed_any = True
+        if not removed_any:
+            break
+    surviving = [node for kept, node in zip(keep, nodes) if kept]
+    if len(surviving) != len(nodes):
+        del graph.node[:]
+        graph.node.extend(surviving)
+
+
+def _maybe_infer_shapes(model: onnx.ModelProto) -> onnx.ModelProto:
+    if not _needs_shape_inference(model):
+        return model
+    try:
+        return shape_inference.infer_shapes(model, data_prop=True)
+    except Exception as exc:  # pragma: no cover - onnx inference errors
+        raise ShapeInferenceError("ONNX shape inference failed") from exc
+
+
 def prepare_onnx_model(model: onnx.ModelProto) -> onnx.ModelProto:
     prepared = onnx.ModelProto()
     prepared.CopyFrom(model)
     prepared, _ = _expand_image_decoder_nodes(prepared)
     prepared, _ = _expand_flexattention_nodes(prepared)
+    # Scan unrolling slices its scan inputs, so it needs their static shapes up
+    # front. Run shape inference and fold the integer shape arithmetic that ONNX
+    # leaves unresolved (e.g. the ConstantOfShape state built via Div in the
+    # expanded LinearAttention function) before expanding any Scan nodes.
+    prepared = _maybe_infer_shapes(prepared)
+    prepared, folded = _fold_constant_of_shape_inputs(prepared)
+    if folded:
+        prepared = _maybe_infer_shapes(prepared)
     prepared, _ = _expand_scan_nodes(prepared)
     prepared, _ = _expand_if_nodes(prepared)
     prepared, _ = _expand_sequence_map_nodes(prepared)
     prepared, _ = _expand_gradient_nodes(prepared)
-    if _needs_shape_inference(prepared):
-        try:
-            prepared = shape_inference.infer_shapes(prepared, data_prop=True)
-        except Exception as exc:  # pragma: no cover - onnx inference errors
-            raise ShapeInferenceError("ONNX shape inference failed") from exc
+    prepared = _maybe_infer_shapes(prepared)
     return prepared
 
 

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_2d_axis_negative_1_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_2d_axis_negative_1_expanded__model.onnx.json
@@ -22,5 +22,5 @@
     "Reciprocal"
   ],
   "opset_version": 17,
-  "generated_checksum": "36cc611cb94d075e08119d896854f7f375c2eca54508363a108db380ddbb08e6"
+  "generated_checksum": "3e7cac96c4bc268b7730873936998bc9767c8e7be0432baffe6ac4c6192935bd"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_2d_axis_negative_1_expanded_ver18__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_2d_axis_negative_1_expanded_ver18__model.onnx.json
@@ -22,5 +22,5 @@
     "Reciprocal"
   ],
   "opset_version": 18,
-  "generated_checksum": "9ea29bb6f8fc138a6c2bbcc7b409013f30a828df4832a93b2299ef4d99e125ac"
+  "generated_checksum": "3a5c97b8ec9ee722320f20e707f8bd6e4e3b73cb4a64adc330200e5f6e71e859"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_2d_axis_negative_2_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_2d_axis_negative_2_expanded__model.onnx.json
@@ -22,5 +22,5 @@
     "Reciprocal"
   ],
   "opset_version": 17,
-  "generated_checksum": "7081eeaea551b785a861ab8b320b7c01745a2f35a1f186a72a0d176a0db74d57"
+  "generated_checksum": "8cb2e4fb051c6d4b33146329acc8acf2ccee12778d43e1ed8d9a1a102e691358"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_2d_axis_negative_2_expanded_ver18__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_2d_axis_negative_2_expanded_ver18__model.onnx.json
@@ -22,5 +22,5 @@
     "Reciprocal"
   ],
   "opset_version": 18,
-  "generated_checksum": "423a43f880357efb3d9e6424f95af8416eb698622ab4da599dc9737c83710b1c"
+  "generated_checksum": "b8176b10dc80c582616471cc3c12d4fc4ce81c878c5b419dba4026e32f9fe1ba"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_3d_axis_negative_1_epsilon_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_3d_axis_negative_1_epsilon_expanded__model.onnx.json
@@ -22,5 +22,5 @@
     "Reciprocal"
   ],
   "opset_version": 17,
-  "generated_checksum": "1842dcd2425cf46eb8f987bfa579848f5a2365ae2c3cd3724dbcaa78ea0d3e18"
+  "generated_checksum": "0ecf27085eeafcb15662733e8e81e8575a5fc8b61cabee2a6632543b20caabc0"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_3d_axis_negative_1_epsilon_expanded_ver18__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_3d_axis_negative_1_epsilon_expanded_ver18__model.onnx.json
@@ -22,5 +22,5 @@
     "Reciprocal"
   ],
   "opset_version": 18,
-  "generated_checksum": "ea82a4cea6b4e2936871644cdc0dae57e4a8c16399564c397d23c70ac37642ef"
+  "generated_checksum": "2bde895b73cce6ce87492b48324697a0058485f90b991cf39d51fd51ee7cb4d5"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_3d_axis_negative_2_epsilon_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_3d_axis_negative_2_epsilon_expanded__model.onnx.json
@@ -22,5 +22,5 @@
     "Reciprocal"
   ],
   "opset_version": 17,
-  "generated_checksum": "9aa3160e6568a8c3604cc8755501c142b46f000296e49f9f7d5bc11d00d00000"
+  "generated_checksum": "ebd373228c0e4dd474a9d3845a1b75989cf48e4ac16e7e4dedc0ce545343b511"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_3d_axis_negative_2_epsilon_expanded_ver18__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_3d_axis_negative_2_epsilon_expanded_ver18__model.onnx.json
@@ -22,5 +22,5 @@
     "Reciprocal"
   ],
   "opset_version": 18,
-  "generated_checksum": "5c7164acb79bd38dd2bc89e15e6ceae29426c4bbc086918df3ac64cef6acdc9d"
+  "generated_checksum": "4dd44a290c2d57886f1bb226d43696c03301cf234ff744fc7a982f133c8fe4ab"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_3d_axis_negative_3_epsilon_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_3d_axis_negative_3_epsilon_expanded__model.onnx.json
@@ -22,5 +22,5 @@
     "Reciprocal"
   ],
   "opset_version": 17,
-  "generated_checksum": "b7b7f0fde5b7e24d75026d151b8f2015a13efea81b66dea243e6157f3354c96d"
+  "generated_checksum": "c759bcab0b731989f260ad8c9328a682f9c437722977776335cd424d3b02d63f"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_3d_axis_negative_3_epsilon_expanded_ver18__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_3d_axis_negative_3_epsilon_expanded_ver18__model.onnx.json
@@ -22,5 +22,5 @@
     "Reciprocal"
   ],
   "opset_version": 18,
-  "generated_checksum": "c997a37d22da81cb888a099646e5c6cf597ac53e31363ff900e61d6c05c75122"
+  "generated_checksum": "478a100257de9d4e5fd3cccba854fbf06f2f1e30ae4e75f465d36df7e2ad3096"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_4d_axis_negative_1_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_4d_axis_negative_1_expanded__model.onnx.json
@@ -22,5 +22,5 @@
     "Reciprocal"
   ],
   "opset_version": 17,
-  "generated_checksum": "5246b3b8149a1c30893acdaa764f28d2d9befce56be30e97507ed3861fb64838"
+  "generated_checksum": "72694b0eed533848c4b5e5af38f2a5d2543ce48f1841445a1112a0f8ae829b31"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_4d_axis_negative_1_expanded_ver18__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_4d_axis_negative_1_expanded_ver18__model.onnx.json
@@ -22,5 +22,5 @@
     "Reciprocal"
   ],
   "opset_version": 18,
-  "generated_checksum": "05f03399030a61ca10977de531e3014d15583e5aa8375d44de37940c706f5342"
+  "generated_checksum": "66fd5e0712fe27dd3a4e1bff84ecfba416a4c0444ed0d412ad75eafb7420d0e9"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_4d_axis_negative_2_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_4d_axis_negative_2_expanded__model.onnx.json
@@ -22,5 +22,5 @@
     "Reciprocal"
   ],
   "opset_version": 17,
-  "generated_checksum": "e19a7f48dbfcd3c2d8c62bb7fa2fec31680f678e2f583cfbfc471cf9b8c1e4ba"
+  "generated_checksum": "0981feae876238d17fad0dc3e878919df2111cf9b6d833121f32755d0557438a"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_4d_axis_negative_2_expanded_ver18__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_4d_axis_negative_2_expanded_ver18__model.onnx.json
@@ -22,5 +22,5 @@
     "Reciprocal"
   ],
   "opset_version": 18,
-  "generated_checksum": "1cb25ab19217cc6ee2a044696ef664f49b5314ab327c83cd0327ee50604e90a1"
+  "generated_checksum": "8296a1274709a2c73e3cf809f0cb91b5f59549ad9e47371124d3ba3f3f9fd82a"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_4d_axis_negative_3_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_4d_axis_negative_3_expanded__model.onnx.json
@@ -22,5 +22,5 @@
     "Reciprocal"
   ],
   "opset_version": 17,
-  "generated_checksum": "a398780fa17b089de0ec7c5dcd35bf54041df8ca3d6e68a19ac9478fa118365e"
+  "generated_checksum": "d534c39ecb69180a66b1cd533f5e5c0df75646b27ac02508c78f2d7ed8902f4c"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_4d_axis_negative_3_expanded_ver18__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_4d_axis_negative_3_expanded_ver18__model.onnx.json
@@ -22,5 +22,5 @@
     "Reciprocal"
   ],
   "opset_version": 18,
-  "generated_checksum": "c7e54fb3b4ae7b788260ec5d14b459b0a3e7077856d25cb5f29820f45002e89f"
+  "generated_checksum": "d32470192480228c4c47b9050bbff73f53c6bc1964b22656df18417dbb2ae91c"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_4d_axis_negative_4_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_4d_axis_negative_4_expanded__model.onnx.json
@@ -22,5 +22,5 @@
     "Reciprocal"
   ],
   "opset_version": 17,
-  "generated_checksum": "ab50c9aee6cc5c95f418e2ddd679d7e90e6765cdaffd7c1834249b67a8e29a47"
+  "generated_checksum": "31d361320655de791171e00227a0cba79a61a9cd3fd8732874dcc3200dd3b1e8"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_4d_axis_negative_4_expanded_ver18__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_4d_axis_negative_4_expanded_ver18__model.onnx.json
@@ -22,5 +22,5 @@
     "Reciprocal"
   ],
   "opset_version": 18,
-  "generated_checksum": "3b96e387d0e2e6a4fe547f523e3ce50443533d1e4ec3d2ba55da712caee46b08"
+  "generated_checksum": "234d903526930da78522ee9df9eb9412e30e2bb8e9897522ad4dbabed52af369"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_default_axis_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_default_axis_expanded__model.onnx.json
@@ -22,5 +22,5 @@
     "Reciprocal"
   ],
   "opset_version": 17,
-  "generated_checksum": "dfc6e1c1ff44108a5119832837f740ba47663faacffd17bfa3251d24b298c5b5"
+  "generated_checksum": "65122ee279a1df125db16d899b3bff9be26c49c451f5ddba5e6f24ac2f6fe87d"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_default_axis_expanded_ver18__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_layer_normalization_default_axis_expanded_ver18__model.onnx.json
@@ -22,5 +22,5 @@
     "Reciprocal"
   ],
   "opset_version": 18,
-  "generated_checksum": "99a717315d566ee577d69aae5d81470ff0bd8d2cace13e7f6294729195469f50"
+  "generated_checksum": "7cf2ebd44c6e9665ced1642ab022bca6cff8905c8de7af8f37eaa85ff1d43a19"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_decode_step_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_decode_step_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Missing shape for 'LinearAttention_test_linear_attention_decode_step_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes.",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_linear_attention_decode_step_expanded model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
@@ -16,5 +16,6 @@
     "Scan",
     "CastLike"
   ],
-  "opset_version": 27
+  "opset_version": 27,
+  "generated_checksum": "1c5c793c7f055b67b580c6aae9745fe89b53a1857bb8ef327bdf6db4f56c9ba8"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_delta_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_delta_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Missing shape for 'LinearAttention_test_linear_attention_delta_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes.",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_linear_attention_delta_expanded model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
@@ -17,5 +17,6 @@
     "Scan",
     "CastLike"
   ],
-  "opset_version": 27
+  "opset_version": 27,
+  "generated_checksum": "8d6b90b7d2c8221f9c1cf02603f58176429765b3ec1f2733efd2964e0edd35fa"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_explicit_scale_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_explicit_scale_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Missing shape for 'LinearAttention_test_linear_attention_explicit_scale_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes.",
+  "error": "OK (max ULP 6)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_linear_attention_explicit_scale_expanded model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
@@ -13,5 +13,6 @@
     "Scan",
     "CastLike"
   ],
-  "opset_version": 27
+  "opset_version": 27,
+  "generated_checksum": "378c58f5db8c42f775a46cbad2bc3cf8884c4c3a9777372ed0b2bd9939656bdb"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_fp16_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_fp16_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Missing shape for 'LinearAttention_test_linear_attention_fp16_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes.",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_linear_attention_fp16_expanded model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
@@ -17,5 +17,6 @@
     "Scan",
     "CastLike"
   ],
-  "opset_version": 27
+  "opset_version": 27,
+  "generated_checksum": "f50425450b253ef0f5cf290d6aba3ce10e2305847e8fb2dfd4545f8019ea95a5"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_gated_delta_beta_scalar_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_gated_delta_beta_scalar_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Missing shape for 'LinearAttention_test_linear_attention_gated_delta_beta_scalar_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes.",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_linear_attention_gated_delta_beta_scalar_expanded model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
@@ -17,5 +17,6 @@
     "Scan",
     "CastLike"
   ],
-  "opset_version": 27
+  "opset_version": 27,
+  "generated_checksum": "b681e59bac7ad9d4ebdfd7703f4627b3caf50fe43af66f61730fffe26b9b643a"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_gated_delta_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_gated_delta_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Missing shape for 'LinearAttention_test_linear_attention_gated_delta_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes.",
+  "error": "OK (max ULP 6)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_linear_attention_gated_delta_expanded model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
@@ -17,5 +17,6 @@
     "Scan",
     "CastLike"
   ],
-  "opset_version": 27
+  "opset_version": 27,
+  "generated_checksum": "639ffbd6551173774f9ee400007555755c7ceae7cf168d078f5019b324fbba07"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_gated_delta_gqa_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_gated_delta_gqa_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Missing shape for 'LinearAttention_test_linear_attention_gated_delta_gqa_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes.",
+  "error": "OK (max ULP 19)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_linear_attention_gated_delta_gqa_expanded model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
@@ -17,5 +17,6 @@
     "Scan",
     "CastLike"
   ],
-  "opset_version": 27
+  "opset_version": 27,
+  "generated_checksum": "fbb3804fd61e5f7548b69c032bd549e636ee5e8d0b1449b7cf3406e481a97dd9"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_gated_delta_mqa_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_gated_delta_mqa_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Missing shape for 'LinearAttention_test_linear_attention_gated_delta_mqa_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes.",
+  "error": "OK (max ULP 3)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_linear_attention_gated_delta_mqa_expanded model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
@@ -17,5 +17,6 @@
     "Scan",
     "CastLike"
   ],
-  "opset_version": 27
+  "opset_version": 27,
+  "generated_checksum": "376374753ebe4f2827e8e286525f66299072ea19238dcca62be3beffce3ea1f7"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_gated_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_gated_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Missing shape for 'LinearAttention_test_linear_attention_gated_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes.",
+  "error": "OK (max ULP 67)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_linear_attention_gated_expanded model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
@@ -17,5 +17,6 @@
     "Scan",
     "CastLike"
   ],
-  "opset_version": 27
+  "opset_version": 27,
+  "generated_checksum": "24273cb02ebf5f959610bb7b20c184a01b01a2752d4f80550c6a05b0a7a78672"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_gated_per_head_decay_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_gated_per_head_decay_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Missing shape for 'LinearAttention_test_linear_attention_gated_per_head_decay_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes.",
+  "error": "OK (max ULP 33)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_linear_attention_gated_per_head_decay_expanded model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
@@ -17,5 +17,6 @@
     "Scan",
     "CastLike"
   ],
-  "opset_version": 27
+  "opset_version": 27,
+  "generated_checksum": "bc75948f41c8812f554cff6a56db772c755af9c80b7525c0eea2a8fbc0be511c"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_linear_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_linear_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Missing shape for 'LinearAttention_test_linear_attention_linear_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes.",
+  "error": "OK (max ULP 1)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_linear_attention_linear_expanded model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
@@ -17,5 +17,6 @@
     "Scan",
     "CastLike"
   ],
-  "opset_version": 27
+  "opset_version": 27,
+  "generated_checksum": "691ef234c238ed8a7fc893fac699e40560c5adb0243943f9cbca3805e6f22b43"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_linear_t1_no_past_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_linear_t1_no_past_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Missing shape for 'LinearAttention_test_linear_attention_linear_t1_no_past_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes.",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_linear_attention_linear_t1_no_past_expanded model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
@@ -17,5 +17,6 @@
     "Scan",
     "CastLike"
   ],
-  "opset_version": 27
+  "opset_version": 27,
+  "generated_checksum": "52689f5c41659aba0e82e6f0365eddbb35766bcd8e47803de1989886cb52e600"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_no_past_explicit_zeros_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_no_past_explicit_zeros_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Missing shape for 'LinearAttention_test_linear_attention_no_past_explicit_zeros_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes.",
+  "error": "OK (max ULP 6)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_linear_attention_no_past_explicit_zeros_expanded model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
@@ -16,5 +16,6 @@
     "Scan",
     "CastLike"
   ],
-  "opset_version": 27
+  "opset_version": 27,
+  "generated_checksum": "68289df88fa79f1d8de1ed6d0035eb352602bab54200f5fed16767fbaf4d2463"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_prefill_with_past_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_linear_attention_prefill_with_past_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Missing shape for 'LinearAttention_test_linear_attention_prefill_with_past_expanded_function_Q4D' in Scan expansion. Hint: run ONNX shape inference or export with static shapes.",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_linear_attention_prefill_with_past_expanded model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
@@ -16,5 +16,6 @@
     "Scan",
     "CastLike"
   ],
-  "opset_version": 27
+  "opset_version": 27,
+  "generated_checksum": "7b0f911f5f3d2f40ab153936d3d9c5d483872322b4ff1564e70251d7d23d1151"
 }

--- a/tests/golden/op_constantofshape_constant_of_shape.c
+++ b/tests/golden/op_constantofshape_constant_of_shape.c
@@ -8,10 +8,10 @@
  *   fp16_accumulation_strategy: fp32
  *   large_temp_threshold: 1024
  *   large_weight_threshold: 102400
- * Model checksum (sha256): 173447dfff228bd02444e911a7bab46ce10d045fa62952111c704220891c6671
+ * Model checksum (sha256): 45d13c1344892932e353392af9bb3390da0d1b5702f1948f5e520eb060c0fa6b
  * Model name: model
  * Graph name: constant_of_shape_graph
- * Inputs: 0 Outputs: 1 Nodes: 1 Initializers: 1
+ * Inputs: 0 Outputs: 1 Nodes: 1 Initializers: 2
  * IR version: 7
  * Model version: n/a
  * Domain: n/a
@@ -47,16 +47,16 @@
 #define EMX_SEQUENCE_MAX_LEN 32
 #endif
 
-extern const int64_t weight1_shape[3];
+extern const int64_t weight1_out_folded_shape_0[3];
 
 /*
  * Weight 1:
- * Name: weight1_shape
+ * Name: weight1_out_folded_shape_0
  * Shape: (3,)
  * Elements: 3
  * Dtype: int64
  */
-const EMX_UNUSED int64_t weight1_shape[3] = {
+const EMX_UNUSED int64_t weight1_out_folded_shape_0[3] = {
     2LL, 3LL, 4LL
 };
 
@@ -64,7 +64,7 @@ const EMX_UNUSED int64_t weight1_shape[3] = {
  * Node 0:
  * OpType: ConstantOfShape
  * Name: n/a
- * Inputs: shape
+ * Inputs: out_folded_shape_0
  * Outputs: out
  * Attrs:
  *   value: dims: 1
@@ -90,5 +90,5 @@ _Bool model_load(const char *path) {
 }
 
 void model(float out[restrict 2][3][4]) {
-    node0_constantofshape(weight1_shape, out);
+    node0_constantofshape(weight1_out_folded_shape_0, out);
 }

--- a/tests/test_onnx_import.py
+++ b/tests/test_onnx_import.py
@@ -6,7 +6,12 @@ import onnx
 from onnx import TensorProto, helper
 from shared.scalar_types import ScalarType
 
-from emx_onnx_cgen.onnx_import import import_onnx
+from emx_onnx_cgen.onnx_import import (
+    import_onnx,
+    _fold_constant_of_shape_inputs,
+    _maybe_infer_shapes,
+    prepare_onnx_model,
+)
 from emx_onnx_cgen.dtypes import scalar_type_from_onnx
 
 
@@ -468,3 +473,113 @@ def test_import_flexattention_inlines_score_mod_subgraph() -> None:
     assert "FlexAttention" not in op_types
     # The score_mod body (an Add) is inlined into the expanded graph.
     assert "Add" in op_types
+
+
+def _static_shape(value_info: onnx.ValueInfoProto) -> tuple[int, ...] | None:
+    tensor_type = value_info.type.tensor_type
+    if not tensor_type.HasField("shape"):
+        return None
+    dims = []
+    for dim in tensor_type.shape.dim:
+        if not dim.HasField("dim_value"):
+            return None
+        dims.append(int(dim.dim_value))
+    return tuple(dims)
+
+
+def test_fold_constant_of_shape_resolves_computed_shape() -> None:
+    # ConstantOfShape fed by Shape/Div/Concat: ONNX shape inference cannot fold
+    # the Div, so the output stays dynamic until the constant folder runs.
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [4, 16])
+    out = helper.make_tensor_value_info("out", TensorProto.FLOAT, None)
+    heads = helper.make_tensor("heads", TensorProto.INT64, [1], [4])
+    nodes = [
+        helper.make_node("Shape", ["x"], ["batch"], start=0, end=1),
+        helper.make_node("Shape", ["x"], ["hidden"], start=1, end=2),
+        helper.make_node("Div", ["hidden", "heads"], ["head_size"]),
+        helper.make_node("Concat", ["batch", "head_size"], ["state_shape"], axis=0),
+        helper.make_node("ConstantOfShape", ["state_shape"], ["state"]),
+        helper.make_node("Identity", ["state"], ["out"]),
+    ]
+    graph = helper.make_graph(nodes, "fold_graph", [x], [out], initializer=[heads])
+    model = helper.make_model(
+        graph,
+        producer_name="onnx2c",
+        opset_imports=[helper.make_operatorsetid("", 27)],
+    )
+    model.ir_version = 10
+
+    model = _maybe_infer_shapes(model)
+    model, folded = _fold_constant_of_shape_inputs(model)
+    assert folded
+    model = _maybe_infer_shapes(model)
+
+    resolved = {value_info.name: value_info for value_info in model.graph.value_info}
+    resolved.update({out.name: out for out in model.graph.output})
+    assert _static_shape(resolved["state"]) == (4, 4)
+
+
+def _make_scan_model(opset: int) -> onnx.ModelProto:
+    body = helper.make_graph(
+        [
+            helper.make_node("Add", ["state_in", "scan_in"], ["state_out"]),
+            helper.make_node("Identity", ["state_out"], ["scan_out"]),
+        ],
+        "scan_body",
+        [
+            helper.make_tensor_value_info("state_in", TensorProto.FLOAT, [2]),
+            helper.make_tensor_value_info("scan_in", TensorProto.FLOAT, [2]),
+        ],
+        [
+            helper.make_tensor_value_info("state_out", TensorProto.FLOAT, [2]),
+            helper.make_tensor_value_info("scan_out", TensorProto.FLOAT, [2]),
+        ],
+    )
+    scan = helper.make_node(
+        "Scan",
+        ["init_state", "x"],
+        ["final_state", "y"],
+        num_scan_inputs=1,
+        body=body,
+    )
+    graph = helper.make_graph(
+        [scan],
+        "scan_graph",
+        [
+            helper.make_tensor_value_info("init_state", TensorProto.FLOAT, [2]),
+            helper.make_tensor_value_info("x", TensorProto.FLOAT, [3, 2]),
+        ],
+        [
+            helper.make_tensor_value_info("final_state", TensorProto.FLOAT, [2]),
+            helper.make_tensor_value_info("y", TensorProto.FLOAT, [3, 2]),
+        ],
+    )
+    model = helper.make_model(
+        graph,
+        producer_name="onnx2c",
+        opset_imports=[helper.make_operatorsetid("", opset)],
+    )
+    model.ir_version = 10
+    onnx.checker.check_model(model)
+    return model
+
+
+def test_scan_expansion_uses_input_style_slice_for_modern_opset() -> None:
+    prepared = prepare_onnx_model(_make_scan_model(27))
+    slices = [node for node in prepared.graph.node if node.op_type == "Slice"]
+    squeezes = [node for node in prepared.graph.node if node.op_type == "Squeeze"]
+    assert slices
+    # Opset >= 10 Slice takes starts/ends/axes as inputs, not attributes.
+    assert all(len(node.input) >= 3 for node in slices)
+    assert all(not node.attribute for node in slices)
+    # Opset >= 13 Squeeze takes axes as an input rather than an attribute.
+    assert all(len(node.input) == 2 for node in squeezes)
+
+
+def test_scan_expansion_uses_attribute_slice_for_legacy_opset() -> None:
+    prepared = prepare_onnx_model(_make_scan_model(9))
+    slices = [node for node in prepared.graph.node if node.op_type == "Slice"]
+    assert slices
+    # Opset 9 Slice still carries starts/ends/axes as attributes.
+    assert all(len(node.input) == 1 for node in slices)
+    assert all(node.attribute for node in slices)


### PR DESCRIPTION
## Summary
This PR improves ONNX model import by evaluating integer shape arithmetic at compile time and ensuring Scan node expansion generates opset-compatible operators.

## Key Changes

- **Constant Folding for Shape Arithmetic**: Added `_ConstantFolder` class that evaluates integer operations (Add, Div, Concat, etc.) at import time when all inputs are compile-time constants. This resolves dynamic shapes in `ConstantOfShape` outputs that ONNX's shape inference cannot fold, particularly for expanded LinearAttention models that compute state shapes via `Shape/Div/Concat/ConstantOfShape`.

- **Opset-Compatible Slice/Squeeze Generation**: Refactored Scan node expansion to generate opset-appropriate operators:
  - `_emit_slice()`: Generates Slice with attributes (opset < 10) or inputs (opset >= 10)
  - `_emit_squeeze_like()`: Generates Squeeze/Unsqueeze with attributes (opset < 13) or inputs (opset >= 13)
  - Updated `_scan_iteration_inputs()` to use these helpers and pass `opset_version` parameter

- **Dead Code Elimination**: Added `_prune_unused_nodes()` to remove unused shape arithmetic nodes after constant folding, iterating to fixpoint to eliminate chains of dead operations.

- **Improved Shape Inference Pipeline**: Refactored shape inference into `_maybe_infer_shapes()` helper and reordered `prepare_onnx_model()` to:
  1. Run initial shape inference with data propagation
  2. Fold constant shape inputs
  3. Re-infer shapes to resolve folded constants
  4. Then expand Scan/If/SequenceMap/Gradient nodes

## Notable Implementation Details

- The constant folder respects safety limits: only folds integer/boolean arrays with ≤4096 elements and recursion depth ≤128
- Handles subgraph references in If/Loop/Scan bodies when pruning to avoid deleting producers of outer-scope values
- Resolves 14 previously failing LinearAttention expanded test cases by enabling static shape inference for computed dimensions

https://claude.ai/code/session_01Qqeyuyo2Aict2X2FV3UGcQ