### PR TITLE
shapes: replace back-inference heuristics with symbolic shape solving

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
     # >=6.33.5: fixes GHSA-8qvm-5x2c-j2w7/CVE-2025-4565 (DoS, <4.25.8 / >=5.26.0rc1,<5.29.5 / >=6.30.0rc1,<6.31.1)
     #           and GHSA-7gcm-g887-7qv7/CVE-2026-0994 (JSON recursion bypass, <5.29.6 / >=6.30.0rc1,<=6.33.4)
     "protobuf>=6.33.5",
+    # Symbolic shape inference (src/emx_onnx_cgen/symbolic_shapes.py) solves the
+    # shape arithmetic that depends on runtime integer input values.
+    "sympy",
 ]
 
 [project.optional-dependencies]

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -8,6 +8,9 @@ protobuf>=6.33.5
 # Numerics
 numpy==2.2.6
 
+# Symbolic shape inference (emx_onnx_cgen.symbolic_shapes)
+sympy==1.14.0
+
 # Code generation
 Jinja2==3.1.6
 emx-regex-cgen==0.2.0

--- a/src/emx_onnx_cgen/lowering/common.py
+++ b/src/emx_onnx_cgen/lowering/common.py
@@ -217,102 +217,6 @@ def _gather_literal_values(
     return gathered
 
 
-def _split_shape_values_from_static_graph_output(
-    graph: Graph | GraphContext,
-    source_node: Node,
-    name: str,
-) -> list[int] | None:
-    if len(source_node.inputs) != 1 or not source_node.outputs:
-        return None
-    output_count = len(source_node.outputs)
-    if output_count not in {4, 5} or name not in source_node.outputs:
-        return None
-    if isinstance(graph, GraphContext):
-        graph_outputs = graph.graph.outputs
-    else:
-        graph_outputs = graph.outputs
-    if len(graph_outputs) != 1:
-        return None
-    graph_output = graph_outputs[0]
-    if not isinstance(graph_output.type, TensorType):
-        return None
-    output_shape = graph_output.type.shape
-    if any(dim < 0 for dim in output_shape):
-        return None
-    output_index = source_node.outputs.index(name)
-    if output_count == 4:
-        if len(output_shape) != 4 or output_shape[-1] != 2:
-            return None
-        inferred = {
-            0: output_shape[0],
-            2: output_shape[1],
-            3: output_shape[2],
-        }
-    else:
-        if len(output_shape) != 5 or output_shape[-1] != 3:
-            return None
-        inferred = {
-            0: output_shape[0],
-            2: output_shape[1],
-            3: output_shape[2],
-            4: output_shape[3],
-        }
-    value = inferred.get(output_index)
-    if value is None:
-        return None
-    return [value]
-
-
-def _center_crop_pad_shape_values_from_static_output(
-    graph: Graph | GraphContext,
-    name: str,
-    node: Node | None,
-    *,
-    _visited: set[str],
-) -> list[int] | None:
-    if isinstance(graph, GraphContext):
-        graph_outputs = graph.graph.outputs
-    else:
-        graph_outputs = graph.outputs
-    if len(graph_outputs) != 1:
-        return None
-    output = graph_outputs[0]
-    if not isinstance(output.type, TensorType):
-        return None
-    output_shape = output.type.shape
-    if any(dim < 0 for dim in output_shape):
-        return None
-    slice_node = _find_node_by_output(graph, output.name)
-    if slice_node is None or slice_node.op_type != "Slice":
-        return None
-    if len(slice_node.inputs) < 3:
-        return None
-    end_name = slice_node.inputs[2]
-    add_node = _find_node_by_output(graph, end_name)
-    if add_node is None or add_node.op_type != "Add" or name not in add_node.inputs:
-        return None
-    consumer_ops = {consumer.op_type for consumer in _find_consumers(graph, name)}
-    if not {"Max", "Add", "Sub"}.issubset(consumer_ops):
-        return None
-    axes_values: list[int] | None = None
-    if len(slice_node.inputs) > 3 and slice_node.inputs[3]:
-        axes_values = _shape_values_from_input(
-            graph,
-            slice_node.inputs[3],
-            node,
-            _visited=_visited,
-        )
-        if axes_values is None:
-            return None
-    if axes_values is None:
-        return list(output_shape)
-    rank = len(output_shape)
-    normalized_axes = [axis if axis >= 0 else axis + rank for axis in axes_values]
-    if any(axis < 0 or axis >= rank for axis in normalized_axes):
-        return None
-    return [output_shape[axis] for axis in normalized_axes]
-
-
 def _shape_values_from_input(
     graph: Graph | GraphContext,
     name: str,
@@ -331,19 +235,6 @@ def _shape_values_from_input(
             return shape_values
         source_node = _find_node_by_output(graph, name)
         if source_node is None:
-            value = graph.find_value(name)
-            if isinstance(value.type, TensorType) and value.type.dtype in {
-                ScalarType.I64,
-                ScalarType.I32,
-            }:
-                inferred_values = _center_crop_pad_shape_values_from_static_output(
-                    graph,
-                    name,
-                    node,
-                    _visited=_visited,
-                )
-                if inferred_values is not None:
-                    return inferred_values
             return None
         if source_node.op_type == "Shape":
             return _shape_values_from_shape_node(graph, source_node, node)
@@ -354,10 +245,6 @@ def _shape_values_from_input(
             if any(dim < 0 for dim in input_shape):
                 return None
             return [shape_product(input_shape)]
-        if source_node.op_type == "Split":
-            return _split_shape_values_from_static_graph_output(
-                graph, source_node, name
-            )
         if source_node.op_type == "Concat":
             axis = int(source_node.attrs.get("axis", 0))
             if axis not in {0, -1}:
@@ -494,21 +381,6 @@ def _shape_values_from_input(
                     if step == 0:
                         return None
                     return list(data_values[slice(starts[0], ends[0], step)])
-                data_node = _find_node_by_output(graph, source_node.inputs[0])
-                if (
-                    data_node is not None
-                    and data_node.op_type == "Concat"
-                    and len(data_node.inputs) == 5
-                    and starts == [2]
-                    and ends == [5]
-                    and steps == [1]
-                    and len(graph.outputs) == 1
-                ):
-                    output_shape = value_shape(graph, graph.outputs[0].name, node)
-                    if len(output_shape) == 4 and output_shape[-1] == 2:
-                        return [1, output_shape[1], output_shape[2]]
-                    if len(output_shape) == 5 and output_shape[-1] == 3:
-                        return [output_shape[1], output_shape[2], output_shape[3]]
         if source_node.op_type in {"Equal", "And", "Or", "Div", "Mod"}:
             if len(source_node.inputs) != 2 or len(source_node.outputs) != 1:
                 raise UnsupportedOpError(
@@ -690,12 +562,6 @@ def _numeric_values_from_input(
             if any(dim < 0 for dim in input_shape):
                 return None
             return [shape_product(input_shape)]
-        if source_node.op_type == "Split":
-            split_values = _split_shape_values_from_static_graph_output(
-                graph, source_node, name
-            )
-            if split_values is not None:
-                return split_values
         if source_node.op_type == "Concat":
             axis = int(source_node.attrs.get("axis", 0))
             rank = len(value_shape(graph, source_node.outputs[0], node))

--- a/src/emx_onnx_cgen/onnx_import.py
+++ b/src/emx_onnx_cgen/onnx_import.py
@@ -11,6 +11,7 @@ from shared.scalar_types import ScalarType
 
 from .dtypes import scalar_type_from_onnx
 from .errors import ShapeInferenceError, UnsupportedOpError
+from .symbolic_shapes import infer_symbolic_shapes
 from .ir.model import (
     Graph,
     Initializer,
@@ -2144,6 +2145,13 @@ def prepare_onnx_model(model: onnx.ModelProto) -> onnx.ModelProto:
     prepared, _ = _expand_sequence_map_nodes(prepared)
     prepared, _ = _expand_gradient_nodes(prepared)
     prepared = _maybe_infer_shapes(prepared)
+    # Recover dimensions that depend on the values of runtime integer inputs
+    # (e.g. AffineGrid's `size` or CenterCropPad's target `shape`), which ONNX
+    # shape inference leaves dynamic. Re-run inference afterwards so the newly
+    # concrete dims propagate to the remaining tensors.
+    prepared, enriched = infer_symbolic_shapes(prepared)
+    if enriched:
+        prepared = _maybe_infer_shapes(prepared)
     return prepared
 
 

--- a/src/emx_onnx_cgen/symbolic_shapes.py
+++ b/src/emx_onnx_cgen/symbolic_shapes.py
@@ -1,0 +1,680 @@
+"""Symbolic shape inference with output-constraint solving.
+
+ONNX shape inference (even with data propagation) leaves a tensor's shape
+unresolved whenever it is computed from the *values* of a runtime integer input
+-- for example the ``size`` input of ``AffineGrid`` or the target ``shape`` input
+of ``CenterCropPad``. The decomposed (``*_expanded``) reference functions for
+those operators build their internal shapes from such inputs, so the resulting
+graph keeps dynamic dimensions that block static C generation.
+
+This module recovers those dimensions the principled way: it evaluates the
+shape arithmetic *forward* with the runtime integer inputs treated as symbols,
+collects equations by matching each symbolic shape against the statically
+declared shape of the corresponding value (graph outputs and any value_info that
+already carries concrete dims), solves the system, and writes the resulting
+concrete dimensions back into the graph's value_info.
+
+The pass is deliberately conservative:
+
+* Symbols are only created for the elements of 1-D integer *inputs*. Genuinely
+  dynamic tensor dimensions (e.g. a dynamic batch axis on a float input) never
+  become symbols, so models that are meant to stay dynamic are left untouched.
+* It only ever fills in dimensions that are currently dynamic, and never
+  overwrites an existing concrete dimension with a different value.
+* Any failure to evaluate or solve simply leaves the graph unchanged.
+"""
+
+from __future__ import annotations
+
+import onnx
+from onnx import helper, numpy_helper
+
+try:  # sympy is a transitive dependency via onnxruntime tooling
+    import sympy
+except Exception:  # pragma: no cover - sympy unavailable
+    sympy = None  # type: ignore[assignment]
+
+
+_MAX_DEPTH = 256
+
+
+def _static_shape(value_info: onnx.ValueInfoProto) -> tuple[int, ...] | None:
+    tensor_type = value_info.type.tensor_type
+    if not tensor_type.HasField("shape"):
+        return None
+    dims: list[int] = []
+    for dim in tensor_type.shape.dim:
+        if not dim.HasField("dim_value"):
+            return None
+        dims.append(int(dim.dim_value))
+    return tuple(dims)
+
+
+def _has_dynamic_dims(graph: onnx.GraphProto) -> bool:
+    for value_info in (*graph.value_info, *graph.output):
+        tensor_type = value_info.type.tensor_type
+        if not tensor_type.HasField("shape"):
+            continue
+        for dim in tensor_type.shape.dim:
+            if not dim.HasField("dim_value"):
+                return True
+    return False
+
+
+class _SymbolicEvaluator:
+    def __init__(self, graph: onnx.GraphProto) -> None:
+        self._graph = graph
+        self._initializers = {
+            init.name: numpy_helper.to_array(init) for init in graph.initializer
+        }
+        self._producer: dict[str, onnx.NodeProto] = {}
+        for node in graph.node:
+            for output in node.output:
+                if output:
+                    self._producer[output] = node
+        self._input_info = {value_info.name: value_info for value_info in graph.input}
+        self._static_shapes: dict[str, tuple[int, ...]] = {}
+        for value_info in (*graph.input, *graph.value_info, *graph.output):
+            shape = _static_shape(value_info)
+            if shape is not None:
+                self._static_shapes[value_info.name] = shape
+        self._val_cache: dict[str, list | None] = {}
+        self._shape_cache: dict[str, tuple | None] = {}
+        self._symbol_count = 0
+        self.symbols: dict[str, list] = {}
+
+    # -- helpers ---------------------------------------------------------
+    @staticmethod
+    def _attrs(node: onnx.NodeProto) -> dict[str, object]:
+        return {attr.name: helper.get_attribute_value(attr) for attr in node.attribute}
+
+    def _fresh_symbol(self, tag: str):
+        self._symbol_count += 1
+        return sympy.Symbol(f"{tag}__sym{self._symbol_count}", integer=True)
+
+    # -- integer value evaluation ---------------------------------------
+    def eval_value(self, name: str, depth: int = 0) -> list | None:
+        if name in self._val_cache:
+            return self._val_cache[name]
+        if not name or depth > _MAX_DEPTH:
+            return None
+        self._val_cache[name] = None
+        result: list | None = None
+        if name in self._initializers:
+            array = self._initializers[name]
+            if array.dtype.kind in {"i", "u"} and array.ndim <= 1:
+                result = [sympy.Integer(int(v)) for v in array.reshape(-1)]
+        elif name in self._input_info and name not in self._initializers:
+            result = self._symbolic_input(name)
+        else:
+            node = self._producer.get(name)
+            if node is not None:
+                result = self._eval_value_node(node, name, depth)
+        self._val_cache[name] = result
+        return result
+
+    def _symbolic_input(self, name: str) -> list | None:
+        tensor_type = self._input_info[name].type.tensor_type
+        if tensor_type.elem_type not in {
+            onnx.TensorProto.INT64,
+            onnx.TensorProto.INT32,
+        }:
+            return None
+        shape = self._static_shapes.get(name)
+        if shape is None or len(shape) != 1:
+            return None
+        symbols = [self._fresh_symbol(name) for _ in range(shape[0])]
+        self.symbols[name] = symbols
+        return symbols
+
+    def _eval_value_node(
+        self, node: onnx.NodeProto, name: str, depth: int
+    ) -> list | None:
+        op = node.op_type
+        attrs = self._attrs(node)
+        if op == "Constant":
+            if "value" in attrs:
+                array = numpy_helper.to_array(attrs["value"])
+                if array.dtype.kind in {"i", "u"} and array.ndim <= 1:
+                    return [sympy.Integer(int(v)) for v in array.reshape(-1)]
+                return None
+            if "value_ints" in attrs:
+                return [sympy.Integer(int(v)) for v in attrs["value_ints"]]
+            if "value_int" in attrs:
+                return [sympy.Integer(int(attrs["value_int"]))]
+            return None
+        if op in {"Cast", "Identity", "Flatten"}:
+            return self.eval_value(node.input[0], depth + 1)
+        if op == "Shape":
+            shape = self.eval_shape(node.input[0], depth + 1)
+            if shape is None:
+                return None
+            rank = len(shape)
+            start = int(attrs.get("start", 0))
+            end = attrs.get("end")
+            end = rank if end is None else int(end)
+            if start < 0:
+                start += rank
+            if end < 0:
+                end += rank
+            return list(shape[max(0, start) : max(0, end)])
+        if op == "Size":
+            shape = self.eval_shape(node.input[0], depth + 1)
+            if shape is None:
+                return None
+            product = sympy.Integer(1)
+            for dim in shape:
+                product = product * dim
+            return [product]
+        if op == "Concat":
+            values: list = []
+            for input_name in node.input:
+                part = self.eval_value(input_name, depth + 1)
+                if part is None:
+                    return None
+                values.extend(part)
+            return values
+        if op == "Gather":
+            return self._eval_gather(node, depth)
+        if op == "Slice":
+            return self._eval_slice_values(node, depth)
+        if op in {"Squeeze", "Unsqueeze"}:
+            # Reshaping a 1-D shape vector leaves its element order unchanged.
+            return self.eval_value(node.input[0], depth + 1)
+        if op == "Split":
+            return self._eval_split(node, name, depth)
+        if op in {"Add", "Sub", "Mul", "Div", "Mod", "Max", "Min"}:
+            return self._eval_binary(op, node, depth)
+        return None
+
+    def _eval_gather(self, node: onnx.NodeProto, depth: int) -> list | None:
+        data = self.eval_value(node.input[0], depth + 1)
+        indices = self.eval_value(node.input[1], depth + 1)
+        if data is None or indices is None:
+            return None
+        gathered: list = []
+        for index in indices:
+            if not index.is_Integer:
+                return None
+            position = int(index)
+            if position < 0:
+                position += len(data)
+            if position < 0 or position >= len(data):
+                return None
+            gathered.append(data[position])
+        return gathered
+
+    def _eval_slice_values(self, node: onnx.NodeProto, depth: int) -> list | None:
+        data = self.eval_value(node.input[0], depth + 1)
+        if data is None:
+            return None
+        starts = self.eval_value(node.input[1], depth + 1)
+        ends = self.eval_value(node.input[2], depth + 1)
+        if starts is None or ends is None or len(starts) != 1 or len(ends) != 1:
+            return None
+        axes = (
+            self.eval_value(node.input[3], depth + 1)
+            if len(node.input) > 3 and node.input[3]
+            else [sympy.Integer(0)]
+        )
+        steps = (
+            self.eval_value(node.input[4], depth + 1)
+            if len(node.input) > 4 and node.input[4]
+            else [sympy.Integer(1)]
+        )
+        if axes is None or steps is None:
+            return None
+        if [int(a) for a in axes] != [0] or [int(s) for s in steps] != [1]:
+            return None
+        if not (starts[0].is_Integer and ends[0].is_Integer):
+            return None
+        start = int(starts[0])
+        end = min(int(ends[0]), len(data))
+        return data[start:end]
+
+    def _eval_split(self, node: onnx.NodeProto, name: str, depth: int) -> list | None:
+        data = self.eval_value(node.input[0], depth + 1)
+        if data is None:
+            return None
+        outputs = list(node.output)
+        if len(node.input) > 1 and node.input[1]:
+            sizes_values = self.eval_value(node.input[1], depth + 1)
+            if sizes_values is None or any(not s.is_Integer for s in sizes_values):
+                return None
+            sizes = [int(s) for s in sizes_values]
+        else:
+            count = len(outputs)
+            if count == 0 or len(data) % count != 0:
+                return None
+            sizes = [len(data) // count] * count
+        if sum(sizes) != len(data):
+            return None
+        offset = 0
+        for output_name, size in zip(outputs, sizes):
+            self._val_cache[output_name] = data[offset : offset + size]
+            offset += size
+        return self._val_cache.get(name)
+
+    def _eval_binary(self, op: str, node: onnx.NodeProto, depth: int) -> list | None:
+        left = self.eval_value(node.input[0], depth + 1)
+        right = self.eval_value(node.input[1], depth + 1)
+        if left is None or right is None:
+            return None
+        if len(left) == 1 and len(right) != 1:
+            left = left * len(right)
+        if len(right) == 1 and len(left) != 1:
+            right = right * len(left)
+        if len(left) != len(right):
+            return None
+
+        def divide(a, b):
+            if a.is_Integer and b.is_Integer:
+                return sympy.Integer(int(a) // int(b))
+            return a / b
+
+        ops = {
+            "Add": lambda a, b: a + b,
+            "Sub": lambda a, b: a - b,
+            "Mul": lambda a, b: a * b,
+            "Div": divide,
+            "Mod": lambda a, b: a % b,
+            "Max": sympy.Max,
+            "Min": sympy.Min,
+        }
+        func = ops[op]
+        return [func(a, b) for a, b in zip(left, right)]
+
+    # -- shape evaluation ------------------------------------------------
+    def eval_shape(self, name: str, depth: int = 0) -> tuple | None:
+        if name in self._shape_cache:
+            return self._shape_cache[name]
+        if not name or depth > _MAX_DEPTH:
+            return None
+        self._shape_cache[name] = None
+        result: tuple | None = None
+        if name in self._initializers:
+            result = tuple(sympy.Integer(d) for d in self._initializers[name].shape)
+        elif name in self._input_info and name in self._static_shapes:
+            result = tuple(sympy.Integer(d) for d in self._static_shapes[name])
+        else:
+            node = self._producer.get(name)
+            if node is not None:
+                result = self._eval_shape_node(node, depth)
+            elif name in self._static_shapes:
+                result = tuple(sympy.Integer(d) for d in self._static_shapes[name])
+        self._shape_cache[name] = result
+        return result
+
+    _SHAPE_PRESERVING = frozenset(
+        {
+            "Cast",
+            "CastLike",
+            "Identity",
+            "Relu",
+            "Neg",
+            "Abs",
+            "Sqrt",
+            "Reciprocal",
+            "Sigmoid",
+            "Tanh",
+            "Exp",
+            "Log",
+            "Erf",
+            "Clip",
+            "Elu",
+            "LeakyRelu",
+        }
+    )
+
+    def _eval_shape_node(self, node: onnx.NodeProto, depth: int) -> tuple | None:
+        op = node.op_type
+        attrs = self._attrs(node)
+        if op == "Reshape":
+            return self._eval_reshape_shape(node, depth)
+        if op == "ConstantOfShape":
+            values = self.eval_value(node.input[0], depth + 1)
+            return tuple(values) if values is not None else None
+        if op in self._SHAPE_PRESERVING:
+            return self.eval_shape(node.input[0], depth + 1)
+        if op == "Transpose":
+            return self._eval_transpose_shape(node, attrs, depth)
+        if op == "Unsqueeze":
+            return self._eval_unsqueeze_shape(node, attrs, depth)
+        if op == "Squeeze":
+            return self._eval_squeeze_shape(node, attrs, depth)
+        if op == "Slice":
+            return self._eval_slice_shape(node, depth)
+        if op == "Pad":
+            return self._eval_pad_shape(node, depth)
+        if op == "MatMul":
+            left = self.eval_shape(node.input[0], depth + 1)
+            right = self.eval_shape(node.input[1], depth + 1)
+            if left is None or right is None or len(right) < 1:
+                return None
+            return tuple([*left[:-1], right[-1]])
+        if op == "Concat":
+            return self._eval_concat_shape(node, attrs, depth)
+        if op == "Range":
+            return self._eval_range_shape(node, depth)
+        if op == "Expand":
+            return self._eval_expand_shape(node, depth)
+        if op in self._ELEMENTWISE_BINARY:
+            return self._eval_broadcast_shape(node, depth)
+        return None
+
+    _ELEMENTWISE_BINARY = frozenset(
+        {
+            "Add",
+            "Sub",
+            "Mul",
+            "Div",
+            "Mod",
+            "Pow",
+            "Max",
+            "Min",
+            "Equal",
+            "Greater",
+            "Less",
+            "And",
+            "Or",
+        }
+    )
+
+    def _eval_range_shape(self, node: onnx.NodeProto, depth: int) -> tuple | None:
+        start = self.eval_value(node.input[0], depth + 1)
+        limit = self.eval_value(node.input[1], depth + 1)
+        delta = self.eval_value(node.input[2], depth + 1)
+        if not (start and limit and delta):
+            return None
+        start_v, limit_v, delta_v = start[0], limit[0], delta[0]
+        if delta_v == 1 and start_v == 0:
+            length = limit_v
+        elif delta_v.is_Integer and start_v.is_Integer:
+            length = sympy.ceiling((limit_v - start_v) / delta_v)
+        else:
+            return None
+        return (sympy.Max(sympy.Integer(0), length),)
+
+    def _eval_expand_shape(self, node: onnx.NodeProto, depth: int) -> tuple | None:
+        source = self.eval_shape(node.input[0], depth + 1)
+        target = self.eval_value(node.input[1], depth + 1)
+        if source is None or target is None:
+            return None
+        return self._broadcast(source, tuple(target))
+
+    def _eval_broadcast_shape(self, node: onnx.NodeProto, depth: int) -> tuple | None:
+        result: tuple | None = ()
+        for input_name in node.input:
+            shape = self.eval_shape(input_name, depth + 1)
+            if shape is None:
+                return None
+            result = self._broadcast(result, shape)
+            if result is None:
+                return None
+        return result
+
+    @staticmethod
+    def _broadcast(left: tuple, right: tuple) -> tuple | None:
+        result: list = []
+        for i in range(max(len(left), len(right))):
+            a = left[-1 - i] if i < len(left) else sympy.Integer(1)
+            b = right[-1 - i] if i < len(right) else sympy.Integer(1)
+            if a.is_Integer and int(a) == 1:
+                result.append(b)
+            elif b.is_Integer and int(b) == 1:
+                result.append(a)
+            elif a == b:
+                result.append(a)
+            else:
+                return None
+        return tuple(reversed(result))
+
+    def _eval_reshape_shape(self, node: onnx.NodeProto, depth: int) -> tuple | None:
+        target = self.eval_value(node.input[1], depth + 1)
+        if target is None:
+            return None
+        source = self.eval_shape(node.input[0], depth + 1)
+        dims = list(target)
+        for index, dim in enumerate(dims):
+            if dim == 0 and source is not None and index < len(source):
+                dims[index] = source[index]
+        if any(dim == -1 for dim in dims):
+            if source is None:
+                return None
+            total = sympy.Integer(1)
+            for dim in source:
+                total = total * dim
+            known = sympy.Integer(1)
+            for dim in dims:
+                if dim != -1:
+                    known = known * dim
+            for index, dim in enumerate(dims):
+                if dim == -1:
+                    dims[index] = sympy.simplify(total / known)
+        return tuple(dims)
+
+    def _eval_transpose_shape(self, node, attrs, depth) -> tuple | None:
+        shape = self.eval_shape(node.input[0], depth + 1)
+        if shape is None:
+            return None
+        perm = attrs.get("perm")
+        if perm is None:
+            perm = list(range(len(shape)))[::-1]
+        return tuple(shape[p] for p in perm)
+
+    def _eval_unsqueeze_shape(self, node, attrs, depth) -> tuple | None:
+        shape = self.eval_shape(node.input[0], depth + 1)
+        axes = (
+            self.eval_value(node.input[1], depth + 1)
+            if len(node.input) > 1 and node.input[1]
+            else attrs.get("axes")
+        )
+        if shape is None or axes is None:
+            return None
+        axes = [int(a) for a in axes]
+        rank = len(shape) + len(axes)
+        normalized = sorted((a + rank if a < 0 else a) for a in axes)
+        dims = list(shape)
+        for axis in normalized:
+            dims.insert(axis, sympy.Integer(1))
+        return tuple(dims)
+
+    def _eval_squeeze_shape(self, node, attrs, depth) -> tuple | None:
+        shape = self.eval_shape(node.input[0], depth + 1)
+        if shape is None:
+            return None
+        axes = (
+            self.eval_value(node.input[1], depth + 1)
+            if len(node.input) > 1 and node.input[1]
+            else attrs.get("axes")
+        )
+        if axes is None:
+            return tuple(dim for dim in shape if dim != 1)
+        rank = len(shape)
+        normalized = {int(a) + rank if int(a) < 0 else int(a) for a in axes}
+        return tuple(dim for index, dim in enumerate(shape) if index not in normalized)
+
+    def _eval_slice_shape(self, node: onnx.NodeProto, depth: int) -> tuple | None:
+        shape = self.eval_shape(node.input[0], depth + 1)
+        if shape is None:
+            return None
+        starts = self.eval_value(node.input[1], depth + 1)
+        ends = self.eval_value(node.input[2], depth + 1)
+        if starts is None or ends is None:
+            return None
+        axes = (
+            self.eval_value(node.input[3], depth + 1)
+            if len(node.input) > 3 and node.input[3]
+            else None
+        )
+        steps = (
+            self.eval_value(node.input[4], depth + 1)
+            if len(node.input) > 4 and node.input[4]
+            else None
+        )
+        rank = len(shape)
+        axis_list = (
+            [int(a) for a in axes] if axes is not None else list(range(len(starts)))
+        )
+        step_list = [int(s) for s in steps] if steps is not None else [1] * len(starts)
+        dims = list(shape)
+        for index, axis in enumerate(axis_list):
+            if step_list[index] != 1:
+                return None
+            axis = axis + rank if axis < 0 else axis
+            start = starts[index]
+            end = ends[index]
+            dim = shape[axis]
+            if start.is_Integer and end.is_Integer and dim.is_Integer:
+                extent = int(dim)
+                start_i = int(start) + extent if int(start) < 0 else int(start)
+                end_i = int(end) + extent if int(end) < 0 else int(end)
+                end_i = min(end_i, extent)
+                start_i = max(0, min(start_i, extent))
+                dims[axis] = sympy.Integer(max(0, end_i - start_i))
+            else:
+                # Symbolic crop: trust end - start (clamping is not modelled).
+                dims[axis] = sympy.simplify(end - start)
+        return tuple(dims)
+
+    def _eval_pad_shape(self, node: onnx.NodeProto, depth: int) -> tuple | None:
+        shape = self.eval_shape(node.input[0], depth + 1)
+        pads = (
+            self.eval_value(node.input[1], depth + 1)
+            if len(node.input) > 1 and node.input[1]
+            else None
+        )
+        if shape is None or pads is None:
+            return None
+        rank = len(shape)
+        # Pad-18 adds an optional `axes` input; pads then covers only those axes.
+        if len(node.input) > 3 and node.input[3]:
+            axes = self.eval_value(node.input[3], depth + 1)
+            if axes is None:
+                return None
+            axes = [int(a) + rank if int(a) < 0 else int(a) for a in axes]
+        else:
+            axes = list(range(rank))
+        if len(pads) != 2 * len(axes):
+            return None
+        dims = list(shape)
+        for index, axis in enumerate(axes):
+            dims[axis] = dims[axis] + pads[index] + pads[index + len(axes)]
+        return tuple(dims)
+
+    def _eval_concat_shape(self, node, attrs, depth) -> tuple | None:
+        shapes = [self.eval_shape(input_name, depth + 1) for input_name in node.input]
+        if any(shape is None for shape in shapes):
+            return None
+        rank = len(shapes[0])
+        axis = int(attrs.get("axis", 0))
+        axis = axis + rank if axis < 0 else axis
+        dims = list(shapes[0])
+        total = sympy.Integer(0)
+        for shape in shapes:
+            total = total + shape[axis]
+        dims[axis] = total
+        return tuple(dims)
+
+
+def infer_symbolic_shapes(model: onnx.ModelProto) -> tuple[onnx.ModelProto, bool]:
+    """Fill dynamic value_info dims that are determined by runtime integer inputs.
+
+    Returns ``(model, changed)`` where ``changed`` indicates whether any concrete
+    dimension was recovered and written back.
+    """
+
+    if sympy is None:
+        return model, False
+    graph = model.graph
+    if not _has_dynamic_dims(graph):
+        return model, False
+
+    evaluator = _SymbolicEvaluator(graph)
+
+    # Collect equations: every value with a declared concrete shape constrains
+    # its symbolically inferred shape.
+    equations = []
+    constrained_names = {value_info.name for value_info in graph.output}
+    constrained_names.update(evaluator._static_shapes)
+    for name in constrained_names:
+        declared = evaluator._static_shapes.get(name)
+        if declared is None:
+            continue
+        inferred = evaluator.eval_shape(name)
+        if inferred is None or len(inferred) != len(declared):
+            continue
+        for declared_dim, inferred_dim in zip(declared, inferred):
+            if inferred_dim is None or inferred_dim.is_Integer:
+                continue
+            equations.append(sympy.Eq(inferred_dim, declared_dim))
+
+    if not equations:
+        return model, False
+    try:
+        solutions = sympy.solve(equations, dict=True)
+    except Exception:  # pragma: no cover - solver failure is non-fatal
+        return model, False
+    if not solutions:
+        return model, False
+    solution = solutions[0]
+    if not solution:
+        return model, False
+
+    # Substitute the solved symbols into every tensor's inferred shape and write
+    # back the ones that become fully concrete and non-negative.
+    resolved: dict[str, tuple[int, ...]] = {}
+    names = {name for node in graph.node for name in node.output if name}
+    names.update(value_info.name for value_info in graph.output)
+    for name in names:
+        if name in evaluator._static_shapes:
+            continue
+        inferred = evaluator.eval_shape(name)
+        if inferred is None:
+            continue
+        concrete: list[int] = []
+        ok = True
+        for dim in inferred:
+            if dim is None:
+                ok = False
+                break
+            value = dim.subs(solution)
+            if not value.is_Integer or int(value) < 0:
+                ok = False
+                break
+            concrete.append(int(value))
+        if ok:
+            resolved[name] = tuple(concrete)
+
+    if not resolved:
+        return model, False
+    _apply_resolved_shapes(graph, resolved)
+    return model, True
+
+
+def _apply_resolved_shapes(
+    graph: onnx.GraphProto, resolved: dict[str, tuple[int, ...]]
+) -> None:
+    for value_info in graph.value_info:
+        _maybe_set_dims(value_info, resolved.get(value_info.name))
+    for value_info in graph.output:
+        _maybe_set_dims(value_info, resolved.get(value_info.name))
+
+
+def _maybe_set_dims(
+    value_info: onnx.ValueInfoProto, shape: tuple[int, ...] | None
+) -> None:
+    if shape is None:
+        return
+    tensor_type = value_info.type.tensor_type
+    if not tensor_type.HasField("shape"):
+        return
+    dims = tensor_type.shape.dim
+    if len(dims) != len(shape):
+        return
+    for dim, value in zip(dims, shape):
+        if dim.HasField("dim_value"):
+            # Never overwrite an existing concrete dimension.
+            continue
+        dim.ClearField("dim_param")
+        dim.dim_value = value

--- a/src/emx_onnx_cgen/symbolic_shapes.py
+++ b/src/emx_onnx_cgen/symbolic_shapes.py
@@ -27,12 +27,8 @@ The pass is deliberately conservative:
 from __future__ import annotations
 
 import onnx
+import sympy
 from onnx import helper, numpy_helper
-
-try:  # sympy is a transitive dependency via onnxruntime tooling
-    import sympy
-except Exception:  # pragma: no cover - sympy unavailable
-    sympy = None  # type: ignore[assignment]
 
 
 _MAX_DEPTH = 256
@@ -584,8 +580,6 @@ def infer_symbolic_shapes(model: onnx.ModelProto) -> tuple[onnx.ModelProto, bool
     dimension was recovered and written back.
     """
 
-    if sympy is None:
-        return model, False
     graph = model.graph
     if not _has_dynamic_dims(graph):
         return model, False

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_and_pad_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_and_pad_expanded__model.onnx.json
@@ -14,5 +14,5 @@
     "Slice"
   ],
   "opset_version": 18,
-  "generated_checksum": "5f70acaf5a9e998a3e3778e43debe21e2fd99f2f0330b47bda95524d8d980b4f"
+  "generated_checksum": "249fd1a35a6459be3fcdc5d61290e83f5fb3c8912d7c9df0e3de21c4094a31bf"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_axes_chw_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_axes_chw_expanded__model.onnx.json
@@ -15,5 +15,5 @@
     "Slice"
   ],
   "opset_version": 18,
-  "generated_checksum": "a286c188fae5de2e79aeffe739f9dd9ef3e50c79c45768b4849a11cce7a53094"
+  "generated_checksum": "8705235ed207323c7b8b11c1ad22d1c741ee45cd18fd283c5b396a9d4ebc4e59"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_axes_hwc_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_axes_hwc_expanded__model.onnx.json
@@ -15,5 +15,5 @@
     "Slice"
   ],
   "opset_version": 18,
-  "generated_checksum": "6b34600b6b508f7ba2afde03f14bd34c6bd4f34f401ecd66714b7369d56e9db9"
+  "generated_checksum": "c1329e1c78c60c3d71c7be5213d791185a91664f1a06f2a09cab998a4e8acfda"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_expanded__model.onnx.json
@@ -14,5 +14,5 @@
     "Slice"
   ],
   "opset_version": 18,
-  "generated_checksum": "734386dd289e1bd6607273041ec3a7930623128215798775a97f36831adf5a2a"
+  "generated_checksum": "9d401be7eeb8c20717984202b17fee8b803b2add1ce481f5c78fab7ce4b367be"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_negative_axes_hwc_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_crop_negative_axes_hwc_expanded__model.onnx.json
@@ -15,5 +15,5 @@
     "Slice"
   ],
   "opset_version": 18,
-  "generated_checksum": "6b41ce1d603f0fb7eef4888e5a04b40a981fdd5dff62c7ab7d9eff5339d85cbd"
+  "generated_checksum": "d03a43d2cff9ead64e8a2c40c45bf2ec4b63050b7f87337c698435b5452f6acf"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_pad_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_center_crop_pad_pad_expanded__model.onnx.json
@@ -14,5 +14,5 @@
     "Slice"
   ],
   "opset_version": 18,
-  "generated_checksum": "74e26d2b107c69c41d9b838b96fda6ecf5593bcd378a462ff11bee06843a7297"
+  "generated_checksum": "48d3fa63172fff8af645b0b93bebbc293905e09f79de43bcc9cd2d880e871f65"
 }

--- a/tests/test_symbolic_shapes.py
+++ b/tests/test_symbolic_shapes.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import onnx
+from onnx import TensorProto, helper, shape_inference
+
+from emx_onnx_cgen.symbolic_shapes import infer_symbolic_shapes
+
+
+def _dims(value_info: onnx.ValueInfoProto) -> list[object]:
+    dims = []
+    for dim in value_info.type.tensor_type.shape.dim:
+        dims.append(dim.dim_value if dim.HasField("dim_value") else dim.dim_param)
+    return dims
+
+
+def _value_info(model: onnx.ModelProto, name: str) -> onnx.ValueInfoProto:
+    for value_info in (*model.graph.value_info, *model.graph.output):
+        if value_info.name == name:
+            return value_info
+    raise KeyError(name)
+
+
+def test_reshape_target_resolved_from_static_output() -> None:
+    # `r` is reshaped using the runtime `size` input, so ONNX leaves its shape
+    # dynamic. The declared static output pins the symbols and the pass fills it.
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [12])
+    size = helper.make_tensor_value_info("size", TensorProto.INT64, [2])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [3, 4])
+    nodes = [
+        helper.make_node("Reshape", ["x", "size"], ["r"]),
+        helper.make_node("Relu", ["r"], ["y"]),
+    ]
+    graph = helper.make_graph(nodes, "reshape_graph", [x, size], [y])
+    model = helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 18)])
+    model.ir_version = 9
+    model = shape_inference.infer_shapes(model, data_prop=True)
+
+    # Precondition: the intermediate is dynamic before the pass.
+    assert any(isinstance(d, str) for d in _dims(_value_info(model, "r")))
+
+    model, changed = infer_symbolic_shapes(model)
+    assert changed
+    assert _dims(_value_info(model, "r")) == [3, 4]
+
+
+def test_dynamic_batch_is_left_untouched() -> None:
+    # A genuinely dynamic dimension (no runtime integer input feeds it) must not
+    # be pinned to a concrete value.
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, ["batch", 4])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, ["batch", 4])
+    graph = helper.make_graph(
+        [helper.make_node("Relu", ["x"], ["y"])], "dyn_graph", [x], [y]
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 18)])
+    model.ir_version = 9
+    model = shape_inference.infer_shapes(model, data_prop=True)
+
+    model, changed = infer_symbolic_shapes(model)
+    assert not changed
+    assert _dims(model.graph.output[0]) == ["batch", 4]
+
+
+def test_existing_static_dim_is_never_overwritten() -> None:
+    # The pass only fills dynamic dims; concrete dims declared on outputs stay.
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [12])
+    size = helper.make_tensor_value_info("size", TensorProto.INT64, [2])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [3, 4])
+    graph = helper.make_graph(
+        [helper.make_node("Reshape", ["x", "size"], ["y"])],
+        "reshape_out_graph",
+        [x, size],
+        [y],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 18)])
+    model.ir_version = 9
+    model = shape_inference.infer_shapes(model, data_prop=True)
+
+    model, _ = infer_symbolic_shapes(model)
+    assert _dims(model.graph.output[0]) == [3, 4]


### PR DESCRIPTION
## Summary

Replaces three brittle "back-inference" shape heuristics in `lowering/common.py` with a general, principled **symbolic shape-solving** pass (`symbolic_shapes.py`).

The removed heuristics recovered dynamic shapes for the expanded **AffineGrid** and **CenterCropPad** reference functions by pattern-matching specific graph structures and hardcoded magic dimensions:
- `len(data_node.inputs) == 5 and starts == [2] and ends == [5]` → `output_shape[-1] == 2/3` mappings
- `Split` with exactly 4 or 5 outputs + fixed output-index maps
- a structural match on `graph-output → Slice → Add` with consumers `{Max, Add, Sub}`

They worked, but only for those exact patterns.

## Why these shapes were dynamic

The dimensions are computed from the **values** of a runtime integer input (AffineGrid's `size`, CenterCropPad's target `shape`), which ONNX shape inference does not propagate — so the decomposed graphs keep dynamic dims that block static C generation.

## The replacement

`infer_symbolic_shapes` evaluates the shape arithmetic **forward** with those input elements as symbols, equates each symbolic shape against the statically declared shapes (graph outputs / value_info), solves the system, and writes the recovered concrete dimensions back. The remaining shapes then resolve through normal forward inference. (Forward evaluation + output-pinning sidesteps the non-invertible `Slice` that blocks pure backward propagation.)

## Safety

- Symbols are only created for **1-D integer inputs**, so genuinely dynamic dims (e.g. a dynamic batch axis on a float input) are never pinned.
- Only fills dimensions that are currently dynamic; never overwrites an existing concrete dim; any evaluation/solve failure leaves the graph unchanged.
- Across the full **6223-model corpus** the pass modifies **exactly the 10 models** the removed heuristics handled, and produces shapes that match onnxruntime ground truth (0 mismatches).

## Result

- **−134 lines** of pattern-matching heuristics removed; **+1** focused, unit-tested module.
- All 10 affected models behave identically to before; 6 CenterCropPad checksum refs refreshed (error strings unchanged).
- New unit tests in `tests/test_symbolic_shapes.py` cover the core inversion, the dynamic-dim safety guard, and the no-overwrite guarantee.

> Note on the two 3D AffineGrid models showing "Out of tolerance" locally: that is a pre-existing environment/float artifact — the **non-expanded** `test_affine_grid_3d` (which touches none of this code) fails identically locally and is "OK" in CI. Their refs are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qqeyuyo2Aict2X2FV3UGcQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qqeyuyo2Aict2X2FV3UGcQ)_