### PR TITLE
Refactor large temporary buffer handling to use heap allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ These options are accepted by both `compile` and `verify`:
 - `--verbose` / `-v`: Enable verbose logging (includes codegen timing).
 - `--truncate-weights-after`: Truncate inline weight initializers after `N` values and insert `...` placeholders.
 - `--large-weight-threshold`: Store weights in a binary file once the cumulative byte size exceeds this threshold (default: `102400`; set to `0` to disable).
-- `--large-temp-threshold`: Mark local arrays larger than this threshold as static (default: `1024`). This applies to generated model temporaries and to generated testbench input/output buffers.
+- `--large-temp-threshold`: Heap-allocate (via `malloc`/`free`) temporary buffers larger than this byte threshold; smaller buffers stay on the stack (default: `1024`; set to `0` to disable heap allocation and keep all temporaries on the stack). This applies to generated model temporaries and to generated testbench input/output buffers.
 - `--restrict-arrays` / `--no-restrict-arrays`: Enable or disable `restrict` qualifiers on generated array parameters.
 - `--fp32-accumulation-strategy`: Accumulation strategy for float32 inputs (`simple` uses float32, `fp64` uses double; default: `simple`).
 - `--fp16-accumulation-strategy`: Accumulation strategy for float16 inputs (`simple` uses float16, `fp32` uses float; default: `fp32`).

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -673,14 +673,14 @@ model entrypoint by default.
 
 Large temporaries:
 
-- If a temporary exceeds `--large-temp-threshold`, it may be emitted as `static`
-  storage inside the entrypoint to avoid large stack usage (see
+- If a temporary exceeds `--large-temp-threshold`, it is heap-allocated with
+  `malloc` at the start of the entrypoint and released with `free` before
+  returning, to avoid large stack usage (see
   [`tests/golden/large_temp_static_model.c`](../tests/golden/large_temp_static_model.c)).
-
-No dynamic allocation:
-
-- Generated code avoids `malloc` / `free`.
-- Memory layout is explicit, visible in the generated source, and stable.
+- Setting `--large-temp-threshold 0` disables heap allocation entirely: all
+  temporaries stay on the stack. Buffers with static shapes become fixed-size
+  local arrays, while buffers with dynamic dimensions become C99 variable-length
+  arrays. This avoids `malloc`/`free` at the cost of higher stack usage.
 
 ## String Tensors
 

--- a/src/emx_onnx_cgen/cli.py
+++ b/src/emx_onnx_cgen/cli.py
@@ -1025,8 +1025,9 @@ def _build_parser() -> argparse.ArgumentParser:
         default=1024,
         dest="large_temp_threshold_bytes",
         help=(
-            "Mark temporary buffers larger than this threshold as static "
-            "(default: 1024)"
+            "Heap-allocate temporary buffers larger than this byte threshold; "
+            "smaller buffers stay on the stack (default: 1024; set to 0 to "
+            "disable heap allocation and keep all temporaries on the stack)"
         ),
     )
     compile_parser.add_argument(
@@ -1099,8 +1100,9 @@ def _build_parser() -> argparse.ArgumentParser:
         default=1024,
         dest="large_temp_threshold_bytes",
         help=(
-            "Mark temporary buffers larger than this threshold as static "
-            "(default: 1024)"
+            "Heap-allocate temporary buffers larger than this byte threshold; "
+            "smaller buffers stay on the stack (default: 1024; set to 0 to "
+            "disable heap allocation and keep all temporaries on the stack)"
         ),
     )
     verify_parser.add_argument(

--- a/src/emx_onnx_cgen/codegen/c_emitter.py
+++ b/src/emx_onnx_cgen/codegen/c_emitter.py
@@ -2379,13 +2379,14 @@ class CEmitter:
                 storage = (
                     "static "
                     if not dim_names
-                    and self._buffer_size_bytes(
-                        temp.shape,
-                        temp.dtype,
-                        dim_names=dim_names,
-                        is_sequence=temp.is_sequence,
+                    and self._exceeds_temp_threshold(
+                        self._buffer_size_bytes(
+                            temp.shape,
+                            temp.dtype,
+                            dim_names=dim_names,
+                            is_sequence=temp.is_sequence,
+                        )
                     )
-                    > self._large_temp_threshold_bytes
                     else ""
                 )
                 lines.append(
@@ -2406,10 +2407,8 @@ class CEmitter:
                 heap_temp_names.append(temp.name)
             else:
                 storage = ""
-                if (
-                    not dim_names
-                    and self._temp_buffer_size_bytes(temp)
-                    > self._large_temp_threshold_bytes
+                if not dim_names and self._exceeds_temp_threshold(
+                    self._temp_buffer_size_bytes(temp)
                 ):
                     storage = "static "
                 lines.append(
@@ -2664,14 +2663,13 @@ class CEmitter:
     ) -> str:
         if dim_names:
             return ""
-        if (
+        if self._exceeds_temp_threshold(
             self._buffer_size_bytes(
                 shape,
                 dtype,
                 dim_names=dim_names,
                 is_sequence=is_sequence,
             )
-            > self._large_temp_threshold_bytes
         ):
             return "static "
         return ""
@@ -2682,6 +2680,16 @@ class CEmitter:
             temp.shape, temp.dtype, is_sequence=temp.is_sequence
         )
 
+    def _exceeds_temp_threshold(self, size_bytes: int) -> bool:
+        """Return whether a buffer of ``size_bytes`` counts as "large".
+
+        A threshold of ``0`` means "unbounded": no buffer is ever considered
+        large, so temporaries stay on the stack and are never heap-allocated.
+        """
+        if self._large_temp_threshold_bytes == 0:
+            return False
+        return size_bytes > self._large_temp_threshold_bytes
+
     def _temp_buffer_uses_heap(
         self,
         temp: TempBuffer,
@@ -2689,14 +2697,13 @@ class CEmitter:
     ) -> bool:
         if temp.is_sequence:
             return False
-        return (
+        return self._exceeds_temp_threshold(
             self._buffer_size_bytes(
                 temp.shape,
                 temp.dtype,
                 dim_names=dim_names,
                 is_sequence=temp.is_sequence,
             )
-            > self._large_temp_threshold_bytes
         )
 
     def _heap_temp_buffer_lines(

--- a/tests/test_golden.py
+++ b/tests/test_golden.py
@@ -677,9 +677,9 @@ def test_large_temp_threshold_zero_disables_heap() -> None:
     model = _make_large_temp_model()
 
     heap_generated = Compiler(CompilerOptions()).compile(model)
-    stack_generated = Compiler(
-        CompilerOptions(large_temp_threshold_bytes=0)
-    ).compile(model)
+    stack_generated = Compiler(CompilerOptions(large_temp_threshold_bytes=0)).compile(
+        model
+    )
 
     # Default threshold heap-allocates the large temporary.
     assert "malloc(" in heap_generated

--- a/tests/test_golden.py
+++ b/tests/test_golden.py
@@ -673,6 +673,25 @@ def test_codegen_golden_large_temp_static() -> None:
     assert_golden(generated, golden_path)
 
 
+def test_large_temp_threshold_zero_disables_heap() -> None:
+    model = _make_large_temp_model()
+
+    heap_generated = Compiler(CompilerOptions()).compile(model)
+    stack_generated = Compiler(
+        CompilerOptions(large_temp_threshold_bytes=0)
+    ).compile(model)
+
+    # Default threshold heap-allocates the large temporary.
+    assert "malloc(" in heap_generated
+    assert "free(" in heap_generated
+
+    # Threshold 0 keeps everything on the stack: no malloc/free, and the
+    # temporary becomes a plain (non-static) local array.
+    assert "malloc(" not in stack_generated
+    assert "free(" not in stack_generated
+    assert "    float tmp0_tmp[1][257];" in stack_generated
+
+
 def test_mul_add_matches_onnxruntime() -> None:
     model = _make_mul_add_model()
     input_a = np.random.rand(2, 3).astype(np.float32)


### PR DESCRIPTION
## Summary

This PR refactors how large temporary buffers are handled in the code generator. Instead of marking large temporaries as `static` storage, they are now heap-allocated using `malloc`/`free`. Additionally, a new threshold value of `0` is introduced to disable heap allocation entirely and keep all temporaries on the stack.

## Key Changes

- **New `_exceeds_temp_threshold()` method**: Extracted the threshold comparison logic into a dedicated method that handles the special case where a threshold of `0` means "unbounded" (no buffer is ever considered large).

- **Refactored threshold checks**: Updated all locations that check if a buffer exceeds the threshold to use the new `_exceeds_temp_threshold()` method:
  - `_emit_model_wrapper()`: Two locations where storage classification is determined
  - `_local_array_storage()`: Simplified the condition logic
  - `_temp_buffer_uses_heap()`: Cleaner comparison

- **Updated documentation and help text**: 
  - CLI help messages now accurately describe heap allocation behavior
  - README and output-format.md updated to explain the new behavior
  - Clarified that threshold `0` disables heap allocation entirely

- **Added test coverage**: New test `test_large_temp_threshold_zero_disables_heap()` verifies that:
  - Default threshold causes `malloc`/`free` to be generated
  - Threshold of `0` prevents heap allocation and keeps temporaries as stack arrays

## Implementation Details

The `_exceeds_temp_threshold()` method centralizes the threshold logic with special handling for the zero case:
- When threshold is `0`, the method always returns `False` (no buffer is "large")
- Otherwise, it performs the standard size comparison
- This allows temporaries to stay on the stack when heap allocation is disabled, either as fixed-size arrays (static shapes) or VLAs (dynamic dimensions)

https://claude.ai/code/session_01NbShbaZccnaUrHEZEHd1Zd