### PR TITLE
Add --input-dim flag to pin dynamic input dimensions to static values

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ How verification works:
 
 Common problems and how to resolve them.
 
-### "Code generation requires static shapes" / dynamic input dimensions
+### Dynamic shapes and shape-inference failures
 
 A model whose inputs have dynamic dimensions (a symbolic `dim_param` such as
 `batch`, or a fully unknown axis) is compiled with those axes as C99
@@ -299,11 +299,24 @@ lists what is dynamic:
   Dynamic input dimensions (1): in[0]=batch
 ```
 
-If you need a fully static signature, or if code generation fails with
-`Code generation requires static shapes. Reason: tensor 'X' has dynamic
-dimensions ...` (this happens when a dynamic dimension reaches a place that
-needs a concrete size, e.g. a buffer or reshape), pin the dimension with
-[`--input-dim`](#common-options):
+Dynamic input dimensions are the root cause of a whole family of failures,
+because the code generator (and ONNX shape inference itself) often cannot
+resolve the rest of the graph while an input axis is still symbolic. These
+surface in several different ways, for example:
+
+- `Code generation requires static shapes. Reason: tensor 'X' has dynamic
+  dimensions ...` — a dynamic dimension reaches a place that needs a concrete
+  size (a buffer, a reshape, ...).
+- `ONNX shape inference failed` — inference cannot make progress with the
+  unresolved input shapes.
+- Operator-specific lowering errors that mention `-1`/dynamic extents,
+  unresolved `Reshape`/`MatMul`/broadcast shapes, or a shape that "could not be
+  inferred".
+
+The general fix is to make the input shapes concrete *before* shape inference
+runs, by pinning the dynamic dimensions with [`--input-dim`](#common-options).
+Because pinning happens before inference, the fixed values propagate through the
+graph and usually let inference resolve everything downstream:
 
 ```bash
 # Fix every axis named "batch" graph-wide:
@@ -312,16 +325,18 @@ emx-onnx-cgen compile model.onnx --input-dim batch=1
 emx-onnx-cgen compile model.onnx --input-dim images:0=1
 ```
 
-Pinning runs before shape inference, so the fixed value propagates to the
-dependent intermediate and output shapes. Note that `--input-dim` only helps
-for dimensions *derived from* the pinned input dimension; shapes computed from
-runtime tensor *values* are recovered automatically and are not affected.
+Caveats:
 
-Beware of inconsistent pinning: `--input-dim` does not check that the chosen
-value agrees with the rest of the graph, so contradictory or partial choices
-can make shape inference or lowering fail (e.g. pinning two operands of an
-`Add` to incompatible extents reports a "Broadcasting mismatch"). Named
-`dim_param`s are pinned graph-wide and stay consistent by construction.
+- `--input-dim` only helps for dimensions *derived from* the pinned input
+  dimension. Shapes computed from runtime tensor *values* (e.g. `AffineGrid`'s
+  `size`) are recovered automatically and are not affected by `--input-dim`.
+- It is a sharp tool: `--input-dim` only checks that the target is a dynamic
+  input dimension, not that the chosen value agrees with the rest of the graph.
+  Contradictory or partial choices can therefore *introduce* shape-inference or
+  lowering failures (e.g. pinning two operands of an `Add` to incompatible
+  extents reports a "Broadcasting mismatch"). Named `dim_param`s are pinned
+  graph-wide and stay consistent by construction; the risk is mainly the
+  positional form on unnamed (`?`) axes.
 
 ### "Code generation requires explicit ragged-sequence bounds"
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ These options are accepted by both `compile` and `verify`:
 - `--fp16-accumulation-strategy`: Accumulation strategy for float16 inputs (`simple` uses float16, `fp32` uses float; default: `fp32`).
 - `--replicate-ort-bugs`: Compatibility switch for verification/debugging. Enables emulation of known behavior differences of the ONNX Runtime version pinned in `requirements-ci.txt`.
 - `--sequence-element-shape`: Declare rank and per-axis maxima for sequence inputs with variable element shapes.
-- `--input-dim`: Pin a dynamic input dimension to a fixed value so the generated code uses a static array extent instead of a runtime parameter. Repeatable. Use a dim-parameter name (`--input-dim batch=1`) to fix every axis carrying that name across the graph, or an input position (`--input-dim images:0=1`) to fix a single axis. The CLI also prints the model's dynamic input dimensions (and any that were fixed) as part of the model report.
+- `--input-dim`: Pin a dynamic input dimension to a fixed value so the generated code uses a static array extent instead of a runtime parameter. Repeatable. Use a dim-parameter name (`--input-dim batch=1`) to fix every axis carrying that name across the graph, or an input position (`--input-dim images:0=1`) to fix a single axis. The CLI prints the model's dynamic input dimensions as part of the model report; a fixed dimension is shown inline as `in0[0]=batch -> 4`.
 
 ### `compile`
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ These options are accepted by both `compile` and `verify`:
 - `--fp16-accumulation-strategy`: Accumulation strategy for float16 inputs (`simple` uses float16, `fp32` uses float; default: `fp32`).
 - `--replicate-ort-bugs`: Compatibility switch for verification/debugging. Enables emulation of known behavior differences of the ONNX Runtime version pinned in `requirements-ci.txt`.
 - `--sequence-element-shape`: Declare rank and per-axis maxima for sequence inputs with variable element shapes.
+- `--input-dim`: Pin a dynamic input dimension to a fixed value so the generated code uses a static array extent instead of a runtime parameter. Repeatable. Use a dim-parameter name (`--input-dim batch=1`) to fix every axis carrying that name across the graph, or an input position (`--input-dim images:0=1`) to fix a single axis. The CLI also prints the model's dynamic input dimensions (and any that were fixed) as part of the model report.
 
 ### `compile`
 

--- a/README.md
+++ b/README.md
@@ -221,8 +221,9 @@ These options are accepted by both `compile` and `verify`:
 - `--sequence-element-shape`: Declare rank and per-axis maxima for sequence inputs with variable element shapes.
 - `--input-dim`: Pin a dynamic input dimension to a fixed value so the generated code uses a static array extent instead of a runtime parameter. Repeatable. Use a dim-parameter name (`--input-dim batch=1`) to fix every axis carrying that name across the graph, or an input position (`--input-dim images:0=1`) to fix a single axis. The CLI prints the model's dynamic input dimensions as part of the model report; a fixed dimension is shown inline as `in0[0]=batch -> 4`.
 
-  Pinning happens immediately after the model is loaded and **before shape inference**, so the fixed value propagates through the rest of the graph. This has two consequences worth knowing:
+  Pinning happens immediately after the model is loaded and **before shape inference**, so the fixed value propagates through the rest of the graph. This has three consequences worth knowing:
 
+  - **Avoiding C99 VLAs:** by default a dynamic dimension is emitted as a runtime parameter and the buffers become C99 variable-length arrays (e.g. `const float in[batch][3][4]`). Some targets cannot use these — MSVC does not support VLAs at all, C11 makes them optional (`__STDC_NO_VLA__`), and safety-critical guidelines such as MISRA C forbid them because their stack usage is unbounded and not statically analyzable. Pinning the dimension with `--input-dim` turns the extent into a compile-time constant, so the generated code is plain fixed-size arrays portable to any C compiler.
   - **Resolving dynamic-shape problems:** if a model otherwise fails to generate static C because an input dimension is symbolic or unknown (`tensor 'X' has dynamic dimensions`), pinning that input makes it concrete and lets shape inference derive the dependent intermediate and output shapes. (This only helps for dimensions *derived from the input dimension*; shapes computed from runtime tensor *values*, e.g. `AffineGrid`'s `size`, are recovered separately and are unaffected by `--input-dim`.)
   - **Possible inconsistencies:** `--input-dim` only checks that the target is a dynamic input dimension; it does not validate that the chosen value is consistent with the rest of the graph. Contradictory or partial pinning can therefore make a model that previously stayed dynamic fail during shape inference or lowering — for example pinning two operands of an `Add` to incompatible extents (`--input-dim a:0=3 --input-dim b:0=5` → "Broadcasting mismatch"), or pinning only one of two axes that an operator requires to be equal. Such failures are reported as a normal error, not a crash. Named `dim_param`s are always pinned graph-wide, so `--input-dim batch=N` stays consistent by construction; the risk is mainly with the positional form on unnamed (`?`) axes.
 
@@ -299,7 +300,14 @@ lists what is dynamic:
   Dynamic input dimensions (1): in[0]=batch
 ```
 
-Dynamic input dimensions are the root cause of a whole family of failures,
+**Avoiding VLAs:** even when the dynamic build succeeds, the runtime-parameter
+form relies on C99 variable-length arrays. If your toolchain cannot use them —
+MSVC has no VLA support, C11 makes them optional (`__STDC_NO_VLA__`), and
+MISRA C / safety-critical guidelines forbid them due to unbounded stack usage —
+pin the dimensions with `--input-dim` (below) so the generated code uses plain
+fixed-size arrays instead.
+
+Dynamic input dimensions are also the root cause of a whole family of failures,
 because the code generator (and ONNX shape inference itself) often cannot
 resolve the rest of the graph while an input axis is still symbolic. These
 surface in several different ways, for example:

--- a/README.md
+++ b/README.md
@@ -221,6 +221,11 @@ These options are accepted by both `compile` and `verify`:
 - `--sequence-element-shape`: Declare rank and per-axis maxima for sequence inputs with variable element shapes.
 - `--input-dim`: Pin a dynamic input dimension to a fixed value so the generated code uses a static array extent instead of a runtime parameter. Repeatable. Use a dim-parameter name (`--input-dim batch=1`) to fix every axis carrying that name across the graph, or an input position (`--input-dim images:0=1`) to fix a single axis. The CLI prints the model's dynamic input dimensions as part of the model report; a fixed dimension is shown inline as `in0[0]=batch -> 4`.
 
+  Pinning happens immediately after the model is loaded and **before shape inference**, so the fixed value propagates through the rest of the graph. This has two consequences worth knowing:
+
+  - **Resolving dynamic-shape problems:** if a model otherwise fails to generate static C because an input dimension is symbolic or unknown (`tensor 'X' has dynamic dimensions`), pinning that input makes it concrete and lets shape inference derive the dependent intermediate and output shapes. (This only helps for dimensions *derived from the input dimension*; shapes computed from runtime tensor *values*, e.g. `AffineGrid`'s `size`, are recovered separately and are unaffected by `--input-dim`.)
+  - **Possible inconsistencies:** `--input-dim` only checks that the target is a dynamic input dimension; it does not validate that the chosen value is consistent with the rest of the graph. Contradictory or partial pinning can therefore make a model that previously stayed dynamic fail during shape inference or lowering — for example pinning two operands of an `Add` to incompatible extents (`--input-dim a:0=3 --input-dim b:0=5` → "Broadcasting mismatch"), or pinning only one of two axes that an operator requires to be equal. Such failures are reported as a normal error, not a crash. Named `dim_param`s are always pinned graph-wide, so `--input-dim batch=N` stays consistent by construction; the risk is mainly with the positional form on unnamed (`?`) axes.
+
 ### `compile`
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -283,6 +283,57 @@ How verification works:
 5. **ORT unsupported models**: when using `onnxruntime`, if ORT reports
    `NOT_IMPLEMENTED`, verification is skipped with a warning (exit code 0).
 
+## Troubleshooting
+
+Common problems and how to resolve them.
+
+### "Code generation requires static shapes" / dynamic input dimensions
+
+A model whose inputs have dynamic dimensions (a symbolic `dim_param` such as
+`batch`, or a fully unknown axis) is compiled with those axes as C99
+variable-length-array runtime parameters by default, e.g.
+`void model(int batch, const float in[batch][3][4], ...)`. The model report
+lists what is dynamic:
+
+```
+  Dynamic input dimensions (1): in[0]=batch
+```
+
+If you need a fully static signature, or if code generation fails with
+`Code generation requires static shapes. Reason: tensor 'X' has dynamic
+dimensions ...` (this happens when a dynamic dimension reaches a place that
+needs a concrete size, e.g. a buffer or reshape), pin the dimension with
+[`--input-dim`](#common-options):
+
+```bash
+# Fix every axis named "batch" graph-wide:
+emx-onnx-cgen compile model.onnx --input-dim batch=1
+# Or fix a single axis positionally (use this for unnamed "?" axes):
+emx-onnx-cgen compile model.onnx --input-dim images:0=1
+```
+
+Pinning runs before shape inference, so the fixed value propagates to the
+dependent intermediate and output shapes. Note that `--input-dim` only helps
+for dimensions *derived from* the pinned input dimension; shapes computed from
+runtime tensor *values* are recovered automatically and are not affected.
+
+Beware of inconsistent pinning: `--input-dim` does not check that the chosen
+value agrees with the rest of the graph, so contradictory or partial choices
+can make shape inference or lowering fail (e.g. pinning two operands of an
+`Add` to incompatible extents reports a "Broadcasting mismatch"). Named
+`dim_param`s are pinned graph-wide and stay consistent by construction.
+
+### "Code generation requires explicit ragged-sequence bounds"
+
+A sequence input with variable element shapes needs explicit per-axis maxima.
+Declare them with [`--sequence-element-shape`](#common-options), e.g.
+`--sequence-element-shape boxes=[<=100,4]`.
+
+### "No C compiler found" (verify)
+
+`verify` builds and runs a testbench, so it needs a C compiler. Provide one via
+`--cc`, the `CC` environment variable, or install a `cc`/`gcc`/`clang` on `PATH`.
+
 ## Official ONNX test coverage
 
 `emx-onnx-cgen` tracks support using generated coverage reports checked into the repository and is listed on the official [ONNX Backend Scoreboard](https://onnx.ai/backend-scoreboard/).

--- a/src/emx_onnx_cgen/cli.py
+++ b/src/emx_onnx_cgen/cli.py
@@ -30,6 +30,14 @@ from .errors import CodegenError, ShapeInferenceError, UnsupportedOpError
 from .ir.model import SequenceType, TensorType
 from .onnx_import import import_onnx
 from .determinism import deterministic_reference_runtime
+from .input_dim_overrides import (
+    AppliedInputDim,
+    DynamicInputDim,
+    InputDimOverrides,
+    apply_input_dim_overrides,
+    collect_dynamic_input_dims,
+    parse_input_dim_overrides,
+)
 from .onnxruntime_utils import make_deterministic_session_options
 from .sequence_shape_hints import (
     SequenceElementShapeHint,
@@ -221,6 +229,14 @@ def _parse_testbench_output_format_arg(value: str) -> str:
 def _parse_sequence_element_shape_arg(value: str) -> str:
     try:
         parse_sequence_element_shape_hints([value])
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+    return value
+
+
+def _parse_input_dim_arg(value: str) -> str:
+    try:
+        parse_input_dim_overrides([value])
     except ValueError as exc:
         raise argparse.ArgumentTypeError(str(exc)) from exc
     return value
@@ -947,6 +963,21 @@ def _build_parser() -> argparse.ArgumentParser:
             ),
         )
 
+    def add_input_dim_flag(subparser: argparse.ArgumentParser) -> None:
+        subparser.add_argument(
+            "--input-dim",
+            action="append",
+            default=[],
+            type=_parse_input_dim_arg,
+            help=(
+                "Pin a dynamic input dimension to a fixed value so the generated "
+                "code uses a static shape instead of a runtime parameter. Repeatable. "
+                "Use a dim parameter name (--input-dim batch=1) to fix every axis "
+                "carrying that name, or an input position (--input-dim images:0=1) "
+                "to fix a single axis."
+            ),
+        )
+
     compile_parser = subparsers.add_parser(
         "compile", help="Compile an ONNX model into C source"
     )
@@ -1044,6 +1075,7 @@ def _build_parser() -> argparse.ArgumentParser:
     add_fp16_accumulation_strategy_flag(compile_parser)
     add_runtime_compat_flag(compile_parser)
     add_sequence_shape_hint_flag(compile_parser)
+    add_input_dim_flag(compile_parser)
 
     verify_parser = subparsers.add_parser(
         "verify",
@@ -1192,6 +1224,7 @@ def _build_parser() -> argparse.ArgumentParser:
     add_fp16_accumulation_strategy_flag(verify_parser)
     add_runtime_compat_flag(verify_parser)
     add_sequence_shape_hint_flag(verify_parser)
+    add_input_dim_flag(verify_parser)
     return parser
 
 
@@ -1294,6 +1327,11 @@ def _compile_model(
         return None, None, None, None, str(exc)
     operators = _collect_model_operators(model)
     opset_version = _model_opset_version(model)
+    dynamic_input_dims = collect_dynamic_input_dims(model)
+    try:
+        fixed_input_dims = apply_input_dim_overrides(model, _input_dim_overrides(args))
+    except ValueError as exc:
+        return None, None, None, None, str(exc)
     _report_model_details(
         active_reporter,
         model_path=model_path,
@@ -1304,6 +1342,8 @@ def _compile_model(
         initializer_count=len(model.graph.initializer),
         input_count=len(model.graph.input),
         output_count=len(model.graph.output),
+        dynamic_input_dims=dynamic_input_dims,
+        fixed_input_dims=fixed_input_dims,
     )
     active_reporter.info("")
     codegen_started = active_reporter.start_step("Generating C code")
@@ -1383,6 +1423,10 @@ def _compile_testbench_declarations(
     try:
         model, _model_checksum = _load_model_and_checksum(model_path)
     except OSError as exc:
+        raise CodegenError(str(exc)) from exc
+    try:
+        apply_input_dim_overrides(model, _input_dim_overrides(args))
+    except ValueError as exc:
         raise CodegenError(str(exc)) from exc
     options = CompilerOptions(
         model_name=model_name,
@@ -1779,6 +1823,11 @@ def _verify_model(
 
     operators = _collect_model_operators(model)
     opset_version = _model_opset_version(model)
+    dynamic_input_dims = collect_dynamic_input_dims(model)
+    try:
+        fixed_input_dims = apply_input_dim_overrides(model, _input_dim_overrides(args))
+    except ValueError as exc:
+        return None, str(exc), operators, opset_version, None
     _report_model_details(
         active_reporter,
         model_path=model_path,
@@ -1789,6 +1838,8 @@ def _verify_model(
         initializer_count=len(model.graph.initializer),
         input_count=len(model.graph.input),
         output_count=len(model.graph.output),
+        dynamic_input_dims=dynamic_input_dims,
+        fixed_input_dims=fixed_input_dims,
     )
 
     try:
@@ -3039,6 +3090,10 @@ def _sequence_element_shape_map(
     return parse_sequence_element_shape_hints(args.sequence_element_shape)
 
 
+def _input_dim_overrides(args: argparse.Namespace) -> InputDimOverrides:
+    return parse_input_dim_overrides(getattr(args, "input_dim", []))
+
+
 def _model_sequence_input_requires_shape_hint(
     model: onnx.ModelProto, input_name: str
 ) -> bool:
@@ -3091,6 +3146,8 @@ def _report_model_details(
     initializer_count: int,
     input_count: int,
     output_count: int,
+    dynamic_input_dims: Sequence[DynamicInputDim] = (),
+    fixed_input_dims: Sequence[AppliedInputDim] = (),
 ) -> None:
     operators_display = ", ".join(operators) if operators else "(none)"
     reporter.info(f"  Model operators ({len(operators)}): {operators_display}")
@@ -3107,6 +3164,17 @@ def _report_model_details(
         f"inputs={input_count}, "
         f"outputs={output_count}"
     )
+    dynamic_display = (
+        ", ".join(dim.format() for dim in dynamic_input_dims)
+        if dynamic_input_dims
+        else "(none)"
+    )
+    reporter.info(
+        f"  Dynamic input dimensions ({len(dynamic_input_dims)}): {dynamic_display}"
+    )
+    if fixed_input_dims:
+        fixed_display = ", ".join(dim.format() for dim in fixed_input_dims)
+        reporter.info(f"  Fixed input dimensions (--input-dim): {fixed_display}")
 
 
 def _report_codegen_timings(

--- a/src/emx_onnx_cgen/cli.py
+++ b/src/emx_onnx_cgen/cli.py
@@ -3164,17 +3164,25 @@ def _report_model_details(
         f"inputs={input_count}, "
         f"outputs={output_count}"
     )
+    fixed_by_position = {
+        (dim.input_name, dim.axis): dim.value for dim in fixed_input_dims
+    }
+
+    def format_dynamic_dim(dim: DynamicInputDim) -> str:
+        text = dim.format()
+        value = fixed_by_position.get((dim.input_name, dim.axis))
+        if value is not None:
+            text += f" -> {value}"
+        return text
+
     dynamic_display = (
-        ", ".join(dim.format() for dim in dynamic_input_dims)
+        ", ".join(format_dynamic_dim(dim) for dim in dynamic_input_dims)
         if dynamic_input_dims
         else "(none)"
     )
     reporter.info(
         f"  Dynamic input dimensions ({len(dynamic_input_dims)}): {dynamic_display}"
     )
-    if fixed_input_dims:
-        fixed_display = ", ".join(dim.format() for dim in fixed_input_dims)
-        reporter.info(f"  Fixed input dimensions (--input-dim): {fixed_display}")
 
 
 def _report_codegen_timings(

--- a/src/emx_onnx_cgen/compiler.py
+++ b/src/emx_onnx_cgen/compiler.py
@@ -217,7 +217,8 @@ class Compiler:
             raise UnsupportedOpError(
                 "Code generation requires static shapes. "
                 f"Reason: {missing_shape_reason}. "
-                "Hint: export the model with static shapes."
+                "Hint: pin dynamic input dimensions with --input-dim "
+                "(e.g. --input-dim batch=1) or export the model with static shapes."
             )
         variable_dim_inputs, variable_dim_outputs = self._time_step(
             "collect_variable_dims", lambda: self._collect_variable_dims(graph)

--- a/src/emx_onnx_cgen/input_dim_overrides.py
+++ b/src/emx_onnx_cgen/input_dim_overrides.py
@@ -19,6 +19,21 @@ Override syntax (``--input-dim KEY=VALUE``):
 * ``<input>:<axis>=<int>`` -- fix a single axis positionally, e.g. ``images:0=1``.
   If that axis happens to carry a ``dim_param``, the parameter is pinned
   graph-wide as well.
+
+Ordering and consequences:
+
+* Pinning runs after the model is loaded but **before shape inference**, so the
+  fixed value propagates to dependent intermediate and output shapes. It can
+  therefore be used to resolve "tensor 'X' has dynamic dimensions" code
+  generation failures -- but only for dimensions *derived from* the pinned
+  input dimension, not for shapes computed from runtime tensor values.
+* :func:`apply_input_dim_overrides` only validates that an override targets a
+  dynamic input dimension; it does not check that the value is consistent with
+  the rest of the graph. Contradictory or partial pinning can make shape
+  inference or lowering fail later (e.g. pinning two ``Add`` operands to
+  incompatible extents). Named ``dim_param``\\ s are always pinned graph-wide and
+  stay consistent by construction; the risk is mainly the positional form on
+  unnamed axes.
 """
 
 from __future__ import annotations

--- a/src/emx_onnx_cgen/input_dim_overrides.py
+++ b/src/emx_onnx_cgen/input_dim_overrides.py
@@ -3,9 +3,12 @@
 ONNX models frequently declare inputs with dynamic dimensions, either as named
 symbolic parameters (``dim_param`` such as ``batch``) or as fully unknown axes.
 The code generator turns such dimensions into runtime parameters of the
-generated C function. Users sometimes want a fully static signature instead --
-for example to emit ``void model(const float in[4][3][4], ...)`` rather than
-``void model(int batch, const float in[batch][3][4], ...)``.
+generated C function, which makes the buffers C99 variable-length arrays.
+Users sometimes want a fully static signature instead -- for example to emit
+``void model(const float in[4][3][4], ...)`` rather than
+``void model(int batch, const float in[batch][3][4], ...)`` -- either for a
+simpler API or to avoid VLAs entirely on toolchains that do not support them
+well (MSVC has none, C11 makes them optional, MISRA C forbids them).
 
 This module recovers the list of dynamic input dimensions (for reporting) and
 applies user-provided overrides that fix them to concrete values, mutating the

--- a/src/emx_onnx_cgen/input_dim_overrides.py
+++ b/src/emx_onnx_cgen/input_dim_overrides.py
@@ -1,0 +1,257 @@
+"""Parse and apply CLI overrides that pin dynamic input dimensions.
+
+ONNX models frequently declare inputs with dynamic dimensions, either as named
+symbolic parameters (``dim_param`` such as ``batch``) or as fully unknown axes.
+The code generator turns such dimensions into runtime parameters of the
+generated C function. Users sometimes want a fully static signature instead --
+for example to emit ``void model(const float in[4][3][4], ...)`` rather than
+``void model(int batch, const float in[batch][3][4], ...)``.
+
+This module recovers the list of dynamic input dimensions (for reporting) and
+applies user-provided overrides that fix them to concrete values, mutating the
+ONNX model in place so the rest of the pipeline sees static shapes.
+
+Override syntax (``--input-dim KEY=VALUE``):
+
+* ``<dim_param>=<int>`` -- fix every axis carrying that symbolic name, e.g.
+  ``batch=1``. When the same ``dim_param`` is shared by inputs, outputs and
+  intermediate values, all of them are pinned so the graph stays consistent.
+* ``<input>:<axis>=<int>`` -- fix a single axis positionally, e.g. ``images:0=1``.
+  If that axis happens to carry a ``dim_param``, the parameter is pinned
+  graph-wide as well.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+import onnx
+
+
+_PARAM_KEY_RE = re.compile(r"^(?P<name>[A-Za-z_][A-Za-z0-9_]*)$")
+_POSITION_KEY_RE = re.compile(r"^(?P<name>.+):(?P<axis>0|[1-9][0-9]*)$")
+_VALUE_RE = re.compile(r"^[1-9][0-9]*$")
+
+
+@dataclass(frozen=True)
+class DynamicInputDim:
+    """A dynamic axis of a model input."""
+
+    input_name: str
+    axis: int
+    dim_param: str | None
+
+    def format(self) -> str:
+        return f"{self.input_name}[{self.axis}]={self.dim_param or '?'}"
+
+
+@dataclass(frozen=True)
+class AppliedInputDim:
+    """A dynamic axis that was pinned to a concrete value."""
+
+    input_name: str
+    axis: int
+    value: int
+
+    def format(self) -> str:
+        return f"{self.input_name}[{self.axis}]={self.value}"
+
+
+@dataclass(frozen=True)
+class InputDimOverrides:
+    """Parsed ``--input-dim`` overrides."""
+
+    by_param: dict[str, int]
+    by_position: dict[tuple[str, int], int]
+
+    def is_empty(self) -> bool:
+        return not self.by_param and not self.by_position
+
+
+def parse_input_dim_overrides(specs: list[str] | tuple[str, ...]) -> InputDimOverrides:
+    """Parse ``--input-dim`` specifications into an :class:`InputDimOverrides`."""
+
+    by_param: dict[str, int] = {}
+    by_position: dict[tuple[str, int], int] = {}
+    for spec in specs:
+        key, sep, raw_value = spec.partition("=")
+        if not sep:
+            raise ValueError(
+                f"Invalid --input-dim {spec!r}: expected KEY=VALUE "
+                "(for example batch=1 or images:0=1)."
+            )
+        if not _VALUE_RE.match(raw_value):
+            raise ValueError(
+                f"Invalid --input-dim {spec!r}: dimension value must be a positive "
+                "integer."
+            )
+        value = int(raw_value)
+        position_match = _POSITION_KEY_RE.match(key)
+        if position_match:
+            name = position_match.group("name")
+            axis = int(position_match.group("axis"))
+            position = (name, axis)
+            if position in by_position:
+                raise ValueError(f"Duplicate --input-dim for {name}:{axis}.")
+            by_position[position] = value
+            continue
+        param_match = _PARAM_KEY_RE.match(key)
+        if param_match:
+            name = param_match.group("name")
+            if name in by_param:
+                raise ValueError(f"Duplicate --input-dim for {name}.")
+            by_param[name] = value
+            continue
+        raise ValueError(
+            f"Invalid --input-dim {spec!r}: key must be a dim parameter name "
+            "(batch) or an input position (images:0)."
+        )
+    return InputDimOverrides(by_param=by_param, by_position=by_position)
+
+
+def _initializer_names(model: onnx.ModelProto) -> set[str]:
+    names = {initializer.name for initializer in model.graph.initializer}
+    names.update(
+        sparse_init.values.name for sparse_init in model.graph.sparse_initializer
+    )
+    return names
+
+
+def collect_dynamic_input_dims(model: onnx.ModelProto) -> list[DynamicInputDim]:
+    """Return the dynamic axes of all (non-initializer) tensor inputs."""
+
+    skip = _initializer_names(model)
+    dynamic: list[DynamicInputDim] = []
+    for value_info in model.graph.input:
+        if value_info.name in skip:
+            continue
+        if value_info.type.WhichOneof("value") != "tensor_type":
+            continue
+        tensor_type = value_info.type.tensor_type
+        if not tensor_type.HasField("shape"):
+            continue
+        for axis, dim in enumerate(tensor_type.shape.dim):
+            if dim.HasField("dim_value"):
+                continue
+            dim_param = dim.dim_param if dim.HasField("dim_param") else None
+            dynamic.append(
+                DynamicInputDim(
+                    input_name=value_info.name,
+                    axis=axis,
+                    dim_param=dim_param or None,
+                )
+            )
+    return dynamic
+
+
+def _is_dynamic(dim: onnx.TensorShapeProto.Dimension) -> bool:
+    return not dim.HasField("dim_value")
+
+
+def _set_dim(dim: onnx.TensorShapeProto.Dimension, value: int) -> None:
+    dim.ClearField("dim_param")
+    dim.dim_value = value
+
+
+def _fix_dim_param(model: onnx.ModelProto, dim_param: str, value: int) -> bool:
+    """Pin every dynamic axis carrying ``dim_param`` graph-wide. Returns hit."""
+
+    graph = model.graph
+    changed = False
+    for value_info in (*graph.input, *graph.output, *graph.value_info):
+        if value_info.type.WhichOneof("value") != "tensor_type":
+            continue
+        tensor_type = value_info.type.tensor_type
+        if not tensor_type.HasField("shape"):
+            continue
+        for dim in tensor_type.shape.dim:
+            if _is_dynamic(dim) and dim.dim_param == dim_param:
+                _set_dim(dim, value)
+                changed = True
+    return changed
+
+
+def _is_value_info_fully_static(value_info: onnx.ValueInfoProto) -> bool:
+    if value_info.type.WhichOneof("value") != "tensor_type":
+        return False
+    tensor_type = value_info.type.tensor_type
+    if not tensor_type.HasField("shape"):
+        return False
+    return all(dim.HasField("dim_value") for dim in tensor_type.shape.dim)
+
+
+def apply_input_dim_overrides(
+    model: onnx.ModelProto, overrides: InputDimOverrides
+) -> list[AppliedInputDim]:
+    """Pin dynamic input dimensions in ``model`` according to ``overrides``.
+
+    Mutates ``model`` in place and returns the list of axes that were fixed.
+    Raises :class:`ValueError` when an override does not match a dynamic input
+    dimension (so typos surface instead of being silently ignored).
+    """
+
+    if overrides.is_empty():
+        return []
+
+    input_by_name = {value_info.name: value_info for value_info in model.graph.input}
+    dynamic_dims = collect_dynamic_input_dims(model)
+    dynamic_params = {dim.dim_param for dim in dynamic_dims if dim.dim_param}
+    dynamic_positions = {(dim.input_name, dim.axis) for dim in dynamic_dims}
+
+    applied: list[AppliedInputDim] = []
+
+    # Positional overrides first so a param attached to the targeted axis is
+    # discovered and pinned graph-wide.
+    for (name, axis), value in overrides.by_position.items():
+        if (name, axis) not in dynamic_positions:
+            if name not in input_by_name:
+                raise ValueError(
+                    f"--input-dim {name}:{axis}: no model input named {name!r}."
+                )
+            raise ValueError(
+                f"--input-dim {name}:{axis}: axis {axis} of input {name!r} is not "
+                "a dynamic dimension."
+            )
+        tensor_type = input_by_name[name].type.tensor_type
+        dim = tensor_type.shape.dim[axis]
+        dim_param = dim.dim_param if dim.HasField("dim_param") else ""
+        if dim_param:
+            _fix_dim_param(model, dim_param, value)
+        else:
+            _set_dim(dim, value)
+        applied.append(AppliedInputDim(input_name=name, axis=axis, value=value))
+
+    for dim_param, value in overrides.by_param.items():
+        if dim_param not in dynamic_params:
+            raise ValueError(
+                f"--input-dim {dim_param}={value}: no dynamic input dimension uses "
+                f"the parameter {dim_param!r}."
+            )
+        _fix_dim_param(model, dim_param, value)
+        for dim in dynamic_dims:
+            if dim.dim_param == dim_param:
+                applied.append(
+                    AppliedInputDim(
+                        input_name=dim.input_name, axis=dim.axis, value=value
+                    )
+                )
+
+    # Drop now-stale dynamic intermediate shapes so shape inference recomputes
+    # them from the freshly concrete inputs.
+    graph = model.graph
+    kept = [vi for vi in graph.value_info if _is_value_info_fully_static(vi)]
+    if len(kept) != len(graph.value_info):
+        del graph.value_info[:]
+        graph.value_info.extend(kept)
+
+    # Stable, de-duplicated ordering for reporting.
+    seen: set[tuple[str, int]] = set()
+    ordered: list[AppliedInputDim] = []
+    for item in applied:
+        key = (item.input_name, item.axis)
+        if key in seen:
+            continue
+        seen.add(key)
+        ordered.append(item)
+    return ordered

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -587,6 +587,78 @@ def test_cli_compile_accepts_io_bound_dynamic_intermediates(
     assert "int N" in generated
 
 
+def test_cli_compile_reports_dynamic_input_dimensions(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    model = _make_dynamic_identity_chain_model()
+    model_path = tmp_path / "model.onnx"
+    output_path = tmp_path / "model.c"
+    onnx.save_model(model, model_path)
+
+    exit_code = cli.main(["compile", str(model_path), str(output_path)])
+
+    assert exit_code == 0
+    captured = capsys.readouterr().out
+    assert "Dynamic input dimensions (1): x[0]=N" in captured
+
+
+def test_cli_compile_input_dim_pins_dynamic_dimension(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    model = _make_dynamic_identity_chain_model()
+    model_path = tmp_path / "model.onnx"
+    output_path = tmp_path / "model.c"
+    onnx.save_model(model, model_path)
+
+    result = cli.run_cli_command(
+        ["compile", str(model_path), str(output_path), "--input-dim", "N=4"]
+    )
+
+    assert result.exit_code == 0
+    assert result.generated is not None
+    generated = result.generated
+    # The dynamic dimension becomes a static array extent, not a runtime arg.
+    assert "int N" not in generated
+    assert "[4]" in generated
+
+    exit_code = cli.main(
+        ["compile", str(model_path), str(output_path), "--input-dim", "N=4"]
+    )
+    assert exit_code == 0
+    captured = capsys.readouterr().out
+    assert "Fixed input dimensions (--input-dim): x[0]=4" in captured
+
+
+def test_cli_compile_input_dim_accepts_positional_form(tmp_path: Path) -> None:
+    model = _make_dynamic_identity_chain_model()
+    model_path = tmp_path / "model.onnx"
+    output_path = tmp_path / "model.c"
+    onnx.save_model(model, model_path)
+
+    result = cli.run_cli_command(
+        ["compile", str(model_path), str(output_path), "--input-dim", "x:0=4"]
+    )
+
+    assert result.exit_code == 0
+    assert result.generated is not None
+    assert "int N" not in result.generated
+
+
+def test_cli_compile_input_dim_rejects_unknown_parameter(tmp_path: Path) -> None:
+    model = _make_dynamic_identity_chain_model()
+    model_path = tmp_path / "model.onnx"
+    output_path = tmp_path / "model.c"
+    onnx.save_model(model, model_path)
+
+    result = cli.run_cli_command(
+        ["compile", str(model_path), str(output_path), "--input-dim", "missing=4"]
+    )
+
+    assert result.exit_code == 1
+    assert result.result is not None
+    assert "no dynamic input dimension uses the parameter 'missing'" in result.result
+
+
 def test_augment_model_with_tensor_node_outputs_skips_non_top_level_outputs() -> None:
     output = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1])
     identity = helper.make_node("Identity", inputs=["x"], outputs=["y"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -626,7 +626,7 @@ def test_cli_compile_input_dim_pins_dynamic_dimension(
     )
     assert exit_code == 0
     captured = capsys.readouterr().out
-    assert "Fixed input dimensions (--input-dim): x[0]=4" in captured
+    assert "Dynamic input dimensions (1): x[0]=N -> 4" in captured
 
 
 def test_cli_compile_input_dim_accepts_positional_form(tmp_path: Path) -> None:

--- a/tests/test_input_dim_overrides.py
+++ b/tests/test_input_dim_overrides.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import onnx
+import pytest
+from onnx import TensorProto, helper
+
+from emx_onnx_cgen.input_dim_overrides import (
+    apply_input_dim_overrides,
+    collect_dynamic_input_dims,
+    parse_input_dim_overrides,
+)
+
+
+def _relu_model(*, input_dims: list, output_dims: list) -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, input_dims)
+    out = helper.make_tensor_value_info("out", TensorProto.FLOAT, output_dims)
+    node = helper.make_node("Relu", ["x"], ["out"])
+    graph = helper.make_graph([node], "g", [x], [out])
+    return helper.make_model(graph, opset_imports=[helper.make_opsetid("", 18)])
+
+
+def _input_dims(model: onnx.ModelProto, name: str) -> list:
+    for value_info in model.graph.input:
+        if value_info.name == name:
+            return [
+                dim.dim_value if dim.HasField("dim_value") else dim.dim_param
+                for dim in value_info.type.tensor_type.shape.dim
+            ]
+    raise AssertionError(name)
+
+
+def _output_dims(model: onnx.ModelProto, name: str) -> list:
+    for value_info in model.graph.output:
+        if value_info.name == name:
+            return [
+                dim.dim_value if dim.HasField("dim_value") else dim.dim_param
+                for dim in value_info.type.tensor_type.shape.dim
+            ]
+    raise AssertionError(name)
+
+
+def test_parse_param_and_position_forms() -> None:
+    overrides = parse_input_dim_overrides(["batch=4", "images:0=1"])
+    assert overrides.by_param == {"batch": 4}
+    assert overrides.by_position == {("images", 0): 1}
+
+
+@pytest.mark.parametrize(
+    "spec",
+    ["batch", "batch=0", "batch=-1", "batch=x", ":0=1", "1bad=2"],
+)
+def test_parse_rejects_invalid_specs(spec: str) -> None:
+    with pytest.raises(ValueError):
+        parse_input_dim_overrides([spec])
+
+
+def test_parse_rejects_duplicates() -> None:
+    with pytest.raises(ValueError):
+        parse_input_dim_overrides(["batch=1", "batch=2"])
+    with pytest.raises(ValueError):
+        parse_input_dim_overrides(["x:0=1", "x:0=2"])
+
+
+def test_collect_dynamic_input_dims_reports_param_and_unknown() -> None:
+    model = _relu_model(input_dims=["batch", 3, None], output_dims=["batch", 3, None])
+    dims = collect_dynamic_input_dims(model)
+    assert [(d.input_name, d.axis, d.dim_param) for d in dims] == [
+        ("x", 0, "batch"),
+        ("x", 2, None),
+    ]
+
+
+def test_collect_dynamic_input_dims_skips_initializers() -> None:
+    model = _relu_model(input_dims=["batch", 2], output_dims=["batch", 2])
+    weight = helper.make_tensor("x", TensorProto.FLOAT, [2, 2], [0.0] * 4)
+    model.graph.initializer.append(weight)
+    assert collect_dynamic_input_dims(model) == []
+
+
+def test_apply_param_override_fixes_inputs_and_outputs() -> None:
+    model = _relu_model(input_dims=["batch", 3], output_dims=["batch", 3])
+    applied = apply_input_dim_overrides(model, parse_input_dim_overrides(["batch=8"]))
+    assert [a.format() for a in applied] == ["x[0]=8"]
+    assert _input_dims(model, "x") == [8, 3]
+    assert _output_dims(model, "out") == [8, 3]
+
+
+def test_apply_position_override_pins_param_graph_wide() -> None:
+    model = _relu_model(input_dims=["batch", 3], output_dims=["batch", 3])
+    apply_input_dim_overrides(model, parse_input_dim_overrides(["x:0=2"]))
+    # The axis carries dim_param "batch", so the output is pinned too.
+    assert _input_dims(model, "x") == [2, 3]
+    assert _output_dims(model, "out") == [2, 3]
+
+
+def test_apply_position_override_fixes_unknown_axis_only() -> None:
+    model = _relu_model(input_dims=[None, 3], output_dims=[None, 3])
+    apply_input_dim_overrides(model, parse_input_dim_overrides(["x:0=5"]))
+    assert _input_dims(model, "x") == [5, 3]
+    # The unknown output axis is left dynamic (no shared dim_param).
+    assert _output_dims(model, "out")[1] == 3
+
+
+def test_apply_rejects_unknown_param() -> None:
+    model = _relu_model(input_dims=["batch", 3], output_dims=["batch", 3])
+    with pytest.raises(ValueError, match="no dynamic input dimension"):
+        apply_input_dim_overrides(model, parse_input_dim_overrides(["seq=4"]))
+
+
+def test_apply_rejects_unknown_input_name() -> None:
+    model = _relu_model(input_dims=["batch", 3], output_dims=["batch", 3])
+    with pytest.raises(ValueError, match="no model input named"):
+        apply_input_dim_overrides(model, parse_input_dim_overrides(["missing:0=4"]))
+
+
+def test_apply_rejects_static_axis() -> None:
+    model = _relu_model(input_dims=["batch", 3], output_dims=["batch", 3])
+    with pytest.raises(ValueError, match="not a dynamic dimension"):
+        apply_input_dim_overrides(model, parse_input_dim_overrides(["x:1=4"]))
+
+
+def test_apply_clears_stale_dynamic_value_info() -> None:
+    model = _relu_model(input_dims=["batch", 3], output_dims=["batch", 3])
+    # An intermediate left dynamic by some unrelated axis must be dropped so
+    # shape inference recomputes it from the now-static inputs.
+    dynamic_vi = helper.make_tensor_value_info(
+        "intermediate", TensorProto.FLOAT, ["other", 3]
+    )
+    static_vi = helper.make_tensor_value_info("fixed", TensorProto.FLOAT, [2, 3])
+    model.graph.value_info.extend([dynamic_vi, static_vi])
+    apply_input_dim_overrides(model, parse_input_dim_overrides(["batch=4"]))
+    remaining = {vi.name for vi in model.graph.value_info}
+    assert "intermediate" not in remaining
+    assert "fixed" in remaining
+
+
+def test_apply_noop_without_overrides() -> None:
+    model = _relu_model(input_dims=["batch", 3], output_dims=["batch", 3])
+    assert apply_input_dim_overrides(model, parse_input_dim_overrides([])) == []
+    assert _input_dims(model, "x") == ["batch", 3]


### PR DESCRIPTION
## Summary
This PR adds support for pinning dynamic input dimensions to concrete values via a new `--input-dim` CLI flag. This allows users to generate C code with fully static function signatures instead of runtime dimension parameters.

## Key Changes

- **New module `input_dim_overrides.py`**: Implements parsing and application of dimension override specifications
  - `parse_input_dim_overrides()`: Parses `--input-dim KEY=VALUE` specifications supporting two forms:
    - `dim_param=value` (e.g., `batch=1`): pins all axes carrying that symbolic dimension parameter
    - `input:axis=value` (e.g., `images:0=1`): pins a specific input axis positionally
  - `collect_dynamic_input_dims()`: Reports all dynamic axes in model inputs for diagnostics
  - `apply_input_dim_overrides()`: Mutates the ONNX model to replace dynamic dimensions with concrete values, with validation to catch typos and invalid overrides

- **CLI integration**:
  - Added `--input-dim` flag to both `compile` and `verify` subcommands (repeatable)
  - Integrated dimension collection and override application into the compilation pipeline
  - Enhanced model details reporting to show dynamic dimensions and which ones were pinned

- **Comprehensive test coverage**: 
  - Unit tests for parsing, validation, and override application
  - Integration tests verifying CLI behavior and error handling
  - Tests confirm that pinning a dimension parameter graph-wide affects inputs, outputs, and intermediate values consistently

## Implementation Details

- Overrides are validated against the actual model structure; unknown parameters or non-dynamic axes raise `ValueError` with helpful messages
- When a positional override targets an axis with a `dim_param`, that parameter is pinned graph-wide to maintain consistency
- Stale dynamic intermediate shape information is cleared after applying overrides so shape inference recomputes from the now-static inputs
- Applied dimensions are deduplicated and reported in stable order for consistent output

https://claude.ai/code/session_01NU6xkymtozsFThyY66iokr