### PR TITLE
ci: install python3.11 before checking its version in linux-release

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -23,10 +23,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Show Python version
-        run: |
-          "$PYTHON_BIN" --version
-
       - name: Install system dependencies
         run: |
           if command -v dnf >/dev/null 2>&1; then
@@ -41,6 +37,10 @@ jobs:
             echo "No supported package manager found (dnf/yum/apt-get)." >&2
             exit 1
           fi
+
+      - name: Show Python version
+        run: |
+          "$PYTHON_BIN" --version
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
The `quay.io/pypa/manylinux_2_28_x86_64` image (pulled as `latest`) no longer ships `/usr/bin/python3.11`, so the "Show Python version" sanity check — which ran as the first step — failed with exit 127 before the "Install system dependencies" step could install python3.11 via dnf. This broke the v1.4.0 linux-release build.

Fix: move the version check after the system-dependency installation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)