### PR TITLE
import: back-propagate declared shapes through shape-preserving ops

### DIFF
--- a/ONNX_ERRORS.md
+++ b/ONNX_ERRORS.md
@@ -9,8 +9,6 @@ Aggregates non-success verification outcomes.
 | --- | --- | --- |
 | Out of tolerance | 38 | 7, 17 |
 | Unsupported value type '*' for '*'. Hint: export the model with tensor inputs/outputs. | 8 |  |
-| Unsupported op Loop (while lowering node_index=9, op_type=Loop, name=<unnamed>, inputs=[Range_test_range_bfloat16_type_positive_delta_expanded_function_n: tensor[dtype=int64, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_loop_cond: tensor[dtype=bool, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_start_s: tensor[dtype=float, shape=()]], outputs=[Range_test_range_bfloat16_type_positive_delta_expanded_function_variadic_output: tensor[dtype=float, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_output_s: tensor[dtype=float, shape=()]]) | 1 | 27 |
-| Unsupported op Loop (while lowering node_index=9, op_type=Loop, name=<unnamed>, inputs=[Range_test_range_float16_type_positive_delta_expanded_function_n: tensor[dtype=int64, shape=()], Range_test_range_float16_type_positive_delta_expanded_function_loop_cond: tensor[dtype=bool, shape=()], Range_test_range_float16_type_positive_delta_expanded_function_start_s: tensor[dtype=float, shape=()]], outputs=[Range_test_range_float16_type_positive_delta_expanded_function_variadic_output: tensor[dtype=float, shape=()], Range_test_range_float16_type_positive_delta_expanded_function_output_s: tensor[dtype=float, shape=()]]) | 1 | 27 |
 
 ## Error frequency by opset
 
@@ -18,8 +16,6 @@ Aggregates non-success verification outcomes.
 | --- | --- | --- |
 | Out of tolerance | 7 | 4 |
 | Out of tolerance | 17 | 13 |
-| Unsupported op Loop (while lowering node_index=9, op_type=Loop, name=<unnamed>, inputs=[Range_test_range_bfloat16_type_positive_delta_expanded_function_n: tensor[dtype=int64, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_loop_cond: tensor[dtype=bool, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_start_s: tensor[dtype=float, shape=()]], outputs=[Range_test_range_bfloat16_type_positive_delta_expanded_function_variadic_output: tensor[dtype=float, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_output_s: tensor[dtype=float, shape=()]]) | 27 | 1 |
-| Unsupported op Loop (while lowering node_index=9, op_type=Loop, name=<unnamed>, inputs=[Range_test_range_float16_type_positive_delta_expanded_function_n: tensor[dtype=int64, shape=()], Range_test_range_float16_type_positive_delta_expanded_function_loop_cond: tensor[dtype=bool, shape=()], Range_test_range_float16_type_positive_delta_expanded_function_start_s: tensor[dtype=float, shape=()]], outputs=[Range_test_range_float16_type_positive_delta_expanded_function_variadic_output: tensor[dtype=float, shape=()], Range_test_range_float16_type_positive_delta_expanded_function_output_s: tensor[dtype=float, shape=()]]) | 27 | 1 |
 
 ## Failing ONNX files
 
@@ -27,8 +23,6 @@ Lists every ONNX file with a non-success verification outcome.
 
 | File | Opset | Verification | Supported | Error |
 | --- | --- | --- | --- | --- |
-| node/test_range_bfloat16_type_positive_delta_expanded/model.onnx | 27 | Data/Data | ❌ | Unsupported op Loop (while lowering node_index=9, op_type=Loop, name=<unnamed>, inputs=[Range_test_range_bfloat16_type_positive_delta_expanded_function_n: tensor[dtype=int64, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_loop_cond: tensor[dtype=bool, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_start_s: tensor[dtype=float, shape=()]], outputs=[Range_test_range_bfloat16_type_positive_delta_expanded_function_variadic_output: tensor[dtype=float, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_output_s: tensor[dtype=float, shape=()]]) |
-| node/test_range_float16_type_positive_delta_expanded/model.onnx | 27 | Data/Data | ❌ | Unsupported op Loop (while lowering node_index=9, op_type=Loop, name=<unnamed>, inputs=[Range_test_range_float16_type_positive_delta_expanded_function_n: tensor[dtype=int64, shape=()], Range_test_range_float16_type_positive_delta_expanded_function_loop_cond: tensor[dtype=bool, shape=()], Range_test_range_float16_type_positive_delta_expanded_function_start_s: tensor[dtype=float, shape=()]], outputs=[Range_test_range_float16_type_positive_delta_expanded_function_variadic_output: tensor[dtype=float, shape=()], Range_test_range_float16_type_positive_delta_expanded_function_output_s: tensor[dtype=float, shape=()]]) |
 | test/contrib_ops/attention_op_test/AttentionPastState_dynamic_run0/model.onnx |  | Data/Data | ❌ | Out of tolerance (max ULP 86151) |
 | test/contrib_ops/attention_op_test/Attention_Mask1D_Fp32_B2_S64_run0/model.onnx |  | Data/Data | ❌ | Out of tolerance (max ULP 1020241) |
 | test/contrib_ops/attention_op_test/Attention_Mask2D_Fp32_B2_S32_run0/model.onnx |  | Data/Data | ❌ | Out of tolerance (max ULP 980755) |

--- a/ONNX_SUPPORT.md
+++ b/ONNX_SUPPORT.md
@@ -7,7 +7,7 @@ Overview:
 
 | Test suite | Coverage | Version |
 | --- | --- | --- |
-| [Official ONNX test coverage](#official-onnx-test-coverage) | 1912 / 1914, 99.9% | 1.22.0 |
+| [Official ONNX test coverage](#official-onnx-test-coverage) | 1914 / 1914, 100.0% | 1.22.0 |
 | [ONNX Runtime artifact coverage](#onnx-runtime-artifact-coverage) | 4278 / 4324, 98.9% | n/a |
 | [Local ONNX test coverage](#local-onnx-test-coverage) | 9 / 9, 100.0% | n/a |
 
@@ -21,7 +21,7 @@ The `Verification` column uses `Input/Reference` notation (for example `Random/O
 
 Test directory: `onnx-org/onnx/backend/test/data`
 
-Coverage 1912 / 1914 ONNX files (99.9%).
+Coverage 1914 / 1914 ONNX files (100.0%).
 
 | File | Opset | Verification | Supported | Error |
 | --- | --- | --- | --- | --- |
@@ -1230,9 +1230,9 @@ Coverage 1912 / 1914 ONNX files (99.9%).
 | node/test_quantizelinear_uint2/model.onnx | 25 | Data/Data | ✅ | OK (max abs diff 0) |
 | node/test_quantizelinear_uint4/model.onnx | 25 | Data/Data | ✅ | OK (max abs diff 0) |
 | node/test_range_bfloat16_type_positive_delta/model.onnx | 27 | Data/Data | ✅ | OK (max abs diff 0) |
-| node/test_range_bfloat16_type_positive_delta_expanded/model.onnx | 27 | Data/Data | ❌ | Unsupported op Loop (while lowering node_index=9, op_type=Loop, name=<unnamed>, inputs=[Range_test_range_bfloat16_type_positive_delta_expanded_function_n: tensor[dtype=int64, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_loop_cond: tensor[dtype=bool, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_start_s: tensor[dtype=float, shape=()]], outputs=[Range_test_range_bfloat16_type_positive_delta_expanded_function_variadic_output: tensor[dtype=float, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_output_s: tensor[dtype=float, shape=()]]) |
+| node/test_range_bfloat16_type_positive_delta_expanded/model.onnx | 27 | Data/Data | ✅ | OK (max abs diff 0) |
 | node/test_range_float16_type_positive_delta/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 0) |
-| node/test_range_float16_type_positive_delta_expanded/model.onnx | 27 | Data/Data | ❌ | Unsupported op Loop (while lowering node_index=9, op_type=Loop, name=<unnamed>, inputs=[Range_test_range_float16_type_positive_delta_expanded_function_n: tensor[dtype=int64, shape=()], Range_test_range_float16_type_positive_delta_expanded_function_loop_cond: tensor[dtype=bool, shape=()], Range_test_range_float16_type_positive_delta_expanded_function_start_s: tensor[dtype=float, shape=()]], outputs=[Range_test_range_float16_type_positive_delta_expanded_function_variadic_output: tensor[dtype=float, shape=()], Range_test_range_float16_type_positive_delta_expanded_function_output_s: tensor[dtype=float, shape=()]]) |
+| node/test_range_float16_type_positive_delta_expanded/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_range_float_type_positive_delta/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_range_float_type_positive_delta_expanded/model.onnx | 27 | Data/Data | ✅ | OK (max ULP 0) |
 | node/test_range_int32_type_negative_delta/model.onnx | 27 | Data/Data | ✅ | OK (max abs diff 0) |

--- a/src/emx_onnx_cgen/onnx_import.py
+++ b/src/emx_onnx_cgen/onnx_import.py
@@ -2118,6 +2118,105 @@ def _prune_unused_nodes(graph: onnx.GraphProto) -> None:
         graph.node.extend(surviving)
 
 
+# Ops whose output tensor always has exactly the same shape as their first
+# (data) input. Used to back-propagate a declared shape to an upstream value
+# that ONNX shape inference left unshaped (e.g. a Loop scan output that only
+# becomes statically sized via the model's declared graph output).
+_SHAPE_PRESERVING_UNARY_OPS = frozenset(
+    {
+        "Cast",
+        "CastLike",
+        "Identity",
+        "Relu",
+        "Ceil",
+        "Floor",
+        "Round",
+        "Abs",
+        "Neg",
+        "Sqrt",
+        "Exp",
+        "Log",
+        "Sigmoid",
+        "Tanh",
+        "Sign",
+        "Reciprocal",
+        "Erf",
+        "Softplus",
+        "Softsign",
+        "Not",
+    }
+)
+
+
+def _tensor_type_proto(value_info: onnx.ValueInfoProto) -> onnx.TypeProto.Tensor | None:
+    if value_info.type.WhichOneof("value") != "tensor_type":
+        return None
+    return value_info.type.tensor_type
+
+
+def _has_complete_tensor_shape(value_info: onnx.ValueInfoProto) -> bool:
+    tensor_type = _tensor_type_proto(value_info)
+    if tensor_type is None or not tensor_type.HasField("shape"):
+        return False
+    for dim in tensor_type.shape.dim:
+        if not (dim.HasField("dim_value") or dim.HasField("dim_param")):
+            return False
+    return True
+
+
+def _propagate_shapes_backward(model: onnx.ModelProto) -> tuple[onnx.ModelProto, bool]:
+    """Fill missing shapes by copying a consumer's shape back to its producer.
+
+    ONNX shape inference only flows forward, so a value feeding a shape-preserving
+    unary op (e.g. a Loop scan output consumed by a final Cast to a declared graph
+    output) can stay unshaped even though its consumer carries a static shape. This
+    copies the consumer's shape onto such an upstream value, keeping the upstream
+    value's own element type intact (Cast changes dtype but not shape).
+    """
+    graph = model.graph
+    produced_names = {out for node in graph.node for out in node.output if out}
+    value_info_by_name: dict[str, onnx.ValueInfoProto] = {}
+    for value_info in graph.value_info:
+        value_info_by_name[value_info.name] = value_info
+    for value_info in graph.output:
+        value_info_by_name.setdefault(value_info.name, value_info)
+
+    changed = False
+    progressed = True
+    while progressed:
+        progressed = False
+        for node in graph.node:
+            if node.op_type not in _SHAPE_PRESERVING_UNARY_OPS:
+                continue
+            if len(node.input) < 1 or len(node.output) != 1:
+                continue
+            source_name = node.input[0]
+            consumer_name = node.output[0]
+            if not source_name or not consumer_name:
+                continue
+            # Only fill intermediate values; never fabricate shapes for graph
+            # inputs or initializers, where a missing shape means "dynamic".
+            if source_name not in produced_names:
+                continue
+            consumer_info = value_info_by_name.get(consumer_name)
+            if consumer_info is None or not _has_complete_tensor_shape(consumer_info):
+                continue
+            source_info = value_info_by_name.get(source_name)
+            # Require an existing entry so the upstream element type is known
+            # (Cast changes dtype, so we must not copy the consumer's).
+            if source_info is None:
+                continue
+            source_tensor = _tensor_type_proto(source_info)
+            if source_tensor is None or not source_tensor.HasField("elem_type"):
+                continue
+            if _has_complete_tensor_shape(source_info):
+                continue
+            source_tensor.shape.CopyFrom(consumer_info.type.tensor_type.shape)
+            changed = True
+            progressed = True
+    return model, changed
+
+
 def _maybe_infer_shapes(model: onnx.ModelProto) -> onnx.ModelProto:
     if not _needs_shape_inference(model):
         return model
@@ -2151,6 +2250,11 @@ def prepare_onnx_model(model: onnx.ModelProto) -> onnx.ModelProto:
     # concrete dims propagate to the remaining tensors.
     prepared, enriched = infer_symbolic_shapes(prepared)
     if enriched:
+        prepared = _maybe_infer_shapes(prepared)
+    # Back-fill shapes that forward inference cannot reach (e.g. a Loop scan
+    # output statically sized only via the declared graph output it feeds).
+    prepared, back_filled = _propagate_shapes_backward(prepared)
+    if back_filled:
         prepared = _maybe_infer_shapes(prepared)
     return prepared
 

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_range_bfloat16_type_positive_delta_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_range_bfloat16_type_positive_delta_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op Loop (while lowering node_index=9, op_type=Loop, name=<unnamed>, inputs=[Range_test_range_bfloat16_type_positive_delta_expanded_function_n: tensor[dtype=int64, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_loop_cond: tensor[dtype=bool, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_start_s: tensor[dtype=float, shape=()]], outputs=[Range_test_range_bfloat16_type_positive_delta_expanded_function_variadic_output: tensor[dtype=float, shape=()], Range_test_range_bfloat16_type_positive_delta_expanded_function_output_s: tensor[dtype=float, shape=()]])",
+  "error": "OK (max abs diff 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_range_bfloat16_type_positive_delta_expanded model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
@@ -10,5 +10,6 @@
     "Relu",
     "Loop"
   ],
-  "opset_version": 27
+  "opset_version": 27,
+  "generated_checksum": "3a3e8e7e00ee59cb40886eae797daab3fb00c463310afafecad13b5e5c9f00d3"
 }

--- a/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_range_float16_type_positive_delta_expanded__model.onnx.json
+++ b/tests/expected_errors/onnx-org__onnx__backend__test__data__node__test_range_float16_type_positive_delta_expanded__model.onnx.json
@@ -1,5 +1,5 @@
 {
-  "error": "Unsupported op Loop (while lowering node_index=9, op_type=Loop, name=<unnamed>, inputs=[Range_test_range_float16_type_positive_delta_expanded_function_n: tensor[dtype=int64, shape=()], Range_test_range_float16_type_positive_delta_expanded_function_loop_cond: tensor[dtype=bool, shape=()], Range_test_range_float16_type_positive_delta_expanded_function_start_s: tensor[dtype=float, shape=()]], outputs=[Range_test_range_float16_type_positive_delta_expanded_function_variadic_output: tensor[dtype=float, shape=()], Range_test_range_float16_type_positive_delta_expanded_function_output_s: tensor[dtype=float, shape=()]])",
+  "error": "OK (max ULP 0)",
   "command_line": "verify --model-base-dir onnx-org/onnx/backend/test/data/node/test_range_float16_type_positive_delta_expanded model.onnx --test-data-dir test_data_set_0",
   "verification_mode": "Data/Data",
   "operators": [
@@ -10,5 +10,6 @@
     "Relu",
     "Loop"
   ],
-  "opset_version": 27
+  "opset_version": 27,
+  "generated_checksum": "e2aea09da437612f89b3391f3e892544c84025b17c4255962e3a3d71df538d87"
 }


### PR DESCRIPTION
## Problem

`test_range_bfloat16_type_positive_delta_expanded` (and the float16 sibling) failed with `Unsupported op Loop`.

These are the *expanded* Range functions, which decompose into `Cast/Sub/Div/Ceil/Relu/Loop`. The `Loop` builds the range as a *scan output*, whose static length is only known via the model's **declared graph output**. The plain `float`-typed expanded variant already works because its Loop scan output **is** the declared graph output. For `bfloat16`/`float16`, the scan output instead feeds a final `Cast` to the declared output, so it is an *intermediate* value.

ONNX shape inference only flows **forward**, so it leaves that intermediate scan output unshaped. `Loop` lowering then rejects it (`len(output_shape) != 1`), reporting `Unsupported op Loop`.

## Fix

Add a backward shape-propagation step in `prepare_onnx_model`: when an intermediate value feeds a **shape-preserving unary op** (`Cast`, `Identity`, `Relu`, …), copy the consumer's static shape back onto the producer. The upstream value keeps its own element type (a `Cast` changes dtype but not shape), and graph inputs / initializers are never touched (a missing shape there legitimately means "dynamic").

After back-filling, shape inference is re-run so the new shapes propagate further.

## Result

- `test_range_bfloat16_type_positive_delta_expanded` → `OK (max abs diff 0)`
- `test_range_float16_type_positive_delta_expanded` → `OK (max ULP 0)` (same pattern, fixed as a bonus)
- Official ONNX coverage: 1912/1914 → **1914/1914 (100%)**

Refreshed the two expectation JSONs and regenerated `ONNX_SUPPORT.md` / `ONNX_ERRORS.md`.

## Testing

- Targeted: both previously-failing tests now pass.
- Regression: full unit-test suites pass (compiler, golden, determinism, import, symbolic shapes, dtypes, codegen, e2e). The 451 range/loop/scan/expanded official tests pass. (5 pre-existing `test_ops.py` failures are environment protobuf/onnx version issues, unrelated to this change — confirmed by reproducing them with the change stashed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhtwYAndnLqQshHh5fyHNZ)_