### PR TITLE
Add shape inference JSON report generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,22 @@ Options:
 - `--testbench-output-format`: Choose the generated testbench output format (`json`, `txt`, `txt-emmtrix`, or `txt-emmtrix:<float>`).
 - `--testbench-file`: Emit the testbench into a separate C file at the given path (implies `--emit-testbench`). If not set, the testbench is embedded in the main output C file (legacy behavior).
 - `--emit-data-file`: Emit constant data arrays into a companion `_data` C file.
+- `--shape-inference-json`: Write a JSON report of the shape inference results to the given path. For every named tensor of the model — inputs, outputs, and internal node outputs — the report contains the shape declared in the model file (`model`, with `dim_param` names and `null` for unknown dims) and the shape computed by the compiler (`inferred`). Weight initializers and compiler-internal temporary names are excluded, so the file is stable across runs and can be used as a shape reference. Shapes reflect the model after `--input-dim` pinning.
+
+  ```json
+  {
+    "format": "emx-onnx-cgen-shape-inference",
+    "version": 1,
+    "tensors": {
+      "x":   { "kind": "input",    "model": { "dtype": "float", "dims": [1, 4] },
+                                   "inferred": { "dtype": "float", "dims": [1, 4] } },
+      "mid": { "kind": "internal", "model": null,
+                                   "inferred": { "dtype": "float", "dims": [1, 3] } },
+      "y":   { "kind": "output",   "model": { "dtype": "float" },
+                                   "inferred": { "dtype": "float", "dims": [1, 3] } }
+    }
+  }
+  ```
 
 ### `verify`
 

--- a/README.md
+++ b/README.md
@@ -240,24 +240,7 @@ Options:
 - `--testbench-output-format`: Choose the generated testbench output format (`json`, `txt`, `txt-emmtrix`, or `txt-emmtrix:<float>`).
 - `--testbench-file`: Emit the testbench into a separate C file at the given path (implies `--emit-testbench`). If not set, the testbench is embedded in the main output C file (legacy behavior).
 - `--emit-data-file`: Emit constant data arrays into a companion `_data` C file.
-- `--shape-inference-json`: Write a JSON report of the shape inference results to the given path. For every named tensor of the model — inputs, outputs, and internal node outputs — the report contains the shape declared in the model file (`model`, with `dim_param` names and `null` for unknown dims) and the shape computed by the compiler (`inferred`). Weight initializers and compiler-internal temporary names are excluded, so the file is stable across runs and can be used as a shape reference. Shapes reflect the model after `--input-dim` pinning.
-
-  ```json
-  {
-    "format": "emx-onnx-cgen-shape-inference",
-    "version": 1,
-    "tensors": {
-      "x":   { "kind": "input",    "model": { "dtype": "float", "dims": [1, 4] },
-                                   "inferred": { "dtype": "float", "dims": [1, 4] } },
-      "mid": { "kind": "internal", "model": null,
-                                   "inferred": { "dtype": "float", "dims": [1, 3] } },
-      "y":   { "kind": "output",   "model": { "dtype": "float" },
-                                   "inferred": { "dtype": "float", "dims": [1, 3] } }
-    }
-  }
-  ```
-
-  A complete report for a real model — [`tests/onnx/mixed_ops_dynamic_batch.onnx`](tests/onnx/mixed_ops_dynamic_batch.onnx), including a symbolic `batch` dimension — is checked in as the golden test reference [`tests/golden/mixed_ops_dynamic_batch_shapes.json`](tests/golden/mixed_ops_dynamic_batch_shapes.json).
+- `--shape-inference-json`: Write a JSON report of the shape inference results to the given path. For every named tensor of the model — inputs, outputs, and internal node outputs — the report contains the shape declared in the model file (`model`, with `dim_param` names and `null` for unknown dims) and the shape computed by the compiler (`inferred`). Weight initializers and compiler-internal temporary names are excluded, so the file is stable across runs and can be used as a shape reference. Shapes reflect the model after `--input-dim` pinning. See the golden test reference [`tests/golden/mixed_ops_dynamic_batch_shapes.json`](tests/golden/mixed_ops_dynamic_batch_shapes.json) for an example report.
 
 ### `verify`
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ Options:
   }
   ```
 
+  A complete report for a real model — [`tests/onnx/mixed_ops_dynamic_batch.onnx`](tests/onnx/mixed_ops_dynamic_batch.onnx), including a symbolic `batch` dimension — is checked in as the golden test reference [`tests/golden/mixed_ops_dynamic_batch_shapes.json`](tests/golden/mixed_ops_dynamic_batch_shapes.json).
+
 ### `verify`
 
 ```bash

--- a/src/emx_onnx_cgen/cli.py
+++ b/src/emx_onnx_cgen/cli.py
@@ -846,19 +846,19 @@ def run_cli_command(
                 generated_checksum=generated_checksum,
                 verification_mode=verification_mode,
             )
-        generated, _testbench, data_source, _weight_data, error = _compile_model(args)
-        if error:
+        compile_result = _compile_model(args)
+        if compile_result.error:
             return CliResult(
                 exit_code=1,
                 command_line=args.command_line,
-                result=error,
+                result=compile_result.error,
             )
         return CliResult(
             exit_code=0,
             command_line=args.command_line,
             result="",
-            generated=generated,
-            data_source=data_source,
+            generated=compile_result.generated,
+            data_source=compile_result.data_source,
         )
     except Exception as exc:  # pragma: no cover - defensive reporting
         LOGGER.exception("Unhandled exception while running CLI command.")
@@ -1031,6 +1031,18 @@ def _build_parser() -> argparse.ArgumentParser:
         help=(
             "If set, emit the testbench into a separate C file at this path "
             "(implies --emit-testbench)."
+        ),
+    )
+    compile_parser.add_argument(
+        "--shape-inference-json",
+        type=Path,
+        default=None,
+        help=(
+            "Write a JSON report of the shape inference results to this path. "
+            "The report lists the model-declared and the inferred shape for "
+            "every named tensor of the model (inputs, outputs, and internal "
+            "node outputs); compiler-internal temporary names are excluded. "
+            "Shapes reflect the model after --input-dim pinning."
         ),
     )
     compile_parser.add_argument(
@@ -1274,13 +1286,15 @@ def _handle_compile(args: argparse.Namespace) -> int:
     model_name = args.model_name or "model"
     if args.testbench_file:
         args.emit_testbench = True
-    generated, testbench, data_source, weight_data, error = _compile_model(
-        args, reporter=reporter
-    )
-    if error:
+    compile_result = _compile_model(args, reporter=reporter)
+    if compile_result.error:
         reporter.info("")
-        reporter.result(error, ok=False)
+        reporter.result(compile_result.error, ok=False)
         return 1
+    generated = compile_result.generated
+    testbench = compile_result.testbench
+    data_source = compile_result.data_source
+    weight_data = compile_result.weight_data
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(generated or "", encoding="utf-8")
@@ -1305,14 +1319,30 @@ def _handle_compile(args: argparse.Namespace) -> int:
     if weight_data is not None:
         weights_path = output_path.with_name(f"{model_name}.bin")
         weights_path.write_bytes(weight_data)
+    if compile_result.shape_inference_json is not None:
+        shape_json_path: Path = args.shape_inference_json
+        shape_json_path.parent.mkdir(parents=True, exist_ok=True)
+        shape_json_path.write_text(
+            compile_result.shape_inference_json, encoding="utf-8"
+        )
     return 0
+
+
+@dataclass(frozen=True)
+class _CompileModelResult:
+    generated: str | None = None
+    testbench: str | None = None
+    data_source: str | None = None
+    weight_data: bytes | None = None
+    shape_inference_json: str | None = None
+    error: str | None = None
 
 
 def _compile_model(
     args: argparse.Namespace,
     *,
     reporter: _VerifyReporter | None = None,
-) -> tuple[str | None, str | None, str | None, bytes | None, str | None]:
+) -> _CompileModelResult:
     model_path: Path = args.model
     model_name = args.model_name or "model"
     active_reporter = reporter or _NullVerifyReporter()
@@ -1324,14 +1354,14 @@ def _compile_model(
         active_reporter.step_ok(load_started)
     except OSError as exc:
         active_reporter.step_fail(str(exc))
-        return None, None, None, None, str(exc)
+        return _CompileModelResult(error=str(exc))
     operators = _collect_model_operators(model)
     opset_version = _model_opset_version(model)
     dynamic_input_dims = collect_dynamic_input_dims(model)
     try:
         fixed_input_dims = apply_input_dim_overrides(model, _input_dim_overrides(args))
     except ValueError as exc:
-        return None, None, None, None, str(exc)
+        return _CompileModelResult(error=str(exc))
     _report_model_details(
         active_reporter,
         model_path=model_path,
@@ -1376,12 +1406,16 @@ def _compile_model(
         testbench = None
         if separate_testbench:
             testbench = compiler.compile_testbench(model)
+        shape_inference_json = None
+        if getattr(args, "shape_inference_json", None) is not None:
+            report = compiler.shape_inference_report(model)
+            shape_inference_json = json.dumps(report, indent=2) + "\n"
         active_reporter.step_ok(codegen_started)
         if args.verbose:
             _report_codegen_timings(active_reporter, timings=timings)
     except (CodegenError, ShapeInferenceError, UnsupportedOpError) as exc:
         active_reporter.step_fail(str(exc))
-        return None, None, None, None, str(exc)
+        return _CompileModelResult(error=str(exc))
     output_path: Path = args.output or model_path.with_suffix(".c")
     artifacts = [(str(output_path), len(generated.encode("utf-8")))]
     if testbench is not None:
@@ -1404,11 +1438,21 @@ def _compile_model(
     if weight_data is not None:
         weights_path = output_path.with_name(f"{model_name}.bin")
         artifacts.append((str(weights_path), len(weight_data)))
+    if shape_inference_json is not None:
+        artifacts.append(
+            (str(args.shape_inference_json), len(shape_inference_json.encode("utf-8")))
+        )
     _report_generated_artifacts(active_reporter, artifacts=artifacts)
     active_reporter.info(
         f"  Generated checksum (sha256): {_generated_checksum(generated)}"
     )
-    return generated, testbench, data_source, weight_data, None
+    return _CompileModelResult(
+        generated=generated,
+        testbench=testbench,
+        data_source=data_source,
+        weight_data=weight_data,
+        shape_inference_json=shape_inference_json,
+    )
 
 
 def _compile_testbench_declarations(

--- a/src/emx_onnx_cgen/compiler.py
+++ b/src/emx_onnx_cgen/compiler.py
@@ -51,6 +51,7 @@ from .onnx_import import import_onnx, prepare_onnx_model
 from .sequence_shape_hints import (
     SequenceElementShapeHint,
 )
+from .shape_inference_report import build_shape_inference_report
 
 # Keep this env var near the lowering loop so future shape-debug work can find it fast.
 _DEBUG_LOWERING_FAILURES_ENV = "EMX_DEBUG_LOWERING_FAILURES"
@@ -266,6 +267,15 @@ class Compiler:
                 variable_dim_outputs=ctx.variable_dim_outputs,
             ),
         )
+
+    def shape_inference_report(self, model: onnx.ModelProto) -> dict[str, object]:
+        """Return the shape inference report for ``model``.
+
+        ``model`` must be the original model so the report only contains
+        tensor names and declared shapes from the model file.
+        """
+        ctx = self._build_compile_context(model)
+        return build_shape_inference_report(model, ctx.lowered.op_context)
 
     def compile_testbench(self, model: onnx.ModelProto) -> str:
         ctx = self._build_compile_context(model)

--- a/src/emx_onnx_cgen/shape_inference_report.py
+++ b/src/emx_onnx_cgen/shape_inference_report.py
@@ -1,0 +1,186 @@
+"""Build a JSON-serializable report of shape inference results.
+
+The report lists every tensor named in the original ONNX model (graph inputs,
+graph outputs, and internal node outputs) together with the type declared in
+the model file (``model``) and the type computed by the compiler's shape
+inference (``inferred``). Only names taken from the original model appear in
+the report; tensors introduced by internal transformations (node expansions,
+materialized constants) are excluded so the output is stable across compiler
+versions and can be used as a reference.
+"""
+
+from __future__ import annotations
+
+from itertools import chain
+from typing import Iterable
+
+import onnx
+
+from .dtypes import scalar_type_from_onnx
+from .errors import ShapeInferenceError, UnsupportedOpError
+from .ir.model import SequenceType, TensorType
+from .ir.op_context import OpContext
+
+REPORT_FORMAT = "emx-onnx-cgen-shape-inference"
+REPORT_VERSION = 1
+
+
+def _tensor_type_protos(
+    value_info: onnx.ValueInfoProto,
+) -> tuple[onnx.TypeProto.Tensor | None, bool]:
+    """Return the tensor type proto of ``value_info`` and a sequence flag."""
+    kind = value_info.type.WhichOneof("value")
+    if kind == "optional_type":
+        elem = value_info.type.optional_type.elem_type
+        kind = elem.WhichOneof("value")
+        if kind == "tensor_type":
+            return elem.tensor_type, False
+        if kind == "sequence_type":
+            seq_elem = elem.sequence_type.elem_type
+            if seq_elem.WhichOneof("value") == "tensor_type":
+                return seq_elem.tensor_type, True
+        return None, False
+    if kind == "tensor_type":
+        return value_info.type.tensor_type, False
+    if kind == "sequence_type":
+        elem = value_info.type.sequence_type.elem_type
+        if elem.WhichOneof("value") == "tensor_type":
+            return elem.tensor_type, True
+    return None, False
+
+
+def _declared_entry(value_info: onnx.ValueInfoProto | None) -> dict[str, object] | None:
+    if value_info is None:
+        return None
+    tensor_type, is_sequence = _tensor_type_protos(value_info)
+    if tensor_type is None:
+        return None
+    entry: dict[str, object] = {}
+    if is_sequence:
+        entry["sequence"] = True
+    if tensor_type.HasField("elem_type") and tensor_type.elem_type != 0:
+        scalar = scalar_type_from_onnx(tensor_type.elem_type)
+        if scalar is not None:
+            entry["dtype"] = scalar.onnx_name
+        else:
+            entry["dtype"] = onnx.TensorProto.DataType.Name(
+                tensor_type.elem_type
+            ).lower()
+    if tensor_type.HasField("shape"):
+        dims: list[object] = []
+        for dim in tensor_type.shape.dim:
+            which = dim.WhichOneof("value")
+            if which == "dim_value":
+                dims.append(int(dim.dim_value))
+            elif which == "dim_param" and dim.dim_param:
+                dims.append(dim.dim_param)
+            else:
+                dims.append(None)
+        entry["dims"] = dims
+    return entry or None
+
+
+def _concrete_dims(
+    shape: Iterable[int],
+    dim_params: tuple[str | None, ...],
+    known_dim_params: frozenset[str],
+) -> list[object]:
+    dims: list[object] = []
+    for index, dim in enumerate(shape):
+        if dim >= 0:
+            dims.append(int(dim))
+            continue
+        # Unresolved dim: report the model's dim_param name if it has one,
+        # never the synthetic parameter names the importer invents.
+        dim_param = dim_params[index] if index < len(dim_params) else None
+        if dim_param and dim_param in known_dim_params:
+            dims.append(dim_param)
+        else:
+            dims.append(None)
+    return dims
+
+
+def _inferred_entry(
+    op_context: OpContext,
+    name: str,
+    known_dim_params: frozenset[str],
+) -> dict[str, object] | None:
+    try:
+        value = op_context.graph.find_value(name)
+    except KeyError:
+        value = None
+    if value is not None and isinstance(value.type, SequenceType):
+        elem = value.type.elem
+        return {
+            "sequence": True,
+            "dtype": elem.dtype.onnx_name,
+            "dims": _concrete_dims(elem.shape, elem.dim_params, known_dim_params),
+        }
+    try:
+        shape = op_context.shape(name)
+        dtype = op_context.dtype(name)
+    except (KeyError, ShapeInferenceError, UnsupportedOpError):
+        return None
+    dim_params: tuple[str | None, ...] = ()
+    if isinstance(value.type if value is not None else None, TensorType):
+        if len(value.type.dim_params) == len(shape):
+            dim_params = value.type.dim_params
+    return {
+        "dtype": dtype.onnx_name,
+        "dims": _concrete_dims(shape, dim_params, known_dim_params),
+    }
+
+
+def _collect_model_dim_params(graph: onnx.GraphProto) -> frozenset[str]:
+    params: set[str] = set()
+    for value_info in chain(graph.input, graph.output, graph.value_info):
+        tensor_type, _is_sequence = _tensor_type_protos(value_info)
+        if tensor_type is None or not tensor_type.HasField("shape"):
+            continue
+        for dim in tensor_type.shape.dim:
+            if dim.WhichOneof("value") == "dim_param" and dim.dim_param:
+                params.add(dim.dim_param)
+    return frozenset(params)
+
+
+def build_shape_inference_report(
+    model: onnx.ModelProto,
+    op_context: OpContext,
+) -> dict[str, object]:
+    """Build the report for ``model`` using inference results in ``op_context``.
+
+    ``model`` must be the original (unprepared) model so declared shapes and
+    tensor names match the model file; ``op_context`` must come from a lowered
+    model so inferred shapes match what code generation uses.
+    """
+    graph = model.graph
+    known_dim_params = _collect_model_dim_params(graph)
+    initializer_names = {initializer.name for initializer in graph.initializer}
+    declared_by_name: dict[str, onnx.ValueInfoProto] = {}
+    for value_info in chain(graph.input, graph.output, graph.value_info):
+        declared_by_name.setdefault(value_info.name, value_info)
+    output_names = {value_info.name for value_info in graph.output}
+    tensors: dict[str, dict[str, object]] = {}
+
+    def add(name: str, kind: str) -> None:
+        if not name or name in initializer_names or name in tensors:
+            return
+        tensors[name] = {
+            "kind": kind,
+            "model": _declared_entry(declared_by_name.get(name)),
+            "inferred": _inferred_entry(op_context, name, known_dim_params),
+        }
+
+    for value_info in graph.input:
+        add(value_info.name, "input")
+    for node in graph.node:
+        for output_name in node.output:
+            add(output_name, "output" if output_name in output_names else "internal")
+    for value_info in graph.output:
+        add(value_info.name, "output")
+
+    return {
+        "format": REPORT_FORMAT,
+        "version": REPORT_VERSION,
+        "tensors": tensors,
+    }

--- a/tests/golden/mixed_ops_dynamic_batch_shapes.json
+++ b/tests/golden/mixed_ops_dynamic_batch_shapes.json
@@ -1,0 +1,348 @@
+{
+  "format": "emx-onnx-cgen-shape-inference",
+  "version": 1,
+  "tensors": {
+    "input": {
+      "kind": "input",
+      "model": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          3,
+          32,
+          32
+        ]
+      },
+      "inferred": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          3,
+          32,
+          32
+        ]
+      }
+    },
+    "slice_out": {
+      "kind": "internal",
+      "model": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          3,
+          32,
+          16
+        ]
+      },
+      "inferred": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          3,
+          32,
+          16
+        ]
+      }
+    },
+    "c1_out": {
+      "kind": "internal",
+      "model": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          16,
+          30,
+          14
+        ]
+      },
+      "inferred": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          16,
+          30,
+          14
+        ]
+      }
+    },
+    "p1_out": {
+      "kind": "internal",
+      "model": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          16,
+          30,
+          14
+        ]
+      },
+      "inferred": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          16,
+          30,
+          14
+        ]
+      }
+    },
+    "c2_out": {
+      "kind": "internal",
+      "model": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          32,
+          28,
+          12
+        ]
+      },
+      "inferred": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          32,
+          28,
+          12
+        ]
+      }
+    },
+    "p2_out": {
+      "kind": "internal",
+      "model": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          32,
+          28,
+          12
+        ]
+      },
+      "inferred": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          32,
+          28,
+          12
+        ]
+      }
+    },
+    "c3_out": {
+      "kind": "internal",
+      "model": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          64,
+          26,
+          10
+        ]
+      },
+      "inferred": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          64,
+          26,
+          10
+        ]
+      }
+    },
+    "p3_out": {
+      "kind": "internal",
+      "model": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          64,
+          26,
+          10
+        ]
+      },
+      "inferred": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          64,
+          26,
+          10
+        ]
+      }
+    },
+    "gap_out": {
+      "kind": "internal",
+      "model": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          64,
+          1,
+          1
+        ]
+      },
+      "inferred": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          64,
+          1,
+          1
+        ]
+      }
+    },
+    "sq_out": {
+      "kind": "internal",
+      "model": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          64
+        ]
+      },
+      "inferred": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          64
+        ]
+      }
+    },
+    "tr_out": {
+      "kind": "internal",
+      "model": {
+        "dtype": "float",
+        "dims": [
+          64,
+          "batch"
+        ]
+      },
+      "inferred": {
+        "dtype": "float",
+        "dims": [
+          64,
+          "batch"
+        ]
+      }
+    },
+    "ma_out": {
+      "kind": "internal",
+      "model": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          32
+        ]
+      },
+      "inferred": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          32
+        ]
+      }
+    },
+    "mul_out": {
+      "kind": "internal",
+      "model": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          32
+        ]
+      },
+      "inferred": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          32
+        ]
+      }
+    },
+    "sma_out": {
+      "kind": "internal",
+      "model": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          32
+        ]
+      },
+      "inferred": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          32
+        ]
+      }
+    },
+    "mb_out": {
+      "kind": "internal",
+      "model": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          32
+        ]
+      },
+      "inferred": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          32
+        ]
+      }
+    },
+    "smb_out": {
+      "kind": "internal",
+      "model": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          32
+        ]
+      },
+      "inferred": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          32
+        ]
+      }
+    },
+    "cat_out": {
+      "kind": "internal",
+      "model": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          64
+        ]
+      },
+      "inferred": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          64
+        ]
+      }
+    },
+    "gemm_out": {
+      "kind": "output",
+      "model": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          10
+        ]
+      },
+      "inferred": {
+        "dtype": "float",
+        "dims": [
+          "batch",
+          10
+        ]
+      }
+    }
+  }
+}

--- a/tests/test_shape_inference_report.py
+++ b/tests/test_shape_inference_report.py
@@ -7,6 +7,8 @@ import numpy as np
 import onnx
 from onnx import TensorProto, helper, numpy_helper
 
+from golden_utils import assert_golden
+
 from emx_onnx_cgen import cli
 from emx_onnx_cgen.compiler import Compiler
 
@@ -81,6 +83,28 @@ def test_cli_compile_writes_shape_inference_json(tmp_path: Path) -> None:
     tensors = report["tensors"]
     assert tensors["mid"]["inferred"] == {"dtype": "float", "dims": [1, 3]}
     assert tensors["y"]["model"] == {"dtype": "float", "dims": [1, 3]}
+
+
+# The golden file doubles as the documentation example referenced in README.md.
+def test_shape_inference_json_matches_golden_reference(tmp_path: Path) -> None:
+    model_path = Path(__file__).parent / "onnx" / "mixed_ops_dynamic_batch.onnx"
+    json_path = tmp_path / "shapes.json"
+
+    exit_code = cli.main(
+        [
+            "compile",
+            str(model_path),
+            str(tmp_path / "model.c"),
+            "--shape-inference-json",
+            str(json_path),
+        ]
+    )
+
+    assert exit_code == 0
+    golden_path = (
+        Path(__file__).parent / "golden" / "mixed_ops_dynamic_batch_shapes.json"
+    )
+    assert_golden(json_path.read_text(encoding="utf-8"), golden_path)
 
 
 def test_cli_compile_shape_inference_json_reflects_input_dim_pinning(

--- a/tests/test_shape_inference_report.py
+++ b/tests/test_shape_inference_report.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper, numpy_helper
+
+from emx_onnx_cgen import cli
+from emx_onnx_cgen.compiler import Compiler
+
+
+def _make_matmul_relu_model(
+    *, input_dims: list[object], output_dims: list[object] | None
+) -> onnx.ModelProto:
+    weight = numpy_helper.from_array(np.ones((4, 3), dtype=np.float32), name="w")
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, input_dims)
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, output_dims)
+    nodes = [
+        helper.make_node("MatMul", ["x", "w"], ["mid"]),
+        helper.make_node("Relu", ["mid"], ["y"]),
+    ]
+    graph = helper.make_graph(nodes, "g", [x], [y], initializer=[weight])
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 21)])
+
+
+def test_shape_inference_report_contains_model_and_inferred_shapes() -> None:
+    model = _make_matmul_relu_model(input_dims=[1, 4], output_dims=None)
+    report = Compiler().shape_inference_report(model)
+
+    assert report["format"] == "emx-onnx-cgen-shape-inference"
+    tensors = report["tensors"]
+    assert list(tensors) == ["x", "mid", "y"]
+    assert "w" not in tensors
+
+    assert tensors["x"]["kind"] == "input"
+    assert tensors["x"]["model"] == {"dtype": "float", "dims": [1, 4]}
+    assert tensors["x"]["inferred"] == {"dtype": "float", "dims": [1, 4]}
+
+    # Internal node output without value_info: no declared, but inferred shape.
+    assert tensors["mid"]["kind"] == "internal"
+    assert tensors["mid"]["model"] is None
+    assert tensors["mid"]["inferred"] == {"dtype": "float", "dims": [1, 3]}
+
+    # Output declared without shape: dtype only on the model side.
+    assert tensors["y"]["kind"] == "output"
+    assert tensors["y"]["model"] == {"dtype": "float"}
+    assert tensors["y"]["inferred"] == {"dtype": "float", "dims": [1, 3]}
+
+
+def test_shape_inference_report_keeps_model_dim_params() -> None:
+    model = _make_matmul_relu_model(input_dims=["N", 4], output_dims=["N", 3])
+    report = Compiler().shape_inference_report(model)
+
+    tensors = report["tensors"]
+    assert tensors["x"]["model"]["dims"] == ["N", 4]
+    assert tensors["x"]["inferred"]["dims"] == ["N", 4]
+    assert tensors["mid"]["inferred"]["dims"] == ["N", 3]
+    assert tensors["y"]["inferred"]["dims"] == ["N", 3]
+
+
+def test_cli_compile_writes_shape_inference_json(tmp_path: Path) -> None:
+    model = _make_matmul_relu_model(input_dims=[1, 4], output_dims=[1, 3])
+    model_path = tmp_path / "model.onnx"
+    onnx.save_model(model, model_path)
+    json_path = tmp_path / "shapes.json"
+
+    exit_code = cli.main(
+        [
+            "compile",
+            str(model_path),
+            str(tmp_path / "model.c"),
+            "--shape-inference-json",
+            str(json_path),
+        ]
+    )
+
+    assert exit_code == 0
+    report = json.loads(json_path.read_text(encoding="utf-8"))
+    tensors = report["tensors"]
+    assert tensors["mid"]["inferred"] == {"dtype": "float", "dims": [1, 3]}
+    assert tensors["y"]["model"] == {"dtype": "float", "dims": [1, 3]}
+
+
+def test_cli_compile_shape_inference_json_reflects_input_dim_pinning(
+    tmp_path: Path,
+) -> None:
+    model = _make_matmul_relu_model(input_dims=["N", 4], output_dims=["N", 3])
+    model_path = tmp_path / "model.onnx"
+    onnx.save_model(model, model_path)
+    json_path = tmp_path / "shapes.json"
+
+    exit_code = cli.main(
+        [
+            "compile",
+            str(model_path),
+            str(tmp_path / "model.c"),
+            "--input-dim",
+            "N=2",
+            "--shape-inference-json",
+            str(json_path),
+        ]
+    )
+
+    assert exit_code == 0
+    report = json.loads(json_path.read_text(encoding="utf-8"))
+    tensors = report["tensors"]
+    assert tensors["x"]["model"]["dims"] == [2, 4]
+    assert tensors["mid"]["inferred"]["dims"] == [2, 3]
+    assert tensors["y"]["inferred"]["dims"] == [2, 3]


### PR DESCRIPTION
## Summary
Add a new `--shape-inference-json` CLI option that generates a JSON report documenting the model-declared and compiler-inferred shapes for all named tensors in an ONNX model.

## Key Changes
- **New module `shape_inference_report.py`**: Implements `build_shape_inference_report()` to generate a JSON-serializable report containing:
  - Model-declared shapes (with `dim_param` names and `null` for unknown dimensions)
  - Compiler-inferred shapes after shape inference
  - Tensor metadata (kind: input/output/internal, dtype)
  - Excludes weight initializers and compiler-internal temporary names for stability

- **Compiler API enhancement**: Added `shape_inference_report()` method to `Compiler` class to generate reports from the original model

- **CLI integration**:
  - New `--shape-inference-json` flag for the `compile` command
  - Writes JSON report to specified path
  - Shapes reflect the model after `--input-dim` pinning
  - Refactored `_compile_model()` to return a `_CompileModelResult` dataclass for cleaner result handling

- **Tests**: Unit tests covering declared vs. inferred shapes, `dim_param` preservation, CLI file output, and `--input-dim` pinning, plus a golden reference test: the report for `tests/onnx/mixed_ops_dynamic_batch.onnx` is checked in as `tests/golden/mixed_ops_dynamic_batch_shapes.json` (refreshable via `UPDATE_REFS=1`)

- **Documentation**: Updated README with example JSON output format and a link to the checked-in golden report as a complete real-model example

## Implementation Details
- Report format is versioned (`"format": "emx-onnx-cgen-shape-inference"`, `"version": 1`) for future compatibility
- Handles complex type scenarios: optional types, sequence types, and symbolic dimension parameters
- Preserves original model `dim_param` names from the ONNX file rather than synthetic compiler-generated names
- Gracefully handles shape inference failures by omitting inferred shapes when unavailable

https://claude.ai/code/session_01UThgBdu8vVut8v6EhtP7Sq